### PR TITLE
Add CLAUDE.md, the design brief, and ADRs 0001-0011

### DIFF
--- a/.claude/tracker.json
+++ b/.claude/tracker.json
@@ -1,0 +1,4 @@
+{
+  "linearTeam": "Jeff Larson",
+  "linearProject": "Little CPU"
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,131 @@
+# Little CPU
+
+A hobby RISC-V core in SystemVerilog on the open toolchain (Yosys / iverilog / SymbiYosys —
+no vendor EDA). Target **RV32IMC_Zicsr**, machine mode only; eventual home is an ice40 up5k.
+
+**This project optimizes for readability, not throughput.** That is the stated point of it. CPI is
+deliberately sacrificed for a design that reads well. Do not "improve" it by adding machinery.
+
+## Current state — read this before believing anything else
+
+**This is a half-finished rewrite, not a working core.** A serialized FSM core
+(`rtl/riscv.v` + `rtl/alu.v`) once passed riscv-formal sans CSRs; it was torn down in two waves
+(2021: `9758a39`→`1709433`; 2023: `49b317a`→`4fbd650`→`13fec44`) into today's staged design, and
+the rewrite stalled partway. The project went from *formally verified* to *unverified*, and getting
+back is the whole plan.
+
+The README is the project's voice and is deliberately left as-is. **Ground truth lives here.**
+
+What does not work right now:
+
+- **The core computes wrong results.** `rtl/regfile.v` reads registers synchronously with no
+  compensating structure, so operands are one instruction stale — always.
+- **`make test` does not exist** despite the README advertising it. No RISC-V cross compiler is
+  installed by default; `test/asm/riscv_test.h` is missing though every `.S` includes it.
+- **The iverilog leg does not elaborate at all** — ~60 declaration-after-use bind errors in
+  `rtl/decoder.v` and `rtl/littlecpu.v`. Yosys tolerates these; iverilog does not.
+- **`test/monitor.v` does not elaborate under yosys** — `$time` inside `$display` at line 90 hits
+  `ERROR: Don't know how to detect sign and width for AST_AUTOWIRE node`. The build needs a
+  sanitized derived copy; the tracked file stays pristine.
+- **RVFI ports are declared and never driven**, so no riscv-formal check can pass.
+- **`formal/checks.cfg` and `formal/wrapper.v` still reference the deleted core.**
+- `make riscv.json` references `rtl/handshake.v` / `rtl/skidbuffer.v`, deleted in `49b317a`.
+
+What does work: `yosys ... write_cxxrtl` elaborates the current RTL cleanly with zero warnings, and
+the cxxrtl binary builds and runs. That is the foundation everything else is built on.
+
+## Invariants — do not break these
+
+These are the design. Violating one is a bug even if tests pass.
+
+1. **Fetch is combinational and the decoder owns the PC.** There are never wrong-path instructions.
+   **No flush logic may be introduced, ever.** If a change appears to need one, something upstream
+   has gone wrong — stop and reconsider rather than adding a kill signal.
+2. **All traps are detected and committed in decode.** Nothing faults after decode. This is what
+   makes CSR commit precise without a reorder buffer.
+3. **Every inter-stage struct carries a `valid` bit.** A bubble is `valid = 0`; retire is `valid`
+   reaching writeback, which gates `wen` and drives `rvfi_valid`.
+4. **Hazards are handled by stall-only interlock in decode.** No forwarding network. Adding one is
+   a CPI-only optimization and requires a new ADR.
+5. **CSR instructions and `mret` serialize** — held in decode until execute/access/writeback drain.
+6. **The regfile is combinational-read with write-through bypass.**
+7. **`test/monitor.v` is generated but tracked.** Regenerate it; never hand-edit it.
+
+## ISA target
+
+RV32IMC_Zicsr, M-mode only. `misa = 0x4000_1104`.
+
+Traps: illegal instruction = 2, breakpoint = 3, load address misaligned = 4, store address
+misaligned = 6, environment call from M-mode = 11. **Instruction-address-misaligned (0) is
+unreachable** — C makes 2-byte targets legal — and is not implemented. No interrupts: `mie` and
+`mip` are read-only zero.
+
+The C extension stays because **code density is a product constraint** on the up5k, not a
+preference. See ADR-0002 and ADR-0003.
+
+## Commands
+
+```sh
+make setup          # install the RISC-V toolchain (brew on macOS)
+make test           # assemble test/asm/*.S, run under cxxrtl, pass/fail table
+make waves          # iverilog + VCD for one program (currently broken — see above)
+make monitor-check  # regenerate test/monitor.v at the pin and diff
+
+make -C formal components_decoder   # component proofs
+make -C formal check                # the riscv-formal ladder (needs the M2 port)
+```
+
+Toolchain: macOS `brew install riscv64-elf-gcc`; Linux `apt install gcc-riscv64-unknown-elf`.
+Tests are freestanding assembly (`-march=rv32imc_zicsr -mabi=ilp32 -nostdlib -T sections.lds`), so
+no multilib or newlib is needed. Formal needs a pinned YosysHQ OSS CAD Suite.
+
+## Verification — three legs, each load-bearing
+
+| Leg | Role | Catches what the others can't |
+|---|---|---|
+| **cxxrtl** | primary runner | real mul/div arithmetic (formal runs under ALTOPS), long/randomized runs |
+| **iverilog** | microscope | waveforms, `$display`, second elaboration frontend |
+| **riscv-formal** | oracle | exhaustive per-instruction semantics, pipeline corners |
+
+**riscv-formal runs with `RISCV_FORMAL_ALTOPS`, so it never checks the real multiplier or divider.**
+That arithmetic is covered only by the `.S` suite and the executor component proof. Do not assume a
+green formal ladder means the ALU is correct.
+
+`test/monitor.v` rides along in both sim legs, so every run is self-checking per-retire — a test
+that corrupts state transiently but converges to the right final registers still fails loudly.
+
+## Engineering rules in force
+
+- **Compiler and elaboration warnings are errors.** Fix them; don't silence them.
+- **Every non-trivial change adds or updates tests and runs the full suite** before being declared
+  done. Elaboration succeeding is not a substitute for tests passing.
+- **Never commit build artifacts.** `test/rtl.cc`, `sim`, `*.vvp`, `*.vcd`, `rvfi_macros.vh`, and
+  `formal/` output dirs are all generated. (`test/monitor.v` is the one deliberate exception.)
+- **riscv-formal is SHA-pinned.** Bumping the pin requires regenerating `test/monitor.v` and
+  rerunning the ladder.
+- Prefer verified/first-party GitHub Actions. Simplest approach unless asked otherwise.
+
+## Milestone ladder
+
+| | Milestone | Green means |
+|---|---|---|
+| M0 | Foundation | this file, riscv-formal SHA-pinned, dead references gone |
+| M1 | Finish the pipeline | all RV32IM `.S` tests pass under cxxrtl |
+| M2 | **Parity checkpoint** | the pipelined core re-proves everything the serialized core proved |
+| M3 | Past the old core | CSRs + machine-mode traps |
+| M4 | Full ladder + CI | nightly formal green; tag a release |
+
+M1 is the critical path. **M2 is the milestone that erases the verified→unverified regression** —
+treat it as the real finish line, not M1.
+
+## Pointers
+
+- Design brief: [`docs/ideas/finish-the-rewrite.md`](docs/ideas/finish-the-rewrite.md)
+- Decisions: [`docs/adr/`](docs/adr/) — seven accepted ADRs, plus a deferred list
+- Reference text from the old core: `git show 1709433^:rtl/riscv.v` (RVFI retire block),
+  `git show e67875c^:rtl/alu.v` (arithmetic)
+- Tracker: Linear, project **Little CPU** (team JEF)
+
+**Deferred behind future ADRs** — forwarding network, radix-4 divider, negedge-BRAM regfile, FPGA
+timing closure, interrupts, Spike co-sim. Each trades away simplicity the current design depends
+on; none are safe to build while the core is unverified.

--- a/docs/adr/0001-finish-the-staged-rewrite.md
+++ b/docs/adr/0001-finish-the-staged-rewrite.md
@@ -1,0 +1,63 @@
+# ADR-0001: Finish the staged rewrite rather than resurrect the serialized core
+
+**Status:** Accepted · 2026-07-27
+
+## Context
+
+Little CPU has been through two architectural teardowns. A 491-line serialized FSM core
+(`rtl/riscv.v` + 159-line `rtl/alu.v`, single memory port with a picorv32-style
+`mem_valid`/`mem_instr`/`mem_ready` handshake) **passed riscv-formal sans CSRs**. It was replaced
+by a handshake/skidbuffer pipeline in 2021 (`9758a39` → `1709433` → `9ea584a`), which was then
+stripped down to the current fused staged design in 2023 (`49b317a` → `4fbd650` → `13fec44`).
+
+The rewrite is unfinished. Operands are one instruction stale (registered-read regfile with no
+compensating structure), `executor.stalled` is computed but unwired, RVFI ports are declared but
+never driven, and the `formal/` harness still speaks the deleted core's interface. The project has
+therefore gone from *formally verified* to *unverified*.
+
+## Decision
+
+**Finish the staged rewrite.** Do not resurrect the serialized core as mainline, as a component, or
+as a co-simulation oracle.
+
+The serialized core's role is **reference text**: its RVFI retire block, `rs1_valid`/`rs2_valid`
+masking, `rvfi_order` accumulation, and memory rmask/wmask conventions port near line-for-line into
+the new shadow-payload design (`git show 1709433^:rtl/riscv.v`). Its arithmetic is the reference
+for fixing the mul/div bugs the rewrite inherited (`git show e67875c^:rtl/alu.v`).
+
+The wave-0 `formal/` harness is **ported, not rewritten** — see ADR-0006.
+
+The milestone ladder carries an explicit **parity checkpoint (M2)**: the pipelined core must
+re-prove everything the serialized core proved (rv32imc insn/reg/pc_fwd/pc_bwd/unique/causal, no
+CSRs) before any new ground is broken.
+
+## Rationale
+
+1. The staged design is the repo's stated identity, and the author tore the old core down *twice*.
+   Reverting reverses years of intent to save roughly one milestone of work.
+2. The fused-fetch design retains the serialized core's key verification property — no wrong-path
+   instructions, therefore no flush — while pipelining. It is the rare rewrite that keeps the old
+   verification story intact.
+3. The old core's green run depended on the single-port handshake memory interface that no longer
+   exists anywhere in the SoC. Resurrecting it means maintaining two cores *and* two memory systems.
+4. A co-sim oracle against the old core is redundant machinery: riscv-formal's ISA spec modules are
+   already the golden model, and sequential equivalence between an FSM core and a pipeline is not
+   something `equiv_simple`/`equiv_induct` can establish.
+
+## Consequences
+
+- Work is framed as **completing** the rewrite, not repairing damage. Defects are sorted into
+  *genuine bugs* (wrong in any architecture — six of them) and *unreached scaffolding*. The two
+  read very differently and are planned differently.
+- The project stays unverified until M2. That is the single largest risk carried by this plan, and
+  the reason M2 is a hard checkpoint rather than a soft goal.
+- Git history becomes load-bearing documentation. `CLAUDE.md` must carry the rewrite narrative and
+  the `git show` incantations, or the next reader loses the reference text.
+
+## Alternatives considered
+
+- **Port CSRs and C onto the known-good serialized core, treat the staged version as a later
+  refactor.** Rejected: discards the design the author is proud of, and forfeits the no-wrong-path
+  property that makes the staged core unusually easy to verify.
+- **Keep both cores, use the old as a co-sim reference.** Rejected: two cores plus two memory
+  systems to maintain, for an oracle riscv-formal already provides better.

--- a/docs/adr/0002-isa-target-rv32imc-zicsr.md
+++ b/docs/adr/0002-isa-target-rv32imc-zicsr.md
@@ -1,0 +1,63 @@
+# ADR-0002: ISA target is RV32IMC_Zicsr, machine mode only
+
+**Status:** Accepted · 2026-07-27
+
+## Context
+
+The repo's ISA target was ambiguous. The README says "RISCV 32 base ISA (IM)"; the root Makefile
+passes `-DRISCV_FORMAL_COMPRESSED`; `test/monitor.v` is generated with `-i rv32imc`;
+`formal/checks.cfg` says `isa rv32imc`; and `rtl/decoder.v` carries substantial but incomplete
+C-extension decode. Meanwhile `test/asm/` contains 13 RV64-only tests, and there is no CSR support
+at all.
+
+The compressed extension is expensive to verify: it complicates instruction fetch and roughly
+doubles the riscv-formal `insn_*` check count. An initial recommendation was to cut it.
+
+## Decision
+
+**Target RV32IMC_Zicsr, machine mode only.** The C extension stays.
+
+- `misa = 0x4000_1104` (MXL=1, C+I+M).
+- Traps implemented: illegal instruction (2), breakpoint (3), load address misaligned (4), store
+  address misaligned (6), environment call from M-mode (11).
+- **Instruction-address-misaligned (mcause 0) is unreachable and not implemented** — with C, only
+  2-byte alignment is required; branch and JAL immediates have bit 0 = 0, and JALR clears bit 0.
+  `mepc` hardwires bit [0] only.
+- No interrupts: `mie` and `mip` are read-only zero (no interrupt sources exist).
+- No S-mode, no U-mode, no PMP, no `mtval` values (hardwired 0, which is spec-legal).
+
+The existing `-DRISCV_FORMAL_COMPRESSED`, `-i rv32imc` monitor generation, and
+`checks.cfg`'s `isa rv32imc` were already correct and are **kept unchanged**.
+
+Decode gaps to close: **C.EBREAK** (quadrant 10, funct4=1001, rd=0, rs2=0 — currently falls between
+`instr_cadd` and `instr_cjalr` into illegal), plus `mret`, `wfi`, `fence`, and `fence.i`.
+
+## Rationale
+
+**C stays because code density is a product constraint, not a preference.** The core targets an
+ice40 up5k, whose on-chip memory is small. Compressed instructions buy roughly 25–30% code size on
+typical RV32 code, which directly determines what programs fit. That outweighs the verification
+cost, provided the cost can be contained — and ADR-0003 shows it can, at zero cost to the design's
+central invariant.
+
+Secondary: the decoder's C support is already substantial (all the CI/CR/CB/CJ forms, RV32-only
+C.JAL correctly present, and the reserved encodings that must trap already falling through to
+`!instr_valid`). Cutting it would discard working code and require touching every config that
+already says `rv32imc`.
+
+Machine-mode-only Zicsr is the minimum that makes traps precise and satisfies riscv-formal's
+`[csrs] mcycle minstret`. Anything more (S-mode, PMP, interrupts) has no consumer in this design.
+
+## Consequences
+
+- riscv-formal's `insn_*` check set grows to the full `isa_rv32imc.txt` (~75 checks). These are
+  individually small BMCs; they land in the nightly tier, with `insn_c_addi`, `insn_c_lw`, and
+  `insn_c_j` in the PR smoke set.
+- Fetch requires the dual-word window of ADR-0003.
+- The 13 RV64-only `.S` tests are deleted (they cannot assemble for RV32 — there is no "RV32 port"
+  of `addw`). `fence_i.S` is deleted too: self-modifying code is impossible on this Harvard core.
+- The test suite gains compressed coverage it does not currently have at all: riscv-tests'
+  `rv32uc/rvc.S` plus a straddle-specific test.
+- `rvfi_insn` reports the 16-bit value zero-extended for compressed instructions;
+  `rvfi_pc_wdata` steps by 2 or 4.
+- up5k budget stays feasible at roughly 55–70% of the part (see the brief's decision 13).

--- a/docs/adr/0003-dual-word-combinational-fetch-window.md
+++ b/docs/adr/0003-dual-word-combinational-fetch-window.md
@@ -1,0 +1,59 @@
+# ADR-0003: Dual-word combinational fetch window for compressed instructions
+
+**Status:** Accepted · 2026-07-27
+
+## Context
+
+The core's most valuable structural property is that **there are never wrong-path instructions**.
+`rtl/fetcher.v` is purely combinational (`imem_addr = pc`, output = `imem_data` in the same cycle),
+and `rtl/decoder.v` owns the PC and resolves branches in the same cycle the instruction is fetched.
+Nothing speculative is ever issued, so **no flush logic exists anywhere in the design** — which is
+simultaneously why the core is a good read and why its formal verification surface is small.
+
+The C extension (ADR-0002) requires fetching 32-bit instructions that may straddle a 4-byte
+boundary when `pc % 4 == 2`. The conventional answer — a fetch aligner with a halfword buffer —
+introduces fetch state and, with it, buffer invalidation on redirect. That is a flush by another
+name, and it would cost the invariant above.
+
+## Decision
+
+Fetch presents **two adjacent words combinationally** and selects a 32-bit window from them:
+
+```
+imem_addr  = {pc[31:2], 2'b00}
+imem_addr2 = imem_addr + 4
+instr      = ({imem_data2, imem_data} >> (pc[1] ? 16 : 0))[31:0]
+```
+
+The decoder masks the upper half when `quadrant != 2'b11` (compressed instruction).
+`pc_inc = uncompressed ? 4 : 2`, which `rtl/decoder.v:278-279` already implements correctly.
+
+## Rationale
+
+The window is **stateless**. Fetch stays combinational, the decoder still owns the PC, branches
+still resolve with zero wrong-path instructions, and a straddling 32-bit instruction at
+`pc % 4 == 2` costs *nothing*: no aligner FSM, no halfword buffer, no invalidation on redirect, no
+straddle stall. The invariant survives the C extension completely intact.
+
+Alternatives rejected:
+
+- **32-bit fetch + halfword buffer.** Adds fetch state, straddle stalls, and redirect invalidation
+  — reintroducing exactly the flush semantics the design has never needed.
+- **Straddle-stall two-cycle fetch.** Adds a state bit and creates mid-straddle redirect corner
+  cases (what happens when a branch resolves while a straddle is half-fetched?).
+
+## Consequences
+
+- **Cost: a second combinational ROM read.** Free in simulation and formal — `rtl/imemory.v` and
+  the testbench read the array twice; `rtl/littlesoc.v` wires two reads.
+- **On real ice40 BRAM this needs work**: even/odd interleaved 16-bit banks, or negedge reads.
+  Deferred with the rest of FPGA timing closure (post-M4). This does not block any milestone.
+- The formal wrapper models both `imem_data` inputs as `rvformal_rand_reg` with stability
+  assumptions while the PC is stalled, matching real ROM behaviour.
+- `formal/imemcheck.sv` already models fetch at **16-bit granularity** (`imem_data[15:0]`) — the
+  wave-0 harness anticipated compressed straddle. Re-pointed at the split `imem_addr`/`imem_data`
+  interface, it becomes the ready-made consistency check for this window.
+- **This is the one genuinely novel piece of the plan.** Wave-0 fetched through a handshake; the
+  current design has never done C straddle. Expect M2's surprises here. Mitigations: `imemcheck` at
+  16-bit granularity, a dedicated straddle `.S` test (32-bit instruction at `pc % 4 == 2`, branch
+  into a misaligned target), and the `insn_c_*` formal checks.

--- a/docs/adr/0004-stall-only-hazard-interlock.md
+++ b/docs/adr/0004-stall-only-hazard-interlock.md
@@ -1,0 +1,63 @@
+# ADR-0004: Stall-only hazard interlock with a combinational-read regfile
+
+**Status:** Accepted · 2026-07-27
+
+## Context
+
+The core has **no hazard handling at all** — no forwarding, no stalls, no load-use interlock.
+Worse, it is broken before hazards even matter: `rtl/regfile.v:15-17` performs *registered* reads,
+so the operand values the decoder consumes in cycle N belong to the rs1/rs2 indices of the
+*previous* instruction. Every register-consuming instruction receives wrong operands, always. This
+— not the missing CSRs — is why the core does not work.
+
+Separately, `rtl/executor.v:23-25` computes a `stalled` signal that is wired to nothing. During the
+multi-cycle divide, nothing upstream stalls, and `executor_out` holds the previous instruction's
+load/store flags, so the accessor re-issues that memory operation once per divide iteration.
+
+## Decision
+
+Adopt a **stall-only interlock**, keeping the fused front end:
+
+1. **Regfile becomes combinational-read with write-through bypass.** If `wen && waddr == rs`,
+   forward `wdata` directly. This fixes the operand-timing defect and covers the writeback-stage
+   hazard for free.
+2. **Every inter-stage struct carries a `valid` bit.** A bubble is `valid = 0`. Retire is `valid`
+   reaching writeback, which also gates `wen` and drives `rvfi_valid`.
+3. **A stall-only scoreboard in decode.** If rs1 or rs2 — when actually used by this instruction —
+   matches a live `rd` in `decoder_out` or `executor_out`, freeze the PC and emit a bubble.
+   Write-through covers the writeback stage, so only two stages need checking.
+4. **The divider freezes decode globally** via the now-wired `stalled` signal, and drops `valid`
+   until it completes.
+5. **No forwarding network.** Adding one is a CPI-only optimisation and requires a new ADR.
+
+## Rationale
+
+This is the smallest delta from what exists, and it preserves the design's one genuinely elegant
+idea (ADR-0003's no-wrong-path invariant). Every simplification compounds: traps-in-decode
+(ADR-0005) makes CSR commit precise for free; the valid-bit protocol doubles as the RVFI retire
+signal (ADR-0006); and stall-only hazards keep the formal state space small.
+
+Alternatives rejected:
+
+- **Textbook 5-stage — registered IF/ID, branch resolution in EX, flush on taken branch, full
+  forwarding.** Roughly 3× the new state machinery: PC ownership moves out of the decoder (a
+  rewrite of the repo's central module), plus kill/flush logic, wrong-path RVFI suppression, three
+  forwarding muxes, and a load-use interlock. It buys Fmax the project does not need yet, at the
+  price of the complexity class the project exists to avoid — and flush × stall × divider
+  interaction is the classic source of pipeline bugs.
+- **Collapse to a multicycle FSM core (picorv32 shape).** Trivially precise and easy to verify, but
+  it discards the staged-modules-with-structs identity of the repo. That would be a different
+  project — and it is the direction ADR-0001 explicitly declines.
+
+## Consequences
+
+- **CPI cost:** worst-case 2-cycle RAW bubble; ~32-cycle divide (see ADR-0002's brief for the
+  iteration-count fix). Accepted — this core optimises for readability, not throughput.
+- **Fmax risk:** the combinational path is long — `pc` → ROM → decode → branch compare → `pc`, now
+  with a combinational regfile read and a CSR read on it. Real, accepted, deferred with FPGA timing.
+  Documented escape hatch: negedge-read BRAM regfile.
+- **Area:** the regfile moves from BRAM to flip-flops (~992 FF on up5k). The budget still closes at
+  roughly 55–70% of the part.
+- Forwarding paths can be added later as pure CPI upgrades without disturbing anything above.
+- Invariant for `CLAUDE.md`: **no flush logic may be introduced.** If a change appears to need one,
+  the design has gone wrong somewhere upstream.

--- a/docs/adr/0005-traps-and-csrs-commit-in-decode.md
+++ b/docs/adr/0005-traps-and-csrs-commit-in-decode.md
@@ -1,0 +1,81 @@
+# ADR-0005: Traps and CSR accesses are detected and committed in decode
+
+**Status:** Accepted · 2026-07-27
+
+## Context
+
+The core has no CSRs. `rtl/decoder.v:207-214` decodes `csrrw`/`csrrs`/`csrrc` (folding the
+immediate variants into the register forms, losing the zimm-vs-rs1 distinction and never carrying
+the CSR address from `instr[31:20]`), `rtl/executor.v:116` is an explicit empty statement for all
+of them, and `rtl/writeback.v:25` is `// TODO: csrs`. `rtl/littlecpu.v:47-51` synthesises a `trap`
+output combinationally with no `mepc`/`mcause`/`mtvec` behind it.
+
+`formal/checks.cfg` already lists `[csrs] mcycle minstret`, so riscv-formal's `csrw` checks are in
+scope. CSR reads and writes must be **precise** and correctly ordered against the pipeline.
+
+## Decision
+
+**All traps are detected and committed in decode. The CSR file is a sibling module of the decoder,
+read and written in the decode stage. CSR instructions and `mret` serialize.**
+
+- **Traps in decode.** Illegal instruction, `ecall`, `ebreak`, *and* load/store misalignment are all
+  detected in decode. Misalignment detection is possible there because `mem_addr = rs1 + imm` is
+  already computed in decode. **Nothing can fault after decode**, so no instruction ever needs to be
+  killed downstream.
+- **Serialization.** CSR instructions and `mret` are held in decode until execute/access/writeback
+  drain (≤3 cycles). This makes counter reads trivially exact and eliminates every CSR/pipeline
+  interaction corner.
+- **CSR read results** ride the pass-through trick the decoder already uses for `lui`/`jal`:
+  `out.rs1 <= csr_rdata; out.is_add <= 1; out.rs2 <= 0`.
+- **`minstret` increments at issue**, which is equivalent to counting retires because post-decode
+  nothing faults.
+
+### CSR set (exact)
+
+**Read/write:** `mstatus` (MIE, MPIE, MPP only; MPP is WARL → `2'b11`), `mtvec` (direct mode only;
+base WARL, 4-byte aligned), `mepc` (WARL, bit [0] = 0 — only bit 0, because C makes 2-byte targets
+legal), `mcause` (WLRL over the implemented codes), `mscratch`, `mcycle`/`mcycleh`,
+`minstret`/`minstreth`.
+
+**Read-only:** `mtval` = 0 (spec-legal), `mie` = 0, `mip` = 0 (no interrupt sources),
+`misa` = `0x4000_1104` (RV32IMC), `mvendorid`/`marchid`/`mimpid`/`mhartid` = 0.
+
+**Trap causes:** illegal instruction = 2, breakpoint = 3, load address misaligned = 4, store
+address misaligned = 6, environment call from M-mode = 11. Instruction-address-misaligned (0) is
+unreachable under C — see ADR-0002.
+
+### Zicsr semantics that must hold
+
+- CSRRS/CSRRC with `rs1 == x0` (or `zimm == 0`) **suppress the write** — no illegal-instruction
+  trap on a read-only CSR.
+- CSRRW with `rd == x0` **suppresses the read** side effects.
+- Access to an unimplemented CSR, or a write to a CSR with `addr[11:10] == 2'b11` (read-only),
+  raises illegal instruction.
+- An explicit write to a counter **takes precedence** over that cycle's increment.
+- `mret` restores `MIE ← MPIE` and `pc ← mepc`.
+- `wfi` executes as a NOP (spec-legal). `fence` and `fence.i` are NOPs — no caches, Harvard ROM.
+
+### Decode changes required
+
+`decoder_output` gains `csr_addr` and `is_csr_imm`. Immediate-form CSR instructions must **not**
+create an rs1 interlock (the zimm field is not a register). `mret` needs its own decode — currently
+`rtl/decoder.v:216-219` matches *any* SYSTEM instruction with funct12 ≠ 0 as `ebreak`, so `mret`
+(0x302) and `wfi` (0x105) both decode as EBREAK. `ebreak` must be funct12 == 1 exactly.
+
+## Rationale
+
+Because nothing faults after decode and issue is strictly in-order, decode-stage commit **is**
+precise — no reorder buffer, no exception PC tracking down the pipe, no downstream kill. Serializing
+CSR instructions costs at most 3 cycles on an instruction class that is rare in real code, and buys
+away the entire class of CSR/pipeline hazards, including the hard one (what does `mcycle` read
+when there are three instructions in flight?).
+
+## Consequences
+
+- CSR access latency is ~4 cycles. Irrelevant for this core's workload.
+- The `csrw_mcycle` / `csrw_minstret` formal checks become tractable, because the counter's value at
+  the moment of a CSR read is unambiguous.
+- **This is new ground for the project** — the serialized core hardwired `rvfi_csr_* = 0`, which is
+  exactly why its green run was "sans CSRs." Expect iteration in M4.
+- Invariants for `CLAUDE.md`: nothing faults after decode; CSR instructions and `mret` serialize.
+- ~390 FF for the CSR file (two 64-bit counters plus five small CSRs) and ~200 LUT of read mux.

--- a/docs/adr/0006-port-the-wave-0-formal-harness.md
+++ b/docs/adr/0006-port-the-wave-0-formal-harness.md
@@ -1,0 +1,93 @@
+# ADR-0006: Port the wave-0 formal harness; RVFI via per-stage shadow payloads
+
+**Status:** Accepted · 2026-07-27
+
+## Context
+
+`rtl/littlecpu.v:14-45` declares the full RVFI port set, including `rvfi_csr_mcycle_*` and
+`rvfi_csr_minstret_*`. **Not one of them is ever assigned** — `grep -rn "rvfi_" rtl/` finds no
+drivers. riscv-formal therefore cannot pass.
+
+The `formal/` directory looks stale: `checks.cfg`'s `[script-sources]` reads `rtl/riscv.v` and
+`rtl/alu.v`, which no longer exist, and `formal/wrapper.v` instantiates a module named `riscv` with
+a picorv32-style `mem_valid`/`mem_instr`/`mem_ready` handshake the current core does not have.
+
+The first instinct was to treat all of this as dead and rewrite from scratch. Git archaeology
+showed otherwise: **this is the harness from the era when the core passed riscv-formal sans CSRs**
+(ADR-0001). It is proven-good work against a different interface, not junk.
+
+## Decision
+
+**Port the wave-0 harness rather than rewrite it**, and generate RVFI from **per-stage shadow
+payloads** rather than a separate retire tracker.
+
+### Harness disposition
+
+| Artifact | Verdict | Delta |
+|---|---|---|
+| `checks.cfg` | Keep | ISA, depths, and `[csrs]` are already right (rv32imc, mcycle/minstret). Update `[script-sources]` to the staged RTL. Keep `RISCV_FORMAL_ALTOPS`. |
+| `complete.sv` | Keep | Already ported to `littlecpu` by the author in `fd36a52`. Finish: drive imem/dmem inputs rand-stable. |
+| `wrapper.v` | Port | The only file still instantiating `riscv` with the handshake. Rewrite the port list for `littlecpu`; the `RVFI_WIRES`/`RVFI_CONN` skeleton carries over. Fairness becomes "bounded consecutive internal stall" — there is no `mem_ready` any more. |
+| `imemcheck.sv` | Port — valuable | Already models fetch at 16-bit granularity (`imem_data[15:0]`); wave-0 anticipated compressed straddle. Re-pointed, it directly stresses ADR-0003's fetch window. |
+| `dmemcheck.sv` | Port | Same shape, re-pointed at `mem_addr`/`wstrb`/`wdata`/`rdata` without the handshake fire condition. |
+| `cover.sv` | Port (cheap) | Counts loads/stores and compressed-vs-long retires — exactly the "do compressed instructions actually retire" sanity we want. |
+| `equiv.sh` | **Keep** | Not serialized-vs-pipelined equivalence, as first assumed. It proves **RVFI instrumentation does not change core behaviour** (gold = plain build, gate = `RISCV_FORMAL` build with rvfi ports deleted). With large `ifdef` shadow payloads landing in the structs, this earns its keep. |
+
+Delete only the genuinely dead: the `handshake`/`skidbuffer` tasks in `components.sby` (files
+removed in `49b317a`) and the matching references at `Makefile:22`.
+
+**Pin riscv-formal to a SHA** (the `formal/Makefile` currently clones unpinned HEAD against a
+Jan-2023 vendored `genchecks.py` — a version-skew time bomb).
+
+### RVFI generation
+
+Extend the stage structs in `rtl/structs.v` with an `ifdef RISCV_FORMAL` section carrying `insn`,
+`pc_rdata`/`pc_wdata`, rs1/rs2 addr+rdata, rd_addr, mem addr/masks/data, trap, and csr
+rdata/wdata/masks. Capture in decode, carry down, drive `rvfi_*` from writeback. `rvfi_order`
+counts retires. Trapping instructions retire as valid-with-`rvfi_trap`, `pc_wdata = mtvec`.
+
+The **logic** is ported from the serialized core's retire block (`git show 1709433^:rtl/riscv.v`):
+`rs1_valid`/`rs2_valid` masking (`!is_lui && !is_jal && !is_auipc`…), order accumulation, and
+memory capture conventions — re-keyed from FSM states to ADR-0004's valid bits.
+
+### Component proofs: exactly two
+
+1. **Decoder** — the `$onehot` / valid-decode assertions, rewritten. The current FAIL at
+   `decoder.v:396-406` is a **decode-hole detector, not a broken property**: the vector already
+   uses merged base-op signals, so compressed forms alias correctly and contribute one bit. Its
+   reachable holes are the missing C.EBREAK and the funct12-wildcard `ebreak`. Fix the holes,
+   extend the vector with `mret`/`wfi`/`fence`/csr ops, and add `cover` statements so each op is
+   provably reachable.
+2. **Executor arithmetic BMC** (new, ~depth 70) — proves the divider and multiplier against the
+   `/`, `%`, and `*` operators. **This is load-bearing precisely because ALTOPS means riscv-formal
+   never checks the real arithmetic**, and the current code has three arithmetic defects
+   (mulh sign bit, inverted divider comparison, wrong iteration count).
+
+Delete the rest. `components_fetcher` asserts a property of a free input (`fetcher.v:34` asserts
+`out.pc == 0` after reset, but `out.pc` is combinationally the free `pc` input) — the assertion is
+simply wrong. `components_executor` currently **"PASSes" with zero assertions** — `executor.v:159-166`
+contains only reset assumptions. `components_accessor` and `components_writeback` are likewise
+vacuous.
+
+## Rationale
+
+A separate RVFI retire tracker would re-implement the pipeline registers it watches. The shadow
+payload rides the valid-bit protocol that ADR-0004 introduces anyway, so retire detection is free.
+
+Porting beats rewriting because the wave-0 files encode conventions that were *validated by a green
+run* — particularly the rs-validity masks and memory mask semantics, which are the fiddly parts of
+an RVFI hookup and the easiest to get subtly wrong.
+
+## Consequences
+
+- **M2 is a port, not a rewrite** — materially smaller and lower-risk than writing a wrapper from
+  scratch.
+- M2 becomes the **parity checkpoint**: the pipelined core proves everything the serialized core
+  proved (rv32imc insn/reg/pc_fwd/pc_bwd/unique/causal, no CSRs).
+- `equiv.sh` guards against the shadow payloads perturbing synthesis behaviour — a real risk given
+  how much `ifdef`'d state the structs are about to carry.
+- Solver runtimes: ~75 `insn_*` checks at depth 20–30 is nightly-scale (est. 1–3 h wall with `-j`);
+  PR smoke runs in minutes. Liveness may need a stall-fairness assumption bounded by the divider's
+  32 cycles.
+- Bumping the riscv-formal pin requires regenerating `test/monitor.v` and rerunning the ladder. CI
+  enforces monitor freshness by regenerating and diffing.

--- a/docs/adr/0007-cxxrtl-is-the-primary-simulator.md
+++ b/docs/adr/0007-cxxrtl-is-the-primary-simulator.md
@@ -1,0 +1,84 @@
+# ADR-0007: cxxrtl is the primary simulator; iverilog is the microscope
+
+**Status:** Accepted · 2026-07-27
+
+## Context
+
+The repo carries two simulation stacks. `test/cxxrtl.cc` (27 lines) drives a yosys `write_cxxrtl`
+build; `test/testbench.v` (155 lines) drives an iverilog build with the generated riscv-formal
+monitor (`test/monitor.v`, 7008 lines) instantiated at lines 102–126.
+
+Neither is wired to a test suite. The README advertises `make test`, but **the root Makefile has no
+`test` target**. `test/asm/*.S` are riscv-tests-style but nothing assembles or links them, and every
+one of them `#include`s `riscv_test.h`, which is not in the repo.
+
+An initial recommendation was to delete the cxxrtl path and standardise on iverilog, on the grounds
+that two sim stacks is double maintenance.
+
+## Decision
+
+**Keep both, with distinct roles. cxxrtl is the primary runner.**
+
+### cxxrtl — the workhorse
+
+`test/cxxrtl.cc` grows to a ~150-line test runner:
+
+- Parse `--rom <hex> --cycles N [--vcd out.vcd]`.
+- Load the program hex directly into ROM via `debug_items` (more robust than `$readmemh` through
+  yosys).
+- Run until a write of the magic pass/fail value to the `tohost` address.
+- Return a real process exit code.
+
+`make test` = assemble every `.S` → `objcopy -O verilog --verilog-data-width=4` → run each under
+the cxxrtl binary.
+
+### iverilog — the microscope
+
+`test/testbench.v` stays the debugging bench: VCD waveforms, `$display` tracing, same monitor
+instance. CI runs one smoke program through it to keep the second-frontend elaboration path alive.
+Not the bulk runner.
+
+### riscv-formal — the oracle
+
+Exhaustive per-instruction semantics and pipeline corners to bounded depth, with ALTOPS masking the
+real mul/div arithmetic — which is precisely the hole the `.S` suite covers.
+
+### `test/monitor.v` stays tracked
+
+It is deterministic output of `riscv-formal/monitor/generate.py -i rv32imc -c 1 -a -p monitor`, and
+that ISA string is already correct for ADR-0002. It stays in-tree because it is directly useful for
+debugging. Keeping it honest: the generation rule stays in the Makefile with a header comment
+naming the riscv-formal pin; regeneration is required when the pin or ISA string changes; **CI
+verifies freshness by regenerating and diffing**; conflicts are resolved by regenerating, never by
+hand-editing.
+
+## Rationale
+
+**cxxrtl runs one to two orders of magnitude faster than iverilog** for a core this size, and that
+matters exactly where this design hurts. Even at the corrected 32 divider iterations (ADR-0004),
+`div.S` and `rem.S` run to thousands of cycles; a hazard/divider torture test or an overnight
+randomised run is only practical under cxxrtl. It also keeps the yosys frontend honest, since it
+uses the same elaboration path CI depends on.
+
+iverilog earns its place as a waveform microscope and a second elaboration frontend — the two jobs
+cxxrtl is worst at. This is not double maintenance; it is one runner and one debugger.
+
+Keeping `test/monitor.v` in both builds means **every run is self-checking per-retire**, not merely
+end-state-checking. That catches what `.S` pass/fail cannot: a test that corrupts state transiently
+but converges to the right final register values still fails loudly, and torture or randomised runs
+become self-checking without expected-output files.
+
+## Consequences
+
+- `test/rtl.cc` (2533 generated lines) stays **generated at build**. It is already gitignored; the
+  stale on-disk copy should be removed from disk, not from git.
+- `make test` depends on a RISC-V toolchain. Because the tests are freestanding assembly, no
+  multilib or newlib is needed: `-march=rv32imc_zicsr -mabi=ilp32 -nostdlib -T sections.lds`.
+  macOS: `brew install riscv64-elf-gcc`. CI: `apt install gcc-riscv64-unknown-elf iverilog` plus a
+  pinned YosysHQ OSS CAD Suite release for yosys/sby/solvers.
+- A minimal local `riscv_test.h` must be written (RVTEST_CODE_BEGIN / PASS / FAIL writing the
+  `tohost` magic). M1 work.
+- The 13 RV64-only `.S` files are deleted (ADR-0002); `rv32uc/rvc.S` and a straddle test are added;
+  trap/CSR tests arrive in M3.
+- **Residual risk:** if the monitor's `$display` error reporting misbehaves under cxxrtl, the
+  fallback is a C++-side check of the monitor's error flag. Small and contained.

--- a/docs/adr/0008-test-memory-map-and-tohost-protocol.md
+++ b/docs/adr/0008-test-memory-map-and-tohost-protocol.md
@@ -1,0 +1,56 @@
+# ADR-0008: Test memory map and the `tohost` protocol
+
+**Status:** Accepted · 2026-07-27
+
+## Context
+
+ADR-0007 specifies a cxxrtl runner that "runs until a write of the magic pass/fail value to the
+`tohost` address" — without defining the address, the encoding, or how the iverilog bench observes
+the same event.
+
+Worse, the link script makes the tests unpassable as written. `test/asm/sections.lds` has a `*(*)`
+catch-all that places `.text` **and** `.data` into a single output section at address 0. This core
+is Harvard: `imem_addr` indexes ROM based at 0, `mem_addr` indexes RAM based at 0, and the two are
+disjoint. Every `.S` file's `TEST_DATA` block therefore links into instruction memory where loads
+cannot reach it — `lw.S`, `sw.S`, `lb.S` and the rest cannot pass regardless of how correct the
+core is.
+
+There is also no `tohost` symbol anywhere in the repo, and `formal/dmemcheck.sv` will eventually
+need to agree with whatever convention is chosen.
+
+## Decision
+
+**Two regions, two images, riscv-tests' `tohost` encoding.**
+
+1. **Split `sections.lds` into two regions.** `.text` goes to `>rom` (base 0). `.data`, `.rodata`,
+   and `.bss` go to `>ram` at a non-zero base decoded by both testbenches. Export `tohost` as a
+   symbol in the RAM region.
+2. **The runner takes two images:** `--rom <hex>` and `--ram <hex>`. Both are produced by
+   `objcopy -O verilog --verilog-data-width=4` from their respective sections.
+3. **`tohost` is a fixed word address in RAM.** The runner watches writes to it via `debug_items`.
+4. **Encoding follows riscv-tests**, which `test/asm/test_macros.h` already assumes:
+   pass = `1`; fail = `(testnum << 1) | 1`. The runner reports the failing test number.
+5. **Exit codes:** 0 = pass, 1 = fail (with the test number), 2 = cycle-limit timeout.
+6. **The iverilog bench observes the same address** with the same encoding, so both sim legs score
+   tests identically.
+
+## Rationale
+
+Two regions is the only option that makes load/store tests passable on a Harvard core without
+inventing a unified address space the RTL does not have. Two images follows directly, and keeps the
+runner honest about which memory it is filling.
+
+Reusing riscv-tests' `tohost` encoding costs nothing — `test_macros.h` is already written against
+it — and means the `.S` files need no edits beyond the missing `riscv_test.h`.
+
+## Consequences
+
+- `test/asm/sections.lds` is rewritten. `test/asm/riscv_test.h` is written against this map.
+- The cxxrtl runner CLI grows `--ram`. The brief's single-`--rom` sketch was insufficient.
+- `test/testbench.v` and `rtl/littlesoc.v` must decode the RAM base consistently.
+- `formal/dmemcheck.sv` inherits this map when it is ported in M2.
+- A per-test cycle budget is needed. Until the divider iteration-count fix lands (bug 6), `div.S`
+  and `rem.S` run ~2× longer than they should, so the budget must be generous enough that a
+  timeout means a hang, not a slow divide.
+- Verify rather than assume: `MASK_XLEN` in `test/asm/test_macros.h:11` keys off `__riscv_xlen`, so
+  the 64-bit literals in the RV64-sourced files should truncate correctly at `rv32im_zicsr`.

--- a/docs/adr/0009-stall-protocol-semantics.md
+++ b/docs/adr/0009-stall-protocol-semantics.md
@@ -1,0 +1,53 @@
+# ADR-0009: Stall protocol — upstream freezes, downstream drains
+
+**Status:** Accepted · 2026-07-27
+
+## Context
+
+ADR-0004 says the decode scoreboard "freezes the PC and emits a bubble" and that the divider
+"freezes decode globally and drops `valid` until it completes." That text is underspecified in a
+way that matters: it does not say whether stall is a single broadcast signal or a chain of
+per-stage ready signals, and — the part that actually bites — whether the accessor and writeback
+**keep draining** while the executor is dividing, or freeze along with it.
+
+Draining is what ADR-0004 implies and what avoids the memory-replay defect (today the accessor
+re-issues the previous load/store once per divide iteration). Freezing is the more obvious
+implementation. Two competent engineers will build these two different ways from the current text,
+and only one of them is correct.
+
+## Decision
+
+**A single global `stall` broadcast from `rtl/littlecpu.v`.**
+
+- **Upstream of the stalling stage freezes.** The PC holds; the fetch window re-presents the same
+  bytes (which is also exactly the rand-stable behaviour ADR-0003 asks the formal wrapper to
+  model); decode holds its output.
+- **Downstream of the stalling stage drains.** Instructions already past the stall point continue
+  to retire normally.
+- **`valid = 0` is injected at the stalling stage's output**, so the drain is fed bubbles rather
+  than repeats. This is the direct fix for the divide-replay defect.
+- **No per-stage ready/valid handshake.** A skidbuffer/handshake pipeline existed here once and was
+  deliberately removed in `49b317a`. Do not reintroduce it.
+
+**Reset semantics:** reset clears `valid` on every struct and zeroes the payload. Zeroing costs
+nothing in FF count that matters and makes `formal/complete.sv`'s reset handling trivial in M2.
+
+## Rationale
+
+A single broadcast is the simplest thing that works and matches the design's existing shape — there
+is no backpressure source in this core other than the divider and the decode scoreboard, so a
+handshake network would be machinery with one customer.
+
+Freeze-upstream/drain-downstream is the only variant that fixes the memory replay. Freezing
+everything would leave the accessor holding a live load/store request across the whole divide,
+which is the bug.
+
+## Consequences
+
+- Add to the `CLAUDE.md` invariant list, since it is the kind of thing a later change can silently
+  violate.
+- The regression test is direct and checkable: **for every store, `|mem_wstrb` is high for exactly
+  one cycle.** That assertion belongs in the testbench permanently.
+- Formal assertions this enables: a stalled cycle never advances `pc`; `valid == 0` implies
+  `out.rd == 0`; `rs1 == 0` / `rs2 == 0` never cause a stall.
+- Worst case is a 2-cycle RAW bubble and a ~32-cycle divide. Accepted per ADR-0004.

--- a/docs/adr/0010-muldiv-verification-under-altops.md
+++ b/docs/adr/0010-muldiv-verification-under-altops.md
@@ -1,0 +1,69 @@
+# ADR-0010: A randomized differential bench is the primary mul/div guarantee
+
+**Status:** Accepted · 2026-07-27 · *Supplements ADR-0006*
+
+## Context
+
+riscv-formal runs with `RISCV_FORMAL_ALTOPS`, which replaces multiply and divide with cheap
+placeholder functions. **The formal ladder therefore never checks the real arithmetic.**
+ADR-0006 designates a depth-~70 executor BMC against the SystemVerilog `*`, `/`, and `%` operators
+as the plug for that hole.
+
+Two problems surfaced when the plan was checked against the actual code:
+
+1. **The BMC may not converge.** A 33×33 bitvector multiply plus a 32-iteration restoring divider
+   unrolled to depth 70 is a genuinely hard SMT instance. The multiplier half is easy; the divider
+   half is of uncertain tractability. Two independent reviewers flagged this.
+2. **There is no `.S` coverage of the M extension at all** — `test/asm/` contains no `mul.S`, no
+   `div.S`, nothing. So today the arithmetic has *zero* checks of any kind.
+
+This matters more than it looks, because the multiplier turns out to be badly broken:
+`rtl/executor.v:28-30` uses **declaration initializers**, not continuous assignments, so the
+product is evaluated once before time 0 and never again — all four MUL variants return a constant.
+The sign enables are also swapped (MULHSU is signed × unsigned, the code has it backwards), and
+the sign bits are taken from bit 0 rather than bit 31. Three stacked defects in three lines, none
+of which any current check would catch.
+
+## Decision
+
+**The randomized differential unit bench is the primary guarantee. The BMC is secondary and
+bounded-effort.**
+
+1. **Primary — `test/exec_tb.v`**, run under iverilog on every PR: drives `executor` standalone with
+   ≥10,000 randomized operand pairs per operation across `mul`, `mulh`, `mulhu`, `mulhsu`, `div`,
+   `divu`, `rem`, `remu`, comparing against SystemVerilog `*`, `/`, `%` with RISC-V divide-by-zero
+   and `INT_MIN / -1` semantics. Exits non-zero on any mismatch.
+   **Required directed vectors:** `MULH(-1,-1) = 0`, `MULHSU(-1,1) = -1`,
+   `MULHU(-1,-1) = 0xFFFFFFFE`. These are exactly the cases the swapped sign enables get wrong.
+   The bench also asserts the divider produces its result **33 cycles** after issue (32 iterations
+   plus capture), which is the regression test for the 65→32 iteration-count fix.
+2. **Secondary — the executor BMC** (`sby -f formal/components.sby executor`): nightly,
+   bounded-effort. If it does not converge within 30 minutes, restrict it (bounded operand range or
+   reduced depth) and **record the restriction as a comment in the sby task**. A restricted proof
+   that runs is worth more than an unrestricted one that never returns.
+3. **Never vacuous.** `components_executor` currently reports `PASS 0 0` — it passes because it
+   contains no assertions at all. A task with zero assertions is a lie and must not be allowed to
+   stand as a gate.
+4. **The eight `rv32um` tests** (`mul`, `mulh`, `mulhsu`, `mulhu`, `div`, `divu`, `rem`, `remu`) are
+   added to the `.S` suite as end-to-end coverage.
+5. **The BMC does not gate PRs until its runtime has been measured.**
+
+## Rationale
+
+The purpose of the ALTOPS hole-plug is to catch arithmetic defects. A check that may not terminate
+cannot be the primary mechanism for that. A randomized differential bench over 10k vectors per
+operation will find every defect currently in this code within seconds, and it runs in CI without
+risk.
+
+This is not a retreat from formal methods — it is putting the exhaustive tool where it converges
+and the statistical tool where it doesn't.
+
+## Consequences
+
+- Amends ADR-0006's component-proof #2 from "the guarantee" to "one of two, the slower one."
+- The PR gate gains a fast, reliable arithmetic check instead of a possibly-hanging one.
+- If the BMC proves tractable at full depth, promote it later — that is a strict improvement and
+  needs no new ADR.
+- `rtl/memory.v` has the same shape of problem: it is in **no** current test path (the cxxrtl top is
+  `testbench`, which has its own inline memory, and the synthesis path is broken). Its
+  read-override bug needs a dedicated bench for the same reason.

--- a/docs/adr/0011-misalignment-detection-stays-in-accessor-until-m3.md
+++ b/docs/adr/0011-misalignment-detection-stays-in-accessor-until-m3.md
@@ -1,0 +1,50 @@
+# ADR-0011: Load/store misalignment detection stays in the accessor until M3
+
+**Status:** Accepted · 2026-07-27 · *Scoping decision under ADR-0005*
+
+## Context
+
+ADR-0005 states that all traps — including load/store misalignment — are detected and committed in
+**decode**, and that "nothing can fault after decode." That is the target design, and it is what
+makes precise trap handling possible without a reorder buffer.
+
+Today, misalignment is detected in `rtl/accessor.v:25-27` and ORed into `trap` at
+`rtl/littlecpu.v:51`. That is post-decode, and it contradicts the invariant.
+
+The ADR-0004 interlock work touches exactly this wiring. Without an explicit scoping decision, the
+engineer implementing the interlock will encounter the contradiction and may "helpfully" restructure
+trap detection mid-ticket — quietly growing an ADR-0005 implementation inside a ticket scoped to
+hazard control, in the same files, in the same PR.
+
+## Decision
+
+**The move to decode-stage misalignment detection is M3 work, not M1.**
+
+The M1 interlock ticket's only obligation regarding misalignment is to **gate the existing
+accessor-side signal with `valid`**, so that bubbles and squashed instructions do not raise spurious
+traps. The detection logic stays where it is.
+
+When M3 implements the CSR file and machine-mode traps, misalignment detection moves to decode
+along with illegal-instruction, `ecall`, and `ebreak` — as one coherent change, in one ticket,
+against ADR-0005.
+
+## Rationale
+
+Trap restructuring and hazard control are separable concerns that happen to touch adjacent lines.
+Bundling them makes the M1 ticket unreviewable and gives it no clean acceptance criterion — "traps
+are precise" is not checkable until there is a `mepc` to check it against.
+
+Deferring costs nothing: with `valid` gating, the accessor-side signal is functionally correct for
+M1's purposes (the `.S` suite has no misalignment tests, and there is no trap handler to enter).
+The invariant is temporarily unmet, but it is unmet *today* — this decision does not make anything
+worse, it just declines to fix it in the wrong ticket.
+
+## Consequences
+
+- **ADR-0005's "nothing faults after decode" invariant is not fully satisfied until M3.**
+  `CLAUDE.md` states it as a design invariant, which is correct as an intent; this ADR records that
+  the implementation lands in M3.
+- The M1 interlock ticket carries an explicit constraint note forbidding the restructure.
+- The M3 CSR ticket carries the move as an explicit deliverable, so it does not get lost.
+- M2's formal parity checkpoint does not depend on this — the serialized core never had precise
+  traps either, so parity is unaffected.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,40 @@
+# Architecture Decision Records
+
+Load-bearing decisions for Little CPU. Each ADR records the context, the decision, why it was made,
+and what it costs. Reversing one is fine — write a new ADR that supersedes it.
+
+| # | Decision | Status |
+|---|---|---|
+| [0001](0001-finish-the-staged-rewrite.md) | Finish the staged rewrite rather than resurrect the serialized core | Accepted |
+| [0002](0002-isa-target-rv32imc-zicsr.md) | ISA target is RV32IMC_Zicsr, machine mode only | Accepted |
+| [0003](0003-dual-word-combinational-fetch-window.md) | Dual-word combinational fetch window for compressed instructions | Accepted |
+| [0004](0004-stall-only-hazard-interlock.md) | Stall-only hazard interlock with a combinational-read regfile | Accepted |
+| [0005](0005-traps-and-csrs-commit-in-decode.md) | Traps and CSR accesses are detected and committed in decode | Accepted |
+| [0006](0006-port-the-wave-0-formal-harness.md) | Port the wave-0 formal harness; RVFI via per-stage shadow payloads | Accepted |
+| [0007](0007-cxxrtl-is-the-primary-simulator.md) | cxxrtl is the primary simulator; iverilog is the microscope | Accepted |
+| [0008](0008-test-memory-map-and-tohost-protocol.md) | Test memory map and the `tohost` protocol | Accepted |
+| [0009](0009-stall-protocol-semantics.md) | Stall protocol — upstream freezes, downstream drains | Accepted |
+| [0010](0010-muldiv-verification-under-altops.md) | A randomized differential bench is the primary mul/div guarantee | Accepted |
+| [0011](0011-misalignment-detection-stays-in-accessor-until-m3.md) | Misalignment detection stays in the accessor until M3 | Accepted |
+
+0001–0007 came from the design brief
+([`docs/ideas/finish-the-rewrite.md`](../ideas/finish-the-rewrite.md)). 0008–0011 came out of
+sprint planning, when the panel ran the toolchain and found the brief's assumptions needed
+resolving before work could start. 0010 supplements 0006; 0011 scopes 0005.
+
+## Deferred decisions
+
+These are deliberately *not* decided yet. Each requires a new ADR before being built, because each
+trades away simplicity the current design depends on.
+
+- **Forwarding network** — CPI-only optimisation on top of ADR-0004's stall-only interlock. Safe to
+  add post-verification; unsafe to add while the core is unverified.
+- **Radix-4 divider / early termination** — CPI-only. Roughly doubles comparator and mux logic on a
+  part already at 55–70% utilisation, and the payoff is largely absorbed by ADR-0007 (cxxrtl) and by
+  the 65→32 iteration-count fix.
+- **negedge-BRAM regfile** — escape hatch if ADR-0004's flip-flop regfile blocks timing closure.
+- **FPGA timing closure / nextpnr flow** — including ADR-0003's second ROM read becoming interleaved
+  16-bit banks. Post-M4.
+- **Interrupts** (`mie`/`mip` real rather than read-only zero) — no interrupt sources exist.
+- **Spike or Sail co-simulation** — riscv-formal is the oracle. Revisit only if formal and
+  simulation ever disagree.

--- a/docs/ideas/finish-the-rewrite.md
+++ b/docs/ideas/finish-the-rewrite.md
@@ -1,0 +1,443 @@
+# Finish the rewrite: Little CPU to verified RV32IMC_Zicsr
+
+**Status:** brief settled 2026-07-27 · ladder M0–M4 · target `RV32IMC_Zicsr`, machine mode, ice40 up5k
+
+## Idea
+
+Complete the half-finished serialized→pipelined rewrite of Little CPU: finish the pipeline
+control the rewrite never reached, port forward the formerly-green riscv-formal harness, add
+the CSR/trap story neither core ever had, and land sim + formal green in CI.
+
+## Problem & context
+
+This is not a broken CPU — it is a **stalled rewrite**.
+
+Git history shows a 491-line serialized FSM core (`rtl/riscv.v` + 159-line `rtl/alu.v`, single
+memory port with a picorv32-style `mem_valid`/`mem_instr`/`mem_ready` handshake) that **passed
+riscv-formal sans CSRs**. It was torn down in two waves:
+
+| Wave | Commits | Effect |
+|---|---|---|
+| 1 (2021) | `9758a39` *pipeline refactor wip* → `alu.v` deleted Apr → `riscv.v` deleted May in `1709433` *cleanup* → `9ea584a` *rename* (`pipeline.v`→`littlecpu.v`) | FSM core replaced by a handshake/skidbuffer pipeline |
+| 2 (2023) | `49b317a` *remove skidbuffer* → `4fbd650` *structs and testbench* → `13fec44` *slash and burn* | stripped down to today's fused staged design |
+
+Recent commits (`49dc5e9` *single cycle fetch*, `6871818` *single cycle accessor*, `fd36a52`
+*fixes*) are the author working forward through wave 2.
+
+**The `formal/` directory is the wave-0 harness that actually passed — not junk.** The plan is
+therefore: *finish what was started, restore the verified property that was lost, then extend it
+past where the old core ever got (CSRs).*
+
+## Project state, honestly sorted
+
+### (a) Genuine bugs — wrong in any architecture
+
+1. `rtl/executor.v:28-30` — mulh sign bits taken from **bit 0 instead of bit 31**
+   (`in.rs1[0] & in.is_mulh`), and the 33×33 product is formed from unsigned concats.
+   MULH/MULHSU wrong for negative operands. Needs `$signed({rs1[31] & sign_en, rs1}) * $signed(…)`.
+   **Invisible to riscv-formal under ALTOPS** — only sim and the component BMC catch it.
+2. `rtl/executor.v:124` — restoring divider subtracts when `mul_div_x <= mul_div_y`; comparison
+   is inverted (should be `>=`).
+3. `rtl/memory.v:23-27` — on a pure read (`wstrb==0`) the final `mem_rdata <= mem_wdata`
+   **overrides** the RAM read; loads through `littlesoc` never return memory contents. The inline
+   testbench memory is correct; `memory.v` regressed.
+4. `rtl/decoder.v:216-219` — `instr_ebreak` matches *any* SYSTEM funct12≠0 with funct3=0/rs1=0/rd=0,
+   so `mret` (0x302) and `wfi` (0x105) decode as EBREAK. Must be funct12==1 exactly.
+5. `rtl/fetcher.v:34` — component assertion `assert(out.pc == 32'b0)` after reset asserts a
+   property of a free input; wrong as an assert.
+6. `rtl/executor.v:102,109` — **divider iteration count is 65; correct value is 32.**
+   `mul_div_y` starts at `rs2 << 31` and shifts right once per iteration, so iterations `i = 0..31`
+   produce exactly 32 quotient bits. At 65, the divisor shifts to zero around iteration 33 and the
+   remaining cycles keep shifting `mul_div_store` — the quotient is destroyed regardless of which
+   direction the comparison in bug 2 goes. Plausibly a leftover from when this lived in the
+   RV64-flavoured `alu.v`. Fixing it halves the divide stall for free.
+
+Arithmetic reference when fixing 1/2/6: `git show e67875c^:rtl/alu.v`.
+
+### (b) Unfinished rewrite scaffolding — not bugs, just unreached
+
+- Registered-read regfile (`rtl/regfile.v:15-17`) with no compensating pipeline structure →
+  operands are one instruction stale, **always**. This, not CSRs, is why "it doesn't work."
+- `executor.stalled` computed (`executor.v:23-25`) but wired to nothing; no valid bits, so the
+  accessor replays the previous load/store for the whole divide.
+- RVFI ports declared (`littlecpu.v:14-45`), never driven. The old core's working hookup
+  (`git show 1709433^:rtl/riscv.v`, `ifdef RISCV_FORMAL` block) was never ported.
+- `// TODO: csrs` (`writeback.v:25`); CSR address/zimm dropped in decode; no `mret`/`fence` decode.
+- `formal/wrapper.v`, `checks.cfg [script-sources]`, `dmemcheck`/`imemcheck` port lists still speak
+  wave-0's interface.
+- No `make test`; `riscv_test.h` missing entirely despite every `.S` including it; dangling
+  `handshake.v`/`skidbuffer.v` references in `Makefile:22` and `components.sby`.
+
+## Was the rewrite's direction right?
+
+**Yes — finish the staged rewrite. Do not resurrect the serialized core as mainline or as a
+co-sim oracle.**
+
+1. The staged design is the repo's stated identity, and the author tore the old core down *twice*.
+   Going back reverses years of intent to save roughly one milestone.
+2. The fused-fetch design retains the serialized core's key verification property — no wrong-path
+   instructions, no flush — while pipelining. It is the rare rewrite that keeps the old
+   verification story.
+3. The old core's green run depended on the single-port handshake memory interface that no longer
+   exists anywhere in the SoC. Resurrecting it means maintaining two cores *and* two memory systems.
+4. A co-sim oracle against the old core is redundant: **riscv-formal's ISA spec modules are already
+   the golden model**, and sequential equivalence between an FSM core and a pipeline is not
+   something `equiv_simple`/`equiv_induct` can do.
+
+The old core's role is **reference text**: its RVFI retire block, rs1/rs2-validity masking, and mem
+rmask/wmask conventions port near line-for-line into the shadow-payload design.
+
+The real risk is not the rewrite's direction — it is *staying* in the current "was verified, now
+unverified" limbo. Hence the ladder's explicit **parity checkpoint at M2**.
+
+## What ports forward from the wave-0 harness
+
+M2 is a **port, not a rewrite**.
+
+| Artifact | Verdict | Delta needed |
+|---|---|---|
+| `formal/checks.cfg` | **Keep** | ISA/depths/`[csrs]` already right (rv32imc, mcycle/minstret). Update `[script-sources]` to the staged RTL; keep ALTOPS. |
+| `formal/complete.sv` | **Keep** | Author already ported it to `littlecpu` in `fd36a52`. Finish: drive imem/dmem inputs rand-stable. |
+| `formal/wrapper.v` | **Port** | Only file still instantiating `riscv` with the handshake. Rewrite port list to `littlecpu`; `RVFI_WIRES`/`RVFI_CONN` skeleton and fairness pattern carry over. Fairness becomes "bounded consecutive internal stall" (no `mem_ready` anymore). |
+| `formal/imemcheck.sv` | **Port — valuable** | Already models fetch at **16-bit granularity** (`imem_data[15:0]`) — wave-0 anticipated compressed straddle. Re-point at the split `imem_addr`/`imem_data` interface; it directly stresses the new C fetch window. |
+| `formal/dmemcheck.sv` | **Port** | Same shape, re-pointed at `mem_addr`/`wstrb`/`wdata`/`rdata` without the handshake fire condition. |
+| `formal/cover.sv` | **Port (cheap)** | Counts loads/stores/compressed-vs-long retires — exactly the "do compressed instructions actually retire" sanity we want. Port list only. |
+| `formal/equiv.sh` | **Keep — misunderstood gem** | Not serialized-vs-pipelined equivalence. It proves **RVFI instrumentation doesn't change core behaviour** (gold = plain build, gate = `RISCV_FORMAL` build with rvfi ports deleted). With big `ifdef` shadow payloads landing in the structs, this earns its keep. Update file list/top. |
+| old `riscv.v` RVFI block | **Reference text** | Retire-edge driving, `rs1_valid`/`rs2_valid` masking (`!is_lui && !is_jal && !is_auipc`…), `rvfi_order` accumulation, mem capture conventions, `rvfi_csr_* <= 0` (exactly why the old run was "sans CSRs"). Port the *logic*, re-keyed from FSM states to the pipeline's valid bits. |
+| old `alu.v` | Obsolete | Its mul/div moved into `executor.v` in the rewrite, bringing bugs 1/2/6 with it. |
+
+Delete only the truly dead: `components.sby` handshake/skidbuffer tasks, `Makefile:22` references
+to deleted RTL, the vacuous component tasks.
+
+## Goals / non-goals
+
+**Goals**
+
+1. RV32IMC_Zicsr + machine-mode traps, correct and precise.
+2. `make test`: `.S` suite assembled and run fast under cxxrtl, RVFI-monitored, exit-code green.
+3. riscv-formal parity with the old core (M2), then `csrw`/liveness on top (M4).
+4. CI: PR gate + nightly deep formal.
+5. `CLAUDE.md` capturing invariants and command surface.
+
+**Non-goals** — FPGA timing closure / nextpnr (deferred; feasibility budget below), interrupts
+(`mie`/`mip` RO-zero), S/U-mode, PMP, `mtval` values, Spike/Sail co-sim (riscv-formal is the
+oracle; revisit only if formal and sim disagree), README rewrite (the honest state lives in
+`CLAUDE.md`), littlesoc SPI flash.
+
+## C-extension design
+
+C stays: ice40 code density is a product constraint (up5k SPRAM is small and `littlesoc` already
+targets it).
+
+### Fetch: dual-word combinational window — no state, no stall, no flush
+
+The fetcher presents `imem_addr = {pc[31:2], 2'b00}` **and** `imem_addr2 = imem_addr + 4`; the
+instruction handed to decode is the 32-bit window:
+
+```
+({imem_data2, imem_data} >> (pc[1] ? 16 : 0))[31:0]
+```
+
+This preserves the design's signature invariant completely: fetch stays combinational, the decoder
+still owns the PC, branches still resolve with zero wrong-path instructions, and a straddling
+32-bit instruction at `pc%4==2` costs *nothing* — no aligner FSM, no halfword buffer, no buffer
+invalidation on redirect.
+
+Rejected alternatives:
+
+- **32-bit fetch + halfword buffer** — adds fetch state, straddle stalls, and redirect
+  invalidation (a flush by another name).
+- **Straddle-stall two-cycle fetch** — adds a state bit and mid-straddle redirect corners.
+
+Cost of the window: a second combinational ROM read. Free in sim/formal (`imemory.v` and the
+testbench read the array twice; `littlesoc` wires two reads). On real ice40 BRAM this becomes
+even/odd interleaved 16-bit banks or negedge reads — deferred with the rest of FPGA timing. The
+formal wrapper models both imem inputs as rand-stable; wave-0's 16-bit-granular `imemcheck.sv` is
+the ready-made consistency check.
+
+### Decode: mostly done, two real gaps
+
+Present and plausible: C.LWSP/SWSP/LW/SW, C.J/JAL/JR/JALR, C.BEQZ/BNEZ, C.LI/LUI/ADDI/ADDI16SP/
+ADDI4SPN, C.SLLI/SRLI/SRAI/ANDI, C.MV/ADD/AND/OR/XOR/SUB — with RV32-only C.JAL correctly present.
+
+Reserved encodings that must trap already fall through to `!instr_valid` correctly: `16'h0000`
+(canonical illegal, caught by the `caddi4spn_immediate != 0` guard), C.LUI/C.ADDI16SP with imm=0,
+C.LWSP rd=0, RV32-reserved `shamt[5]=1` shift forms.
+
+**Missing:**
+
+1. **C.EBREAK** (quadrant 10, funct4=1001, rd=0, rs2=0) — currently falls between `instr_cadd`
+   (needs rs2≠0) and `instr_cjalr` (needs rd≠0) into illegal.
+2. **C-aware trap set**: with C, only 2-byte alignment is required, so
+   **instruction-address-misaligned (mcause 0) becomes unreachable** — branch/JAL immediates have
+   bit0=0 and JALR clears bit0. Drop it from the trap set; `mepc` hardwires only bit[0].
+
+`pc_inc = uncompressed ? 4 : 2` (`decoder.v:278-279`) and the compressed-immediate muxing are
+already correct. C.NOP and the rd=x0 HINT space fall out as harmless x0-writing base ops.
+
+### RVFI with C
+
+Keep `-DRISCV_FORMAL_COMPRESSED` (root Makefile already sets it) and the `-i rv32imc` monitor
+(already right). Decode-stage shadow capture stores `rvfi_insn` as the 16-bit value zero-extended
+for compressed instructions (mask the window's upper half when `quadrant != 2'b11`);
+`rvfi_pc_wdata = pc + pc_inc` (2 or 4). Insn-check count grows to the full `isa_rv32imc.txt` set
+(~75 checks) — each a small BMC; nightly tier, with a handful (`insn_c_addi`, `insn_c_lw`,
+`insn_c_j`) in the PR smoke set.
+
+### The decoder `$onehot` assertion
+
+`decoder.v:396-406` currently FAILs. The property as stated — "for a valid instruction, exactly one
+*merged base-op* signal fires" — is the right property; the vector already uses merged signals, so
+compressed forms alias into their base op and contribute one bit. **The FAIL is a decode-hole
+detector, not a broken property.** Known reachable holes: the C.EBREAK gap and the funct12-wildcard
+`instr_ebreak` (bug 4).
+
+Action: pull the counterexample from `formal/components_decoder/engine_0/`, fix the hole it names,
+extend the vector with the new ops (`mret`, `wfi`, `fence`, csr ops), and add `cover` statements so
+each op is provably reachable.
+
+## Simulation: three legs, each load-bearing
+
+**cxxrtl — the workhorse.** `test/cxxrtl.cc` grows from 27 lines to a ~150-line runner: parse args
+(`--rom <hex> --cycles N [--vcd out.vcd]`), load the program hex directly into ROM via
+`debug_items` (more robust than `$readmemh` through yosys), run until a write of the magic
+pass/fail value to the `tohost` address, return a real exit code. `make test` = assemble every `.S`
+→ `objcopy -O verilog --verilog-data-width=4` hex → run each under the cxxrtl binary.
+
+What this buys: cxxrtl runs one-to-two orders of magnitude faster than iverilog for a core this
+size, which matters exactly where this design hurts — even at the corrected 32 iterations, `div.S`
+and `rem.S` are thousands of cycles, and a hazard/div torture test or an overnight randomised run
+is only practical here. It also keeps the yosys frontend honest (same `write_cxxrtl` elaboration CI
+uses). `test/rtl.cc` stays **generated at build** (already gitignored; delete the stale on-disk
+copy, it isn't tracked). The RVFI monitor compiles into this leg, so every cxxrtl run is
+self-checking per-retire, not just end-state-checking.
+
+**iverilog — the microscope.** `test/testbench.v` stays the debugging bench: VCD waveforms,
+`$display` tracing, same monitor instance. Runs one smoke program in CI to keep the
+second-frontend elaboration path alive. Not the bulk runner.
+
+**riscv-formal — the oracle.** Exhaustive per-instruction semantics and pipeline corners to
+bounded depth, with ALTOPS masking real mul/div arithmetic — precisely the hole the other legs
+cover.
+
+### Do the `.S` files provide behavioural accuracy?
+
+**Partially — one leg of a three-legged stool, and today that leg is missing a foot.**
+
+What they uniquely give: end-to-end checks of real programs through the real assembler against
+architected state, and critically **the only place the real divider and multiplier arithmetic gets
+tested at all**, because riscv-formal runs under ALTOPS. Plus decent hazard coverage via
+riscv-tests' built-in bypass-pattern macros.
+
+What they don't give: exhaustiveness (fixed operand vectors, fixed instruction sequences — that's
+riscv-formal's job).
+
+Three concrete gaps:
+
+1. **Thirteen files can never run.** `addw.S`, `addiw.S`, `sd.S`, `ld.S`, `lwu.S`, `sllw.S`,
+   `slliw.S`, `sraw.S`, `sraiw.S`, `srlw.S`, `srliw.S`, `subw.S` are RV64-only — the suite was
+   copied wholesale from riscv-tests, whose canonical sources are RV64; upstream's rv32 target
+   simply *excludes* the `*w`/doubleword tests in its Makefile. There is no "RV32 port" of `addw` —
+   the instruction does not exist. `fence_i.S` is likewise dead: on this Harvard core (ROM fetch,
+   RAM data) self-modifying code is impossible. **Decision: delete them**, mirroring what upstream
+   riscv-tests does for rv32. (Alternatives — keeping them inert forces `make test` to carry an
+   exclusion list forever and misleads readers about coverage; "porting" them is not possible.)
+2. **No compressed tests, and C is in scope.** Pull in riscv-tests' `rv32uc/rvc.S`, plus a small
+   straddle-specific test (32-bit instruction at `pc%4==2`; branch into a misaligned target) since
+   that's the novel fetch path.
+3. **No trap/CSR tests.** Add `csr.S`, `ecall.S`, `ebreak.S`, `illegal.S`, `mret.S` in M3, adapting
+   riscv-tests' machine-mode patterns.
+
+Also: `riscv_test.h` is missing entirely. A minimal local version (RVTEST_CODE_BEGIN/PASS/FAIL
+writing the `tohost` magic) is M1 work.
+
+## `test/monitor.v` — tracked and useful
+
+Stays tracked. It is deterministic output of
+`riscv-formal/monitor/generate.py -i rv32imc -c 1 -a -p monitor`, and that ISA string is **already
+correct** for the RV32IMC decision — no immediate regeneration needed.
+
+Keeping it from rotting:
+
+1. The generation command stays a Makefile target (the `test/monitor.v:` rule already exists) —
+   add a header comment naming the riscv-formal pin it was generated from.
+2. Regeneration is required exactly when the riscv-formal SHA pin or the ISA string changes.
+3. **CI verifies freshness** by regenerating and diffing — cheap, catches drift.
+4. Merge-conflict risk is near zero in a solo repo; conflicts resolve by regenerating, never by
+   hand-editing.
+
+Wired into `test/testbench.v` today (lines 102–126) and compiles into the cxxrtl build the same way
+(it lives behind `RISCV_FORMAL`, and `testbench.v` is the cxxrtl top).
+
+What it catches that `.S` pass/fail doesn't: per-retire checking of *every* instruction in *every*
+run — decode legality, rd/rs consistency, PC chaining, memory-access consistency. A test that
+corrupts state transiently but converges to the right final register values still fails loudly, and
+torture/randomised runs become self-checking without expected-output files.
+
+## `CLAUDE.md` contents (M0 deliverable)
+
+- **What this is** — hobby RV32IMC_Zicsr core optimised for *readability*; mid-rewrite from a
+  serialized core (pointer to git history + ADRs); README is the project's voice, state-of-the-repo
+  truth lives here.
+- **Invariants (do not break)** — fetch is combinational and the decoder owns the PC, so there are
+  never wrong-path instructions and **no flush logic may be introduced**; all traps are detected and
+  committed in decode, nothing faults after decode; every inter-stage struct carries a `valid` bit,
+  bubbles are `valid=0`, retire is `valid` reaching writeback and drives `rvfi_valid`; hazards are
+  handled by stall-only interlock in decode (no forwarding network — adding one is a CPI
+  optimisation requiring an ADR); CSR instructions and `mret` serialize; regfile is
+  combinational-read with write-through.
+- **ISA target** — RV32IMC_Zicsr, M-mode only, `misa = 0x4000_1104`; traps: illegal=2, ebreak=3,
+  load/store-misaligned=4/6, ecall-from-M=11; no interrupts; instruction-address-misaligned
+  unreachable (C).
+- **Command surface** — `make test` (cxxrtl runner over `test/asm`), `make waves` (iverilog VCD),
+  `make -C formal` targets and the PR-vs-nightly split, monitor regeneration command, toolchain
+  install lines.
+- **Engineering rules in force** — warnings are errors; every non-trivial change adds/updates tests
+  and runs the full suite before done; never commit build artifacts (`test/rtl.cc`, `sim`, `*.vvp`,
+  `*.vcd`, formal output dirs); `test/monitor.v` is generated-but-tracked, regenerate never
+  hand-edit; riscv-formal is SHA-pinned, bumping it requires regenerating the monitor and rerunning
+  the ladder.
+- **Pointers** — `docs/adr/` index, M-ladder status, known-deferred list.
+
+## Key decisions
+
+See `docs/adr/` for the load-bearing ones.
+
+1. **ISA target: RV32IMC_Zicsr.** C stays for ice40 code density. Fetch becomes a dual-word
+   combinational window; decode gains C.EBREAK; instr-addr-misaligned dropped as unreachable;
+   `misa = 0x4000_1104`. The existing monitor/`checks.cfg`/`-DRISCV_FORMAL_COMPRESSED` config was
+   already right and stays. → ADR-0002, ADR-0003
+2. **Pipeline approach: fused fetch/decode, PC-in-decode, comb-read regfile + write-through,
+   stall-only decode scoreboard, valid bits everywhere, divider freezes decode, no flush anywhere.**
+   → ADR-0004
+3. **Frame: complete the rewrite.** Distinguish real bugs (six) from unreached scaffolding; port
+   wave-0 assets rather than rewrite. Serialized core = reference text, not a component or oracle.
+   → ADR-0001
+4. **Traps in decode; CSR file beside the decoder; CSR/`mret` serialize by draining E/A/W.**
+   CSR set: RW `mstatus{MIE,MPIE,MPP}`, `mtvec` (direct mode), `mepc`, `mcause` {2,3,4,6,11},
+   `mscratch`, `mcycle(h)`, `minstret(h)`; RO-zero `mtval`, `mie`, `mip`,
+   `mvendorid`/`marchid`/`mimpid`/`mhartid`; `misa` RO. Zicsr side-effect suppression rules
+   (CSRRS/RC with rs1=x0 or zimm=0 suppress the write; CSRRW with rd=x0 suppresses the read),
+   illegal on RO-write or unimplemented CSR, counter-write beats increment, `minstret` counted at
+   issue (equivalent to retire because post-decode nothing faults). `wfi`/`fence`/`fence.i` = NOP.
+   → ADR-0005
+5. **RVFI = shadow payloads in the stage structs**, ported from the old core's retire block
+   (rs-validity masks, order counter, mem capture) rather than invented. Compressed insns report
+   16-bit `rvfi_insn`; `pc_wdata` steps of 2. → ADR-0006
+6. **Formal harness: port, don't delete.** Pin riscv-formal to a SHA. → ADR-0006
+7. **Component proofs: exactly two.** Decoder onehot/valid (fixed), and an executor arithmetic BMC
+   (~depth 70, real `/ % *` vs the divider/multiplier) — the ALTOPS hole-plug. Others deleted as
+   vacuous. Note `components_executor` currently "PASSes" with **zero assertions**.
+8. **cxxrtl is the primary sim runner**; iverilog kept for waveforms + second-frontend smoke;
+   `test/rtl.cc` generated at build. → ADR-0007
+9. **`test/monitor.v` stays tracked**, with regeneration rule + CI freshness diff.
+10. **README untouched; `CLAUDE.md` is the truth file.**
+11. **Toolchain:** brew `riscv64-elf-gcc` locally, `apt gcc-riscv64-unknown-elf` + pinned OSS CAD
+    Suite in CI. Freestanding assembly needs no multilib libs;
+    `-march=rv32imc_zicsr -mabi=ilp32 -nostdlib`.
+12. **CI:** PR gate ≈ elaborate (warnings-as-errors) + full cxxrtl `.S` suite + iverilog smoke +
+    2 component proofs + smoke formal (`insn_add`, `insn_c_addi`, `insn_lw`, `insn_c_j`, `reg`) +
+    monitor freshness. Nightly = full genchecks ladder (~75 insn checks + reg/pc_fwd/pc_bwd/unique/
+    causal, later liveness/csrw) + imem/dmem/cover/equiv. Green PR job = merge.
+13. **up5k feasibility: fits, tight.** Rough budget on 5280 LUT4 / 5280 FF — comb-read regfile
+    992 FF + ~600 LUT of read mux; decoder incl. C ~500–700 LUT; ALU/shifter ~400; divider datapath
+    ~300 LUT / 200 FF; CSR file ~390 FF + ~200 LUT mux; pipeline structs ~300 FF; mul → 4 DSPs
+    (Makefile already passes `-dsp`). Total ≈ 2.7–3.5k LUT, ≈ 2k FF — **55–70% of the part**. RVFI
+    shadow logic is `ifdef`'d out of synthesis. Escape hatch if it doesn't close: negedge-BRAM
+    regfile. FPGA timing itself stays deferred.
+
+## Multiplier / divider performance
+
+**The multiplier needs nothing.** `executor.v:30` is already a combinational 33×33 product
+registered on the next edge, and `-dsp` infers 4 DSP blocks on up5k. Its only defect is the
+sign-bit bug (#1).
+
+**The divider's 65 is not a speed choice — it is bug #6.** The correct count is 32. Fixing it
+halves the stall for free as part of M1 bug-fix work, not as an optimisation.
+
+**Beyond that, do not optimise now.** Radix-4 would reach ~17 cycles but roughly doubles the
+comparator/mux logic on a part already at 55–70%, and the payoff is thin from three directions:
+formal never sees it (ALTOPS), cxxrtl-as-primary-runner absorbs most of the sim cost, and the one
+genuine benefit — tightening the M4 liveness fairness bound — is already halved by the 65→32 fix.
+Radix-4 and early-termination-on-leading-zeros are logged as deferred CPI items behind an ADR gate,
+same treatment as the forwarding network. Both are safe post-verification additions; neither is
+safe to do *while* the core is unverified.
+
+## Risks & unknowns
+
+- **The dual-word fetch window is the one genuinely novel piece.** Wave-0 fetched through the
+  handshake; wave-2 never did C straddle. Mitigations already in the plan: `imemcheck` at 16-bit
+  granularity, a dedicated straddle `.S` test, and the `insn_c_*` checks. This is where M2's
+  surprises should be expected.
+- **`csrw`/counter formal checks are new ground for this project** — the old core hardwired
+  `rvfi_csr_* = 0`. The serialize-CSRs decision minimises corners; expect iteration in M4.
+- **Solver runtimes** at depth 20–30 with ~75 insn checks: nightly-scale (est. 1–3 h wall on a
+  runner with `-j`); PR smoke in minutes. Liveness may need a stall-fairness assumption — the
+  divider's (corrected) 32 cycles sets the bound.
+- **cxxrtl + monitor `$display` path** — recent yosys supports it, but if the monitor's error
+  reporting misbehaves under cxxrtl, fallback is a C++-side check of the monitor's error flag.
+  Small, contained.
+- Genuinely open: nothing that blocks M0/M1.
+
+## Milestone ladder
+
+Ordered so the repo is never in a worse state than it started.
+
+**M0 — Foundation (small).** Write `CLAUDE.md` (contents above, including the rewrite-history
+narrative this brief recovered). Pin riscv-formal to a SHA. Delete dead references only
+(`Makefile:22` handshake/skidbuffer, `components.sby` stale tasks, vacuous component tasks, the 13
+RV64 `.S` files, stale on-disk artifacts). Add a monitor-freshness make target.
+*Green = repo is self-describing; nothing works differently yet.*
+
+**M1 — Finish the pipeline; sim green (the big one).** Comb-read regfile + write-through; valid
+bits; decode scoreboard stall; divider stall integration; **C fetch window**; C.EBREAK + `mret` /
+`wfi` / `fence` decode; fix all six real bugs; local `riscv_test.h`; cxxrtl runner + `make test`;
+toolchain installed.
+*Green = all RV32IMC `.S` tests (incl. new `rvc.S` + straddle test) pass under cxxrtl, and the
+smoke test passes under iverilog.* **This is where "it doesn't work" dies.**
+
+**M2 — Back to green (parity checkpoint).** Port RVFI from the old core's retire block into shadow
+payloads; port `wrapper.v` / `checks.cfg` / `imemcheck` / `dmemcheck` / `cover` / `equiv.sh`; fix
+the two kept component proofs.
+*Green = the pipelined core proves everything the serialized core proved: rv32imc
+insn/reg/pc_fwd/pc_bwd/unique/causal, no CSRs.* **This erases the regression from "verified" to
+"unverified."**
+
+**M3 — Past the old core: CSRs + machine mode.** CSR module, traps-in-decode commit, serialization;
+trap/CSR `.S` tests; RVFI csr signals go from hardwired-zero to real.
+*Green = M2 ladder still green + trap tests pass.*
+
+**M4 — Full ladder + CI.** `csrw_mcycle` / `csrw_minstret`, liveness with stall fairness; both
+GitHub workflows (PR gate + nightly); monitor freshness check.
+*Green = nightly ladder fully green; tag a release.*
+
+## Deferred
+
+FPGA timing / nextpnr closure (budget says feasible; do after M4) · forwarding network (CPI-only,
+ADR-gated) · radix-4 divider and early-termination (CPI-only, ADR-gated) · interrupts · `mtval`
+values · Spike/Sail co-sim · littlesoc SPI flash · negedge-BRAM regfile (escape hatch, only if
+synthesis demands) · the C decode paths are *kept*, not deferred.
+
+## Handoff to plan-sprint
+
+> **Theme:** Finish the serialized→pipelined rewrite and get back to formally green — pipeline
+> control and C fetch first, harness port to parity second, CSRs third — with cxxrtl as the fast sim
+> leg and the wave-0 formal harness ported, not rewritten.
+
+Plan against M0–M4 with **M1 as critical path** and **M2 as the explicit restore-the-lost-property
+checkpoint**. Decisions 1–13 are settled. Panel: **infra** — toolchain, CI, and formal mechanics
+dominate the non-RTL work; no product or data questions in play.
+
+## References
+
+**Files:** `rtl/{decoder,executor,regfile,accessor,memory,littlecpu,fetcher,structs}.v` ·
+`formal/{checks.cfg,wrapper.v,complete.sv,imemcheck.sv,dmemcheck.sv,cover.sv,equiv.sh,components.sby,Makefile}` ·
+`test/{testbench.v,cxxrtl.cc,monitor.v,asm/}` · `Makefile`
+
+**Historical:** `git show 1709433^:rtl/riscv.v` · `git show e67875c^:rtl/alu.v`
+
+**External:** [riscv-formal verification procedure](https://yosyshq.readthedocs.io/projects/riscv-formal/en/latest/procedure.html) ·
+[YosysHQ/riscv-formal](https://github.com/YosysHQ/riscv-formal) ·
+[riscv-gnu-toolchain](https://github.com/riscv-collab/riscv-gnu-toolchain/blob/master/README.md) ·
+[Homebrew riscv64-elf-gcc](https://formulae.brew.sh/formula/riscv64-elf-gcc) ·
+[Sentinel riscv-formal setup (prior art)](https://sentinel-cpu.readthedocs.io/en/main/development/testing.html)


### PR DESCRIPTION
Planning artifacts for finishing the serialized→pipelined rewrite. **Docs only — no code changes.**

Lands ahead of the sprint-1 tickets ([JEF-604](https://linear.app/jeff-larson/issue/JEF-604) … [JEF-608](https://linear.app/jeff-larson/issue/JEF-608)), which all reference these files.

## The framing

This is not a broken CPU — it's a **stalled rewrite**. Git archaeology found that a 491-line serialized FSM core (`rtl/riscv.v` + `rtl/alu.v`) **passed riscv-formal sans CSRs** before being torn down in two waves (2021: `9758a39`→`1709433`; 2023: `49b317a`→`13fec44`). The `formal/` directory is that era's working harness, not junk — so M2 is a **port, not a rewrite**.

## Contents

- **`CLAUDE.md`** — invariants, ISA target, command surface, and an honest current-state section (the iverilog leg doesn't elaborate; `test/monitor.v` doesn't parse under yosys)
- **`docs/ideas/finish-the-rewrite.md`** — the full design brief and M0–M4 ladder
- **`docs/adr/0001`–`0007`** — from the brief: finish the staged rewrite · RV32IMC_Zicsr (C stays for ice40 code density) · dual-word combinational fetch window · stall-only interlock · traps/CSRs commit in decode · port the wave-0 harness · cxxrtl primary
- **`docs/adr/0008`–`0011`** — from sprint planning, once the panel ran the toolchain: test memory map + `tohost` · stall protocol · mul/div verification under ALTOPS · misalignment stays in the accessor until M3
- **`.claude/tracker.json`** — pins the tracker to the Linear project

## Central invariant

Fetch is combinational and the decoder owns the PC, so there are never wrong-path instructions and **no flush logic exists anywhere**. Every decision protects that — including keeping C, via a stateless fetch window rather than an aligner FSM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)