### PR TITLE
Fix the seven datapath/decode defects and restore iverilog elaboration

### DIFF
--- a/rtl/decoder.v
+++ b/rtl/decoder.v
@@ -39,6 +39,20 @@ module decoder (
   logic [6:0] funct7;
   assign funct7 = instr[31:25];
 
+  // Forward declarations: the immediate-select and rd-select blocks below reference
+  // these before their own assign groups (further down) come into scope. iverilog
+  // (unlike yosys) requires every identifier declared before its first use, so the
+  // bare declarations live here; each signal's driving `assign` stays with its group.
+  logic instr_lui_op, instr_jal_op, instr_jalr_op, instr_cj, instr_cjal, instr_cjr, instr_cjalr,
+    instr_clui;
+  logic instr_branch_op, instr_cbeqz, instr_cbnez;
+  logic instr_load_op, instr_clwsp, instr_clw;
+  logic instr_store_op, instr_cswsp, instr_csw;
+  logic instr_math_immediate, instr_math_immediate_op, instr_cli, instr_caddi, instr_caddi16sp,
+    instr_caddi4spn, instr_cslli, instr_csrli, instr_csrai, instr_candi, instr_addi, instr_slti,
+    instr_sltiu, instr_xori, instr_ori, instr_andi, instr_slli, instr_srli, instr_srai;
+  logic [4:0] rd;
+
   // all instructions
   logic instr_auipc, instr_jal, instr_jalr, instr_beq, instr_bne, instr_blt, instr_bltu, instr_bge,
         instr_bgeu, instr_add, instr_sub, instr_mul, instr_mulh, instr_mulhu, instr_mulhsu,
@@ -96,8 +110,6 @@ module decoder (
   end
 
   // Table 24.2 RV32I and Table 16.5-7
-  logic instr_lui_op, instr_jal_op, instr_jalr_op, instr_cj, instr_cjal, instr_cjr, instr_cjalr,
-    instr_clui;
   assign instr_lui_op = opcode == 5'b01101 && uncompressed;
   assign instr_lui = instr_lui_op || instr_clui;
   assign instr_clui = quadrant == 2'b01 && cfunct3 == 3'b011 && clui_immediate != 0 &&
@@ -114,7 +126,6 @@ module decoder (
   assign instr_cjalr = quadrant == 2'b10 && cfunct3 == 3'b100 && instr[12] == 1 && instr[6:2] == 0 &&
     instr[11:7] != 0;
 
-  logic instr_branch_op, instr_cbeqz, instr_cbnez;
   assign instr_branch_op = opcode == 5'b11000 && uncompressed;
   assign instr_beq = (instr_branch_op && funct3 == 3'b000) || instr_cbeqz;
   assign instr_bne = (instr_branch_op && funct3 == 3'b001) || instr_cbnez;
@@ -125,7 +136,6 @@ module decoder (
   assign instr_cbeqz = quadrant == 2'b01 && cfunct3 == 3'b110;
   assign instr_cbnez = quadrant == 2'b01 && cfunct3 == 3'b111;
 
-  logic instr_load_op, instr_clwsp, instr_clw;
   assign instr_load_op = opcode == 5'b00000 && uncompressed;
   assign instr_lb = instr_load_op && funct3 == 3'b000;
   assign instr_lh = instr_load_op && funct3 == 3'b001;
@@ -135,7 +145,6 @@ module decoder (
   assign instr_clwsp = quadrant == 2'b10 && cfunct3 == 3'b010 && instr[11:7] != 5'b0;
   assign instr_clw = quadrant == 2'b00 && cfunct3 == 3'b010;
 
-  logic instr_store_op, instr_cswsp, instr_csw;
   assign instr_store_op = opcode == 5'b01000 && uncompressed;
   assign instr_sb = instr_store_op && funct3 == 3'b000;
   assign instr_sh = instr_store_op && funct3 == 3'b001;
@@ -147,9 +156,6 @@ module decoder (
   assign math_low = funct7 == 7'b0000000;
   logic math_high;
   assign math_high = funct7 == 7'b0100000;
-  logic instr_math_immediate, instr_math_immediate_op, instr_cli, instr_caddi, instr_caddi16sp,
-    instr_caddi4spn, instr_cslli, instr_csrli, instr_csrai, instr_candi, instr_addi, instr_slti,
-    instr_sltiu, instr_xori, instr_ori, instr_andi, instr_slli, instr_srli, instr_srai;
   assign instr_math_immediate_op = opcode == 5'b00100 && uncompressed;
   assign instr_addi = (instr_math_immediate_op && funct3 == 3'b000) || instr_cli || instr_caddi ||
     instr_caddi16sp || instr_caddi4spn;
@@ -215,8 +221,10 @@ module decoder (
 
   logic instr_error;
   assign instr_error = opcode == 5'b11100 && uncompressed && funct3 == 0 && rs1 == 0 && rd == 0;
-  assign instr_ecall = instr_error && !{|instr[31:20]};
-  assign instr_ebreak = instr_error && |instr[31:20];
+  assign instr_ecall = instr_error && instr[31:20] == 12'h0;
+  // funct12 must be exactly 1 (ebreak's SYSTEM encoding); any other nonzero funct12
+  // (e.g. mret = 0x302, wfi = 0x105) is a different SYSTEM instruction, not ebreak.
+  assign instr_ebreak = instr_error && instr[31:20] == 12'h1;
   logic instr_valid;
 
   assign instr_valid = instr_auipc || instr_jal || instr_jalr || instr_beq || instr_bne || instr_blt
@@ -226,7 +234,6 @@ module decoder (
     instr_lui || instr_lb || instr_lbu || instr_lh || instr_lhu || instr_lw || instr_sb || instr_sh
     || instr_sw || instr_ecall || instr_ebreak;
 
-  logic [4:0] rd;
   always_comb begin
     (* parallel_case, full_case *)
     case (1'b1)
@@ -268,7 +275,7 @@ module decoder (
   assign instr_math = instr_add || instr_sub || instr_sll || instr_slt || instr_sltu || instr_xor || instr_srl ||
     instr_sra || instr_or || instr_and || instr_mul || instr_mulh || instr_mulhu || instr_mulhsu || instr_div ||
     instr_divu || instr_rem || instr_remu;
-  assign instr_shift = instr_sll || instr_slt || instr_sltu || instr_xor || instr_srl || instr_sra;
+  assign instr_shift = instr_slli || instr_srli || instr_srai;
 
   logic [31:0] math_arg;
   always_comb

--- a/rtl/executor.v
+++ b/rtl/executor.v
@@ -14,6 +14,13 @@ module executor(
   assign rs1 = in.rs1;
   assign rs2 = in.rs2;
 
+  // Signed div/rem operate on the two's-complement magnitude of the operands; the
+  // restoring divider below only performs unsigned division. Quotient/remainder signs
+  // are restored from the original operand signs once the loop completes.
+  logic [31:0] div_x, div_y;
+  assign div_x = (in.is_div || in.is_rem) && rs1[31] ? -rs1 : rs1;
+  assign div_y = (in.is_div || in.is_rem) && rs2[31] ? -rs2 : rs2;
+
   logic [1:0]  state;
   localparam init = 2'b00;
   localparam divide = 2'b10;
@@ -24,10 +31,15 @@ module executor(
   always_comb
     stalled = state != init;
 
-  // multiply from:
-  logic mul_sign_x = in.rs1[0] & in.is_mulh;
-  logic mul_sign_y = in.rs2[0] & (in.is_mulh | in.is_mulhsu);
-  logic signed [63:0] multiply = {mul_sign_x, in.rs1} * {mul_sign_y, in.rs2};
+  // multiply: continuous assignments, so the product tracks the operands every cycle
+  // instead of being latched once at time 0. sign_x covers is_mulh (signed rs1) and
+  // is_mulhsu (rs1 is signed, rs2 is unsigned); sign_y covers only is_mulh. Extension
+  // bits come from bit 31 (the true sign bit), not bit 0.
+  logic mul_sign_x, mul_sign_y;
+  assign mul_sign_x = in.rs1[31] & (in.is_mulh | in.is_mulhsu);
+  assign mul_sign_y = in.rs2[31] & in.is_mulh;
+  logic signed [63:0] multiply;
+  assign multiply = $signed({mul_sign_x, in.rs1}) * $signed({mul_sign_y, in.rs2});
 
   // state machine
   always_ff @(posedge clk) begin
@@ -99,14 +111,14 @@ module executor(
                 else out.rd_data <= 32'b0; // remainder = 0
                 // state stays init; no division needed
               end else begin
-                mul_div_counter <= 65;
+                mul_div_counter <= 32;
                 state <= divide;
                 mul_div_store <= 0;
-                mul_div_x <= {32'b0, rs1};
-                mul_div_y <= {1'b0, rs2, 31'b0};
+                mul_div_x <= {32'b0, div_x};
+                mul_div_y <= {1'b0, div_y, 31'b0};
               end
              `else
-              mul_div_counter <= 65;
+              mul_div_counter <= 32;
               state <= divide;
               mul_div_store <= 0;
               mul_div_x <= {32'b0, rs1};
@@ -121,7 +133,7 @@ module executor(
         divide: begin
          `ifndef RISCV_FORMAL_ALTOPS
           if (mul_div_counter > 0) begin
-            if (mul_div_x <= mul_div_y) begin
+            if (mul_div_x >= mul_div_y) begin
               mul_div_store <= (mul_div_store << 1) | 1;
               mul_div_x <= mul_div_x - mul_div_y;
             end else begin
@@ -163,5 +175,162 @@ module executor(
   // assume we've reset at clk 0
   initial assume(reset);
   always_comb if(!clocked) assume(reset);
+  // `state` otherwise has no defined value before the first clock edge applies
+  // `reset`, which lets the solver "start" mid-divide for free at step 0 —
+  // pin it down explicitly so the arithmetic assertions below only fire on
+  // real, freshly-issued operations.
+  initial state = init;
+  // The divide-family assertions below span many cycles; without this, the
+  // solver can re-assert `reset` mid-divide to jump straight from `divide` to
+  // `init` (out.rd_data zeroed by the reset branch, not computed by the
+  // divider) and "complete" a division in a handful of steps. Reset is a
+  // once-at-the-start pulse everywhere else in this design, so assume it
+  // stays low for the remainder of the trace.
+  always_comb if (clocked) assume(!reset);
+
+  // ---- Executor arithmetic BMC (ADR-0006 component proof #2 / ADR-0010) ----
+  // The *primary* guarantee for real mul/div arithmetic is the randomized
+  // differential bench, test/exec_tb.v (>=10,000 vectors per op) — riscv-formal
+  // runs under RISCV_FORMAL_ALTOPS and never checks this arithmetic at all. This
+  // BMC is secondary and bounded-effort per ADR-0010. It was previously vacuous
+  // (PASS 0 0): these are its first real assertions.
+  //
+  // The op-select flags (is_add, is_mul, ...) are guaranteed mutually exclusive
+  // by the decoder in the real pipeline; this component proof stands alone, so
+  // that has to be an explicit environmental assumption or the solver can pick
+  // nonsensical combinations no real instruction produces.
+  always_comb assume($onehot0({in.is_add, in.is_sub, in.is_xor, in.is_or, in.is_and,
+    in.is_sll, in.is_slt, in.is_sltu, in.is_srl, in.is_sra, in.is_lui,
+    in.is_mul, in.is_mulh, in.is_mulhu, in.is_mulhsu,
+    in.is_div, in.is_divu, in.is_rem, in.is_remu,
+    in.is_lb, in.is_lbu, in.is_lh, in.is_lhu, in.is_lw, in.is_sb, in.is_sh, in.is_sw,
+    in.is_ecall, in.is_ebreak, in.is_csrrw, in.is_csrrs, in.is_csrrc}));
+
+  // Multiply: a single combinational stage, so full 32-bit-operand correctness
+  // is provable directly (no restriction needed). Independently re-derives
+  // MUL/MULH/MULHU/MULHSU against plain SystemVerilog signed/unsigned
+  // multiplication — this catches exactly the swapped-sign-enable / wrong-
+  // sign-bit class of bug this ticket fixes, not just re-states the RTL.
+  logic [63:0] mul_ref_uu;
+  logic signed [63:0] mul_ref_ss, mul_ref_su;
+  assign mul_ref_uu = in.rs1 * in.rs2;                            // mul, mulhu
+  assign mul_ref_ss = $signed(in.rs1) * $signed(in.rs2);          // mulh
+  assign mul_ref_su = $signed(in.rs1) * $signed({1'b0, in.rs2});  // mulhsu
+  // Sliced into plain 32-bit halves so $past() below applies to a simple
+  // signal rather than a part-select of a $past() result.
+  logic [31:0] mul_ref_lo, mul_ref_uu_hi, mul_ref_ss_hi, mul_ref_su_hi;
+  assign mul_ref_lo = mul_ref_uu[31:0];
+  assign mul_ref_uu_hi = mul_ref_uu[63:32];
+  assign mul_ref_ss_hi = mul_ref_ss[63:32];
+  assign mul_ref_su_hi = mul_ref_su[63:32];
+
+  always_ff @(posedge clk)
+    if (clocked && !reset && !$past(reset) && $past(state) == init && $past(in.is_mul))
+      assert(out.rd_data == $past(mul_ref_lo));
+  always_ff @(posedge clk)
+    if (clocked && !reset && !$past(reset) && $past(state) == init && $past(in.is_mulh))
+      assert(out.rd_data == $past(mul_ref_ss_hi));
+  always_ff @(posedge clk)
+    if (clocked && !reset && !$past(reset) && $past(state) == init && $past(in.is_mulhu))
+      assert(out.rd_data == $past(mul_ref_uu_hi));
+  always_ff @(posedge clk)
+    if (clocked && !reset && !$past(reset) && $past(state) == init && $past(in.is_mulhsu))
+      assert(out.rd_data == $past(mul_ref_su_hi));
+
+  // Divide: an end-to-end assertion unrolling the restoring divider's full
+  // 33-cycle latency (out.rd_data correct N cycles after issue) is not provable
+  // by k-induction as such a property — sby's default engine depth here is 20
+  // steps, well short of 33, and induction can't "remember" that far back
+  // without restating the whole trajectory as an invariant anyway. So this
+  // proves a loop invariant instead (below), which needs only one induction
+  // step regardless of how many iterations the divider takes, and separately
+  // restricts operands to 4 bits (0-15) so the invariant's intermediate
+  // arithmetic stays comfortably inside 64 bits without wraparound (ADR-0010:
+  // "restrict it... record the restriction as a comment in the sby task" —
+  // recorded here instead, since formal/components.sby is owned by the
+  // parallel JEF-604 ticket and must not be edited from this one).
+  //
+  // The invariant, proved by ordinary one-step induction instead of unrolling:
+  // at every point while state == divide,
+  //   dividend == remainder-so-far + quotient-so-far * (divisor << iterations-remaining)
+  // and remainder-so-far < (divisor << iterations-remaining). Both are
+  // preserved by each iteration of the shift/subtract loop regardless of how
+  // many iterations have run, which is exactly what makes them provable
+  // without unrolling the whole operation. At the last iteration (0 remaining)
+  // this collapses to the ordinary division identity dividend == remainder +
+  // quotient * divisor with 0 <= remainder < divisor, tying the invariant to
+  // real division and — combined with the assertions below — to out.rd_data.
+  always_comb assume(in.rs1 <= 32'h0000000f);
+  always_comb assume(in.rs2 <= 32'h0000000f);
+  // The pipeline (once ADR-0004's stall-only interlock lands) holds `in` steady
+  // for the full duration of a multi-cycle divide; assume that environment here
+  // so the opcode selection at capture time can't be corrupted by a free-
+  // running formal input mid-divide (the real bug this would otherwise hide:
+  // executor.v reads in.is_div/is_divu/is_rem/is_remu fresh at capture time,
+  // not latched at issue).
+  always_ff @(posedge clk)
+    // Covers both the first divide-state cycle (state == divide; otherwise
+    // that cycle's `in` is a free input that can disagree with what was just
+    // latched into mul_div_x/mul_div_y at issue) and the capture cycle
+    // ($past(state) == divide, state == init; otherwise the capture edge's
+    // `in.is_divu`/`is_remu` used below can disagree with the operands the
+    // divider actually ran on).
+    if (clocked && (state == divide || $past(state) == divide)) begin
+      assume(in.rs1 == $past(in.rs1));
+      assume(in.rs2 == $past(in.rs2));
+      assume(in.is_div == $past(in.is_div));
+      assume(in.is_divu == $past(in.is_divu));
+      assume(in.is_rem == $past(in.is_rem));
+      assume(in.is_remu == $past(in.is_remu));
+    end
+
+  // k-induction otherwise has no reason to rule out an (unreachable) starting
+  // state with a wild mul_div_counter value — bound it to the range the RTL
+  // actually drives it through, so the counter can serve as an exact iteration
+  // count ("how many halvings of the divisor remain") in the invariant below.
+  always_comb if (state == divide) assert(mul_div_counter <= 32);
+
+  // Ties the actual mul_div_y register to the same "divisor scaled by
+  // iterations remaining" quantity the invariant below reasons about — without
+  // this, mul_div_y is a free register as far as the solver's concerned, and
+  // the comparison the RTL actually branches on (mul_div_x >= mul_div_y) has
+  // no connection to what the invariant expects it to be. Scoped to
+  // mul_div_counter > 0: at counter == 0, mul_div_y has taken its last
+  // (possibly LSB-dropping) right-shift and is no longer read by anything.
+  always_comb
+    if (state == divide && mul_div_counter > 0)
+      assert(mul_div_y == ({32'b0, div_y} << (mul_div_counter - 1)));
+
+  // Uses div_x/div_y (what the divider actually loaded), not in.rs1/in.rs2
+  // directly, so this covers is_div/is_rem's abs-value conversion too, not just
+  // the unsigned ops.
+  logic [63:0] div_scaled_divisor;
+  assign div_scaled_divisor = ({32'b0, div_y}) << mul_div_counter;
+  always_comb
+    if (state == divide)
+      assert(mul_div_x + mul_div_store * div_scaled_divisor == {32'b0, div_x});
+  always_comb
+    if (state == divide)
+      assert(mul_div_x < div_scaled_divisor);
+  // Without this, the equality invariant above is only an equation over
+  // 64-bit *modular* arithmetic, and the solver can satisfy it with a
+  // mul_div_store far outside any value the real 32-iteration algorithm would
+  // ever produce (a wraparound "solution" mod 2^64) as an induction starting
+  // point. True quotients never exceed the dividend for a divisor >= 1, so
+  // this is also a real fact about the algorithm, not just a proof crutch.
+  always_comb
+    if (state == divide)
+      assert(mul_div_store <= {32'b0, div_x});
+
+  logic [31:0] divu_ref, remu_ref;
+  assign divu_ref = (in.rs2 == 0) ? 32'hffffffff : (in.rs1 / in.rs2);
+  assign remu_ref = (in.rs2 == 0) ? in.rs1 : (in.rs1 % in.rs2);
+
+  always_ff @(posedge clk)
+    if (clocked && !reset && $past(state) == divide && state == init && $past(in.is_divu))
+      assert(out.rd_data == divu_ref);
+  always_ff @(posedge clk)
+    if (clocked && !reset && $past(state) == divide && state == init && $past(in.is_remu))
+      assert(out.rd_data == remu_ref);
  `endif
 endmodule

--- a/rtl/fetcher.v
+++ b/rtl/fetcher.v
@@ -31,10 +31,5 @@ module fetcher(
   initial assume(reset);
   always_comb if(!clocked) assume(reset);
 
-  always_ff @(posedge clk) if(clocked && $past(reset)) assert(out.pc == 32'b0);
-  // imem_data forwarding: when not in reset, fetched instruction reflects current imem_data
-  always_comb if(!reset) assert(out.instr == imem_data);
-  // PC forwarding: when not in reset, output PC matches the input PC
-  always_comb if(!reset) assert(out.pc == pc);
  `endif
 endmodule

--- a/rtl/littlecpu.v
+++ b/rtl/littlecpu.v
@@ -44,6 +44,9 @@ module littlecpu(
   output logic [63:0] rvfi_csr_minstret_wdata
   `endif //  `ifdef RISCV_FORMAL
   );
+  // Declared here (ahead of the decoder instantiation below) because the trap
+  // assignment below references it; iverilog requires declare-before-use.
+  decoder_output decoder_out;
   // trap is asserted when the decoded instruction is unrecognized (illegal-instruction)
   // or when the accessor detects a misaligned memory access.  Gated by !reset so that
   // the pipeline flush state does not produce spurious traps.
@@ -78,7 +81,6 @@ module littlecpu(
     .wdata(wdata)
   );
 
-  decoder_output decoder_out;
   decoder decoder(
     .clk(clk),
     .reset(reset),

--- a/rtl/memory.v
+++ b/rtl/memory.v
@@ -20,8 +20,6 @@ module memory #(
         if(mem_wstrb[1]) ram[mem_addr >> 2][15:8] <= mem_wdata[15:8];
         if(mem_wstrb[2]) ram[mem_addr >> 2][23:16] <= mem_wdata[23:16];
         if(mem_wstrb[3]) ram[mem_addr >> 2][31:24] <= mem_wdata[31:24];
-      end else begin
-        mem_rdata <= mem_wdata;
       end
     end else begin
       mem_rdata <= mem_wdata;

--- a/test/decoder_tb.v
+++ b/test/decoder_tb.v
@@ -1,0 +1,96 @@
+`timescale 1 ns / 1 ps
+`default_nettype none
+`include "structs.v"
+
+// Decode-vector bench for JEF-605 criterion 6: confirms the SLTI/SLTIU/XORI
+// immediate-source fix (decoder.v's `instr_shift`) and the funct12-exact EBREAK
+// fix, directly against the decoder — no full pipeline needed for either check.
+module decoder_tb;
+  logic clk = 0;
+  always #5 clk = ~clk;
+
+  logic reset;
+  fetcher_output in;
+  logic [31:0] reg_rs1, reg_rs2;
+  logic [31:0] pc;
+  logic [4:0] rs1, rs2;
+  decoder_output out;
+
+  decoder dut (
+    .clk(clk),
+    .reset(reset),
+    .in(in),
+    .reg_rs1(reg_rs1),
+    .reg_rs2(reg_rs2),
+    .pc(pc),
+    .rs1(rs1),
+    .rs2(rs2),
+    .out(out)
+  );
+
+  int errors = 0;
+
+  task automatic check_hex(input string what, input logic [31:0] got, input logic [31:0] expected);
+    begin
+      if (got !== expected) begin
+        $display("MISMATCH %s: got=%08x expected=%08x", what, got, expected);
+        errors++;
+      end
+    end
+  endtask
+
+  task automatic check_bit(input string what, input logic got, input logic expected);
+    begin
+      if (got !== expected) begin
+        $display("MISMATCH %s: got=%b expected=%b", what, got, expected);
+        errors++;
+      end
+    end
+  endtask
+
+  initial begin
+    reset = 1;
+    in = '0;
+    reg_rs1 = 0;
+    reg_rs2 = 0;
+    repeat (2) @(posedge clk);
+    #1;
+    reset = 0;
+
+    // xori x1, x2, -1  =>  imm=0xfff (sign -1), rs1=x2, funct3=100, rd=x1,
+    // opcode=0010011 (I-type math-immediate).
+    in.instr = 32'hfff14093;
+    in.pc = 32'h0;
+    #1; // math_arg is purely combinational off `in.instr`; no clock edge needed
+    check_hex("xori math_arg", dut.math_arg, 32'hffffffff);
+    @(posedge clk);
+    #1;
+    check_hex("xori out.rs2 (registered math_arg)", out.rs2, 32'hffffffff);
+
+    // ebreak: 0x00100073 (funct12 == 1) must set is_ebreak.
+    in.instr = 32'h00100073;
+    @(posedge clk);
+    #1;
+    check_bit("ebreak sets is_ebreak", out.is_ebreak, 1'b1);
+
+    // mret: 0x30200073 (funct12 == 0x302) must NOT set is_ebreak.
+    in.instr = 32'h30200073;
+    @(posedge clk);
+    #1;
+    check_bit("mret does not set is_ebreak", out.is_ebreak, 1'b0);
+
+    // wfi: 0x10500073 (funct12 == 0x105) must NOT set is_ebreak.
+    in.instr = 32'h10500073;
+    @(posedge clk);
+    #1;
+    check_bit("wfi does not set is_ebreak", out.is_ebreak, 1'b0);
+
+    if (errors != 0) begin
+      $display("FAILED: %0d mismatches", errors);
+      $fatal(1);
+    end else begin
+      $display("PASSED: decode vectors (xori immediate, ebreak/mret/wfi)");
+      $finish;
+    end
+  end
+endmodule

--- a/test/exec_tb.v
+++ b/test/exec_tb.v
@@ -1,0 +1,225 @@
+`timescale 1 ns / 1 ps
+`default_nettype none
+`include "structs.v"
+
+// Standalone randomized differential bench for the executor's multiply/divide
+// datapath (ADR-0010): this is the *primary* guarantee for real mul/div
+// arithmetic, because riscv-formal runs under RISCV_FORMAL_ALTOPS and never
+// checks it. Drives `executor` directly (no decoder/pipeline involved) and
+// compares against SystemVerilog `*`, `/`, `%` with RISC-V divide-by-zero and
+// INT_MIN / -1 semantics. Exits non-zero (via $fatal) on any mismatch.
+module exec_tb;
+  localparam int RANDOM_VECTORS = 10000;
+  localparam logic [1:0] DIVIDE_STATE = 2'b10; // must match executor.v's `divide` state
+
+  logic clk = 0;
+  always #5 clk = ~clk;
+
+  logic reset;
+  decoder_output in;
+  executor_output out;
+
+  executor dut (
+    .clk(clk),
+    .reset(reset),
+    .in(in),
+    .out(out)
+  );
+
+  int errors = 0;
+
+  // ---- reference model: SystemVerilog *, /, % with RISC-V semantics ----
+  function automatic logic [31:0] ref_mul(input logic [31:0] a, input logic [31:0] b);
+    logic [63:0] p;
+    begin
+      p = a * b;
+      ref_mul = p[31:0];
+    end
+  endfunction
+
+  function automatic logic [31:0] ref_mulh(input logic [31:0] a, input logic [31:0] b);
+    logic signed [63:0] p;
+    begin
+      p = $signed(a) * $signed(b);
+      ref_mulh = p[63:32];
+    end
+  endfunction
+
+  function automatic logic [31:0] ref_mulhu(input logic [31:0] a, input logic [31:0] b);
+    logic [63:0] p;
+    begin
+      p = a * b;
+      ref_mulhu = p[63:32];
+    end
+  endfunction
+
+  function automatic logic [31:0] ref_mulhsu(input logic [31:0] a, input logic [31:0] b);
+    logic signed [63:0] p;
+    begin
+      // rs1 is signed, rs2 is unsigned (zero-extended one bit so it stays non-negative
+      // once cast signed).
+      p = $signed(a) * $signed({1'b0, b});
+      ref_mulhsu = p[63:32];
+    end
+  endfunction
+
+  function automatic logic [31:0] ref_div(input logic [31:0] a, input logic [31:0] b);
+    begin
+      if (b == 0) ref_div = 32'hffffffff;
+      else if (a == 32'h80000000 && b == 32'hffffffff) ref_div = 32'h80000000;
+      else ref_div = $signed(a) / $signed(b);
+    end
+  endfunction
+
+  function automatic logic [31:0] ref_divu(input logic [31:0] a, input logic [31:0] b);
+    begin
+      ref_divu = (b == 0) ? 32'hffffffff : (a / b);
+    end
+  endfunction
+
+  function automatic logic [31:0] ref_rem(input logic [31:0] a, input logic [31:0] b);
+    begin
+      if (b == 0) ref_rem = a;
+      else if (a == 32'h80000000 && b == 32'hffffffff) ref_rem = 32'b0;
+      else ref_rem = $signed(a) % $signed(b);
+    end
+  endfunction
+
+  function automatic logic [31:0] ref_remu(input logic [31:0] a, input logic [31:0] b);
+    begin
+      ref_remu = (b == 0) ? a : (a % b);
+    end
+  endfunction
+
+  task automatic clear_in;
+    begin
+      in = '0;
+      in.rd = 5'd1;
+    end
+  endtask
+
+  task automatic check(input string op_name, input logic [31:0] rs1_v, input logic [31:0] rs2_v,
+                        input logic [31:0] expected);
+    begin
+      if (out.rd_data !== expected) begin
+        $display("MISMATCH %s rs1=%08x rs2=%08x got=%08x expected=%08x",
+                  op_name, rs1_v, rs2_v, out.rd_data, expected);
+        errors++;
+      end
+    end
+  endtask
+
+  // Multiply-family ops settle one cycle after issue (the executor never leaves
+  // `init` for them). Divide-family ops may enter the multi-cycle restoring
+  // divider (see criterion 4 below); the special-case (div-by-zero, INT_MIN/-1)
+  // paths finish within `init` like the multiply-family ops do. Either way, the
+  // executor is done exactly when it has returned to `init` after the issue
+  // edge, so poll for that instead of hardcoding a cycle count — that keeps this
+  // bench correct regardless of exactly how long the divider takes, and leaves
+  // criterion 4's specific cycle count to the dedicated timing monitor below.
+  task automatic run_op(input string op_name, input logic [31:0] rs1_v, input logic [31:0] rs2_v,
+                         input logic [31:0] expected);
+    int guard;
+    begin
+      clear_in();
+      in.rs1 = rs1_v;
+      in.rs2 = rs2_v;
+      if (op_name == "mul") in.is_mul = 1'b1;
+      else if (op_name == "mulh") in.is_mulh = 1'b1;
+      else if (op_name == "mulhu") in.is_mulhu = 1'b1;
+      else if (op_name == "mulhsu") in.is_mulhsu = 1'b1;
+      else if (op_name == "div") in.is_div = 1'b1;
+      else if (op_name == "divu") in.is_divu = 1'b1;
+      else if (op_name == "rem") in.is_rem = 1'b1;
+      else if (op_name == "remu") in.is_remu = 1'b1;
+      @(posedge clk); // issue edge
+      #1;
+      guard = 0;
+      while (dut.state == DIVIDE_STATE) begin
+        @(posedge clk);
+        #1;
+        guard++;
+        if (guard > 64) begin
+          $display("HANG: %s never left the divide state (rs1=%08x rs2=%08x)",
+                    op_name, rs1_v, rs2_v);
+          $fatal(1);
+        end
+      end
+      check(op_name, rs1_v, rs2_v, expected);
+    end
+  endtask
+
+  logic [31:0] a, b;
+  int i;
+
+  initial begin
+    reset = 1;
+    clear_in();
+    repeat (2) @(posedge clk);
+    #1;
+    reset = 0;
+
+    // Required directed vectors (JEF-605): exactly the cases the swapped sign
+    // enables get wrong.
+    run_op("mulh",   32'hffffffff, 32'hffffffff, 32'h00000000);
+    run_op("mulhsu", 32'hffffffff, 32'h00000001, 32'hffffffff);
+    run_op("mulhu",  32'hffffffff, 32'hffffffff, 32'hfffffffe);
+
+    // Directed divide-by-zero / INT_MIN-over-negative-one vectors.
+    run_op("div",  32'h00000064, 32'h00000000, 32'hffffffff);
+    run_op("divu", 32'h00000064, 32'h00000000, 32'hffffffff);
+    run_op("rem",  32'h00000064, 32'h00000000, 32'h00000064);
+    run_op("remu", 32'h00000064, 32'h00000000, 32'h00000064);
+    run_op("div",  32'h80000000, 32'hffffffff, 32'h80000000);
+    run_op("rem",  32'h80000000, 32'hffffffff, 32'h00000000);
+
+    // Randomized differential coverage: >=10,000 vectors per operation.
+    for (i = 0; i < RANDOM_VECTORS; i++) begin
+      a = $random;
+      b = $random;
+      run_op("mul",    a, b, ref_mul(a, b));
+      run_op("mulh",   a, b, ref_mulh(a, b));
+      run_op("mulhu",  a, b, ref_mulhu(a, b));
+      run_op("mulhsu", a, b, ref_mulhsu(a, b));
+      run_op("div",    a, b, ref_div(a, b));
+      run_op("divu",   a, b, ref_divu(a, b));
+      run_op("rem",    a, b, ref_rem(a, b));
+      run_op("remu",   a, b, ref_remu(a, b));
+    end
+
+    if (errors != 0) begin
+      $display("FAILED: %0d mismatches", errors);
+      $fatal(1);
+    end else begin
+      $display("PASSED: %0d randomized vectors per op (mul/mulh/mulhu/mulhsu/div/divu/rem/remu), 0 mismatches", RANDOM_VECTORS);
+      $finish;
+    end
+  end
+
+  // Criterion 4: the divider produces its result exactly 33 cycles after issue
+  // (32 restoring-division iterations plus one capture cycle), not 66. Checked
+  // against every real division performed during the run above, not just once.
+  int cycle_count;
+  logic prev_divide;
+
+  initial begin
+    cycle_count = 0;
+    prev_divide = 0;
+    forever begin
+      @(posedge clk);
+      #1;
+      if (dut.state == DIVIDE_STATE) begin
+        cycle_count++;
+        prev_divide = 1;
+      end else if (prev_divide) begin
+        if (cycle_count !== 33) begin
+          $display("TIMING MISMATCH: divider completed in %0d cycles, expected 33", cycle_count);
+          errors++;
+          $fatal(1);
+        end
+        prev_divide = 0;
+        cycle_count = 0;
+      end
+    end
+  end
+endmodule

--- a/test/mem_tb.v
+++ b/test/mem_tb.v
@@ -1,0 +1,112 @@
+`timescale 1 ns / 1 ps
+`default_nettype none
+
+// Standalone bench for rtl/memory.v (JEF-605 criterion 5). memory.v is not
+// exercised by any other test path: the cxxrtl top (`testbench`) has its own
+// inline memory, and the synthesis path (littlesoc) is currently broken (see
+// ADR-0010's technical notes), so this is the only place its read/write
+// behaviour gets checked.
+module mem_tb;
+  localparam int RAM_WORDS = 16;
+
+  logic clk = 0;
+  always #5 clk = ~clk;
+
+  logic [31:0] mem_addr;
+  logic [31:0] mem_wdata;
+  logic [3:0]  mem_wstrb;
+  logic [31:0] mem_rdata;
+
+  memory #(.RAM(RAM_WORDS)) dut (
+    .clk(clk),
+    .mem_addr(mem_addr),
+    .mem_wdata(mem_wdata),
+    .mem_wstrb(mem_wstrb),
+    .mem_rdata(mem_rdata)
+  );
+
+  int errors = 0;
+
+  task automatic check(input string what, input logic [31:0] got, input logic [31:0] expected);
+    begin
+      if (got !== expected) begin
+        $display("MISMATCH %s: got=%08x expected=%08x", what, got, expected);
+        errors++;
+      end
+    end
+  endtask
+
+  task automatic check_ne(input string what, input logic [31:0] got, input logic [31:0] unwanted);
+    begin
+      if (got === unwanted) begin
+        $display("MISMATCH %s: got=%08x, which must not alias %08x", what, got, unwanted);
+        errors++;
+      end
+    end
+  endtask
+
+  task automatic do_write(input logic [31:0] addr, input logic [31:0] data);
+    begin
+      mem_addr = addr;
+      mem_wdata = data;
+      mem_wstrb = 4'b1111;
+      @(posedge clk);
+      #1;
+      mem_wstrb = 4'b0000;
+    end
+  endtask
+
+  task automatic do_read(input logic [31:0] addr, output logic [31:0] data);
+    begin
+      mem_addr = addr;
+      // A decoy write-data value, distinct from anything ever written, so a read
+      // that accidentally echoes mem_wdata (rtl/memory.v's deleted bug) is caught
+      // instead of coincidentally matching.
+      mem_wdata = 32'hdeadbeef;
+      mem_wstrb = 4'b0000;
+      @(posedge clk);
+      #1;
+      data = mem_rdata;
+    end
+  endtask
+
+  logic [31:0] got;
+
+  initial begin
+    mem_addr = 0;
+    mem_wdata = 0;
+    mem_wstrb = 0;
+    @(posedge clk);
+    #1;
+
+    // Criterion 5a: a wstrb == 0 read following a write to the same address
+    // returns ram[addr>>2], not a stale echo of the bus's mem_wdata.
+    do_write(32'h00000004, 32'hcafef00d);
+    do_read(32'h00000004, got);
+    check("write-then-read same address", got, 32'hcafef00d);
+
+    // A second pair at a different address, to rule out a fluke.
+    do_write(32'h0000000c, 32'h01234567);
+    do_read(32'h0000000c, got);
+    check("write-then-read second address", got, 32'h01234567);
+
+    // Criterion 5b: an out-of-range read must not alias an in-range ram word.
+    do_write(32'h00000000, 32'ha5a5a5a5);
+    do_read(32'h00000000, got);
+    check("in-range sanity read", got, 32'ha5a5a5a5);
+
+    do_read(4 * RAM_WORDS, got); // first address past the end of ram
+    check_ne("out-of-range read does not alias ram[0] (boundary)", got, 32'ha5a5a5a5);
+
+    do_read(32'hfffffffc, got); // far out of range
+    check_ne("out-of-range read does not alias ram[0] (far)", got, 32'ha5a5a5a5);
+
+    if (errors != 0) begin
+      $display("FAILED: %0d mismatches", errors);
+      $fatal(1);
+    end else begin
+      $display("PASSED: memory.v read-after-write and out-of-range checks");
+      $finish;
+    end
+  end
+endmodule


### PR DESCRIPTION
Closes JEF-605

## Summary

Fixes the seven pipeline-agnostic defects listed in the ticket, without touching pipeline structure or the files reserved for the ADR-0004 interlock ticket (`rtl/structs.v`, `rtl/regfile.v`, `rtl/accessor.v`, `rtl/writeback.v` are untouched).

- `rtl/executor.v` — multiplier rewritten as continuous assignments (was declaration-initializers, evaluated once at time 0), sign bits now taken from bit 31 (not bit 0), swapped `mulh`/`mulhsu` sign enables corrected.
- `rtl/executor.v` — restoring-divider comparison `<=` → `>=`; iteration count 65 → 32.
- `rtl/executor.v` — **found while building the required differential bench, not itemized in the ticket text but required for it to pass**: signed `div`/`rem` fed the divider the raw two's-complement operand instead of its magnitude, which corrupted every negative-operand signed division. Fixed with an abs-value conversion (`div_x`/`div_y`) gated on `is_div || is_rem`, restoring the sign afterward exactly as the existing post-loop logic already expected.
- `rtl/decoder.v` — `instr_shift` no longer includes the register-form ALU ops that alias with `slti`/`sltiu`/`xori`, so those three now take the sign-extended 12-bit immediate instead of the zero-extended 5-bit rs2 field.
- `rtl/decoder.v` — `instr_ebreak` now requires `funct12 == 12'h1` exactly, so `mret` (0x302) and `wfi` (0x105) no longer decode as `ebreak`.
- `rtl/memory.v` — deleted the trailing `mem_rdata <= mem_wdata` that overrode the correct RAM read on `wstrb == 0`.
- `rtl/fetcher.v` — removed the formal assertion of a property on a free input (`out.pc == 0`) and the two tautological restatements of the `always_comb` block, per ADR-0006 (`components_fetcher` is deleted outright there; this ticket just removes the now-pointless assertions from the file).
- `rtl/decoder.v` / `rtl/littlecpu.v` — reordered declarations so every identifier is declared before use, which is what was blocking iverilog elaboration entirely.

## Tests

- `test/exec_tb.v` — new. Drives `executor` standalone, 10,000 randomized vectors per op (mul/mulh/mulhu/mulhsu/div/divu/rem/remu) against SystemVerilog `*`/`/`/`%` with RISC-V divide-by-zero and INT_MIN/-1 semantics, plus the three required directed vectors and the divide-by-zero/overflow directed vectors. A second concurrent monitor asserts every real division completes in exactly 33 cycles (32 iterations + capture), checked against every division performed during the run, not just once.
- `test/mem_tb.v` — new. Standalone bench for `rtl/memory.v` (not exercised by any other test path — the cxxrtl top has its own inline memory and the synthesis path is broken per ADR-0010's technical notes). Covers write-then-read-same-address and out-of-range non-aliasing.
- `test/decoder_tb.v` — new. Decode vectors for the `xori` immediate-source fix (checks `math_arg` directly, both combinationally and through the registered `out.rs2`) and the `mret`/`wfi`/`ebreak` funct12 fix.
- `rtl/executor.v` gains its first real formal assertions. `components_executor` was `PASS 0 0` (vacuous) before this PR. The multiplier is proved directly at full 32-bit operand width (single combinational stage). The divider is proved via a loop invariant — `dividend == remainder-so-far + quotient-so-far * (divisor << iterations-remaining)`, preserved by every iteration regardless of how many have run — which needs only one induction step instead of unrolling the full 33-cycle latency (which does not fit sby's default 20-step engine depth). Restricted to 4-bit operands (0-15) so the invariant's intermediate arithmetic stays inside 64 bits without wraparound; documented inline in `rtl/executor.v` under `ifdef FORMAL` since `formal/components.sby` is owned by the parallel JEF-604 ticket and must not be edited from this one.

Every regression case above was verified to actually fail against the pre-fix code before being counted as meaningful (git-stashed the fix, reran the same bench, confirmed a real mismatch/hang, then restored).

## Verification (real output, this worktree)

**1. `iverilog` elaboration** — exits 0, no `error:`, no `warning:`. (Baseline before this PR: ~24 bind errors from the same declare-before-use issue, consistent with the ticket's "~60" across the wider set of source files it lists.) Pre-existing, unrelated to this ticket: Icarus prints `sorry: constant selects in always_* processes are not fully supported` for several `case(1'b1)` / packed-struct-port constructs in `decoder.v`, `accessor.v`, and `test/testbench.v` — a real Icarus optimizer limitation (falls back to over-broad sensitivity, not a correctness issue), present identically before and after this PR, in files both touched and untouched by it. Not a `warning:` or `error:` by Icarus's own classification.

```
$ iverilog -I./rtl/ -DICARUS -g2012 -o testbench.vvp rtl/structs.v rtl/accessor.v rtl/decoder.v rtl/executor.v rtl/fetcher.v rtl/regfile.v rtl/writeback.v rtl/littlecpu.v test/testbench.v
$ echo $?
0
```

**2. `yosys write_cxxrtl`** — exits 0, zero warnings (unchanged from baseline).

```
$ yosys -p 'read_verilog -sv <same sources>; hierarchy -top testbench; write_cxxrtl /dev/null'
$ echo $?
0
```

**3+4. `test/exec_tb.v`**

```
$ iverilog -I./rtl/ -DICARUS -g2012 -o exec_tb.vvp rtl/structs.v rtl/executor.v test/exec_tb.v && vvp exec_tb.vvp
PASSED: 10000 randomized vectors per op (mul/mulh/mulhu/mulhsu/div/divu/rem/remu), 0 mismatches
$ echo $?
0
```

**5. `test/mem_tb.v`**

```
$ iverilog -I./rtl/ -DICARUS -g2012 -o mem_tb.vvp rtl/memory.v test/mem_tb.v && vvp mem_tb.vvp
PASSED: memory.v read-after-write and out-of-range checks
$ echo $?
0
```

**6. `test/decoder_tb.v`**

```
$ iverilog -I./rtl/ -DICARUS -g2012 -o decoder_tb.vvp rtl/structs.v rtl/decoder.v test/decoder_tb.v && vvp decoder_tb.vvp
PASSED: decode vectors (xori immediate, ebreak/mret/wfi)
$ echo $?
0
```

**7. `sby -f formal/components.sby executor`**

```
$ sby -f formal/components.sby executor
...
SBY summary: engine_0 (smtbmc) returned pass for basecase
SBY summary: engine_0 (smtbmc) returned pass for induction
SBY summary: successful proof by k-induction.
SBY DONE (PASS, rc=0)
$ cat formal/components_executor/status
PASS 0 3
```
(Baseline before this PR: `PASS 0 0`.)

**8. `git status`** — clean aside from `formal/components/`, which predates this branch (present in the worktree before any change in this PR) and is not a build artifact this PR introduces.

## Scope notes / risks

- **DECISION NEEDED (already resolved, flagging for visibility):** the signed div/rem abs-value bug (item 3 above) was not in the ticket's itemized defect list, but criterion 3's mandatory randomized bench cannot pass without it — every negative-operand signed division would fail ~50% of the time. Fixed within `rtl/executor.v`, the file the ticket already authorizes touching; no pipeline-structure or interlock changes involved.
- Did not touch `rtl/structs.v`, `rtl/regfile.v`, `rtl/accessor.v`, `rtl/writeback.v`, `Makefile`, `formal/Makefile`, `formal/components.sby`, or `.gitignore`, per the constraint note and the parallel JEF-604 ticket boundary.
- No flush logic introduced (ADR-0004). No valid bits or stall wiring added.
- `formal/components.sby`'s `decoder` task (a separate, pre-existing task from this PR's `executor` task) still fails — verified this is pre-existing (identical failure at the same PC-increment assertion against the unmodified `decoder.v` via `git stash`), and is explicitly flagged in ADR-0006 as known/out-of-scope decode-hole work for a later ticket, not something JEF-605's defect list covers.
- The executor's divider formal proof is restricted to 4-bit operands per ADR-0010's explicit allowance ("restrict it... record the restriction"); the randomized differential bench (`test/exec_tb.v`) is the full-width primary guarantee per that same ADR.