### PR TITLE
ADR-0012 and ADR-0013: decisions from integrating the first build sprint

### DIFF
--- a/docs/adr/0012-divider-is-unsigned-signs-are-a-wrapper.md
+++ b/docs/adr/0012-divider-is-unsigned-signs-are-a-wrapper.md
@@ -1,0 +1,59 @@
+# ADR-0012: The divider is unsigned; sign handling is a wrapper around it
+
+**Status:** Accepted · 2026-07-27 · *Supplements ADR-0010*
+
+## Context
+
+JEF-605 was scoped to seven itemized datapath/decode defects. Building the ADR-0010 differential
+bench surfaced an eighth, in the same three lines of `rtl/executor.v` the ticket already had open:
+
+`executor.v`'s restoring divider is **unsigned**. It loads `mul_div_x <= {32'b0, rs1}` and
+`mul_div_y <= {1'b0, rs2, 31'b0}` and iterates compare/subtract/shift. Sign restoration was already
+present at capture (`in.rs1[31] != in.rs2[31] ? -store : store` for `div`, `in.rs1[31] ? -x : x` for
+`rem`) — but the operands fed *in* were raw two's complement. Every signed division with a negative
+operand was therefore wrong, and no check in the repo would have caught it, because ALTOPS means
+riscv-formal never runs the real divider and there was no `.S` M-extension coverage at all.
+
+The engineer raised this as a `DECISION NEEDED`: fix out-of-list, or ship a bench that fails?
+
+## Decision
+
+**Fix it in JEF-605**, and record the structure it implies.
+
+**The restoring divider operates on magnitudes only.** `div_x`/`div_y` are the absolute values of
+`rs1`/`rs2` for `div`/`rem`, and pass through unchanged for `divu`/`remu`. Signs are applied on the
+way in (negate) and restored on the way out (negate the quotient when the operand signs differ; the
+remainder takes the dividend's sign). The two RISC-V special cases — divide-by-zero and
+`INT_MIN / -1` — are handled combinationally in `init` and never enter the loop.
+
+Fixing it here was correct rather than deferring: it is in `rtl/executor.v`, which JEF-605 already
+owned exclusively (JEF-604 held `Makefile`/`formal/`, so there was no collision risk), and ADR-0010
+makes the differential bench a mandatory deliverable of this ticket. A ticket that requires a bench
+and forbids the fix the bench demands is not a shippable ticket.
+
+## Rationale
+
+Radix-2 restoring division has no signed form. Every implementation either converts to magnitude or
+uses non-restoring division with sign correction. Magnitude conversion is two negations and reads
+straightforwardly; the alternative buys nothing on a project whose stated goal is readability
+(`CLAUDE.md`), and the deferred-decisions list already rules out radix-4 for the same reason.
+
+## Consequences
+
+- **The executor reads `in.is_div`/`is_divu`/`is_rem`/`is_remu` fresh at capture time**, 33 cycles
+  after issue — they are not latched with the operands. This is correct only because ADR-0009's
+  stall protocol holds the decode output steady for the whole multi-cycle operation. The executor's
+  component proof states this as an explicit environmental assumption
+  (`rtl/executor.v`, the `state == divide || $past(state) == divide` assume block). **If ADR-0009's
+  stall wiring ever lets `in` move mid-divide, the divider silently returns the wrong sign** —
+  latching the op select at issue is the fix, and it is cheap.
+- The component BMC proves the divider by loop invariant over `div_x`/`div_y`, not over
+  `in.rs1`/`in.rs2`, so it covers the magnitude conversion rather than assuming it away. It is
+  restricted to 4-bit operands per ADR-0010's bounded-effort clause; the restriction is documented
+  inline in `rtl/executor.v` rather than in the sby task, because JEF-604 owned
+  `formal/components.sby` in the same sprint. **Move that comment to the sby task** when convenient —
+  ADR-0010 asked for it there.
+- Verified non-vacuous by mutation: reintroducing the `mul_sign_x` bug makes
+  `sby -f formal/components.sby executor` fail at `executor.v:232`, and reverting the magnitude
+  conversion makes `test/exec_tb.v` mismatch within the first few random vectors.
+- ALTOPS builds are untouched; they never enter this path.

--- a/docs/adr/0013-the-riscv-formal-pin-is-an-enforced-control.md
+++ b/docs/adr/0013-the-riscv-formal-pin-is-an-enforced-control.md
@@ -1,0 +1,77 @@
+# ADR-0013: The riscv-formal pin is an enforced control, not a comment
+
+**Status:** Accepted · 2026-07-27 · *Implements ADR-0006's pinning clause*
+
+## Context
+
+ADR-0006 called the unpinned `git clone` of riscv-formal "a version-skew time bomb" and required a
+SHA pin. JEF-604 added one. Reviewing that PR showed the pin **did not work**, in a way worth
+recording so it is not reintroduced.
+
+The clone target was a *directory*, and the checkout was a separate recipe line. Make does not
+delete a target on recipe failure unless `.DELETE_ON_ERROR:` is set — and even then it does not
+remove directories. So:
+
+1. If `git clone` succeeded and `git checkout` failed, the directory survived. Make then considered
+   the target satisfied **forever**, and every subsequent build ran against unpinned upstream HEAD.
+2. Bumping `RISCV_FORMAL_SHA` never re-checked-out an existing clone. The pin silently stopped
+   applying at exactly the moment someone believed they had changed it.
+3. Nothing ever compared the clone's actual `HEAD` to the pin, so none of this was observable.
+
+This is not a cosmetic gap. This repo **executes Python straight out of that clone**
+(`checks/rvfi_macros.py`, `monitor/generate.py`) and commits its stdout as tracked, compiled source
+(`test/monitor.v`, 7008 lines, instantiated in both simulation legs). `formal/genchecks-local.py`
+additionally turns third-party `isa_*.txt` lines into generated makefile recipes that `make -BC`
+then executes. The pin is the only thing standing between an upstream repository and code execution
+here. A control that reads as protection while providing none is worse than no control, because it
+stops anyone from looking.
+
+## Decision
+
+**The pin is enforced mechanically, at both call sites, from one definition.**
+
+- `formal/pin.mk` owns the clone recipe and the pin. Both the root `Makefile` and `formal/Makefile`
+  include it. There is exactly one recipe, so the two cannot drift apart again — which is how they
+  came to differ in the first place.
+- The clone is **atomic**: clone to `$@.tmp`, `checkout --detach`, assert `rev-parse HEAD` equals
+  the pin, and only then `mv` into place. A failure at any step leaves no directory behind, so make
+  retries the whole thing rather than treating a half-built unpinned clone as done.
+- A **parse-time guard** hard-fails both Makefiles if a clone already on disk is at anything other
+  than the pin, naming the exact re-checkout command. `clean` is exempt, since that is the escape
+  hatch. This covers the pre-existing-unpinned-clone and bumped-pin cases, which the atomic clone
+  alone does not.
+- `RISCV_FORMAL_SHA` is `override` (not settable from the command line) and must be 40 hex digits,
+  so it cannot be redirected from a script or pointed at a moving branch or tag.
+
+**Regenerating `test/monitor.v` when the pin moves is required, not optional.** JEF-604's
+regeneration produced a 45-line delta, all of it upstream changing `rvfi_insn >> 32` to
+`rvfi_insn >> 16 >> 16` — a real portability fix, since a 32-bit-wide shift by 32 is not
+well-defined across frontends. Independently reproduced byte-for-byte from a fresh clone at the pin,
+so it is an upstream change and not an artifact of how the generator was invoked. This is exactly
+`CLAUDE.md` invariant 7 and ADR-0007 working as intended: regenerate, never hand-edit.
+
+**`test/monitor.v` depends on `generate.py` and `pin.mk`, with the clone order-only.** Depending on
+the clone *directory* would make a tracked file regenerate whenever anything is written anywhere
+inside the clone — silently overwriting it during an ordinary build and defeating `monitor-check`.
+
+## Rationale
+
+Assume the dependency will betray you. The mitigation for executing third-party code is to keep the
+version you execute pinned, verifiable, and hard to change by accident — not to trust that a
+variable named `RISCV_FORMAL_SHA` is doing something.
+
+Fail closed. Every mode above failed *open*, and each one failed open quietly. The guard is a few
+lines of make and turns three silent conditions into one loud one with the fix in the message.
+
+## Consequences
+
+- Bumping the pin is now a two-step, visible operation: edit `formal/pin.mk`, then re-checkout (the
+  guard tells you how) and regenerate `test/monitor.v`. That friction is the point.
+- `formal/genchecks-local.py` is a fork of a **much older** upstream and diffs ~450 lines against
+  the pinned SHA — it is missing upstream's `csr_spec`/`buslen`/`nbus`/`abspath` options and its
+  isa-string parser. Only the `basedir` change is deliberate. The pin now stops that skew growing,
+  but does not remove it; re-vendoring from the pin and re-applying only `basedir` is open work.
+- The pin is the *only* thing gating `genchecks-local.py`'s isa-line-to-makefile-recipe path. That
+  path should also be hardened on its own merits — it should not be the pin's job alone. Open work.
+- CI (JEF-608) should run `make monitor-check` and a from-scratch clone, which is what actually
+  proves the guard keeps working. Until CI exists, nothing runs this automatically.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -16,11 +16,15 @@ and what it costs. Reversing one is fine — write a new ADR that supersedes it.
 | [0009](0009-stall-protocol-semantics.md) | Stall protocol — upstream freezes, downstream drains | Accepted |
 | [0010](0010-muldiv-verification-under-altops.md) | A randomized differential bench is the primary mul/div guarantee | Accepted |
 | [0011](0011-misalignment-detection-stays-in-accessor-until-m3.md) | Misalignment detection stays in the accessor until M3 | Accepted |
+| [0012](0012-divider-is-unsigned-signs-are-a-wrapper.md) | The divider is unsigned; sign handling is a wrapper around it | Accepted |
+| [0013](0013-the-riscv-formal-pin-is-an-enforced-control.md) | The riscv-formal pin is an enforced control, not a comment | Accepted |
 
 0001–0007 came from the design brief
 ([`docs/ideas/finish-the-rewrite.md`](../ideas/finish-the-rewrite.md)). 0008–0011 came out of
 sprint planning, when the panel ran the toolchain and found the brief's assumptions needed
-resolving before work could start. 0010 supplements 0006; 0011 scopes 0005.
+resolving before work could start. 0012-0013 came out of integrating the first build sprint, when
+review of JEF-604/JEF-605 turned up decisions neither ticket had recorded. 0010 supplements 0006;
+0011 scopes 0005; 0012 supplements 0010; 0013 implements 0006's pinning clause.
 
 ## Deferred decisions
 


### PR DESCRIPTION
Records the two architectural decisions made while integrating PR #8 (JEF-605) and PR #7 (JEF-604).

- **ADR-0012** — the restoring divider is unsigned; signed `div`/`rem` convert to magnitude on the way in and restore signs on the way out. This is the eighth fix JEF-605 raised as a `DECISION NEEDED` and shipped. Also records the latent coupling it leaves: the executor reads `in.is_div`/`is_divu`/`is_rem`/`is_remu` fresh at capture time, 33 cycles after issue, which is safe only under ADR-0009's stall protocol.
- **ADR-0013** — the riscv-formal pin is an enforced control. Records why JEF-604's pin as submitted failed open three ways, and the atomic-clone + `rev-parse` guard that replaced it. Ratifies the `test/monitor.v` regeneration at the new pin under CLAUDE.md invariant 7.

Docs only. No RTL, no build files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)