### PR TITLE
JEF-607: combinational-read regfile, valid bits, stall-only hazard interlock

### DIFF
--- a/rtl/accessor.v
+++ b/rtl/accessor.v
@@ -13,6 +13,26 @@ module accessor(
     input  logic [31:0] mem_rdata,
     // fault signals
     output logic mem_misaligned,
+    // ADR-0009-style stall broadcast (JEF-607): the memory (test/testbench.v,
+    // rtl/memory.v) registers mem_rdata one cycle after the address is
+    // presented — a real, unavoidable round trip, not a choice — so a load
+    // cannot be answered in the single cycle every other instruction takes
+    // through this stage. High for exactly the cycle a load's *request*
+    // fires; littlecpu.v folds this into the same global stall that already
+    // freezes decode for a divide, and rtl/executor.v freezes (emits a
+    // bubble) for that one cycle so nothing new arrives here while the
+    // response is still in flight — otherwise the completing load and a
+    // fresh instruction would collide over this stage's single output
+    // register and the single-port memory bus.
+    output logic stalled,
+    // ADR-0004 hazard scoreboard (JEF-607): a load's result is a live
+    // producer from the moment its request is issued here until write-through
+    // makes it visible, which is one cycle later than decoder_out/executor_out
+    // alone can see (that's what `stalled` above is fixing). Decode also
+    // checks this — a third stage, but only for this specific one-cycle gap,
+    // not a general widening of the scoreboard.
+    output logic       pending_valid,
+    output logic [4:0] pending_rd,
     // outputs
     output accessor_output out
 );
@@ -20,26 +40,51 @@ module accessor(
   assign addr16 = in.mem_addr[1];
   logic [1:0] addr24;
   assign addr24 = in.mem_addr[1:0];
+  logic is_load;
+  assign is_load = in.is_lw || in.is_lh || in.is_lhu || in.is_lb || in.is_lbu;
+  assign stalled = in.valid && is_load;
+
+  // pending_valid/pending_rd are declared as ports above (the hazard
+  // scoreboard needs them too); the rest of the pending-load state below is
+  // internal-only. All of it is latched at the request cycle below and
+  // consumed one cycle later once mem_rdata actually reflects this load —
+  // see `stalled` above.
+  logic       pending_is_lb, pending_is_lbu, pending_is_lh, pending_is_lhu, pending_is_lw;
+  logic       pending_addr16;
+  logic [1:0] pending_addr24;
   // Misaligned-access detection per RISC-V spec: word accesses require 4-byte alignment,
   // halfword accesses require 2-byte alignment; byte accesses are always aligned.
-  assign mem_misaligned =
-    ((in.is_lw || in.is_sw) && in.mem_addr[1:0] != 2'b00) ||
-    ((in.is_lh || in.is_lhu || in.is_sh) && in.mem_addr[0] != 1'b0);
+  // Gated by in.valid (ADR-0011/JEF-607): a bubble must never raise a spurious
+  // trap. Detection itself stays here — moving it to decode is M3 (ADR-0011).
+  assign mem_misaligned = in.valid &&
+    (((in.is_lw || in.is_sw) && in.mem_addr[1:0] != 2'b00) ||
+     ((in.is_lh || in.is_lhu || in.is_sh) && in.mem_addr[0] != 1'b0));
 
   logic [31:0] write_request;
-  // make the request
+  // mem_wdata must be combinational, in lockstep with mem_addr/mem_wstrb
+  // above: a registered mem_wdata (the original bug here) lags the address
+  // and strobe by one cycle, so the memory model latches the *previous*
+  // cycle's data at the *current* cycle's address — exactly the "address
+  // recovers before data" skew traced while landing JEF-606 (see
+  // test/EXPECTED_FAIL's history and the JEF-607 dispatch notes).
+  assign mem_wdata = write_request;
+  // make the request. Defaults to no request every cycle — reset, a bubble,
+  // and a real non-memory instruction (e.g. add) all fall out of the same
+  // single default below rather than each re-stating "0, 0, 0" — and that's
+  // also the direct fix for the divide-replay defect, where the accessor
+  // used to keep re-issuing whatever request was last in `in` for every
+  // cycle the executor sat busy in `divide`, because nothing here defaulted
+  // back to zero in between.
   always_comb begin
-    if(reset) begin
-      mem_addr = 0;
-      mem_wstrb = 0;
-      write_request = 0;
-    end else begin
+    mem_addr = 0;
+    mem_wstrb = 0;
+    write_request = 0;
+    if (!reset && in.valid) begin
       write_request = in.mem_data;
       // request is synchronous
-      (* parallel_case, full_case *)
+      (* parallel_case *)
       case (1'b1)
         in.is_lw || in.is_lh || in.is_lhu || in.is_lb || in.is_lbu: begin
-          mem_wstrb = 4'b0000;
           mem_addr = {in.mem_addr[31:2], 2'b00};
         end
 
@@ -65,24 +110,33 @@ module accessor(
           endcase // case (1'b1)
           mem_addr = {in.mem_addr[31:2], 2'b00};
         end // case: in.is_sw || in.is_sh || in.is_sb
+
+        // default: not a load or a store this cycle (e.g. an add) — the
+        // zeroed defaults above stand.
       endcase // case (1'b1)
-    end // else: !if(reset)
+    end // if (!reset && in.valid)
   end // always_comb
 
   always_ff @(posedge clk) begin
     // response is registered
     if (reset) begin
       out <= 0;
-      mem_wdata <= 0;
-    end else begin
-      mem_wdata <= write_request;
-      out.rd_data <= in.rd_data;
-      out.rd <= in.rd;
+      pending_valid <= 1'b0;
+      pending_rd <= 0;
+      pending_is_lb <= 0; pending_is_lbu <= 0; pending_is_lh <= 0; pending_is_lhu <= 0; pending_is_lw <= 0;
+      pending_addr16 <= 0;
+      pending_addr24 <= 0;
+    end else if (pending_valid) begin
+      // The request fired last cycle (`stalled` was high then); mem_rdata
+      // now reflects it. rtl/decoder.v froze upstream and rtl/executor.v
+      // bubbled for that one cycle, so `in` here is guaranteed to be a
+      // bubble right now — nothing else is competing for `out` this cycle.
+      out.valid <= 1'b1;
+      out.rd <= pending_rd;
       (* parallel_case, full_case *)
       case (1'b1)
-        // unpack the alignment from above
-        in.is_lb: begin
-          case (addr24)
+        pending_is_lb: begin
+          case (pending_addr24)
             2'b00: out.rd_data <= {{24{mem_rdata[7]}}, mem_rdata[7:0]};
             2'b01: out.rd_data <= {{24{mem_rdata[15]}}, mem_rdata[15:8]};
             2'b10: out.rd_data <= {{24{mem_rdata[23]}}, mem_rdata[23:16]};
@@ -90,8 +144,8 @@ module accessor(
           endcase
         end
 
-        in.is_lbu: begin
-          case (addr24)
+        pending_is_lbu: begin
+          case (pending_addr24)
             2'b00: out.rd_data <= {24'b0, mem_rdata[7:0]};
             2'b01: out.rd_data <= {24'b0, mem_rdata[15:8]};
             2'b10: out.rd_data <= {24'b0, mem_rdata[23:16]};
@@ -99,23 +153,46 @@ module accessor(
           endcase
         end
 
-        in.is_lh: begin
-          case (addr16)
+        pending_is_lh: begin
+          case (pending_addr16)
             1'b0: out.rd_data <= {{16{mem_rdata[15]}}, mem_rdata[15:0]};
             1'b1: out.rd_data <= {{16{mem_rdata[31]}}, mem_rdata[31:16]};
           endcase
         end
 
-        in.is_lhu: begin
-          case (addr16)
+        pending_is_lhu: begin
+          case (pending_addr16)
             1'b0: out.rd_data <= {16'b0, mem_rdata[15:0]};
             1'b1: out.rd_data <= {16'b0, mem_rdata[31:16]};
           endcase
         end
 
-        in.is_lw: out.rd_data <= mem_rdata;
+        pending_is_lw: out.rd_data <= mem_rdata;
       endcase
-    end // else: !if(reset)
+      pending_valid <= 1'b0;
+    end else if (!in.valid) begin
+      out <= 0;
+    end else if (is_load) begin
+      // Request just issued combinationally above; the response isn't back
+      // until next cycle (see `stalled`). Emit a bubble now and remember
+      // what's needed to decode mem_rdata once it arrives.
+      out <= 0;
+      pending_valid <= 1'b1;
+      pending_rd <= in.rd;
+      pending_is_lb <= in.is_lb;
+      pending_is_lbu <= in.is_lbu;
+      pending_is_lh <= in.is_lh;
+      pending_is_lhu <= in.is_lhu;
+      pending_is_lw <= in.is_lw;
+      pending_addr16 <= addr16;
+      pending_addr24 <= addr24;
+    end else begin
+      // Not a load: stores and every other op settle in the one cycle every
+      // other pipeline stage takes.
+      out.valid <= 1'b1;
+      out.rd_data <= in.rd_data;
+      out.rd <= in.rd;
+    end
   end
 
  `ifdef FORMAL

--- a/rtl/decoder.v
+++ b/rtl/decoder.v
@@ -8,6 +8,30 @@ module decoder (
   input  fetcher_output in,
   input  logic [31:0] reg_rs1,
   input  logic [31:0] reg_rs2,
+  // ADR-0004 hazard scoreboard: the other two producer stages (write-through
+  // in the regfile already covers writeback, CLAUDE.md invariant 6).
+  input  executor_output executor_out,
+  // ADR-0009: the executor's multi-cycle-divide busy signal. The divider
+  // latches everything it needs internally at issue (rtl/executor.v), so
+  // decode is free to bubble its own output for the whole divide — and must:
+  // holding it unchanged instead would have the executor misread the same
+  // stale instruction as freshly issued the moment it returns to `init`
+  // (worked through in detail on rtl/executor.v).
+  input  logic divider_stall,
+  // ADR-0009: the accessor's one-cycle load-response stall. Unlike the
+  // divider, nothing downstream has captured *this* cycle's decoder_out yet
+  // when this fires — the executor freezes for that one cycle too (see
+  // rtl/executor.v), so bubbling here would silently drop the very
+  // instruction sitting in decoder_out. Decode must hold it unchanged
+  // instead, for exactly the one cycle this is asserted.
+  input  logic accessor_stall,
+  // ADR-0004 hazard scoreboard, third producer: a load in the accessor's
+  // one-cycle turnaround (see accessor_stall and rtl/accessor.v) is a live
+  // producer for that one extra cycle neither decoder_out nor executor_out
+  // can see it in. Narrow, not a general widening of the scoreboard to a
+  // third pipeline stage.
+  input  logic       accessor_pending_valid,
+  input  logic [4:0] accessor_pending_rd,
   // outputs
   output logic [31:0] pc,
   // rs1 and rs2 are synchronous outputs
@@ -284,14 +308,75 @@ module decoder (
 
   logic [31:0] pc_inc;
   assign pc_inc = uncompressed ? 4 : 2;
+
+  // ADR-0004 stall-only hazard scoreboard. Stall only when THIS instruction
+  // actually consumes rs1/rs2 as a register operand — not, say, a shift's
+  // shamt or a U-type/J-type immediate's overlapping bit position — and that
+  // register has a live (non-x0) producer still in flight at decoder_out (the
+  // module's own `out`, i.e. the instruction decode issued last cycle),
+  // executor_out, or (JEF-607) a load still in the accessor's one-cycle
+  // memory turnaround. Write-through in the regfile covers the writeback
+  // stage itself; the accessor check exists only because a load specifically
+  // needs one more cycle there than every other instruction (see
+  // accessor_stall/rtl/accessor.v) — not a general widening to a third stage.
+  logic uses_rs1, uses_rs2;
+  assign uses_rs1 = !(instr_lui || instr_jal || instr_auipc);
+  assign uses_rs2 = (instr_math && !instr_math_immediate) || instr_sb || instr_sh || instr_sw ||
+    instr_beq || instr_bne || instr_blt || instr_bltu || instr_bge || instr_bgeu;
+
+  // Shared by hazard_rs1/hazard_rs2 below: is register `r` the destination
+  // of a live (not-yet-retired) producer at any of the three checked points?
+  function automatic logic live_producer(input logic [4:0] r);
+    live_producer = (out.valid && out.rd == r) || (executor_out.valid && executor_out.rd == r) ||
+      (accessor_pending_valid && accessor_pending_rd == r);
+  endfunction
+
+  logic hazard_rs1, hazard_rs2, hazard, stall;
+  assign hazard_rs1 = uses_rs1 && rs1 != 0 && live_producer(rs1);
+  assign hazard_rs2 = uses_rs2 && rs2 != 0 && live_producer(rs2);
+  assign hazard = hazard_rs1 || hazard_rs2;
+  // ADR-0009: a single global stall, combining the local RAW hazard with
+  // whatever's busy downstream (the divider, or the accessor's one-cycle
+  // load turnaround). Any reason freezes the PC; see below for why the two
+  // downstream reasons freeze decoder_out differently.
+  assign stall = hazard || divider_stall || accessor_stall;
+
   // publish the decoded results
   always_ff @(posedge clk) begin
     if (reset) begin
-      // zero out the pc
+      // zero out the pc and bubble the output
       pc <= 0;
+      out <= '0;
+    end else if (divider_stall || accessor_stall) begin
+      // ADR-0009: PC holds like any other freeze, but decoder_out must hold
+      // too, unchanged — not bubble. Decode gets exactly one free cycle to
+      // issue the instruction *after* the one that made the executor or
+      // accessor busy before either of these stalls exists (they both fire
+      // one cycle behind their cause); that next instruction is sitting in
+      // decoder_out, genuinely not yet consumed by anything downstream, and
+      // bubbling it here would silently drop it. It's safe to hold rather
+      // than bubble specifically because nothing downstream can reprocess it
+      // while held: the executor's own `case (state)` is mutually exclusive
+      // (it only ever reads `in` from its `init` branch, never while
+      // `state == divide`) and, for the accessor case, the executor is
+      // itself frozen the same cycle (see rtl/executor.v's accessor_stall).
+      // Takes priority over a same-cycle hazard for the same reason — that
+      // hazard is about the *next* instruction, which isn't decode's problem
+      // yet since decoder_out hasn't advanced.
+      pc <= pc;
+    end else if (hazard) begin
+      // ADR-0009: upstream of the stalling stage freezes — the PC (and so
+      // the fetch window) holds, so the stalled instruction re-presents next
+      // cycle. Bubbles rather than holds: unlike divider_stall/accessor_stall
+      // above, nothing stops the executor from reading `in` every cycle here,
+      // so holding decoder_out unchanged would have it reprocess the same
+      // instruction repeatedly instead of retrying the *hazarded* one.
+      pc <= pc;
+      out <= '0;
     end else begin
       // branches handled below
       pc <= fetcher_pc + pc_inc;
+      out.valid <= 1'b1;
       out.mem_addr <= $signed(immediate) + $signed(reg_rs1);
       // forwards
       out.rs1 <= instr_lui ? immediate : reg_rs1;
@@ -336,9 +421,15 @@ module decoder (
       case(1'b1)
         default: ;
         instr_auipc: begin
+          // AUIPC has no rs1/rs2 fields at all (U-type: imm[31:12] | rd |
+          // opcode) — the bit positions decode.v's default rs1/rs2 selection
+          // reads are part of the immediate here, not a register index. The
+          // result is pc + immediate, computed the same way jal/jalr compute
+          // their return address: through is_add with the operands supplied
+          // directly rather than through reg_rs1/reg_rs2.
           out.rd <= rd;
-          out.rs1 <= reg_rs1;
-          out.rs2 <= reg_rs2;
+          out.rs1 <= fetcher_pc;
+          out.rs2 <= immediate;
           out.is_add <= 1;
         end
 
@@ -390,14 +481,63 @@ module decoder (
   // assume we've reset at clk 0
   initial assume(reset);
   always_comb if(!clocked) assume(reset);
+  // Reset is a once-at-the-start pulse everywhere in this design (matches
+  // rtl/executor.v's identical assumption); without this, the solver can
+  // reassert it on an arbitrary later cycle and the pc-increment assertions
+  // below — which reason about "pc advanced by pc_inc since last cycle" —
+  // would have to separately account for every point reset could jump pc
+  // back to 0.
+  always_comb if (clocked) assume(!reset);
 
-  // pc increment logic
+  // This component proof stands alone (no real fetcher instantiated), so
+  // `in` is otherwise a free input. In the real pipeline the decoder owns
+  // pc and the fetcher only echoes it straight back combinationally
+  // (rtl/fetcher.v's `out.pc = pc;`, wired pc->pc in littlecpu.v) — without
+  // pinning that down here, the solver can present a `fetcher_pc` that
+  // bears no relation to what this decoder itself last drove, and the
+  // pc-increment assertions below are unprovable against a fetcher that
+  // isn't behaving like this design's actual one.
+  always_comb assume(in.pc == pc);
+
+  // pc increment logic. Skipped for a cycle whose *previous* cycle was
+  // stalled (the PC held instead of advancing by pc_inc that edge — checked
+  // separately below) or reset (pc is forced to 0 on reset, not advanced by
+  // pc_inc from wherever it was). Every "previous cycle" signal here
+  // (branch_jump, past_pc, prev_stall, prev_reset, prev_uncompressed) is
+  // deliberately its own directly-registered copy of a real (reset-gated)
+  // signal rather than routed through $past() on a free input (in.pc/instr
+  // are unconstrained beyond the in.pc == pc assumption above) — $past()
+  // chained across another register adds an extra cycle of history the
+  // solver can fill with a pre-reset garbage value that this component
+  // proof, standing alone, has no way to rule out.
   logic branch_jump;
-  always_ff @(posedge clk) branch_jump <= instr_jal || instr_jalr || instr_beq || instr_bne || instr_blt || instr_bltu || instr_bge || instr_bgeu;
+  always_ff @(posedge clk) if (reset) branch_jump <= 1'b0;
+    else branch_jump <= instr_jal || instr_jalr || instr_beq || instr_bne || instr_blt || instr_bltu || instr_bge || instr_bgeu;
   logic [31:0] past_pc;
-  always_ff @(posedge clk) past_pc <= $past(fetcher_pc);
-  always_ff @(posedge clk) if(clocked && !branch_jump && $past(uncompressed)) assert(past_pc + 4 == pc);
-  always_ff @(posedge clk) if(clocked && !branch_jump && $past(!uncompressed)) assert(past_pc + 2 == pc);
+  logic prev_reset, prev_stall, prev_uncompressed;
+  always_ff @(posedge clk) begin
+    past_pc <= pc;
+    prev_reset <= reset;
+    prev_stall <= stall;
+    prev_uncompressed <= uncompressed;
+  end
+  always_ff @(posedge clk) if(clocked && !branch_jump && !prev_stall && !prev_reset && prev_uncompressed) assert(past_pc + 4 == pc);
+  always_ff @(posedge clk) if(clocked && !branch_jump && !prev_stall && !prev_reset && !prev_uncompressed) assert(past_pc + 2 == pc);
+
+  // JEF-607 / ADR-0009 criterion 4: a stalled cycle never advances pc.
+  always_ff @(posedge clk) if (clocked && prev_stall && !prev_reset) assert(pc == past_pc);
+
+  // JEF-607 criterion 4: valid == 0 implies out.rd == 0 (a bubble is fully
+  // zeroed, never a partial one that could sneak a spurious rd through).
+  // Gated on `clocked`: before the first clock edge applies `reset`, `out`
+  // is a free, uninitialized register as far as the solver is concerned, so
+  // the property only holds once the design has actually been reset.
+  always_comb if (clocked && !out.valid) assert(out.rd == 0);
+
+  // JEF-607 criterion 4: rs1 == 0 / rs2 == 0 never cause a stall — x0 has no
+  // producer to wait on (write-through already special-cases it to 0).
+  always_comb if (rs1 == 0) assert(!hazard_rs1);
+  always_comb if (rs2 == 0) assert(!hazard_rs2);
 
   logic one_of;
   // Use $onehot() so pairwise overlaps (even count of flags) are detected rather than

--- a/rtl/executor.v
+++ b/rtl/executor.v
@@ -7,8 +7,19 @@ module executor(
 
   // inputs
   input  decoder_output in,
+  // ADR-0009-style stall broadcast from the accessor (JEF-607): high for the
+  // one cycle a load's response is still in flight there. Upstream of the
+  // stalling stage freezes — the executor is upstream of the accessor, so it
+  // must freeze (emit a bubble) rather than advance, or a fresh instruction
+  // would collide with the completing load over the accessor's single output
+  // register and the single-port memory bus.
+  input  logic accessor_stall,
   // outputs
-  output executor_output out
+  output executor_output out,
+  // ADR-0009: broadcast to littlecpu.v (and from there back to the decoder)
+  // whenever a multi-cycle divide is in flight, so decode freezes upstream
+  // and bubbles downstream until it drains.
+  output logic stalled
 );
   logic [31:0] rs1, rs2;
   assign rs1 = in.rs1;
@@ -27,9 +38,16 @@ module executor(
   logic [6:0]  mul_div_counter;
   logic [63:0] mul_div_x, mul_div_y;
   logic [63:0] mul_div_store;
-  logic stalled;
   always_comb
     stalled = state != init;
+
+  // ADR-0009: once decode is stalled for a divide, it bubbles (rather than
+  // literally holding `in` unchanged) so the executor doesn't misread a
+  // stale in-flight instruction the moment it returns to `init` — see
+  // rtl/decoder.v. That means `in` cannot be relied on at completion time,
+  // so the op-select and operand signs the last iteration needs are latched
+  // here at issue, once, instead of read live off `in` 32 iterations later.
+  logic op_is_div, op_is_divu, op_is_rem, op_is_remu, op_sign_x, op_sign_y;
 
   // multiply: continuous assignments, so the product tracks the operands every cycle
   // instead of being latched once at time 0. sign_x covers is_mulh (signed rs1) and
@@ -50,10 +68,27 @@ module executor(
       mul_div_store <= 0;
       mul_div_x <= 0;
       mul_div_y <= 0;
+      op_is_div <= 0;
+      op_is_divu <= 0;
+      op_is_rem <= 0;
+      op_is_remu <= 0;
+      op_sign_x <= 0;
+      op_sign_y <= 0;
+    end else if (accessor_stall) begin
+      // Freeze: emit a bubble and hold every other register (state,
+      // mul_div_*, op_*) unchanged. Never overlaps with a real divide in
+      // progress — decode already freezes everything upstream of the
+      // executor while dividing, so a load can't reach the accessor (and
+      // assert accessor_stall) until the divide has long since drained.
+      out <= 0;
     end else begin
       (* parallel_case, full_case *)
       case (state)
         init: begin
+          // ADR-0009: a bubble (in.valid == 0) propagates straight through as
+          // a bubble here too, except when it's the one real cycle a divide
+          // is issued (out.valid held low below until the divide completes).
+          out.valid <= in.valid;
           out.rd <= in.rd;
           out.rd_data <= 0;
           out.mem_addr <= in.mem_addr;
@@ -71,12 +106,15 @@ module executor(
             in.is_add: out.rd_data <= rs1 + rs2;
             in.is_lui: out.rd_data <= rs1;
             in.is_sub: out.rd_data <= rs1 - rs2;
-            in.is_sll: out.rd_data <= rs1 << rs2;
+            // RV32I shift amount is rs2[4:0] only (RISC-V spec Vol I §2.4.2);
+            // the upper 27 bits are ignored, not folded into the shift as a
+            // wider count.
+            in.is_sll: out.rd_data <= rs1 << rs2[4:0];
             in.is_slt: out.rd_data <= {31'b0, $signed(rs1) < $signed(rs2)};
             in.is_sltu: out.rd_data <= {31'b0, rs1 < rs2};
             in.is_xor: out.rd_data <= rs1 ^ rs2;
-            in.is_srl: out.rd_data <= rs1 >> rs2;
-            in.is_sra: out.rd_data <= $signed(rs1) >>> rs2;
+            in.is_srl: out.rd_data <= rs1 >> rs2[4:0];
+            in.is_sra: out.rd_data <= $signed(rs1) >>> rs2[4:0];
             in.is_or: out.rd_data <= rs1 | rs2;
             in.is_and: out.rd_data <= rs1 & rs2;
             in.is_mul || in.is_mulh || in.is_mulhu || in.is_mulhsu: begin
@@ -98,6 +136,16 @@ module executor(
             end
 
             in.is_div || in.is_divu || in.is_rem || in.is_remu: begin
+              // Latched regardless of which sub-path fires below: harmless
+              // for the div-by-zero/overflow short-circuits (state stays
+              // init, so completion never reads them back), and required for
+              // the real divide (see the comment on their declaration).
+              op_is_div <= in.is_div;
+              op_is_divu <= in.is_divu;
+              op_is_rem <= in.is_rem;
+              op_is_remu <= in.is_remu;
+              op_sign_x <= in.rs1[31];
+              op_sign_y <= in.rs2[31];
              `ifndef RISCV_FORMAL_ALTOPS
               if (rs2 == 0) begin
                 // Division by zero per RISC-V spec Vol I §7.2
@@ -116,6 +164,10 @@ module executor(
                 mul_div_store <= 0;
                 mul_div_x <= {32'b0, div_x};
                 mul_div_y <= {1'b0, div_y, 31'b0};
+                // The result isn't ready this cycle — ADR-0009's replay fix:
+                // downstream drains a bubble, not a repeat of whatever the
+                // executor last held, for the entire multi-cycle divide.
+                out.valid <= 1'b0;
               end
              `else
               mul_div_counter <= 32;
@@ -123,6 +175,7 @@ module executor(
               mul_div_store <= 0;
               mul_div_x <= {32'b0, rs1};
               mul_div_y <= {1'b0, rs2, 31'b0};
+              out.valid <= 1'b0;
              `endif
             end
             in.is_ecall || in.is_ebreak || in.is_csrrw || in.is_csrrs || in.is_csrrc: ;
@@ -142,23 +195,28 @@ module executor(
             mul_div_y <= mul_div_y >> 1;
             mul_div_counter <= mul_div_counter - 1;
           end else begin
+            // Uses the op-select and sign bits latched at issue, not `in`
+            // (which decode has long since bubbled) — see the comment on
+            // their declaration above.
             (* parallel_case, full_case *)
             case (1'b1)
-              in.is_div: out.rd_data <= in.rs1[31] != in.rs2[31] ? -mul_div_store[31:0] : mul_div_store[31:0];
-              in.is_divu: out.rd_data <= mul_div_store[31:0];
-              in.is_rem: out.rd_data <= in.rs1[31] ? -mul_div_x[31:0] : mul_div_x[31:0];
-              in.is_remu: out.rd_data <= mul_div_x[31:0];
+              op_is_div: out.rd_data <= op_sign_x != op_sign_y ? -mul_div_store[31:0] : mul_div_store[31:0];
+              op_is_divu: out.rd_data <= mul_div_store[31:0];
+              op_is_rem: out.rd_data <= op_sign_x ? -mul_div_x[31:0] : mul_div_x[31:0];
+              op_is_remu: out.rd_data <= mul_div_x[31:0];
             endcase
+            out.valid <= 1'b1;
             state <= init;
           end
          `else
           (* parallel_case, full_case *)
           case (1'b1)
-            in.is_div: out.rd_data <= (in.rs1 - in.rs2) ^ 32'h7f8529ec;
-            in.is_divu: out.rd_data <= (in.rs1 - in.rs2) ^ 32'h10e8fd70;
-            in.is_rem: out.rd_data <= (in.rs1 - in.rs2) ^ 32'h8da68fa5;
-            in.is_remu: out.rd_data <= (in.rs1 - in.rs2) ^ 32'h3138d0e1;
+            op_is_div: out.rd_data <= (in.rs1 - in.rs2) ^ 32'h7f8529ec;
+            op_is_divu: out.rd_data <= (in.rs1 - in.rs2) ^ 32'h10e8fd70;
+            op_is_rem: out.rd_data <= (in.rs1 - in.rs2) ^ 32'h8da68fa5;
+            op_is_remu: out.rd_data <= (in.rs1 - in.rs2) ^ 32'h3138d0e1;
           endcase
+          out.valid <= 1'b1;
           state <= init;
          `endif
         end // case: divide
@@ -187,6 +245,19 @@ module executor(
   // once-at-the-start pulse everywhere else in this design, so assume it
   // stays low for the remainder of the trace.
   always_comb if (clocked) assume(!reset);
+
+  // This component proof stands alone (no accessor instantiated), so
+  // accessor_stall is otherwise a free input every cycle — the solver could
+  // hold it asserted forever and defeat every arithmetic assertion below via
+  // the accessor_stall freeze branch (out <= 0 every cycle, never reaching
+  // the case (state) that actually computes anything). In the real pipeline
+  // accessor_stall is a one-cycle pulse strictly caused by a load reaching
+  // the accessor, structurally unrelated to mul/div correctness (JEF-607) —
+  // scoped out here the same way ADR-0010 already restricts this proof's
+  // divide operands, for the same reason: keep the proof about the
+  // arithmetic, not an interaction test/asm/hazard.S and the decoder's own
+  // formal task already cover.
+  always_comb assume(!accessor_stall);
 
   // ---- Executor arithmetic BMC (ADR-0006 component proof #2 / ADR-0010) ----
   // The *primary* guarantee for real mul/div arithmetic is the randomized
@@ -283,6 +354,20 @@ module executor(
       assume(in.is_rem == $past(in.is_rem));
       assume(in.is_remu == $past(in.is_remu));
     end
+
+  // Ties the op_is_*/op_sign_* latches (JEF-607 — see their declaration
+  // above) back to `in` while dividing, mirroring what the environmental
+  // assumption above already establishes about `in` staying constant. Without
+  // this as its own stated (one-step-inductive) invariant, k-induction has no
+  // intermediate fact linking a latch taken once at issue to `in.is_divu`
+  // read many cycles later at the completion assertions below, and induction
+  // (not just the base case) fails to close.
+  always_comb if (state == divide) assert(op_is_div == in.is_div);
+  always_comb if (state == divide) assert(op_is_divu == in.is_divu);
+  always_comb if (state == divide) assert(op_is_rem == in.is_rem);
+  always_comb if (state == divide) assert(op_is_remu == in.is_remu);
+  always_comb if (state == divide) assert(op_sign_x == in.rs1[31]);
+  always_comb if (state == divide) assert(op_sign_y == in.rs2[31]);
 
   // k-induction otherwise has no reason to rule out an (unreachable) starting
   // state with a wild mul_div_counter value — bound it to the range the RTL

--- a/rtl/fetcher.v
+++ b/rtl/fetcher.v
@@ -15,9 +15,13 @@ module fetcher(
   assign imem_addr = pc;
   always_comb begin
     if (reset) begin
+      out.valid = 1'b0;
       out.pc = 32'b0;
       out.instr = 32'b0;
     end else begin
+      // Fetch never presents a wrong-path instruction (CLAUDE.md invariant 1),
+      // so it is valid on every non-reset cycle.
+      out.valid = 1'b1;
       out.instr = imem_data;
       out.pc = pc;
     end

--- a/rtl/littlecpu.v
+++ b/rtl/littlecpu.v
@@ -47,11 +47,23 @@ module littlecpu(
   // Declared here (ahead of the decoder instantiation below) because the trap
   // assignment below references it; iverilog requires declare-before-use.
   decoder_output decoder_out;
+  // Declared here, ahead of the decoder/executor/accessor instantiations,
+  // because decoder's scoreboard reads executor_out and accessor's pending
+  // load, executor's stalled output feeds decoder's divider_stall, and
+  // accessor's stalled output feeds both decoder's accessor_stall and
+  // executor's accessor_stall (ADR-0004/ADR-0009); iverilog requires
+  // declare-before-use.
+  executor_output executor_out;
+  logic divider_stalled, accessor_stalled;
+  logic       accessor_pending_valid;
+  logic [4:0] accessor_pending_rd;
   // trap is asserted when the decoded instruction is unrecognized (illegal-instruction)
   // or when the accessor detects a misaligned memory access.  Gated by !reset so that
-  // the pipeline flush state does not produce spurious traps.
+  // the pipeline flush state does not produce spurious traps, and by decoder_out.valid
+  // so a hazard/divide bubble (which zeroes is_valid_instr along with everything else)
+  // never looks like an illegal instruction (ADR-0009).
   logic mem_misaligned_trap;
-  assign trap = !reset && (!decoder_out.is_valid_instr || mem_misaligned_trap);
+  assign trap = !reset && ((decoder_out.valid && !decoder_out.is_valid_instr) || mem_misaligned_trap);
   logic  [31:0] pc;
   fetcher_output fetcher_out;
   fetcher fetcher(
@@ -88,6 +100,11 @@ module littlecpu(
     .in(fetcher_out),
     .reg_rs1(reg_rs1),
     .reg_rs2(reg_rs2),
+    .executor_out(executor_out),
+    .divider_stall(divider_stalled),
+    .accessor_stall(accessor_stalled),
+    .accessor_pending_valid(accessor_pending_valid),
+    .accessor_pending_rd(accessor_pending_rd),
     // outputs
     .pc(pc),
     .rs1(rs1),
@@ -95,14 +112,15 @@ module littlecpu(
     .out(decoder_out)
   );
 
-  executor_output executor_out;
   executor executor(
     .clk(clk),
     .reset(reset),
     // inputs
     .in(decoder_out),
+    .accessor_stall(accessor_stalled),
     // outputs
-    .out(executor_out)
+    .out(executor_out),
+    .stalled(divider_stalled)
   );
 
   accessor_output accessor_out;
@@ -118,6 +136,9 @@ module littlecpu(
     .mem_rdata(mem_rdata),
     // fault signals
     .mem_misaligned(mem_misaligned_trap),
+    .stalled(accessor_stalled),
+    .pending_valid(accessor_pending_valid),
+    .pending_rd(accessor_pending_rd),
     // forwards
     .out(accessor_out)
   );

--- a/rtl/regfile.v
+++ b/rtl/regfile.v
@@ -12,11 +12,17 @@ module regfile(
 );
   logic [31:0] regs[31:0];
 
+  // Combinational read with write-through bypass (ADR-0004, CLAUDE.md invariant
+  // 6): a same-cycle write to the address currently being read forwards wdata
+  // directly instead of the stale pre-write contents, so the caller sees this
+  // cycle's write, not the previous cycle's answer to a different question. x0
+  // always reads 0, regardless of wen/waddr.
+  always_comb begin
+    reg_rs1 = (rs1 == 5'd0) ? 32'b0 : (wen && waddr == rs1) ? wdata : regs[rs1];
+    reg_rs2 = (rs2 == 5'd0) ? 32'b0 : (wen && waddr == rs2) ? wdata : regs[rs2];
+  end
+
   always_ff @(posedge clk) begin
-    reg_rs1 <= rs1 > 0 ? regs[rs1] : 0;
-    reg_rs2 <= rs2 > 0 ? regs[rs2] : 0;
-    if (wen) begin
-      if(waddr > 0) regs[waddr] <= wdata;
-    end
+    if (wen && waddr != 5'd0) regs[waddr] <= wdata;
   end
 endmodule

--- a/rtl/structs.v
+++ b/rtl/structs.v
@@ -1,12 +1,18 @@
 `default_nettype none
 `ifndef STRUCTS_V
 `define STRUCTS_V
+// ADR-0004 / ADR-0009: every inter-stage struct carries a `valid` bit. A
+// bubble is `valid = 0` with the rest of the struct zeroed (reset does this
+// unconditionally; the stall-only interlock does it whenever a stage
+// withholds a real instruction). Retire is `valid` reaching writeback.
 typedef struct packed {
+  logic        valid;
   logic [31:0] pc;
   logic [31:0] instr;
 } fetcher_output;
 
 typedef struct packed {
+  logic        valid;
   logic [4:0]  rd;
   logic [31:0] rs1;
   logic [31:0] rs2;
@@ -47,6 +53,7 @@ typedef struct packed {
 } decoder_output;
 
 typedef struct packed {
+  logic        valid;
   logic [4:0]  rd;
   logic [31:0] rd_data;
   logic [31:0] mem_addr;
@@ -62,11 +69,13 @@ typedef struct packed {
 } executor_output;
 
 typedef struct packed {
+  logic        valid;
   logic [4:0] rd;
   logic [31:0] rd_data;
 } accessor_output;
 
 typedef struct packed {
+  logic        valid;
   logic        wen;
   logic [31:0] waddr;
   logic [31:0] wdata;

--- a/rtl/writeback.v
+++ b/rtl/writeback.v
@@ -17,7 +17,10 @@ module writeback(
       waddr = 0;
       wdata = 32'b0;
     end else begin
-      wen = (in.rd != 0); // only assert wen when writing to a non-zero register
+      // Retire is `valid` reaching writeback (CLAUDE.md invariant 3): a
+      // bubble must never commit a register write, so wen is gated on both
+      // valid and a non-zero destination.
+      wen = in.valid && (in.rd != 0);
       waddr = in.rd;
       wdata = in.rd_data;
     end

--- a/test/EXPECTED_FAIL
+++ b/test/EXPECTED_FAIL
@@ -1,66 +1,14 @@
-# The sprint-1 M1 baseline (JEF-606). `make test` exits 0 only when the set
-# of tests that do NOT pass matches this file exactly, so this is a working
-# regression gate today, against the current core — turn a line green by
-# deleting it once the fix that makes it pass lands.
+# The M1 regression baseline (ADR-0014). `make test` exits 0 only when the
+# set of tests that do NOT pass matches this file exactly, so this is a
+# working regression gate against the current core. Lines come out one at a
+# time, in the same commit as the fix that makes that test pass — the
+# deletion is the evidence the fix worked. This file is never regenerated
+# wholesale from a run (that would launder a regression into the baseline);
+# edit it by hand, and justify any line added back in the PR that adds it.
 #
-# All 46 tests are listed here right now. That is not a harness bug: every
-# one of them (including simple.S) times out because of a single root
-# cause, found while landing this file — see the JEF-606 PR description for
-# the full trace. In short, rtl/regfile.v's read port is registered
-# (1-cycle latency) but rtl/decoder.v consumes `reg_rs1`/`reg_rs2` the same
-# cycle it *asserts* a new `rs1`/`rs2` request, one cycle before that
-# request's answer comes back — so every instruction's operand is actually
-# the regfile's answer to the *previous* instruction's rs1/rs2, not its own.
-# x0 reads are unaffected (regfile hardwires those to 0 regardless of
-# timing), which is why address-only sequences behave, but no
-# non-x0-sourced register value — including TESTNUM at the final tohost
-# write — currently forwards correctly. That is an rtl/ defect and out of
-# this ticket's scope (JEF-606 touches no file under rtl/); it needs its own
-# fix, after which this file should shrink fast rather than being deleted
-# in one shot.
-add.S
-addi.S
-and.S
-andi.S
-auipc.S
-beq.S
-bge.S
-bgeu.S
-blt.S
-bltu.S
-bne.S
-div.S
-divu.S
-jal.S
-jalr.S
-lb.S
-lbu.S
-lh.S
-lhu.S
-lui.S
-lw.S
-mul.S
-mulh.S
-mulhsu.S
-mulhu.S
-or.S
-ori.S
-rem.S
-remu.S
-sb.S
-sh.S
-simple.S
-sll.S
-slli.S
-slt.S
-slti.S
-sltiu.S
-sltu.S
-sra.S
-srai.S
-srl.S
-srli.S
-sub.S
-sw.S
-xor.S
-xori.S
+# JEF-607 (ADR-0004/ADR-0009: combinational-read regfile + write-through
+# bypass, valid bits, the stall-only hazard interlock, and the divider's
+# stall wired up for real) took this to empty: all 47 tests in the suite
+# (including test/asm/hazard.S, added by that same ticket) genuinely pass.
+# It stays here, empty, so the set-equality check below keeps working as the
+# plain all-pass gate ADR-0014 describes for this state.

--- a/test/asm/hazard.S
+++ b/test/asm/hazard.S
@@ -1,0 +1,81 @@
+# JEF-607: direct regression coverage for ADR-0004's stall-only hazard
+# scoreboard. Every case below has zero cycles of separation between the
+# producer and the consumer, so a core with no interlock (or an incomplete
+# one) reads stale operands and gets the wrong answer.
+#
+# x3 (gp) is TESTNUM and x29 is TEST_CASE's own scratch register (see
+# riscv_test.h/test_macros.h) — every case below avoids both, using x6 as
+# its result register instead.
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  # Back-to-back RAW on rs1: the producer's rd is immediately consumed as
+  # the very next instruction's rs1.
+  TEST_CASE( 2, x6, 30, \
+    li   x1, 10; \
+    addi x1, x1, 20; \
+    addi x6, x1, 0; \
+  )
+
+  # Back-to-back RAW on rs2.
+  TEST_CASE( 3, x6, 30, \
+    li   x2, 10; \
+    addi x2, x2, 20; \
+    add  x6, x0, x2; \
+  )
+
+  # Back-to-back RAW on both rs1 and rs2 of the same producer, same register.
+  TEST_CASE( 4, x6, 80, \
+    li   x1, 20; \
+    add  x1, x1, x1; \
+    add  x6, x1, x1; \
+  )
+
+  # Load-use: the loaded value is consumed by the very next instruction.
+  TEST_CASE( 5, x6, 0x12345678, \
+    la   x1, ldat; \
+    lw   x2, 0(x1); \
+    addi x6, x2, 0; \
+  )
+
+  # Divide immediately followed by a dependent instruction: rs1 of the
+  # consumer is the divide's rd, with zero cycles of separation. Regression
+  # for the accessor replay defect (rtl/executor.v's `stalled` used to be
+  # wired to nothing) combined with the scoreboard needing to reach past a
+  # multi-cycle divide, not just a single-cycle producer.
+  TEST_CASE( 6, x6, 8, \
+    li   x1, 40; \
+    li   x2, 5; \
+    div  x1, x1, x2; \
+    addi x6, x1, 0; \
+  )
+
+  # Divide immediately followed by an independent load: must not stall
+  # beyond the divide's own latency — the two are unrelated, so the load
+  # should issue as soon as the divider drains, with no extra scoreboard
+  # bubble on top.
+  TEST_CASE( 7, x6, 0x0ff00ff0, \
+    li   x1, 40; \
+    li   x2, 5; \
+    div  x1, x1, x2; \
+    la   x4, ldat2; \
+    lw   x6, 0(x4); \
+  )
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+ldat:  .word 0x12345678
+ldat2: .word 0x0ff00ff0
+
+RVTEST_DATA_END

--- a/test/decoder_tb.v
+++ b/test/decoder_tb.v
@@ -15,6 +15,14 @@ module decoder_tb;
   logic [31:0] pc;
   logic [4:0] rs1, rs2;
   decoder_output out;
+  // No in-flight producer at the executor stage and no divide in progress:
+  // this bench exercises decode vectors in isolation, not the hazard
+  // scoreboard (see test/regfile_tb.v and test/asm/hazard.S for that).
+  executor_output executor_out = '0;
+  logic divider_stall = 1'b0;
+  logic accessor_stall = 1'b0;
+  logic accessor_pending_valid = 1'b0;
+  logic [4:0] accessor_pending_rd = 5'b0;
 
   decoder dut (
     .clk(clk),
@@ -22,6 +30,11 @@ module decoder_tb;
     .in(in),
     .reg_rs1(reg_rs1),
     .reg_rs2(reg_rs2),
+    .executor_out(executor_out),
+    .divider_stall(divider_stall),
+    .accessor_stall(accessor_stall),
+    .accessor_pending_valid(accessor_pending_valid),
+    .accessor_pending_rd(accessor_pending_rd),
     .pc(pc),
     .rs1(rs1),
     .rs2(rs2),

--- a/test/exec_tb.v
+++ b/test/exec_tb.v
@@ -19,10 +19,13 @@ module exec_tb;
   decoder_output in;
   executor_output out;
 
+  // No accessor in this standalone bench, so no reason for it to ever
+  // freeze — tie the input low.
   executor dut (
     .clk(clk),
     .reset(reset),
     .in(in),
+    .accessor_stall(1'b0),
     .out(out)
   );
 

--- a/test/regfile_tb.v
+++ b/test/regfile_tb.v
@@ -1,0 +1,128 @@
+`timescale 1 ns / 1 ps
+`default_nettype none
+
+// JEF-607 criterion 1: rtl/regfile.v is combinational-read with write-through
+// bypass. A write in cycle N must be visible on reg_rs1/reg_rs2 in cycle N
+// for the same address (not one cycle later, which was the original defect —
+// see CLAUDE.md and ADR-0004), and rs == 0 must always read 0, even while
+// waddr == 0 and wen == 1.
+module regfile_tb;
+  logic clk = 0;
+  always #5 clk = ~clk;
+
+  logic [4:0]  rs1, rs2;
+  logic [31:0] reg_rs1, reg_rs2;
+  logic        wen;
+  logic [4:0]  waddr;
+  logic [31:0] wdata;
+
+  regfile dut (
+    .clk(clk),
+    .rs1(rs1),
+    .rs2(rs2),
+    .reg_rs1(reg_rs1),
+    .reg_rs2(reg_rs2),
+    .wen(wen),
+    .waddr(waddr),
+    .wdata(wdata)
+  );
+
+  int errors = 0;
+
+  task automatic check_hex(input string what, input logic [31:0] got, input logic [31:0] expected);
+    begin
+      if (got !== expected) begin
+        $display("MISMATCH %s: got=%08x expected=%08x", what, got, expected);
+        errors++;
+      end
+    end
+  endtask
+
+  task automatic check_ne(input string what, input logic [31:0] got, input logic [31:0] unwanted);
+    begin
+      if (got === unwanted) begin
+        $display("MISMATCH %s: got=%08x, which must not have landed", what, got);
+        errors++;
+      end
+    end
+  endtask
+
+  initial begin
+    rs1 = 0;
+    rs2 = 0;
+    wen = 0;
+    waddr = 0;
+    wdata = 0;
+    @(posedge clk);
+    #1;
+
+    // Write-through: a write to x5 in this same cycle is visible on reg_rs1
+    // this same cycle, not the next one — the original defect was a
+    // registered read port, one cycle stale.
+    rs1 = 5'd5;
+    waddr = 5'd5;
+    wdata = 32'hcafef00d;
+    wen = 1'b1;
+    #1;
+    check_hex("write-through same-cycle read (rs1)", reg_rs1, 32'hcafef00d);
+
+    // Same check on the rs2 port, since the operand skew observed while
+    // landing JEF-606 was NOT uniform across ports — rs1 and rs2 recovered
+    // at different depths, so both ports need their own direct check.
+    rs2 = 5'd5;
+    #1;
+    check_hex("write-through same-cycle read (rs2)", reg_rs2, 32'hcafef00d);
+
+    // Let the write actually land, then confirm the value is still readable
+    // (via the array, not the bypass) once wen drops.
+    @(posedge clk);
+    #1;
+    wen = 1'b0;
+    #1;
+    check_hex("registered write persists after wen drops (rs1)", reg_rs1, 32'hcafef00d);
+    check_hex("registered write persists after wen drops (rs2)", reg_rs2, 32'hcafef00d);
+
+    // x0 always reads 0, even with waddr == 0 and wen == 1 pointed straight
+    // at it (the write itself must also be a no-op, checked next).
+    rs1 = 5'd0;
+    rs2 = 5'd0;
+    waddr = 5'd0;
+    wdata = 32'hdeadbeef;
+    wen = 1'b1;
+    #1;
+    check_hex("x0 reads 0 while waddr == 0, wen == 1 (rs1)", reg_rs1, 32'h00000000);
+    check_hex("x0 reads 0 while waddr == 0, wen == 1 (rs2)", reg_rs2, 32'h00000000);
+
+    @(posedge clk);
+    #1;
+    wen = 1'b0;
+    // White-box: confirm the attempted write never reached the backing
+    // array, not just that x0 still reads 0 (which the read mux guarantees
+    // unconditionally regardless of what's stored at index 0).
+    check_ne("x0 write never reaches the backing array", dut.regs[0], 32'hdeadbeef);
+
+    // A different register, unrelated to the write in progress, must not be
+    // disturbed by the bypass (bypass only fires when waddr matches the read
+    // address being asked for). Give x6 a known value first, then confirm a
+    // concurrent bypass-write to x5 doesn't leak into reading x6.
+    waddr = 5'd6;
+    wdata = 32'h22222222;
+    wen = 1'b1;
+    @(posedge clk);
+    #1;
+    waddr = 5'd5;
+    wdata = 32'h11111111;
+    wen = 1'b1;
+    rs1 = 5'd6;
+    #1;
+    check_hex("bypass does not leak into an unrelated read address", reg_rs1, 32'h22222222);
+
+    if (errors != 0) begin
+      $display("FAILED: %0d mismatches", errors);
+      $fatal(1);
+    end else begin
+      $display("PASSED: regfile combinational read / write-through bypass / x0 semantics");
+      $finish;
+    end
+  end
+endmodule

--- a/test/testbench.v
+++ b/test/testbench.v
@@ -162,4 +162,36 @@ module testbench(
       $display("trap!");
     end
   end
+
+  // JEF-607 / ADR-0009 criterion 5: for every store, mem_wstrb is high for
+  // exactly one cycle. Direct regression for the divide-replay defect, where
+  // the accessor kept re-issuing the same store every cycle the executor sat
+  // busy in `divide` because nothing upstream defaulted back to zero in
+  // between. Two DIFFERENT consecutive real stores legitimately produce two
+  // adjacent high cycles, so this checks for the same request repeating
+  // (identical address, data, and strobe on back-to-back high cycles), not
+  // merely back-to-back nonzero cycles.
+  //
+  // $fatal is Icarus-only below: yosys's read_verilog (the write_cxxrtl leg
+  // this file also feeds, per the Makefile) doesn't implement it at all, so
+  // this stays inside `ifdef ICARUS` the same way the clock/reset generation
+  // above does. The $display fires unconditionally, so the violation is
+  // still visible under cxxrtl if it were ever encountered there.
+  logic [31:0] prev_wstrb_mem_addr, prev_wstrb_mem_wdata;
+  logic [3:0]  prev_mem_wstrb;
+  initial prev_mem_wstrb = 4'b0000;
+  always @(posedge clk) begin
+    if (mem_wstrb != 4'b0000 && prev_mem_wstrb != 4'b0000 &&
+        mem_addr == prev_wstrb_mem_addr && mem_wdata == prev_wstrb_mem_wdata &&
+        mem_wstrb == prev_mem_wstrb) begin
+      $display("ASSERTION FAILED: mem_wstrb held high for >1 cycle on the same store (addr=0x%08x)",
+                mem_addr);
+     `ifdef ICARUS
+      $fatal(1);
+     `endif
+    end
+    prev_wstrb_mem_addr <= mem_addr;
+    prev_wstrb_mem_wdata <= mem_wdata;
+    prev_mem_wstrb <= mem_wstrb;
+  end
 endmodule


### PR DESCRIPTION
Closes JEF-607.

## Summary

Implements ADR-0004 and ADR-0009 as one atomic change, per the ticket — this is the change that erases the "core computes wrong results" regression from CLAUDE.md:

- **`rtl/regfile.v`**: combinational-read with write-through bypass (`wen && waddr == rs` forwards `wdata`; `x0` reads 0 unconditionally).
- **`rtl/structs.v`**: every inter-stage struct (`fetcher_output`, `decoder_output`, `executor_output`, `accessor_output`, `writeback_output`) gains a `valid` bit.
- **`rtl/decoder.v`**: a stall-only hazard scoreboard. `uses_rs1`/`uses_rs2` are computed per-instruction (excludes e.g. a shift's shamt or a U-type immediate's overlapping bit position from being mistaken for a register read) so a hazard only fires when the instruction actually consumes the register. Checks three producers: `decoder_out` (its own `out`), `executor_out`, and — new, and explained below — the accessor's pending-load register. `divider_stall` bubbles decode's output; `accessor_stall` **holds** it instead (see design note below).
- **`rtl/executor.v`**: wires the divider's `stalled` signal for real (previously computed and left unconnected). Latches the divide's op-select and operand-sign bits at issue, since decode now bubbles during the divide rather than holding the instruction. Freezes for the accessor's one-cycle stall.
- **`rtl/accessor.v`**: gates every request on `valid` and defaults every request field to zero every cycle (the direct fix for the divide-replay defect: previously nothing defaulted back to zero, so the accessor kept re-issuing the last real load/store's request every cycle the executor sat busy dividing). Adds a one-cycle request/capture split for loads — explained below.
- **`rtl/writeback.v`**: `wen` gated on `valid`, not just `rd != 0` (a bubble could otherwise commit a register write — CLAUDE.md invariant 3).
- **`rtl/littlecpu.v`**: wires the scoreboard/stall signals through; `trap` no longer fires on a bubble's zeroed `is_valid_instr` (a hazard/divide bubble would otherwise look like an illegal instruction).

### Two design points beyond the ticket's literal text

**1. The accessor needs a genuine one-cycle request/capture split for loads, not just gating.** Both memory models this core runs against (`test/testbench.v`, `rtl/memory.v`) register `mem_rdata` one cycle after the address is presented — that's a real, unavoidable round trip, not a choice. The pre-existing accessor captured `mem_rdata` in the *same* edge it presented the address, reading garbage. Fixed with a `pending_valid`/`pending_rd` capture register and a `stalled` output, broadcast into the same global-stall mechanism ADR-0009 already established for the divider. This is a second stall source ADR-0009 didn't anticipate; I judged extending the existing broadcast (not a new mechanism, no flush, no per-stage handshake) the correct, minimal fix, and it's what makes `lb`/`lbu`/`lh`/`lhu`/`lw`/`sw` (and the load-use case in `hazard.S`) actually work.

**2. `divider_stall` bubbles decoder_out; `accessor_stall` holds it — deliberately different.** Decode gets exactly one free cycle to issue the instruction *after* whichever one made the executor or accessor busy, before either stall exists (both fire one cycle behind their cause). For the divider, that next instruction has *not* yet been consumed when the stall starts, but the executor's `case (state)` is mutually exclusive (only reads `in` from `init`), so bubbling here is safe — and holding instead would have the executor misread the same stale instruction as freshly issued the moment it returns to `init` (worked through in a comment in `rtl/decoder.v`). For the accessor, the executor is *also* frozen the same cycle (`rtl/executor.v`'s `accessor_stall`), so bubbling would silently drop a live, not-yet-consumed instruction; holding is what's safe there. Both are documented at the point of decision in `rtl/decoder.v`.

The scoreboard's third check (accessor's pending-load register, not just `decoder_out`/`executor_out`) exists only to cover that same one extra cycle a load specifically needs before write-through picks it up — not a general widening of the 2-stage design ADR-0004 describes.

### Three pre-existing bugs this uncovered

Once the M1 suite could run past the regfile timing defect (this ticket's headline fix), three more bugs blocked every single test from passing and had to be fixed to hit criterion 2/3:

- **AUIPC** computed `reg_rs1 + reg_rs2` instead of `pc + immediate`. U-type has no `rs1`/`rs2` fields at all — those bit positions are part of the immediate — so this was silently reading garbage "registers" derived from immediate bits. Every test's pass/fail write goes through `la t0, tohost` (auipc+addi), so this alone timed out all 46 tests.
- **`mem_wdata`** was registered one cycle behind the already-combinational `mem_addr`/`mem_wstrb`, so a store's *data* landed at the memory model one cycle after its *address* — the exact "address recovers before data" skew flagged in the JEF-607 dispatch notes as the wave-2 finding.
- **SLL/SRL/SRA** used the full 32-bit `rs2` as the shift amount instead of `rs2[4:0]` per RV32I spec §2.4.2.

## Acceptance criteria

1. `test/regfile_tb.v` — write-through same-cycle read on both ports, x0-always-reads-0 (including a white-box check that a `waddr==0` write never reaches the backing array), and bypass-doesn't-leak-to-an-unrelated-address. **Not wired into `make test-units`/the Makefile** — the dispatch notes for this ticket say not to touch the Makefile (a parallel JEF-608 ticket owns `.github/`, and the Makefile was called out too); ran directly via `iverilog`+`vvp`, passes. Flagging as a follow-up for whoever owns the Makefile next.
2. `make test`: 47/47 (46 `.S` files + the new `hazard.S`). `test/EXPECTED_FAIL` is genuinely empty — every test passes for real, not shortened by regenerating from a run (ADR-0014 forbids that).
3. The 8 `rv32um` tests (mul/mulh/mulhsu/mulhu/div/divu/rem/remu) are part of that 47 and pass.
4. `sby -f formal/components.sby decoder` — PASS by k-induction, with the three new inline assertions (stalled cycle never advances pc; `valid == 0` implies `out.rd == 0`; `rs1 == 0`/`rs2 == 0` never cause a stall). Also fixed the pre-existing failure noted in the dispatch: `past_pc`/`branch_jump` were routed through `$past()` on a free input, which could pick up an extra cycle of pre-reset garbage the proof couldn't rule out — replaced with directly-registered, reset-gated copies. `executor` and `accessor` (both touched by this ticket) also verified passing by k-induction; `executor`'s proof needed one new environmental assumption (`accessor_stall` is free in that standalone harness and could otherwise defeat the mul/div arithmetic assertions via the freeze branch — scoped out the same way ADR-0010 already restricts that proof's divide operands) plus explicit invariants tying the new `op_is_*`/`op_sign_*` latches back to `in` while dividing, which induction needed to close.
5. `test/testbench.v` asserts `mem_wstrb` never repeats an identical request (address+data+strobe) on back-to-back high cycles — the direct regression for the divide-replay defect. `$fatal` is Icarus-only (yosys's `read_verilog`, the write_cxxrtl leg this file also feeds, doesn't implement `$fatal` at all); the `$display` fires unconditionally either way.
6. `test/asm/hazard.S`: back-to-back RAW on rs1/rs2/both, load-use, divide→dependent instruction, divide→independent load. All pass.
7. `iverilog` and `yosys` both elaborate with zero warnings (`make sim`, `make testbench.vvp`).
8. Full `make test` green.

## Testing

```
make test        → 47/47 passed, failure list matches (empty) test/EXPECTED_FAIL exactly
make test-units   → exec_tb (10,000 vectors/op), mem_tb, decoder_tb all PASSED
iverilog+vvp test/regfile_tb.v → PASSED
sby -f formal/components.sby decoder/executor/accessor/fetcher/writeback → all PASS (k-induction)
make sim, make testbench.vvp → zero warnings
```

## Scope notes / risks

- **DECISION NEEDED (ratified, documented above and in-code, flagging for the record):** the accessor's one-cycle load stall is a second stall source ADR-0009 didn't originally describe. I extended the existing global-stall broadcast rather than invent new machinery; recorded in comments at the point of decision in `rtl/accessor.v`/`rtl/executor.v`/`rtl/decoder.v`. Worth an ADR addendum if the architect wants one on record.
- `rtl/structs.v` was this ticket's sole property per the dispatch notes — respected.
- Did not touch `.github/` or the `Makefile`, per the dispatch notes (JEF-608 owns `.github/`; Makefile explicitly off-limits this ticket).
- Did not touch ADR-0011's misalignment-detection location (stays in `rtl/accessor.v`, just gated on `valid` now) or the `-march` string (`rv32im_zicsr`, unchanged).
- `test/regfile_tb.v` exists and passes but isn't wired into any Makefile target — see criterion 1 note above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)