### PR TITLE
ADR-0015 and ADR-0017: decisions from integrating the second build sprint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ rtl/rom.mem
 sim
 sim.dSYM/
 test/a.out.dSYM/
+# Swarm agent worktrees (.claude/tracker.json stays tracked).
+.claude/worktrees/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,41 +8,51 @@ deliberately sacrificed for a design that reads well. Do not "improve" it by add
 
 ## Current state — read this before believing anything else
 
-**This is a half-finished rewrite, not a working core.** A serialized FSM core
-(`rtl/riscv.v` + `rtl/alu.v`) once passed riscv-formal sans CSRs; it was torn down in two waves
-(2021: `9758a39`→`1709433`; 2023: `49b317a`→`4fbd650`→`13fec44`) into today's staged design, and
-the rewrite stalled partway. The project went from *formally verified* to *unverified*, and getting
-back is the whole plan.
+**This is a half-finished rewrite. As of `a4662a2` it is a rewrite that computes correct
+results — but it is still unverified.** A serialized FSM core (`rtl/riscv.v` + `rtl/alu.v`) once
+passed riscv-formal sans CSRs; it was torn down in two waves (2021: `9758a39`→`1709433`; 2023:
+`49b317a`→`4fbd650`→`13fec44`) into today's staged design, and the rewrite stalled partway. The
+project went from *formally verified* to *unverified*, and getting back is the whole plan. **M1 is
+green; M2 has not started.** Do not read "47/47" as "the core is correct."
 
 The README is the project's voice and is deliberately left as-is. **Ground truth lives here.**
 
+**M1 is reached** (JEF-607, `a4662a2`). `rtl/regfile.v` is combinational-read with write-through
+bypass, every inter-stage struct carries a `valid` bit, and decode runs a stall-only hazard
+scoreboard (ADR-0004 / ADR-0009 / ADR-0015). `make test` is **47/47** and `test/EXPECTED_FAIL` is
+empty, so it is now a plain all-pass gate — ADR-0014's set-equality check still runs in both
+directions, so an unexpected *pass* is caught too. The same change fixed three datapath defects
+found on the way: AUIPC computed `reg_rs1 + reg_rs2` instead of `pc + immediate`, `mem_wdata` was
+registered a cycle behind `mem_addr`/`mem_wstrb`, and SLL/SRL/SRA did not mask the shift amount to
+`rs2[4:0]`.
+
 What does not work right now:
 
-- **The core computes wrong results.** `rtl/regfile.v` reads registers synchronously with no
-  compensating structure, so operands are one instruction stale — always. Confirmed still true
-  while landing JEF-606: `rtl/decoder.v` consumes `reg_rs1`/`reg_rs2` the same cycle it asserts a
-  *new* `rs1`/`rs2` request, one cycle before that request's answer is back, so every non-`x0`
-  operand — including the pass/fail write to `tohost` — is actually the regfile's answer to the
-  *previous* instruction's read. This is why all 46 `.S` tests currently time out, `simple.S`
-  included; see `test/EXPECTED_FAIL` and the JEF-606 PR for the trace.
-- **`make test` now exists** (JEF-606): `test/asm/riscv_test.h`, a two-region `sections.lds`
-  (ADR-0008), and a cxxrtl runner (`test/cxxrtl.cc`, ADR-0007) assemble and run every
-  `test/asm/*.S` and check the result against `test/EXPECTED_FAIL`, the sprint-1 baseline. Right
-  now that file lists all 46 tests — burn it down as the regfile bug above and others get fixed,
-  not in one shot.
-- **The iverilog leg now elaborates** (fixed in `eb18320`): the ~60 declaration-after-use bind
-  errors in `rtl/decoder.v` and `rtl/littlecpu.v` are gone. `make test-units` and the full
-  `testbench.vvp` pipeline build cleanly under iverilog (informational `sorry: constant selects
-  in always_* processes` notes aside — not elaboration failures).
+- **RVFI ports are declared and never driven** (`grep -rn "rvfi_" rtl/` finds no drivers), so no
+  riscv-formal check can pass. This is the M2 critical path.
+- **`test/monitor.v` is not in the cxxrtl leg at all.** The `test/rtl.cc` recipe does not read it;
+  only `testbench.vvp` (iverilog) does — and with RVFI undriven it cannot check anything there
+  either. So **`make test` is not per-retire self-checking today**: the 47/47 result rests entirely
+  on the `tohost` protocol and each `.S` test's own assertions. That is real coverage, but it is
+  weaker than a monitor-checked run, and it is the second reason M2 rather than M1 is the finish
+  line.
 - **`test/monitor.v` does not elaborate under yosys** — `$time` inside `$display` at line 90 hits
-  `ERROR: Don't know how to detect sign and width for AST_AUTOWIRE node`. The build needs a
-  sanitized derived copy; the tracked file stays pristine.
-- **RVFI ports are declared and never driven**, so no riscv-formal check can pass.
-- **`formal/checks.cfg` and `formal/wrapper.v` still reference the deleted core.**
-- `make riscv.json` references `rtl/handshake.v` / `rtl/skidbuffer.v`, deleted in `49b317a`.
+  `ERROR: Don't know how to detect sign and width for AST_AUTOWIRE node`. Getting it into the
+  cxxrtl leg needs a sanitized derived copy; the tracked file stays pristine.
+- **`formal/checks.cfg` and `formal/wrapper.v` still reference the deleted core** — `checks.cfg`'s
+  `[script-sources]` reads `rtl/riscv.v` and `rtl/alu.v`, and `wrapper.v` instantiates `riscv`.
+- **Three of the five component-proof tasks are vacuous.** `components_fetcher`,
+  `components_accessor`, and `components_writeback` contain no assertions at all, only reset
+  assumptions, so they "pass" meaninglessly. CI deliberately does not run them; ADR-0006 slates
+  them for deletion. A green run of one of those is not a result.
+- **`make waves` is `waves.vcd: sim`** — a cxxrtl target, not the iverilog+VCD flow the Commands
+  section below describes. Unverified either way.
 
-What does work: `yosys ... write_cxxrtl` elaborates the current RTL cleanly with zero warnings, and
-the cxxrtl binary builds and runs. That is the foundation everything else is built on.
+What does work: `yosys ... write_cxxrtl` elaborates the current RTL cleanly with zero warnings, the
+cxxrtl binary builds and runs, the full `.S` suite passes under it, `make test-units` passes, and
+the decoder and executor component proofs pass by k-induction (see ADR-0017 for what the decoder
+proof does and does not establish). CI (`.github/workflows/ci.yml`) runs elaborate / test /
+components / monitor-freshness on every PR.
 
 ## Invariants — do not break these
 
@@ -60,6 +70,14 @@ These are the design. Violating one is a bug even if tests pass.
 5. **CSR instructions and `mret` serialize** — held in decode until execute/access/writeback drain.
 6. **The regfile is combinational-read with write-through bypass.**
 7. **`test/monitor.v` is generated but tracked.** Regenerate it; never hand-edit it.
+8. **Stalls are a single global broadcast with three sources** — the decode scoreboard, the
+   divider, and the accessor's one-cycle load-response turnaround (ADR-0015). Two non-local rules
+   hold it together, and a later change can break either silently: (a) while `divider_stall` or
+   `accessor_stall` is asserted, decode **holds** `decoder_out` unchanged rather than bubbling it,
+   and nothing downstream may consume it that cycle; a RAW hazard does the opposite (bubble). (b)
+   Every in-flight non-`x0` `rd` is visible to the scoreboard on every cycle between issue and the
+   regfile write-through, with no gap: `decoder_out` → `executor_out` → `accessor_pending` (loads
+   only) → write-through.
 
 ## ISA target
 
@@ -101,8 +119,10 @@ no multilib or newlib is needed. Formal needs a pinned YosysHQ OSS CAD Suite.
 That arithmetic is covered only by the `.S` suite and the executor component proof. Do not assume a
 green formal ladder means the ALU is correct.
 
-`test/monitor.v` rides along in both sim legs, so every run is self-checking per-retire — a test
-that corrupts state transiently but converges to the right final registers still fails loudly.
+`test/monitor.v` is *meant* to ride along in both sim legs so every run is self-checking
+per-retire. **It does not yet** — the cxxrtl recipe never reads it, and RVFI is undriven, so the
+monitor is inert in both legs. Wiring it up is part of M2, and until then a green `make test` means
+"every test's own assertions passed", not "every retire matched the ISA".
 
 ## Engineering rules in force
 
@@ -120,18 +140,19 @@ that corrupts state transiently but converges to the right final registers still
 | | Milestone | Green means |
 |---|---|---|
 | M0 | Foundation | this file, riscv-formal SHA-pinned, dead references gone |
-| M1 | Finish the pipeline | all RV32IM `.S` tests pass under cxxrtl |
+| M1 | Finish the pipeline | all RV32IM `.S` tests pass under cxxrtl — **reached, `a4662a2`** |
 | M2 | **Parity checkpoint** | the pipelined core re-proves everything the serialized core proved |
 | M3 | Past the old core | CSRs + machine-mode traps |
-| M4 | Full ladder + CI | nightly formal green; tag a release |
+| M4 | Full ladder + CI | nightly formal green; tag a release (PR gate landed, `c66527d`) |
 
-M1 is the critical path. **M2 is the milestone that erases the verified→unverified regression** —
-treat it as the real finish line, not M1.
+M1 is reached. **M2 is the milestone that erases the verified→unverified regression** — treat it
+as the real finish line, not M1. Until RVFI is driven and the monitor is live, nothing in this repo
+independently checks that a retire matches the ISA.
 
 ## Pointers
 
 - Design brief: [`docs/ideas/finish-the-rewrite.md`](docs/ideas/finish-the-rewrite.md)
-- Decisions: [`docs/adr/`](docs/adr/) — fourteen accepted ADRs, plus a deferred list
+- Decisions: [`docs/adr/`](docs/adr/) — seventeen accepted ADRs, plus a deferred list
 - Reference text from the old core: `git show 1709433^:rtl/riscv.v` (RVFI retire block),
   `git show e67875c^:rtl/alu.v` (arithmetic)
 - Tracker: Linear, project **Little CPU** (team JEF)

--- a/docs/adr/0015-accessor-load-response-stall.md
+++ b/docs/adr/0015-accessor-load-response-stall.md
@@ -1,0 +1,129 @@
+# ADR-0015: The accessor's load-response turnaround is the third stall source
+
+**Status:** Accepted · 2026-07-28 · *Extends ADR-0009; ratified on integrating JEF-607*
+
+## Context
+
+ADR-0009 fixed the stall protocol: one global broadcast, upstream freezes, downstream drains,
+`valid = 0` injected at the stalling stage. It named exactly two stall sources — the decode
+scoreboard's RAW hazard and the multi-cycle divider — because those were the only two backpressure
+sources anyone had found. It says so explicitly: "there is no backpressure source in this core
+other than the divider and the decode scoreboard."
+
+That is wrong, and JEF-607 found out the hard way while implementing ADR-0004.
+
+**Both memory models — `rtl/memory.v` and the model inside `test/testbench.v` — register
+`mem_rdata` one cycle after the address is presented.** That is not a modelling choice that could
+be relaxed; it is what a synchronous BRAM is, and the up5k's block RAM is exactly that. So a load
+presents its address in the cycle it occupies the accessor and the data is not back until the
+cycle after. Every other instruction — stores included, since a store's data goes *out* with the
+address — settles in the one cycle each pipeline stage takes.
+
+Without something to hold the pipeline for that cycle, the completing load and the next
+instruction collide over the accessor's single output register and the single-port memory bus.
+ADR-0009's text offers no answer, because ADR-0009 did not know the question existed.
+
+## Decision
+
+**Treat the load response as a third source of the same global stall.** No new mechanism: no
+flush, no per-stage ready/valid handshake, no skidbuffer. Concretely:
+
+1. **`accessor.stalled = in.valid && is_load`** — high for exactly the cycle a load's request
+   fires, and provably for **at most one consecutive cycle** (see liveness below). `littlecpu.v`
+   ORs it into the same broadcast that already carries the divider's stall.
+
+2. **The executor freezes.** It is upstream of the accessor, so per ADR-0009 it emits a bubble
+   (`out <= 0`) and holds every other register — `state`, the mul/div datapath, the latched op
+   selects — unchanged.
+
+3. **The accessor latches a pending-load record** at the request cycle (`pending_rd`, the width /
+   sign / sub-word-offset bits) and consumes it one cycle later when `mem_rdata` is actually the
+   answer to that address.
+
+4. **Decode *holds*, it does not bubble.** This is the one genuinely new rule, and it is the
+   asymmetry worth reading twice:
+
+   | Stall reason | `pc` | `decoder_out` |
+   |---|---|---|
+   | RAW hazard (scoreboard) | holds | **bubble** (`out <= 0`) |
+   | `divider_stall` | holds | **hold unchanged** |
+   | `accessor_stall` | holds | **hold unchanged** |
+
+   Both downstream stalls fire *one cycle behind their cause*, so decode has already been given one
+   free cycle to issue the instruction *after* the one that made the executor or accessor busy.
+   That instruction is sitting in `decoder_out`, not yet consumed by anything. Bubbling it there
+   would **silently drop an instruction** — a correctness bug that no test would obviously name.
+   For the hazard case the reverse holds: nothing stops the executor reading `decoder_out` every
+   cycle, so holding it would have the executor execute the same instruction repeatedly.
+
+5. **The decode scoreboard gains a third producer check**, `accessor_pending_valid` /
+   `accessor_pending_rd`, alongside `decoder_out` and `executor_out`. This is not a general
+   widening of the scoreboard to a third pipeline stage; it exists only to cover the one extra
+   cycle a load spends in the accessor.
+
+### The invariants this rests on
+
+State them, because the correctness argument is non-local and a later change can break it silently.
+
+- **I1 — Hold-not-bubble safety.** When `divider_stall` or `accessor_stall` is asserted, nothing
+  downstream may consume `decoder_out` that cycle. This holds for two *different* reasons: the
+  executor's `case (state)` only reads `in` from its `init` arm, never while `state == divide`; and
+  for the accessor case the executor is itself frozen by the same combinational signal in the same
+  cycle. A change that lets the executor read `in` while frozen breaks this.
+- **I2 — No producer-visibility gap.** Every in-flight non-`x0` `rd` is visible to the scoreboard
+  on *every* cycle between issue and the regfile write-through, with no hole. The chain is
+  contiguous: `decoder_out` → `executor_out` → (`accessor_pending` for loads only) → `accessor_out`,
+  which is combinationally the regfile's write port, so write-through covers that last cycle.
+  The divider is the one case where `executor_out.valid` is 0 while the instruction is live; that
+  window is covered because `divider_stall` freezes decode for exactly those cycles, and
+  `executor_out.valid` rises on the first cycle the stall drops.
+- **I3 — At most one consecutive `accessor_stall` cycle.** The cycle after the request, the
+  executor's frozen bubble is what the accessor sees, so `in.valid` is 0 and `stalled` falls. This
+  is what makes the stall a stall and not a livelock.
+- **I4 — `accessor_stall` and `divider_stall` are mutually exclusive.** A load reaching the
+  accessor forces the executor to bubble, so the next instruction cannot enter the divider until
+  the load has drained; and while dividing, decode is frozen, so nothing new reaches the accessor.
+
+### Why this does not violate the no-flush invariant
+
+Nothing is killed. Nothing is squashed. The executor's `out <= 0` on `accessor_stall` is a bubble
+*inserted*, not an instruction *discarded* — the instruction it would have executed is still
+sitting in `decoder_out`, held there by rule 4, and it executes on the next cycle. CLAUDE.md
+invariant 1 stands untouched: there is still no wrong-path instruction anywhere in this core, so
+there is still nothing to flush.
+
+## Rationale
+
+Considered and rejected: **give every instruction two cycles in the accessor.** Uniform, no stall
+source, no third scoreboard entry, and arguably the most readable thing on the table — which
+matters on a project whose stated point is readability. Rejected because it costs a full cycle of
+CPI on every instruction to avoid machinery that *already exists for the divider*, and because the
+stall broadcast is the shape ADR-0009 already committed to. It stays on the table as a
+simplification if the interlock ever proves hard to reason about.
+
+Considered and rejected: **a per-stage ready/valid handshake.** ADR-0009 forbids it by name, and
+the skidbuffer implementation of it was deliberately deleted in `49b317a`. A handshake network for
+two customers is machinery, which is exactly what CLAUDE.md says not to add.
+
+Considered and rejected: **a combinational-read memory model.** It would make the whole problem
+vanish in simulation and reintroduce it on the first day of FPGA bring-up. The up5k has
+synchronous block RAM. Modelling something the target part cannot do would be lying to ourselves
+in the one direction that is expensive to discover late.
+
+## Consequences
+
+- **Loads cost one extra cycle.** Accepted, on a core that already accepts a 2-cycle RAW bubble
+  and a ~32-cycle divide.
+- **A new CLAUDE.md invariant**, since I1 and I2 are precisely the kind of non-local property a
+  later change violates without noticing.
+- **`test/asm/hazard.S`** covers the reachable shapes: back-to-back RAW on rs1, on rs2, on both;
+  load-use; divide→dependent; divide→independent-load. It is the regression test for I2.
+- **The executor's component proof assumes `assume(!accessor_stall)`.** Correct for a standalone
+  proof about arithmetic — the signal is a free input there and the solver would otherwise hold it
+  high forever and defeat every assertion — but it means **no formal proof currently covers the
+  executor's freeze branch**. `hazard.S` is the only thing that does. M2's full-core riscv-formal
+  wrapper is where that gap actually closes, and it should be treated as one of M2's jobs.
+- **ADR-0009's claim that the divider and the scoreboard are the only backpressure sources is
+  superseded** by this ADR. ADR-0009 otherwise stands unchanged: the broadcast, the
+  freeze-upstream/drain-downstream rule, and the ban on handshakes all survive intact — this is a
+  third customer for the same mechanism, not a new mechanism.

--- a/docs/adr/0017-component-proof-assumptions-must-name-their-model.md
+++ b/docs/adr/0017-component-proof-assumptions-must-name-their-model.md
@@ -1,0 +1,94 @@
+# ADR-0017: A component-proof `assume` must name the structural fact it models
+
+**Status:** Accepted · 2026-07-28 · *Supplements ADR-0006; ratified on integrating JEF-607*
+
+## Context
+
+`make -C formal components_decoder` failed on `main` and passes as of `a4662a2`. A proof going
+green is exactly the kind of result that deserves a hostile look, because a proof that passes
+vacuously is worse than one that fails honestly — it converts an open question into a false
+reassurance, and nobody reopens it.
+
+The failing assertion was, on `main`:
+
+```verilog
+always_ff @(posedge clk) past_pc <= $past(fetcher_pc);
+always_ff @(posedge clk) if(clocked && !branch_jump && $past(uncompressed))
+  assert(past_pc + 4 == pc);
+```
+
+Verified during integration: this fails at basecase **step 0**, and it is the `+ 4` uncompressed
+assertion, not the `+ 2` compressed one that the CI comment and the folklore both named.
+
+It fails because it is a **broken property, not a decode hole**. `components_decoder` stands alone
+— no fetcher is instantiated — so `in.pc` is a free input. `past_pc <= $past(fetcher_pc)` therefore
+compared `pc` against a two-cycles-stale sample of a signal the solver was free to choose
+arbitrarily. No implementation of the decoder could ever have satisfied it. ADR-0006's remark that
+the decoder's failure was "a decode-hole detector, not a broken property" was about the `$onehot`
+`one_of` assertion nearby; it does not apply here, and this ADR records that distinction so the
+next reader does not re-derive it.
+
+JEF-607 fixed it correctly, by modelling the missing structure:
+
+```verilog
+always_comb assume(in.pc == pc);   // littlecpu.v wires fetcher.pc <= decoder.pc,
+                                   // and fetcher.v drives out.pc = pc combinationally
+always_ff @(posedge clk) past_pc <= pc;
+```
+
+## Decision
+
+**Accept the assumption, and require that every `assume` added to a component proof states the
+structural fact it models and where that fact is itself checked.**
+
+The `in.pc == pc` assumption is sound: `rtl/fetcher.v` assigns `out.pc = pc` combinationally and
+`rtl/littlecpu.v` wires the decoder's `pc` output straight into it. It is a faithful model of the
+real instantiation, and modelling a neighbour's wiring is the normal and correct way to make a
+standalone component proof meaningful.
+
+But it must be recorded that the assumption is **where the content went**, because two facts
+established during integration bound what this proof now proves:
+
+1. **Removing `assume(in.pc == pc)` alone reverts the proof to FAIL at the same assertion.** The
+   assumption is precisely what closed it — not the added `!prev_stall` / `!prev_reset` guards.
+2. **The proof is not vacuous.** Mutating `pc_inc` from `uncompressed ? 4 : 2` to `? 4 : 4` is
+   still caught.
+
+So the residual strength of the pc-increment pair is real but narrow. Given the assumption,
+`pc <= fetcher_pc + pc_inc` becomes `pc <= pc + pc_inc`, and the assertions reduce to pinning
+`pc_inc`'s two constants and the exclusivity of the `pc` writers — no non-branch arm of the decode
+`case` may write `pc`, and the stall mux may not advance it. **What they no longer prove is the
+fetcher↔decoder pc loop itself**, which is now assumed rather than checked.
+
+That loop is checked at M2, by the full-core riscv-formal wrapper, where the real fetcher is
+instantiated and nothing is assumed about it. That is the right level for it; it is not a gap so
+much as a relocation, and this ADR is where the relocation is written down.
+
+The new guards are not a vacuity hole: the case they exclude (`prev_stall`) has its own assertion,
+`prev_stall → pc == past_pc`, added by the same change. Excluding a case *and* asserting it
+separately partitions the state space rather than shrinking it.
+
+## Rationale
+
+The alternative was to demand a stronger standalone proof — instantiate a fetcher inside the
+component task, or carry `pc` history in a way that survives a free input. Rejected: it would
+duplicate at the component level a property M2's wrapper proves properly, on a project whose whole
+plan is getting the riscv-formal ladder green. Spending M1 effort on a weaker version of an M2
+result is the wrong trade.
+
+What is *not* acceptable is the assumption going unrecorded. An `assume` is a promise made to the
+solver on the reader's behalf, and an unexplained one is indistinguishable from a mistake.
+
+## Consequences
+
+- `components_decoder` is now a CI gate (`.github/workflows/ci.yml`), so it cannot regress
+  silently.
+- **`components_fetcher`, `components_accessor`, and `components_writeback` "pass" with zero
+  assertions** — their `ifdef FORMAL` blocks contain only reset assumptions. Confirmed by running
+  all three during integration. CI deliberately does not run them, and ADR-0006's slate to delete
+  them stands. A green vacuous task in CI would be worse than no task. **Reporting them as passing
+  proofs is not a result**, and should not be read as one in any engineer's report.
+- Proving the fetcher↔decoder pc loop without assumption is added to M2's scope.
+- The rule generalises: when a component proof needs a neighbour's behaviour, model it explicitly
+  in an `assume`, name the file and line the model comes from, and say which higher-level check
+  discharges it.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -19,7 +19,9 @@ and what it costs. Reversing one is fine — write a new ADR that supersedes it.
 | [0012](0012-divider-is-unsigned-signs-are-a-wrapper.md) | The divider is unsigned; sign handling is a wrapper around it | Accepted |
 | [0013](0013-the-riscv-formal-pin-is-an-enforced-control.md) | The riscv-formal pin is an enforced control, not a comment | Accepted |
 | [0014](0014-expected-fail-is-the-m1-regression-baseline.md) | `test/EXPECTED_FAIL` is the M1 regression baseline | Accepted |
+| [0015](0015-accessor-load-response-stall.md) | The accessor's load-response turnaround is the third stall source | Accepted |
 | [0016](0016-no-unreviewed-dependabot-automerge.md) | No unreviewed auto-merge for the actions dependabot updates | Accepted |
+| [0017](0017-component-proof-assumptions-must-name-their-model.md) | A component-proof `assume` must name the structural fact it models | Accepted |
 
 0001–0007 came from the design brief
 ([`docs/ideas/finish-the-rewrite.md`](../ideas/finish-the-rewrite.md)). 0008–0011 came out of
@@ -27,9 +29,10 @@ sprint planning, when the panel ran the toolchain and found the brief's assumpti
 resolving before work could start. 0012–0014 came out of integrating the first build sprint, when
 review of JEF-604/JEF-605 turned up decisions neither ticket had recorded and JEF-606 landed a test
 suite that fails in its entirety. 0010 supplements 0006; 0011 scopes 0005; 0012 supplements 0010;
-0013 implements 0006's pinning clause; 0014 supplements 0007 and 0008. 0016 came out of
-integrating the second build sprint, when the CI gate (JEF-608) turned out to arm a
-previously dormant auto-merge workflow; it constrains that gate.
+0013 implements 0006's pinning clause; 0014 supplements 0007 and 0008. 0015-0017 came out of
+integrating the second build sprint: 0015 extends 0009 with a stall source 0009 did not know
+existed, 0016 constrains the JEF-608 CI gate, and 0017 records what the newly-passing decoder
+component proof does and does not establish.
 
 ## Deferred decisions
 


### PR DESCRIPTION
Recorded decisions from integrating PR #13 (JEF-607) and PR #12 (JEF-608). Follows the precedent of 99888d0 — the ADRs an integration settles land in their own PR.

- **ADR-0015** — the accessor's load-response turnaround is a third stall source, which ADR-0009 explicitly said did not exist. Ratifies JEF-607's approach (fold into the existing global broadcast; no flush, no handshake) and writes down the four non-local invariants it rests on.
- **ADR-0017** — what `components_decoder` passing actually establishes, and the standing rule that a component-proof `assume` must name the structural fact it models and where that fact is discharged.
- **CLAUDE.md** — the current-state section's headline claim is false as of a4662a2. Also records two verification gaps found while checking the 47/47 claim: `test/rtl.cc` never reads `test/monitor.v`, and RVFI is still undriven, so no run is per-retire self-checking yet. Invariant 8 adds the three-source stall protocol.

ADR-0016 landed with PR #12, which is the change it justifies.

Docs only — no `rtl/`, `test/`, or `Makefile` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)