### PR TITLE
Wire test/regfile_tb.v into make test-units; fix make waves

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,14 +62,15 @@ What does not work right now:
   `components_accessor`, and `components_writeback` contain no assertions at all, only reset
   assumptions, so they "pass" meaninglessly. CI deliberately does not run them; ADR-0006 slates
   them for deletion. A green run of one of those is not a result.
-- **`make waves` is `waves.vcd: sim`** — a cxxrtl target, not the iverilog+VCD flow the Commands
-  section below describes. Unverified either way.
 
 What does work: `yosys ... write_cxxrtl` elaborates the current RTL cleanly with zero warnings, the
-cxxrtl binary builds and runs, the full `.S` suite passes under it, `make test-units` passes, and
-the decoder and executor component proofs pass by k-induction (see ADR-0017 for what the decoder
-proof does and does not establish). CI (`.github/workflows/ci.yml`) runs elaborate / test /
-components / monitor-freshness on every PR.
+cxxrtl binary builds and runs, the full `.S` suite passes under it, `make test-units` passes (four
+benches: `exec_tb`, `mem_tb`, `decoder_tb`, and `regfile_tb` — the last covers the write-through
+bypass and x0 semantics), and the decoder and executor component proofs pass by k-induction (see
+ADR-0017 for what the decoder proof does and does not establish). `make waves` now runs the
+iverilog leg (`testbench.vvp`) instead of the cxxrtl runner, matching the verification table below,
+and produces a real `waves.vcd`. CI (`.github/workflows/ci.yml`) runs elaborate / test / components
+/ monitor-freshness on every PR.
 
 ## Invariants — do not break these
 
@@ -113,7 +114,7 @@ preference. See ADR-0002 and ADR-0003.
 ```sh
 make setup          # install the RISC-V toolchain (brew on macOS)
 make test           # assemble test/asm/*.S, run under cxxrtl, pass/fail table
-make waves          # iverilog + VCD for one program (currently broken — see above)
+make waves          # iverilog + VCD (testbench.vvp's baked-in program) -> waves.vcd
 make monitor-check  # regenerate test/monitor.v at the pin and diff
 
 make -C formal components_decoder   # component proofs

--- a/Makefile
+++ b/Makefile
@@ -20,12 +20,19 @@ rvfi_macros.vh: $(RISCV_FORMAL_DIR)/checks/rvfi_macros.py
 testbench.vvp: rtl/structs.v rtl/accessor.v rtl/decoder.v rtl/executor.v rtl/fetcher.v rtl/regfile.v rtl/writeback.v rtl/littlecpu.v rvfi_macros.vh test/testbench.v test/monitor.sim.v
 	iverilog -I./rtl/ -DICARUS $(addprefix -D,$(RISCV_FORMAL_MACROS)) -g2012 -o $@ $^
 
-# `./sim` now requires --rom/--ram/--cycles (ADR-0007/ADR-0008's runner, not
-# the old no-args VCD demo) — `make waves` is unmaintained here; use
-# `./sim --rom ... --ram ... --cycles N --vcd waves.vcd` directly, or the
-# iverilog leg (test/testbench.v) for waveform debugging.
-waves.vcd: sim
-	./sim
+# ADR-0007: iverilog is the waveform leg, not cxxrtl (`./sim` now requires
+# --rom/--ram/--cycles and was never a VCD demo — see the `sim:` rule
+# above). testbench.vvp already `$dumpfile`s/`$dumpvars`s under `ifdef
+# ICARUS` (test/testbench.v) and already carries test/monitor.sim.v, so this
+# waveform is also a self-checking per-retire run, not just a raw trace. It
+# runs the fixed increment-loop program baked into test/testbench.v's
+# `initial rom[...]` block for 200 cycles -- there's no --rom flag on this
+# leg, unlike ./sim's.
+.PHONY: waves
+waves: waves.vcd
+waves.vcd: testbench.vvp
+	vvp $<
+	mv testbench.vcd $@
 
 # -O2 -DNDEBUG: the sim binary is the primary runner (ADR-0007) and needs to
 # run 46 tests well under a minute; -g -O0 (the old flags) is 5-10x slower
@@ -107,14 +114,17 @@ else
 	@echo "  sudo apt-get install gcc-riscv64-unknown-elf"
 endif
 
-# Three small benches that landed in `eb18320` with no runner (rtl/executor.v,
-# rtl/memory.v, rtl/decoder.v respectively). Compiled and run straight
-# through iverilog/vvp; each bench $fatal(1)s on a mismatch and $finish
-# (exit 0) on success, so vvp's own exit code is the pass/fail signal — no
-# output-parsing needed. A separate target from `test` (that one is the
-# ADR-0007 cxxrtl regression gate over test/asm/*.S; these are RTL-level unit
-# benches with their own, unrelated pass/fail mechanism) but `test` depends
-# on it so one `make test` still catches everything.
+# Four small benches that landed in `eb18320` and `a4662a2` with no runner
+# (rtl/executor.v, rtl/memory.v, rtl/decoder.v, rtl/regfile.v respectively —
+# regfile_tb.v covers the write-through bypass and x0 semantics, the single
+# most load-bearing change in the project, and was verified by hand via
+# iverilog+vvp before this rule existed to run it in CI). Compiled and run
+# straight through iverilog/vvp; each bench $fatal(1)s on a mismatch and
+# $finish (exit 0) on success, so vvp's own exit code is the pass/fail
+# signal — no output-parsing needed. A separate target from `test` (that one
+# is the ADR-0007 cxxrtl regression gate over test/asm/*.S; these are
+# RTL-level unit benches with their own, unrelated pass/fail mechanism) but
+# `test` depends on it so one `make test` still catches everything.
 .PHONY: test-units
 test-units:
 	@tmp=$$(mktemp -d "$${TMPDIR:-/tmp}/test-units.XXXXXX"); \
@@ -128,7 +138,10 @@ test-units:
 	vvp $$tmp/mem_tb.vvp; \
 	echo "== decoder_tb =="; \
 	iverilog -I./rtl/ -g2012 -o $$tmp/decoder_tb.vvp rtl/structs.v rtl/decoder.v test/decoder_tb.v; \
-	vvp $$tmp/decoder_tb.vvp
+	vvp $$tmp/decoder_tb.vvp; \
+	echo "== regfile_tb =="; \
+	iverilog -I./rtl/ -g2012 -o $$tmp/regfile_tb.vvp rtl/regfile.v test/regfile_tb.v; \
+	vvp $$tmp/regfile_tb.vvp
 
 # Assembles every test/asm/*.S (rv32im_zicsr, -nostdlib, ADR-0008's memory
 # map), runs each under `sim`, and checks the pass/fail table against


### PR DESCRIPTION
## Summary

Two small Makefile fixes, shipped together because they collide in the same file:

1. **`test/regfile_tb.v` now runs.** It covers the write-through bypass, x0 semantics
   (including a white-box no-write check), and bypass isolation for `rtl/regfile.v` —
   the single most load-bearing change in the project — but was never wired into
   `make test-units` or CI. Added alongside `exec_tb.v`, `mem_tb.v`, and `decoder_tb.v`,
   same `iverilog` -> `vvp` pattern; `vvp`'s own exit code is the pass/fail signal.

2. **`make waves` now works.** The old rule was `waves.vcd: sim`, but ADR-0007/ADR-0008's
   cxxrtl runner requires `--rom`/`--ram`/`--cycles`, so a bare `./sim` exited 3 with a
   usage error. Chose **option (a)** from the ticket: point `waves.vcd` at the iverilog
   leg (`testbench.vvp`), which is what `CLAUDE.md`'s verification table already claims
   iverilog is for (the waveform microscope, ADR-0007) — option (b) would have meant
   inventing a `--vcd`-plumbed named-test-program flow for cxxrtl that doesn't otherwise
   exist. `testbench.vvp` already `$dumpfile`s/`$dumpvars`s under `` `ifdef ICARUS `` and
   already carries `test/monitor.sim.v` (`b2dafcc`), so the waveform run comes for free as
   a self-checking per-retire run, not just a raw trace. Also added a `.PHONY: waves`
   alias to `waves.vcd`, since `CLAUDE.md`'s Commands section documents the bare
   `make waves` invocation and no target by that literal name previously existed.

`CLAUDE.md`'s "what does not work" list and Commands section are updated to match.

## Test plan

**Criterion 1 — `make test-units` runs four benches, mutation-tested both directions:**

```
== exec_tb ==
PASSED: 10000 randomized vectors per op ..., 0 mismatches
== mem_tb ==
PASSED: memory.v read-after-write and out-of-range checks
== decoder_tb ==
PASSED: decode vectors (xori immediate, ebreak/mret/wfi)
== regfile_tb ==
PASSED: regfile combinational read / write-through bypass / x0 semantics
```

Mutated `test/regfile_tb.v`'s first expectation (`cafef00d` -> `deadbeef`) and reran:

```
== regfile_tb ==
MISMATCH write-through same-cycle read (rs1): got=cafef00d expected=deadbeef
FAILED: 1 mismatches
FATAL: test/regfile_tb.v:122:
       Time: 37000  Scope: regfile_tb
make: *** [test-units] Error 1
```

`make test-units` exits nonzero, red as expected. Reverted the mutation
(`git diff test/regfile_tb.v` is empty on the final commit) and reran — back to
`PASSED` / exit 0.

**Criterion 2 — `make waves` produces a real, well-formed VCD**, running
`testbench.vvp`'s baked-in increment-loop test program (`test/testbench.v`'s
`initial rom[...]` block, 200 cycles):

```
$ make waves
...
mv testbench.vcd waves.vcd
$ echo $?
0
$ ls -la waves.vcd
-rw-r--r--  1 jeff  staff  176305 ... waves.vcd
$ head -6 waves.vcd
$date
	...
$end
$version
	Icarus Verilog
$end
$ grep -c '^\$var' waves.vcd
2991
$ grep -c 'enddefinitions' waves.vcd
1
$ grep -c '^#' waves.vcd
402
```

176 KB, well-formed header (`$date`/`$version`/`$timescale`/`$var`/`$enddefinitions`),
2991 signals, 402 timesteps. I could not launch a GUI waveform viewer in this
environment, so this is the checkable substitute the ticket allows for.

**Criterion 3 — `make test` still 47/47** (clean-room rerun after all changes):

```
47/47 passed
Failure list matches test/EXPECTED_FAIL exactly.
```

CI's four required jobs (`elaborate`, `test`, `components`, `monitor-freshness`) will run
on this PR.

**Criterion 4** — `CLAUDE.md`'s "what does not work" bullet for `make waves` is removed,
"what does work" now describes both the four-bench `test-units` and the working
`make waves`, and the Commands section's `make waves` comment no longer says "broken".

## Scope

Touched only `Makefile`, `CLAUDE.md`, and (transiently, then reverted) `test/regfile_tb.v`
for the mutation test — per the dispatch note, did not touch `formal/`, `rtl/`, or
`.github/`, which belong to the parallel riscv-formal-porting ticket.