### PR TITLE
Port the riscv-formal ladder to littlecpu (M2) — finds a real C.JR/C.JALR decode bug

### DIFF
--- a/.github/workflows/formal-nightly.yml
+++ b/.github/workflows/formal-nightly.yml
@@ -1,0 +1,92 @@
+name: Formal Nightly
+
+# ADR-0006 estimates ~75 insn_* checks at depth 15-30 as nightly-scale
+# (1-3h wall with -j), not something the PR gate (ci.yml) can afford to run
+# on every push. This workflow is that nightly ladder: the full
+# genchecks-local.py sweep (insn_*/reg/pc_fwd/pc_bwd/liveness/unique/
+# causal/csrw), the hand-authored imemcheck/dmemcheck/cover tasks, the
+# depth-50 whole-ISA `complete` walk, and equiv.sh (ADR-0020). None of this
+# gates merges: there is no required-status-check entry for this workflow,
+# unlike ci.yml's elaborate/test/components/monitor-freshness.
+on:
+  schedule:
+    - cron: "0 9 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  OSS_CAD_SUITE_TAG: "2026-06-29"
+  OSS_CAD_SUITE_FILE: "oss-cad-suite-linux-x64-20260629.tgz"
+  OSS_CAD_SUITE_SHA256: "dfb5df3c28599081d2baca13884c069c025b1990c86e90f4a4d84aadcd255cc5"
+
+jobs:
+  ladder:
+    name: riscv-formal ladder
+    runs-on: ubuntu-latest
+    timeout-minutes: 300
+    steps:
+      - name: Record job start
+        run: echo "JOB_START=$(date +%s)" >> "$GITHUB_ENV"
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up OSS CAD Suite
+        uses: ./.github/actions/setup-oss-cad-suite
+        with:
+          tag: ${{ env.OSS_CAD_SUITE_TAG }}
+          file: ${{ env.OSS_CAD_SUITE_FILE }}
+          sha256: ${{ env.OSS_CAD_SUITE_SHA256 }}
+
+      # genchecks-local.py's insn_*/reg/pc_fwd/pc_bwd/liveness/unique/
+      # causal/csrw sweep (formal/checks.cfg). csrw_mcycle/csrw_minstret are
+      # expected to fail here -- CSRs aren't implemented until M3
+      # (CLAUDE.md) -- so this step is allowed to report failures without
+      # failing the job; the summary below is what actually needs reading.
+      - name: riscv-formal ladder (make -C formal check)
+        run: make -C formal check || true
+
+      - name: imemcheck / dmemcheck / cover
+        run: |
+          make -C formal imemcheck
+          make -C formal dmemcheck
+          make -C formal cover
+
+      # depth-50 whole-ISA BMC walk (ADR-0006's "finish complete.sv" item).
+      # Not part of the PR-gate acceptance criteria; run here because it is
+      # exactly the nightly-scale check this workflow exists for.
+      - name: complete (whole-ISA BMC)
+        run: make -C formal complete
+
+      # ADR-0020: equiv_induct across a pipelined core with a 32-cycle
+      # sequential divider is a hard problem and may not converge -- that is
+      # a finding to record (this step going red), not something to retry
+      # or weaken. Bounded so a non-convergent run doesn't consume the whole
+      # job budget.
+      - name: equiv.sh (ADR-0020)
+        working-directory: formal
+        run: timeout 3600 ./equiv.sh
+
+      - name: Summarize checks
+        if: always()
+        run: |
+          {
+            echo "### formal ladder"
+            echo '```'
+            for d in formal/checks/*/; do
+              name=$(basename "$d")
+              status=$(cat "$d/status" 2>/dev/null || echo "no status")
+              echo "$name: $status"
+            done
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Report job wall time
+        if: always()
+        run: |
+          elapsed=$(( $(date +%s) - JOB_START ))
+          {
+            echo "### ladder"
+            echo "wall time: ${elapsed}s"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/formal/Makefile
+++ b/formal/Makefile
@@ -27,6 +27,14 @@ imemcheck: imemcheck.sby imemcheck.sv | $(RISCV_FORMAL_DIR)
 complete: complete.sby complete.sv | $(RISCV_FORMAL_DIR)
 cover: cover.sby cover.sv | $(RISCV_FORMAL_DIR)
 
+# ADR-0020: proves RVFI instrumentation doesn't change core behaviour. Not a
+# .sby task (equiv_make/equiv_simple/equiv_induct are driven directly from a
+# yosys script, not sby), so it isn't covered by the generic `%: %.sby` rule
+# above.
+.PHONY: equiv
+equiv: equiv.sh
+	./$<
+
 # pipeline stages
 components_fetcher: components.sby ../rtl/fetcher.v
 	sby -f $< fetcher

--- a/formal/checks.cfg
+++ b/formal/checks.cfg
@@ -1,4 +1,13 @@
 [options]
+# Kept at rv32imc, not restricted to rv32im, even though test/asm/*.S only
+# assembles rv32im_zicsr (ADR-0014: the dual-word fetch window ADR-0003
+# describes isn't built yet). That gap doesn't apply here: riscv-formal's
+# base insn_* checks (unlike formal/imemcheck.sv) never constrain how
+# imem_data arrives -- it's a free value every cycle regardless of
+# alignment (see formal/wrapper.v) -- so an insn_c_* check exercises
+# rtl/decoder.v's compressed decode path directly and isn't gated on the
+# fetch window that's missing. Running them is a real, if narrower, proof
+# of the C-extension decode logic than the `.S` suite currently gives.
 isa rv32imc
 # genchecks-local.py defaults to boolector, which OSS CAD Suite ships but a
 # bare `brew install yosys` / apt toolchain does not. yices is the solver
@@ -21,9 +30,14 @@ csrw           30
 
 [script-sources]
 read_verilog -sv @basedir@/../wrapper.v
-read_verilog -sv @basedir@/../../rtl/riscv.v
+read_verilog -sv @basedir@/../../rtl/structs.v
+read_verilog -sv @basedir@/../../rtl/fetcher.v
+read_verilog -sv @basedir@/../../rtl/regfile.v
 read_verilog -sv @basedir@/../../rtl/decoder.v
-read_verilog -sv @basedir@/../../rtl/alu.v
+read_verilog -sv @basedir@/../../rtl/executor.v
+read_verilog -sv @basedir@/../../rtl/accessor.v
+read_verilog -sv @basedir@/../../rtl/writeback.v
+read_verilog -sv @basedir@/../../rtl/littlecpu.v
 
 [defines]
 `define RISCV_FORMAL_ALIGNED_MEM

--- a/formal/complete.sby
+++ b/formal/complete.sby
@@ -14,9 +14,14 @@ verilog_defines -D RISCV_FORMAL_ILEN=32
 verilog_defines -D RISCV_FORMAL_COMPRESSED
 verilog_defines -D RISCV_FORMAL_ALIGNED_MEM
 read_verilog -sv rvfi_macros.vh
-read_verilog -sv riscv.v
+read_verilog -sv structs.v
+read_verilog -sv fetcher.v
+read_verilog -sv regfile.v
 read_verilog -sv decoder.v
-read_verilog -sv alu.v
+read_verilog -sv executor.v
+read_verilog -sv accessor.v
+read_verilog -sv writeback.v
+read_verilog -sv littlecpu.v
 
 --pycode-begin--
 with open("riscv-formal/insns/isa_rv32imc.txt") as f:
@@ -30,9 +35,14 @@ prep -nordff -top rvfi_testbench
 
 [files]
 complete.sv
-../rtl/riscv.v
+../rtl/structs.v
+../rtl/fetcher.v
+../rtl/regfile.v
 ../rtl/decoder.v
-../rtl/alu.v
+../rtl/executor.v
+../rtl/accessor.v
+../rtl/writeback.v
+../rtl/littlecpu.v
 riscv-formal/checks/rvfi_macros.vh
 riscv-formal/insns/isa_rv32imc.v
 

--- a/formal/complete.sv
+++ b/formal/complete.sv
@@ -14,6 +14,46 @@ module rvfi_testbench (
   `RVFI_WIRES
   logic trap;
 
+  // ADR-0006: "finish [complete.sv] by driving imem/dmem inputs rand-stable".
+  // Without this, imem_data/mem_rdata are free every cycle (see wrapper.v),
+  // which is fine for the single-retire insn_* checks but not for this
+  // whole-ISA walk: a load that doesn't see back what an earlier store in
+  // the same trace wrote would fail rvfi_isa_rv32imc's spec check for
+  // reasons that have nothing to do with the core.
+  //
+  // imem is left fully free per cycle, deliberately not made rand-stable:
+  // rtl/fetcher.v drives imem_addr = pc and out.instr = imem_data
+  // combinationally with no cross-cycle latency (CLAUDE.md invariant 1), so
+  // nothing here depends on two different cycles' fetches of the same
+  // address agreeing.
+  //
+  // dmem gets a single-address write-through shadow -- the most recent
+  // store only, not a full memory array -- which is enough to let the
+  // common store-then-immediately-reload pattern through. A read of an
+  // address some *earlier*, since-overwritten store touched stays free;
+  // see dmemcheck.sv for the fuller version of this same argument (why
+  // $past(mem_addr), and why the address-0/idle-default coincidence is
+  // harmless: rtl/accessor.v only reads mem_rdata the cycle after a real
+  // load request).
+  logic [31:0] dmem_shadow;
+  logic [31:0] dmem_shadow_addr;
+  logic        dmem_shadow_valid = 0;
+  always_ff @(posedge clk) begin
+    if (!reset && mem_wstrb) begin
+      dmem_shadow_addr <= mem_addr;
+      if (mem_wstrb[0]) dmem_shadow[ 7: 0] <= mem_wdata[ 7: 0];
+      if (mem_wstrb[1]) dmem_shadow[15: 8] <= mem_wdata[15: 8];
+      if (mem_wstrb[2]) dmem_shadow[23:16] <= mem_wdata[23:16];
+      if (mem_wstrb[3]) dmem_shadow[31:24] <= mem_wdata[31:24];
+      dmem_shadow_valid <= 1'b1;
+    end
+  end
+  always_ff @(posedge clk) begin
+    if (!reset && dmem_shadow_valid && !$past(mem_wstrb) &&
+        $past(mem_addr) == dmem_shadow_addr)
+      assume(mem_rdata == dmem_shadow);
+  end
+
   // Instantiate the actual top-level CPU module (was stale "riscv" with Wishbone interface)
   littlecpu wrapper (
     .clk(clk),

--- a/formal/cover.sby
+++ b/formal/cover.sby
@@ -12,15 +12,25 @@ verilog_defines -D RISCV_FORMAL_XLEN=32
 verilog_defines -D RISCV_FORMAL_ILEN=32
 verilog_defines -D RISCV_FORMAL_ALIGNED_MEM
 read_verilog rvfi_macros.vh
+read_verilog -sv structs.v
+read_verilog -sv fetcher.v
+read_verilog -sv regfile.v
 read_verilog -sv decoder.v
-read_verilog -sv riscv.v
-read_verilog -sv alu.v
+read_verilog -sv executor.v
+read_verilog -sv accessor.v
+read_verilog -sv writeback.v
+read_verilog -sv littlecpu.v
 read_verilog -sv cover.sv
 prep -nordff -top testbench
 
 [files]
-../decoder.v
-../riscv.v
-../alu.v
+../rtl/structs.v
+../rtl/fetcher.v
+../rtl/regfile.v
+../rtl/decoder.v
+../rtl/executor.v
+../rtl/accessor.v
+../rtl/writeback.v
+../rtl/littlecpu.v
 riscv-formal/checks/rvfi_macros.vh
 cover.sv

--- a/formal/cover.sv
+++ b/formal/cover.sv
@@ -1,12 +1,11 @@
 module testbench (
   input var clk,
-  output logic        mem_valid,
-  output logic        mem_instr,
-  input  logic        mem_ready,
+  output logic [31:0] imem_addr,
+  input  logic [31:0] imem_data,
   output logic [31:0] mem_addr,
   output logic [31:0] mem_wdata,
   output logic [3:0]  mem_wstrb,
-  input  logic [31:0] mem_rdata,
+  input  logic [31:0] mem_rdata
 );
   logic reset = 1;
   always_ff @(posedge clk)
@@ -15,12 +14,11 @@ module testbench (
   `RVFI_WIRES
   logic trap;
 
-  riscv wrapper (
+  littlecpu uut (
     .clk(clk),
     .reset(reset),
-    .mem_valid(mem_valid),
-    .mem_instr(mem_instr),
-    .mem_ready(mem_ready),
+    .imem_addr(imem_addr),
+    .imem_data(imem_data),
     .mem_addr(mem_addr),
     .mem_wdata(mem_wdata),
     .mem_wstrb(mem_wstrb),

--- a/formal/dmemcheck.sby
+++ b/formal/dmemcheck.sby
@@ -9,15 +9,25 @@ smtbmc --presat --unroll boolector
 
 [script]
 read_verilog -sv dmemcheck.sv
+read_verilog -sv structs.v
+read_verilog -sv fetcher.v
+read_verilog -sv regfile.v
 read_verilog -sv decoder.v
-read_verilog -sv riscv.v
-read_verilog -sv alu.v
+read_verilog -sv executor.v
+read_verilog -sv accessor.v
+read_verilog -sv writeback.v
+read_verilog -sv littlecpu.v
 prep -nordff -top testbench
 
 [files]
+../rtl/structs.v
+../rtl/fetcher.v
+../rtl/regfile.v
 ../rtl/decoder.v
-../rtl/riscv.v
-../rtl/alu.v
+../rtl/executor.v
+../rtl/accessor.v
+../rtl/writeback.v
+../rtl/littlecpu.v
 dmemcheck.sv
 riscv-formal/checks/rvfi_macros.vh
 riscv-formal/checks/rvfi_channel.sv

--- a/formal/dmemcheck.sv
+++ b/formal/dmemcheck.sv
@@ -8,14 +8,7 @@
 `include "rvfi_dmem_check.sv"
 
 module testbench (
-  input clk,
-  input   mem_ready,
-  output  mem_valid,
-  output  mem_instr,
-  output [31:0] mem_addr,
-  output [31:0] mem_wdata,
-  output [3:0]  mem_wstrb,
-  input  [31:0] mem_rdata
+  input clk
 );
   logic reset = 1;
   logic trap;
@@ -26,7 +19,6 @@ module testbench (
   `RVFI_WIRES
 
   logic [31:0] dmem_addr;
-  logic [31:0] dmem_data;
 
   rvfi_dmem_check checker_inst (
     .clock(clk),
@@ -36,8 +28,33 @@ module testbench (
     `RVFI_CONN
   );
 
+  logic [31:0] imem_addr;
+  logic [31:0] imem_data;
+  logic [31:0] mem_addr;
+  logic [31:0] mem_wdata;
+  logic [3:0]  mem_wstrb;
+  logic [31:0] mem_rdata;
+
+  // rvfi_dmem_check (riscv-formal, unmodified) already builds its own
+  // load-after-store shadow purely from rvfi_mem_*, so it needs no
+  // connection to the raw bus at all -- the block below exists only to
+  // constrain the *environment*: without it mem_rdata is a free signal
+  // every cycle (see wrapper.v), and no design, buggy or not, could ever
+  // satisfy that RVFI-level shadow's assertion. It has to be built from
+  // the raw bus because rvfi_dmem_check has no visibility into cycles that
+  // don't retire a memory op.
+  //
+  // Write side: rtl/accessor.v (ADR-0015) drives a store's address, data,
+  // and strobe together, combinationally, in the one cycle the request
+  // fires ("mem_wdata must be combinational, in lockstep with
+  // mem_addr/mem_wstrb" -- accessor.v's own comment on the bug this fixed).
+  // Gating on `mem_wstrb` alone is exact: rtl/accessor.v's always_comb
+  // defaults `mem_wstrb = 0` every cycle that isn't a real store, so no
+  // separate valid signal is needed here the way the wave-0
+  // mem_valid/mem_ready handshake needed one.
+  logic [31:0] dmem_data;
   always_ff @(posedge clk) begin
-    if (!reset && mem_valid && mem_ready && mem_addr == dmem_addr) begin
+    if (!reset && mem_addr == dmem_addr) begin
       if (mem_wstrb[0]) dmem_data[ 7: 0] <= mem_wdata[ 7: 0];
       if (mem_wstrb[1]) dmem_data[15: 8] <= mem_wdata[15: 8];
       if (mem_wstrb[2]) dmem_data[23:16] <= mem_wdata[23:16];
@@ -45,22 +62,35 @@ module testbench (
     end
   end
 
-  always_comb begin
-    if (!reset && mem_valid && mem_ready && mem_addr == dmem_addr && !mem_wstrb)
+  // Read side is genuinely one cycle behind the request, unlike the
+  // wave-0 handshake harness this replaces: ADR-0015's load turnaround
+  // registers mem_rdata the cycle *after* the address is presented, and
+  // rtl/accessor.v's always_comb reverts mem_addr to its 0 default on that
+  // response cycle (no new request is in flight), so this cycle's
+  // mem_rdata must be checked against *last* cycle's mem_addr, not this
+  // cycle's. $past(mem_addr) == dmem_addr can also fire for an ordinary
+  // idle cycle when the solver happens to pick dmem_addr == 0 (RAM base
+  // per ADR-0008, so 0 is a legal address and, absent a valid signal,
+  // genuinely indistinguishable from idle by address alone) -- that
+  // coincidence is harmless: rtl/accessor.v only ever reads mem_rdata on
+  // the cycle following a *real* load request (its internal
+  // `pending_valid`, invisible from here), so constraining mem_rdata on a
+  // cycle the core doesn't consume it changes nothing observable.
+  always_ff @(posedge clk) begin
+    if (!reset && $past(mem_addr) == dmem_addr && !$past(mem_wstrb))
       assume(dmem_data == mem_rdata);
   end
 
-  riscv uut (
+  littlecpu uut (
     .clk(clk),
     .reset(reset),
-    .trap(trap),
-    .mem_valid(mem_valid),
-    .mem_instr(mem_instr),
-    .mem_ready(mem_ready),
+    .imem_addr(imem_addr),
+    .imem_data(imem_data),
     .mem_addr(mem_addr),
     .mem_wdata(mem_wdata),
     .mem_wstrb(mem_wstrb),
     .mem_rdata(mem_rdata),
+    .trap(trap),
     `RVFI_CONN
   );
 endmodule

--- a/formal/equiv.sh
+++ b/formal/equiv.sh
@@ -1,14 +1,28 @@
 #!/bin/bash
+# ADR-0006 / ADR-0020: proves that RISC-V_FORMAL instrumentation does not
+# change core behaviour -- gold is the plain build, gate is the
+# `RISCV_FORMAL` build with the rvfi_* ports deleted (memory_map/opt then
+# sweep the now-dead shadow-payload logic that only fed them). Run from
+# formal/ (`./equiv.sh`); paths below are relative to that.
+#
+# Per ADR-0020: as of `b2dafcc` this was argued (structurally: every
+# `ifdef RISCV_FORMAL` block is write-only, read only by rtl/writeback.v's
+# RVFI outputs) but not proven -- a hand-built equiv_make/equiv_simple/
+# equiv_induct attempt did not converge in a practical budget. This is that
+# attempt, ported to littlecpu. If it still does not converge, that is
+# itself the finding ADR-0020 asks this script to produce, not something to
+# work around by weakening the proof.
+set -e
 yosys -p '
-  read_verilog -sv ../riscv.v
-  prep -flatten -top riscv
+  read_verilog -sv ../rtl/structs.v ../rtl/fetcher.v ../rtl/regfile.v ../rtl/decoder.v ../rtl/executor.v ../rtl/accessor.v ../rtl/writeback.v ../rtl/littlecpu.v
+  prep -flatten -top littlecpu
   design -stash gold
-  read_verilog -D RISCV_FORMAL -sv ../riscv.v
-  prep -flatten -top riscv
-  delete -port riscv/rvfi_*
+  read_verilog -D RISCV_FORMAL -sv ../rtl/structs.v ../rtl/fetcher.v ../rtl/regfile.v ../rtl/decoder.v ../rtl/executor.v ../rtl/accessor.v ../rtl/writeback.v ../rtl/littlecpu.v
+  prep -flatten -top littlecpu
+  delete -port littlecpu/rvfi_*
   design -stash gate
-  design -copy-from gold -as gold riscv
-  design -copy-from gate -as gate riscv
+  design -copy-from gold -as gold littlecpu
+  design -copy-from gate -as gate littlecpu
   memory_map; opt -fast
   equiv_make gold gate equiv
   hierarchy -top equiv

--- a/formal/imemcheck.sby
+++ b/formal/imemcheck.sby
@@ -9,15 +9,25 @@ smtbmc --presat --unroll boolector
 
 [script]
 read_verilog -sv imemcheck.sv
+read_verilog -sv structs.v
+read_verilog -sv fetcher.v
+read_verilog -sv regfile.v
 read_verilog -sv decoder.v
-read_verilog -sv riscv.v
-read_verilog -sv alu.v
+read_verilog -sv executor.v
+read_verilog -sv accessor.v
+read_verilog -sv writeback.v
+read_verilog -sv littlecpu.v
 prep -nordff -top testbench
 
 [files]
+../rtl/structs.v
+../rtl/fetcher.v
+../rtl/regfile.v
 ../rtl/decoder.v
-../rtl/riscv.v
-../rtl/alu.v
+../rtl/executor.v
+../rtl/accessor.v
+../rtl/writeback.v
+../rtl/littlecpu.v
 imemcheck.sv
 riscv-formal/checks/rvfi_macros.vh
 riscv-formal/checks/rvfi_channel.sv

--- a/formal/imemcheck.sv
+++ b/formal/imemcheck.sv
@@ -8,14 +8,7 @@
 `include "rvfi_imem_check.sv"
 
 module testbench (
-  input clk,
-  input mem_ready,
-  output mem_valid,
-  output mem_instr,
-  output [31:0] mem_addr,
-  output [31:0] mem_wdata,
-  output [3:0] mem_wstrb,
-  input [31:0] mem_rdata
+  input clk
 );
   logic reset = 1;
   logic trap;
@@ -37,26 +30,40 @@ module testbench (
     `RVFI_CONN
   );
 
+  logic [31:0] uut_imem_addr;
+  logic [31:0] uut_imem_data;
+  logic [31:0] mem_addr;
+  logic [31:0] mem_wdata;
+  logic [3:0]  mem_wstrb;
+  logic [31:0] mem_rdata;
+
+  // No mem_valid/mem_ready to gate on: rtl/fetcher.v:15/25 drives
+  // imem_addr = pc and out.instr = imem_data combinationally, unconditionally,
+  // every non-reset cycle (CLAUDE.md invariant 1 -- fetch never stalls or
+  // waits). checker_inst's imem_addr/imem_data are `rand_const_reg`s: fixed
+  // for the whole trace, not resampled per cycle, so this comparison needs
+  // no cycle-history bookkeeping either -- whenever the DUT's fetch this
+  // cycle targets the checker's fixed address, its data must agree,
+  // full stop.
   always_comb begin
-    if (!reset && mem_valid && mem_ready) begin
-      if (mem_addr == imem_addr)
-        assume(mem_rdata[15:0] == imem_data);
-      if (mem_addr + 2 == imem_addr)
-        assume(mem_rdata[31:16] == imem_data);
+    if (!reset) begin
+      if (uut_imem_addr == imem_addr)
+        assume(uut_imem_data[15:0] == imem_data);
+      if (uut_imem_addr + 2 == imem_addr)
+        assume(uut_imem_data[31:16] == imem_data);
     end
   end
 
-  riscv uut (
+  littlecpu uut (
     .clk(clk),
     .reset(reset),
-    .trap(trap),
-    .mem_valid(mem_valid),
-    .mem_instr(mem_instr),
-    .mem_ready(mem_ready),
+    .imem_addr(uut_imem_addr),
+    .imem_data(uut_imem_data),
     .mem_addr(mem_addr),
     .mem_wdata(mem_wdata),
     .mem_wstrb(mem_wstrb),
     .mem_rdata(mem_rdata),
+    .trap(trap),
     `RVFI_CONN
   );
 endmodule

--- a/formal/wrapper.v
+++ b/formal/wrapper.v
@@ -1,24 +1,32 @@
+// ADR-0006: ported from the wave-0 (rtl/riscv.v-era) harness, which spoke a
+// picorv32-style mem_valid/mem_instr/mem_ready handshake. `littlecpu` (the
+// module that replaced `riscv` -- deleted in `1709433`) has no handshake:
+// fetch is combinational and unconditional (CLAUDE.md invariant 1), and the
+// data bus is a plain address/strobe/data bus with a fixed one-cycle load
+// turnaround (ADR-0015), not a request/ready protocol. imem_data and
+// mem_rdata are simply free every cycle, the same as riscv-formal's other
+// non-handshake cores (cores/nerv, cores/serv model the equivalent with an
+// explicit ready/ack bit; littlecpu has none to model).
 module rvfi_wrapper (
   input var clock, reset,
   `RVFI_OUTPUTS
 );
   `RVFI_WIRES
-  (* keep *) `rvformal_rand_reg mem_ready;
+
+  (* keep *) `rvformal_rand_reg [31:0] imem_data;
   (* keep *) `rvformal_rand_reg [31:0] mem_rdata;
 
-  (* keep *) logic        mem_valid;
-  (* keep *) logic        mem_instr;
+  (* keep *) logic [31:0] imem_addr;
   (* keep *) logic [31:0] mem_addr;
   (* keep *) logic [31:0] mem_wdata;
   (* keep *) logic [3:0]  mem_wstrb;
   (* keep *) logic        trap;
 
-  riscv wrapper (
+  littlecpu dut (
     .clk(clock),
     .reset(reset),
-    .mem_valid(mem_valid),
-    .mem_instr(mem_instr),
-    .mem_ready(mem_ready),
+    .imem_addr(imem_addr),
+    .imem_data(imem_data),
     .mem_addr(mem_addr),
     .mem_wdata(mem_wdata),
     .mem_wstrb(mem_wstrb),
@@ -28,11 +36,26 @@ module rvfi_wrapper (
   );
 
  `ifdef RISCV_FAIRNESS
-  // from picorv32
-  logic [2:0] mem_wait = 0;
-  always_ff @(posedge clock) begin
-    mem_wait <= {mem_wait, mem_valid && !mem_ready};
-    assume(~mem_wait || trap);
-  end
+  // picorv32/nerv/serv each need this block to bound an *external* signal
+  // (mem_ready, or a bus ack) that the formal environment controls and could
+  // otherwise withhold forever, starving the liveness check of a next
+  // retire. littlecpu exposes no such signal: imem_data/mem_rdata above are
+  // free every cycle, but nothing in the core *waits* on their value --
+  // fetch is combinational, and the two internal stall sources this design
+  // has are driven entirely by the core's own counters, not by anything an
+  // adversarial environment supplies:
+  //   - rtl/executor.v's divider: `mul_div_counter` (rtl/executor.v:169,
+  //     `mul_div_counter <= 32`) counts strictly down from 32 every cycle
+  //     once loaded, with no way for imem_data/mem_rdata's value to hold it.
+  //   - rtl/accessor.v's load-response turnaround: `stalled` is high for
+  //     exactly the one cycle after a load's request (ADR-0015 invariant
+  //     I3 -- the following cycle `in.valid` is guaranteed 0, so `stalled`
+  //     falls unconditionally).
+  // There is nothing for this block to assume: littlecpu has no port an
+  // adversarial environment could hold to defeat forward progress, so
+  // RISCV_FAIRNESS's usual job (bound the stall) has no signal to act on
+  // here. Left as an explicit empty block, per ADR-0017, rather than a
+  // silently omitted `ifdef` -- a future reader should see this was a
+  // decision, not an oversight, if the liveness check ever surprises them.
  `endif
 endmodule


### PR DESCRIPTION
## Summary

Ports ADR-0006's wave-0 riscv-formal harness (`formal/wrapper.v`, `checks.cfg`, `complete.{sv,sby}`, `imemcheck.{sv,sby}`, `dmemcheck.{sv,sby}`, `cover.{sv,sby}`, `equiv.sh`) from the deleted serialized `rtl/riscv.v`/`rtl/alu.v` picorv32-style handshake to the current `littlecpu` module and its `imem_addr`/`imem_data`/`mem_addr`/`mem_wdata`/`mem_wstrb`/`mem_rdata` bus (no handshake — fetch is combinational, ADR-0015's one-cycle load turnaround is the only latency). Adds `formal/Makefile`'s `equiv` target and a nightly-only `.github/workflows/formal-nightly.yml` for the full ladder (ADR-0006: ~1-3h wall), kept out of the PR-gate (`ci.yml`'s required jobs are untouched).

`rtl/` is untouched, per the ticket's constraint — including for the two real bugs the ladder finds (below). Findings are recorded here for a follow-up ticket, not patched.

**Running the ladder against the real core surfaces a genuine, previously-undiscovered bug in shipped RTL:** `rtl/decoder.v`'s immediate-select case routes compressed **C.JR/C.JALR** through the same `immediate = i_immediate` arm as real (uncompressed) JALR. `i_immediate` reads `instr[31:20]` — for a 16-bit compressed instruction those bits belong to whatever is next in memory, not to this instruction. Every C.JR/C.JALR jump target (`(immediate + rs1) & ~1`) is corrupted by that garbage. This is **not** behind any `RISCV_FORMAL`/`ALTOPS` `ifdef` — it's live, synthesizable RTL, reachable any time a real program uses C.JR/C.JALR. It was never caught by `test/asm/*.S` because that suite assembles `-march=rv32im_zicsr`, without the C extension (ADR-0014). The same case statement already special-cases `instr_cj`/`instr_cjal` with the correct `cj_immediate` a few lines below — the fix pattern exists in the file, it just wasn't applied to `cjr`/`cjalr`.

A second, lower-severity finding is **ALTOPS-only**: `rtl/executor.v`'s `RISCV_FORMAL_ALTOPS` divide-completion case (`op_is_div: out.rd_data <= (in.rs1 - in.rs2) ^ ...`) reads `in.rs1`/`in.rs2` live instead of the latched divide operands. Under ALTOPS the divide FSM collapses to a single cycle, so by the time that line runs, decode has already advanced `decoder_out` to the *next* instruction (per ADR-0015's "one free cycle" rule) — the placeholder result is computed from the wrong instruction's operands. Confirmed ALTOPS-only: `components_executor` (no ALTOPS, real 32-cycle divider) still proves correct by k-induction, unaffected. Never exercised by `test/exec_tb.v` or `.S` either (both use the real divider).

## Counts (not verdicts)

| Check class | Generated | Run | Pass | Fail |
|---|---|---|---|---|
| `insn_*` RV32IM (non-C) | 45 | 45 | 36 | 9 |
| `insn_c_*` (compressed) | 25 | 25 | 19 | 6 |
| `csrw_mcycle`/`csrw_minstret` | 2 | 2 | 0 | 2 |
| `reg`/`pc_fwd`/`pc_bwd`/`liveness`/`unique`/`causal` | 6 | 6 | 5 | 0 (1 inconclusive) |

- **RV32IM fails (9):** `div`, `divu`, `rem`, `remu` — the ALTOPS bug above. `lh`, `lhu`, `lw`, `sh`, `sw` — `rvfi_trap` is hardwired `0` in `littlecpu.v` pending M3 (CLAUDE.md: "No traps or CSRs exist yet"), while riscv-formal's spec correctly expects a misalignment trap for non-byte accesses at an unaligned address once `RISCV_FORMAL_ALIGNED_MEM` is set. The real misalignment circuit exists (`mem_misaligned_trap` in `rtl/accessor.v`, wired to the real `trap` port) — it's specifically missing from the RVFI channel. Expected, not a surprise; resolves at M3.
- **Compressed fails (6):** `c_jalr`, `c_jr` — the decoder bug above. `c_lw`, `c_lwsp`, `c_sw`, `c_swsp` — same hardwired-`rvfi_trap` gap as the base-set loads/stores.
- **csrw fails (2):** expected — no CSR implementation exists yet (M3).
- **Consistency (6):** `pc_fwd`, `pc_bwd`, `liveness`, `unique`, `causal` all **PASS**. `reg` (depth 20) did not finish under `yices` within this PR's session — still running after 20+ minutes, a nightly-ladder candidate, **inconclusive**, not reported as pass or fail.
- **`imemcheck`: PASS.** **`dmemcheck`: PASS.** **`cover`: PASS** — all 5 cover goals reached, including the combined "≥2 loads, ≥2 stores, ≥2 long insns, ≥2 compressed insns" goal (real evidence C-extension instructions retire correctly interleaved with everything else).
- **`complete.sv`:** dead references fixed, `imem`/`mem_rdata` made rand-stable per ADR-0006's ask (a single-address write-through shadow for `mem_rdata`; `imem_data` left free since fetch has no cross-cycle latency to model). Elaborates cleanly. **Not run to completion** — depth-50 whole-ISA BMC is nightly-scale and isn't in this ticket's acceptance criteria.
- **`equiv.sh`:** ported, runs, **does not converge** within this session — `equiv_induct` repeatedly fails on `executor.mul_div_y` bits (the sequential divider), exactly what ADR-0020 predicted ("equiv_induct across a pipelined core containing a 32-cycle sequential divider FSM is a hard problem, not a misconfiguration"). Recorded as the finding ADR-0020 asked for, not weakened to pass.

isa was kept at `rv32imc` (not restricted to `rv32im`) — see `checks.cfg`'s new comment: the base `insn_*` checks never constrain how `imem_data` arrives (no address/alignment assumption outside `imemcheck.sv`), so `insn_c_*` genuinely exercises `rtl/decoder.v`'s compressed decode path independent of ADR-0003's not-yet-built dual-word fetch window (ADR-0014). This is a deliberate call, not a silent pass-through, and it's what surfaced the C.JR/C.JALR bug above.

## Testing

- `make -C formal check` (genchecks-local.py, 78 tasks generated) — ran individually via `sby` with `yices` (locally installed; `boolector` installed via `brew` to match `imemcheck.sby`/`dmemcheck.sby`/`cover.sby`/`complete.sby`'s hardcoded engine). See counts above.
- `make -C formal imemcheck` / `dmemcheck` / `cover` — all PASS.
- `formal/equiv.sh` — runs, does not converge (ADR-0020 finding).
- `make -C formal components_decoder` / `components_executor` — both still PASS (unaffected; confirms the ALTOPS bug is scoped to the `ifdef` branch the component proof doesn't build).
- `make test` — 47/47, `test/EXPECTED_FAIL` matches exactly (unaffected — no `rtl/` or `test/` changes in this PR).
- `make test-units` — `exec_tb` (10k vectors/op, 0 mismatches), `mem_tb`, `decoder_tb` all PASS.
- No reference to `rtl/riscv.v`, `rtl/alu.v`, or `module riscv` remains anywhere under `formal/` (checked with `grep`, excluding the gitignored vendored `formal/riscv-formal/` clone).
- Self-review against the repo's security checklist (`/soundcheck:pr-review`'s category skills don't apply — no HTTP/SQL/secrets surface in a hardware formal-verification harness); manually reviewed the one file with real CI supply-chain surface, the new nightly workflow: least-privilege `permissions: contents: read`, reuses the repo's existing SHA-pinned `actions/checkout` and checksum-verified `setup-oss-cad-suite` action, no new third-party actions, no `pull_request_target`, no secrets.
- `/simplify` pass (single-pass, no Agent tool in this context): no reuse/efficiency/altitude issues found; the near-duplicate "single-address write-through memory shadow" in `dmemcheck.sv` and `complete.sv` was considered for extraction and deliberately left alone — each is a standalone SBY testbench entry point (the repo's existing convention) and the two shadows are keyed differently (a fixed checker-chosen address vs. the most-recently-written address), so unifying them would be a scope-creeping behavior change, not a pure simplification. One trivial hygiene fix applied (`cover.sby` was missing its trailing newline).

## Scope notes / risks

- **DECISION NEEDED (architect):** two real RTL findings above (C.JR/C.JALR decoder bug — HIGH severity, real synthesizable path; ALTOPS-only divide-operand bug — low real-world impact, formal-only). Neither is fixed here per the ticket's "do not touch `rtl/`" constraint and the explicit instruction not to convert a discovery into a silent edit. Recommend: (1) a follow-up ticket to fix `rtl/decoder.v`'s immediate-select for `instr_cjr`/`instr_cjalr` (zero the immediate, matching the `instr_cj`/`instr_cjal` pattern already in the file) — this should also get a `test/asm/c_jr.S`/`c_jalr.S` regression once the C extension is exercised by the `.S` suite; (2) a smaller follow-up to latch `rtl/executor.v`'s ALTOPS divide operands the same way the real divider's `div_x`/`div_y` already are.
- `reg_ch0` and `equiv.sh` did not reach a verdict within this session (both nightly-scale per ADR-0006/ADR-0020) — the new nightly workflow is where they get a real chance to finish; not required for this PR's acceptance criteria.
- No `rtl/` changes, no root `Makefile` changes, no riscv-formal pin bump (still `c992aa61fdfe0846c5ed90324c596202a1c69b76`) — all within the ticket's stated constraints.

## Test plan

- [x] `make -C formal check` elaborates and runs (no deleted-file references anywhere in `formal/`)
- [x] `insn_*` counts reported (70 run: 55 pass / 15 fail, causes identified per-instruction above) — not summarized as "passes"
- [x] `reg`/`pc_fwd`/`pc_bwd`/`unique`/`causal` — 4 of 5 green at configured depths; `reg` inconclusive (still running)
- [x] `liveness` green at configured depths
- [x] `imemcheck`/`dmemcheck`/`cover` run and pass
- [x] `equiv.sh` runs; recorded as non-convergent per ADR-0020
- [x] `make test` 47/47; `make test-units` green; `components_decoder`/`components_executor` green
- [x] Every `assume` added names the structural fact it models (ADR-0017) — see comments in `wrapper.v`, `imemcheck.sv`, `dmemcheck.sv`, `complete.sv`

Closes JEF-638.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
