### PR TITLE
ADRs 0021-0023: decisions from integrating the riscv-formal ladder port

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,13 +51,35 @@ monitor defect** — read ADR-0019 before adding a line back for one.
 
 What does not work right now:
 
-- **`formal/checks.cfg` and `formal/wrapper.v` still reference the deleted core** — `checks.cfg`'s
-  `[script-sources]` reads `rtl/riscv.v` and `rtl/alu.v`, and `wrapper.v` instantiates `riscv`.
-- **`formal/equiv.sh` does not run**, so ADR-0006's guarantee that RVFI instrumentation does not
-  perturb core behaviour is **argued, not proven** (ADR-0020). The argument is that every
+- **Every C.JR and C.JALR jump target is corrupted** (ADR-0021). `rtl/decoder.v:145` folds
+  `instr_cjr`/`instr_cjalr` into `instr_jalr`, and `rtl/decoder.v:114` routes `instr_jalr` through
+  `i_immediate = instr[31:20]`. For a 16-bit instruction those bits are whatever sits next in
+  memory — `rtl/fetcher.v` passes `imem_data` through unmasked — so the decoder adds a neighbouring
+  instruction word to `rs1` as a displacement. Not behind any `ifdef`; this is in the synthesized
+  core. Found by `insn_c_jr`/`insn_c_jalr` on the ladder's first run; invisible to the `.S` suite,
+  which assembles without C, and therefore to the monitor as well. The one-token fix
+  (`instr_jalr` → `instr_jalr_op` at line 114) is verified green against formal but wants
+  ADR-0003's fetch window landing alongside it so the sim legs can test it too.
+- **The ALTOPS divide branch reads stale operands.** `rtl/executor.v:221-224` reads `in.rs1`/
+  `in.rs2` in the `divide` state, one cycle after issue, when decode has already bubbled
+  `decoder_out` (ADR-0009). Scoped to `` `ifdef RISCV_FORMAL_ALTOPS ``, so the synthesized divider
+  is fine and `components_executor` still passes — but it means `insn_div`/`divu`/`rem`/`remu` fail,
+  and the divider's operand routing has **no** formal coverage in any form (ADR-0010 already says
+  the arithmetic has none). The non-ALTOPS branch six lines above gets this right and explains why.
+- **`formal/equiv.sh` runs but does not converge** — `equiv_induct` fails on `executor.mul_div_y`
+  bits, exactly the outcome ADR-0020 predicted. So ADR-0006's guarantee that RVFI instrumentation
+  does not perturb core behaviour is still **argued, not proven**. The argument is that every
   `ifdef RISCV_FORMAL` block is write-only with respect to the core. Any future RVFI change must be
   read against that: an `ifdef`'d value reaching a non-`ifdef`'d signal breaks it, and CI would not
   notice.
+- **`reg` is inconclusive** (ADR-0023) — a single depth-21 BMC query that does not return in a
+  practical budget. It is the check that ties RVFI's self-report to the actual register file, so
+  without it the other 55 passing checks establish that the core's story about itself is
+  spec-consistent, not that the story is true.
+- **The formal nightly cannot go red** (ADR-0022). `.github/workflows/formal-nightly.yml:48` is
+  `make -C formal check || true`, and `formal/Makefile`'s `check` has no `-k`, so the sub-make also
+  stops scheduling at the first failure. Today's nightly runs a partial ladder and reports it as
+  success. It needs `-k` and a `formal/EXPECTED_FAIL` baseline before its green means anything.
 - **Three of the five component-proof tasks are vacuous.** `components_fetcher`,
   `components_accessor`, and `components_writeback` contain no assertions at all, only reset
   assumptions, so they "pass" meaninglessly. CI deliberately does not run them; ADR-0006 slates
@@ -71,6 +93,17 @@ ADR-0017 for what the decoder proof does and does not establish). `make waves` n
 iverilog leg (`testbench.vvp`) instead of the cxxrtl runner, matching the verification table below,
 and produces a real `waves.vcd`. CI (`.github/workflows/ci.yml`) runs elaborate / test / components
 / monitor-freshness on every PR.
+
+**`86e2721` ports the riscv-formal ladder to `littlecpu`** — the first time any riscv-formal
+check has run against the pipelined core since the 2021 teardown. `formal/wrapper.v` speaks the
+real bus (no handshake: `imem_data`/`mem_rdata` are free every cycle, per invariant 1 and
+ADR-0015). Of 78 generated checks: **55 of 70 `insn_*` pass**; `pc_fwd`, `pc_bwd`, `liveness`,
+`unique`, `causal`, `imemcheck` and `dmemcheck` pass; `cover` reaches all five goals, including
+≥2 loads and ≥2 stores and ≥2 uncompressed and ≥2 compressed retires in one trace — which is what
+rules out a vacuous harness. **Read ADR-0023 before quoting any of these numbers.** Every one of
+the 15 failures is accounted for (9 = the M3 trap gap, 2 = the C.JR defect below, 4 = the ALTOPS
+divide defect below), `reg` is inconclusive, and everything ran under `RISCV_FORMAL_ALTOPS`, so
+a green `insn_mul` says nothing whatever about multiplication (ADR-0010). **M2 is not reached.**
 
 ## Invariants — do not break these
 
@@ -118,7 +151,7 @@ make waves          # iverilog + VCD (testbench.vvp's baked-in program) -> waves
 make monitor-check  # regenerate test/monitor.v at the pin and diff
 
 make -C formal components_decoder   # component proofs
-make -C formal check                # the riscv-formal ladder (needs the M2 port)
+make -C formal check                # the riscv-formal ladder (78 checks; see ADR-0023)
 ```
 
 Toolchain: macOS `brew install riscv64-elf-gcc`; Linux `apt install gcc-riscv64-unknown-elf`.
@@ -169,18 +202,20 @@ the oracle (ADR-0019).
 | M1 | Finish the pipeline | all RV32IM `.S` tests pass under cxxrtl — **reached, `a4662a2`** |
 | M2 | **Parity checkpoint** | the pipelined core re-proves everything the serialized core proved |
 | M3 | Past the old core | CSRs + machine-mode traps |
-| M4 | Full ladder + CI | nightly formal green; tag a release (PR gate landed, `c66527d`) |
+| M4 | Full ladder + CI | nightly formal green; tag a release (PR gate `c66527d`; nightly `86e2721`, report-only until ADR-0022) |
 
 M1 is reached. **M2 is the milestone that erases the verified→unverified regression** — treat it
 as the real finish line, not M1. `b2dafcc` cleared M2's blocker (RVFI is driven, the monitor is live
-in both sim legs — see Current State above), but M2 itself is not reached: the riscv-formal ladder
-port (`wrapper.v` / `checks.cfg` / `imemcheck` / `dmemcheck` / `cover` / `equiv.sh`, ADR-0006) is
-separate, outstanding work.
+in both sim legs) and `86e2721` landed the ladder port itself (`wrapper.v` / `checks.cfg` /
+`imemcheck` / `dmemcheck` / `cover` / `equiv.sh`, ADR-0006) — but **M2 is not reached.** M2's own
+wording is "re-proves everything the serialized core proved", and 15 red checks plus an inconclusive
+`reg` plus a non-converging `equiv.sh` is not that. ADR-0023 lists what closing it takes; the
+`formal/EXPECTED_FAIL` baseline of ADR-0022 reaching empty is the signal.
 
 ## Pointers
 
 - Design brief: [`docs/ideas/finish-the-rewrite.md`](docs/ideas/finish-the-rewrite.md)
-- Decisions: [`docs/adr/`](docs/adr/) — twenty accepted ADRs, plus a deferred list
+- Decisions: [`docs/adr/`](docs/adr/) — twenty-three accepted ADRs, plus a deferred list
 - Reference text from the old core: `git show 1709433^:rtl/riscv.v` (RVFI retire block),
   `git show e67875c^:rtl/alu.v` (arithmetic)
 - Work is tracked in Linear, project **Little CPU** (team JEF). Named here so you know where the

--- a/docs/adr/0021-the-formal-ladder-runs-the-compressed-checks.md
+++ b/docs/adr/0021-the-formal-ladder-runs-the-compressed-checks.md
@@ -1,0 +1,63 @@
+# ADR-0021: The formal ladder runs the compressed checks, and it found a real bug on the first run
+
+**Status:** Accepted · 2026-07-29 · *Supplements ADR-0002, ADR-0003, ADR-0006*
+
+## Context
+
+`formal/checks.cfg` sets the ISA that `genchecks-local.py` generates per-instruction checks from.
+The obvious-looking choice at the ladder port was `rv32im` — matching what the `.S` suite actually
+assembles (`-march=rv32im_zicsr`, because ADR-0003's dual-word fetch window does not exist yet, so
+the sim legs cannot execute a compressed program). Under that setting the ladder would have
+generated 45 checks.
+
+`isa rv32imc` was kept instead, generating **70** checks: 45 uncompressed plus 25 `insn_c_*`.
+
+The reason this is sound, and not a check running against a capability the core lacks, is a
+property of riscv-formal's own harness: the base `insn_*` checks never constrain how `imem_data`
+arrives. It is a free value every cycle (`formal/wrapper.v`), with no alignment or fetch-window
+assumption anywhere. That constraint lives only in `formal/imemcheck.sv`, which is a separate task.
+So an `insn_c_*` check drives `rtl/decoder.v`'s compressed decode path directly and is not gated on
+the missing fetch window.
+
+## Decision
+
+**The ladder's ISA stays `rv32imc` — the C-extension checks run.** This is a deliberate choice,
+not a leftover from the wave-0 config.
+
+It is the only mechanised coverage the compressed decoder has. The `.S` suite cannot reach it
+(it assembles without C), and `test/monitor.v` — self-checking per retire though it is — can only
+check instructions a test actually executes. The compressed decode path was, until this ladder ran,
+**entirely unexercised by anything in the repository.**
+
+## Consequences
+
+The decision paid for itself on the first run. `insn_c_jr` and `insn_c_jalr` both fail at
+`rvfi_insn_check.sv:178` — `assert(rvformal_addr_eq(spec_pc_wdata, pc_wdata))`, a wrong jump
+target — and the counterexample points at a real, synthesizable defect in shipping RTL:
+
+- `rtl/decoder.v:145` — `instr_jalr = instr_jalr_op || instr_cjr || instr_cjalr`
+- `rtl/decoder.v:114` — `instr_load_op || instr_jalr: immediate = i_immediate`
+- `rtl/decoder.v:90`  — `i_immediate = {{20{instr[31]}}, instr[31:20]}`
+
+C.JR and C.JALR are 16-bit instructions. `rtl/fetcher.v` drives `out.instr = imem_data` raw, with
+no masking, so for a compressed instruction `instr[31:16]` is whatever halfword happens to sit next
+in memory. Routing C.JR/C.JALR through the JALR arm therefore reads `instr[31:20]` — adjacent
+memory — as a jump displacement, and `rtl/decoder.v:485-487` adds it to `rs1`. **Every C.JR and
+C.JALR target is corrupted by an arbitrary neighbouring instruction word.** Per the ISA spec both
+have an implicit zero offset; the correct behaviour is `immediate = 0`, which is what the `default`
+arm already yields once `instr_jalr` stops claiming them.
+
+This is not behind any `ifdef`. It is in the synthesized core.
+
+**The fix does not land here, and it should not land alone.** `rtl/` was out of scope for the
+harness port, and more importantly a one-line immediate-select repair would be unverifiable by
+this repository's own standards: the `.S` suite cannot assemble a program that executes C.JR until
+ADR-0003's fetch window exists, so the only evidence a fix worked would be the same formal check
+that found it. The fix belongs with the fetch window, where it can be tested in all three legs.
+Until then it is recorded in CLAUDE.md's defect ledger, and the two failing checks are named in
+the ladder's expected-failure baseline (ADR-0022) so their disappearance is noticed.
+
+The general lesson is worth more than the bug: **a leg of verification that only checks what the
+other legs can already execute buys nothing.** The 47-test suite and the per-retire monitor were
+both structurally incapable of seeing this. Formal saw it in one second of solver time. Keep the
+oracle's alphabet wider than the simulator's.

--- a/docs/adr/0022-the-formal-nightly-reports-against-an-explicit-baseline.md
+++ b/docs/adr/0022-the-formal-nightly-reports-against-an-explicit-baseline.md
@@ -1,0 +1,79 @@
+# ADR-0022: The formal nightly reports against an explicit baseline, not `|| true`
+
+**Status:** Accepted · 2026-07-29 · *Supplements ADR-0006, ADR-0013, ADR-0014 · Follow-up required*
+
+## Context
+
+`.github/workflows/formal-nightly.yml` landed with the ladder step written as:
+
+```yaml
+- name: riscv-formal ladder (make -C formal check)
+  run: make -C formal check || true
+```
+
+The stated reason is sound as far as it goes: the ladder has known failures that are not
+regressions (CSRs are M3; see ADR-0011 and ADR-0021), so a non-zero exit is expected and the job
+should not go red for them. This is a reporting job, not a gate — there is no required-status-check
+entry for this workflow, and there must not be one while known failures exist.
+
+Two problems, both discovered by re-running the ladder at integration rather than by reading:
+
+1. **`|| true` makes 15 failures and 30 failures look identical.** The step summary lists every
+   check's status, but nothing compares that list to anything. A reader has to know the expected set
+   by heart to notice a new failure. That is precisely the hole ADR-0014 closed for the `.S` suite
+   with `test/EXPECTED_FAIL` and a **set-equality** check in both directions — a newly-*passing*
+   check is as much a signal as a newly-failing one, and neither is visible today.
+
+2. **The ladder does not actually finish.** `formal/Makefile`'s `check` target runs
+   `$(MAKE) -BC checks -j$(JOBS)` with no `-k`. GNU make stops scheduling new jobs at the first
+   failure. With the current 17 failures out of 78 checks, a nightly run completes roughly the
+   first parallel wave and abandons the rest — and `|| true` then reports that partial run as
+   success. The summary would show a majority of checks as "no status", which reads like an
+   infrastructure hiccup rather than the design working as written. Confirmed at integration: the
+   full sweep only ran here because `-k` was passed by hand.
+
+There is a third, smaller version of the same failure to bound work: `reg_ch0.sby` carries no
+`timeout`, and `reg` does not terminate in any practical budget (ADR-0023). It will sit in the
+solver until `timeout-minutes: 300` kills the whole job, taking the `complete` and `equiv.sh` steps
+with it.
+
+## Decision
+
+**Report-only is the right posture; `|| true` is the wrong mechanism.** The nightly keeps its
+non-gating role, and gains an explicit baseline.
+
+Concretely, the follow-up work is:
+
+- Add `-k` to `formal/Makefile`'s `check` recipe so the whole ladder runs. A ladder that stops at
+  the first failure cannot produce a baseline to compare against.
+- Add a tracked `formal/EXPECTED_FAIL` listing the checks known to fail, each with the reason —
+  applying ADR-0014's pattern, including its set-equality property so an unexpected *pass* also
+  trips. Today's contents, verified at integration:
+  - `csrw_mcycle`, `csrw_minstret` — CSRs are M3.
+  - `insn_lh`, `insn_lhu`, `insn_lw`, `insn_sh`, `insn_sw`, `insn_c_lw`, `insn_c_lwsp`,
+    `insn_c_sw`, `insn_c_swsp` — all fail on `assert(spec_trap == trap)`; `rvfi_trap` is hardwired
+    0 until misalignment traps land (M3, ADR-0011). Every byte-granularity access passes, which is
+    what makes this attribution checkable rather than asserted.
+  - `insn_c_jr`, `insn_c_jalr` — the real decode defect, ADR-0021.
+  - `insn_div`, `insn_divu`, `insn_rem`, `insn_remu` — the ALTOPS operand-latching defect,
+    ADR-0023.
+  - `reg` — inconclusive, ADR-0023.
+- Replace `|| true` with the baseline comparison as the step's exit status.
+- Give `reg` a bounded `timeout` in `checks.cfg` so an unsolvable check is *reported* as
+  inconclusive rather than eating the job budget.
+- The `complete` and `equiv.sh` steps are **not** `|| true` today and will therefore fail the job
+  every night for reasons ADR-0023 documents as expected. Decide per step whether it belongs in the
+  baseline or should be allowed to report; do not paper over either with `|| true`.
+
+**This did not hold the ladder port.** The port is the most valuable change in the project's
+history and the nightly is a new, non-required, trivially-revertible reporting job. Blocking the
+former on the latter would have been the wrong trade. Recording it is the price of merging it.
+
+## Consequences
+
+- Until the baseline lands, **the nightly's green is not evidence of anything** and its summary must
+  be read by a human against this ADR's list. Do not cite a green nightly as a result.
+- No status check from this workflow may be added to branch protection while the expected-failure
+  set is non-empty. The gate is `ci.yml`; this is a report.
+- Every entry in the baseline is a debt with a named owner ADR. The file shrinking to empty is the
+  M2 completion signal, and is a better one than any single check passing.

--- a/docs/adr/0023-the-first-ladder-run-does-not-reach-m2.md
+++ b/docs/adr/0023-the-first-ladder-run-does-not-reach-m2.md
@@ -1,0 +1,109 @@
+# ADR-0023: The first ladder run does not reach M2 — three named holes
+
+**Status:** Accepted · 2026-07-29 · *Supplements ADR-0006, ADR-0010, ADR-0020 · Blocks M2*
+
+## Context
+
+`86e2721` ported `formal/wrapper.v`, `checks.cfg`, `imemcheck`, `dmemcheck`, `cover`, `complete`
+and `equiv.sh` from the deleted `rtl/riscv.v`-era harness to `littlecpu`, and ran the riscv-formal
+ladder against the pipelined core **for the first time since the 2021 teardown.** That is a large
+result and it will be tempting to write it down as M2.
+
+It is not M2. This ADR is the record of exactly what the run establishes, so that nobody has to
+reconstruct it later from a green badge.
+
+Re-verified independently at integration, from a clean `genchecks-local.py` sweep:
+
+| | |
+|---|---|
+| generated | 78 checks (70 `insn_*` = 45 uncompressed + 25 compressed, 2 `csrw_*`, `pc_fwd`, `pc_bwd`, `liveness`, `unique`, `causal`, `reg`) |
+| `insn_*` | **55 pass, 15 fail** |
+| pipeline checks | `pc_fwd`, `pc_bwd`, `liveness`, `unique`, `causal` — all pass |
+| hand-authored | `imemcheck` pass, `dmemcheck` pass, `cover` all 5 goals reached |
+| `reg` | **inconclusive** |
+
+All 15 `insn_*` failures were traced to a specific assertion and a specific cause, and each cause
+was confirmed by minimal experiment rather than by argument:
+
+- **9** (`lh`, `lhu`, `lw`, `sh`, `sw`, `c_lw`, `c_lwsp`, `c_sw`, `c_swsp`) fail on
+  `rvfi_insn_check.sv:198`, `assert(spec_trap == trap)`. `rvfi_trap` is hardwired 0 until
+  misalignment traps land in M3 (ADR-0011). Every byte-granularity access (`lb`, `lbu`, `sb`)
+  passes — the failing set is exactly the set of accesses whose address can be misaligned, which is
+  what makes this attribution checkable rather than asserted.
+- **2** (`c_jr`, `c_jalr`) fail on `:178`, the jump target. A real synthesizable defect — ADR-0021.
+  Changing exactly one token at `rtl/decoder.v:114` (`instr_jalr` → `instr_jalr_op`) turns both
+  green with `insn_jalr` and `insn_lb` still passing.
+- **4** (`div`, `divu`, `rem`, `remu`) fail on `:177`, the result value. `rtl/executor.v:221-224`,
+  inside `` `else `` of `` `ifndef RISCV_FORMAL_ALTOPS ``, reads `in.rs1`/`in.rs2` in the `divide`
+  state — one cycle after issue, when decode has already bubbled `decoder_out` (ADR-0009). The
+  non-ALTOPS branch six lines above gets this right and says so in a comment ("Uses the op-select
+  and sign bits latched at issue, not `in`"); the ALTOPS branch was not held to the same rule.
+  Substituting the already-latched `mul_div_x`/`mul_div_y` makes `insn_div` pass.
+
+The harness is not vacuous and is not over-constrained. `cover` reaches all five goals including
+the compound one (≥2 retired loads **and** ≥2 stores **and** ≥2 uncompressed **and** ≥2 compressed
+in a single trace), `imemcheck` ties `rvfi_insn` to fetched memory, and `dmemcheck` ties
+`rvfi_mem_*` to the data bus. A miswired wrapper does not produce that combination.
+
+## Decision
+
+**Merge, and state plainly that M2 is not reached.** The three holes:
+
+### 1. `reg` is inconclusive, and it is the load-bearing one
+
+`reg_ch0` is a single BMC query at depth 21 (`skip 20`). It did not return in >20 minutes here or
+in the porting run. Not a pass, not a fail — no result.
+
+This matters more than its one-line-in-a-table appearance suggests. Every `insn_*` check reads the
+core's **self-report**: it compares `rvfi_rd_wdata` against the spec model's expectation. `reg` is
+the check that ties that self-report to the actual register file — that the value RVFI *claims* was
+written is the value a later instruction *reads back*. Without it, 55 green checks establish that
+**the core's story about itself is spec-consistent**, not that the story is true. A core that
+computed garbage but reported consistent garbage would pass all 55.
+
+That is not a hypothetical class of bug in this repository. ADR-0019 is exactly a case of an oracle
+being self-consistently wrong, and the pre-`a4662a2` regfile — reads one instruction stale — is
+exactly the class of defect `reg` exists to catch and `insn_*` does not.
+
+Accepted as a merge condition because the compensating evidence is real and independent: the `.S`
+suite is 47/47 through `rtl/regfile.v` under cxxrtl, `test/monitor.v` checks every retire against
+architectural state in both sim legs (`b2dafcc`), and `test/regfile_tb.v` covers write-through and
+x0 directly (`814ee44`). None of those is exhaustive; together they are not nothing.
+
+The nightly is where `reg` gets a real budget. It needs a bounded `timeout` first (ADR-0022) so an
+unsolvable query is reported rather than silently consuming the job, and if it still does not
+converge the answer is a decision to write down — split the depth, change engine, or bound it — not
+a switch to flip. Same shape as ADR-0020's finding.
+
+### 2. ALTOPS means the ladder never checked the multiplier or the divider
+
+Restating ADR-0010 because a 55/70 headline will invite forgetting it: every check ran with
+`RISCV_FORMAL_ALTOPS`. `mul`/`mulh`/`mulhu`/`mulhsu` "pass" against a substituted
+`(rs1 + rs2) ^ const`, **not** against multiplication. The real arithmetic is covered only by the
+`.S` suite and `test/exec_tb.v`'s randomized differential bench. A green `insn_mul` is a statement
+about operand routing and retire timing, and nothing whatever about arithmetic.
+
+For div/rem it is currently worse than that: because of the defect above, ALTOPS does not even
+check the plumbing. The divider's operand routing and stall interaction are **unproven by formal in
+any form** until that one-line fix lands.
+
+### 3. `equiv.sh` still does not converge
+
+Ported and runs; `equiv_induct` does not close, failing on `executor.mul_div_y` bits. This is the
+outcome ADR-0020 predicted and asked to be recorded rather than worked around. ADR-0020 stays open
+and its guarantee stays **argued, not proven**. Inducting equivalence across a 32-cycle sequential
+divider is a hard problem; the likely answers are a bounded miter or blackboxing the divider, and
+either is a decision to write down.
+
+## Consequences
+
+- **M2 stays open.** CLAUDE.md's milestone table must not be marked reached. M2's own wording is
+  "the pipelined core re-proves everything the serialized core proved" — the serialized core proved
+  the ladder sans CSRs, and 15 red checks plus an inconclusive `reg` is not that.
+- Anything summarizing this work — release notes, README, commit messages — says *progress toward
+  M2*, names `reg` as inconclusive, and does not let "55/70" stand unqualified. The project's own
+  history is the argument for this discipline: it went from *formally verified* to *unverified*
+  partly because the claim outran the evidence.
+- Closing M2 requires, at minimum: the C.JR fix (ADR-0021), the ALTOPS divide fix, `rvfi_trap` and
+  misalignment traps (M3, ADR-0011), a conclusive `reg`, and a decision on `equiv.sh` (ADR-0020).
+  The `formal/EXPECTED_FAIL` baseline of ADR-0022 reaching empty is the signal.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -23,6 +23,11 @@ and what it costs. Reversing one is fine — write a new ADR that supersedes it.
 | [0016](0016-no-unreviewed-dependabot-automerge.md) | No unreviewed auto-merge for the actions dependabot updates | **Superseded by 0018** |
 | [0017](0017-component-proof-assumptions-must-name-their-model.md) | A component-proof `assume` must name the structural fact it models | Accepted |
 | [0018](0018-dependabot-automerge-gated-on-required-checks.md) | Dependabot auto-merge is re-armed, gated on required status checks | Accepted |
+| [0019](0019-the-monitor-sanitizer-is-the-place-to-fix-generated-monitor-defects.md) | The monitor sanitizer is where generated-monitor defects get fixed | Accepted |
+| [0020](0020-the-rvfi-non-perturbation-guarantee-is-argued-not-proven.md) | The RVFI non-perturbation guarantee is argued, not proven | Accepted |
+| [0021](0021-the-formal-ladder-runs-the-compressed-checks.md) | The formal ladder runs the compressed checks, and it found a real bug | Accepted |
+| [0022](0022-the-formal-nightly-reports-against-an-explicit-baseline.md) | The formal nightly reports against an explicit baseline, not `\|\| true` | Accepted |
+| [0023](0023-the-first-ladder-run-does-not-reach-m2.md) | The first ladder run does not reach M2 — three named holes | Accepted |
 
 0001–0007 came from the design brief
 ([`docs/ideas/finish-the-rewrite.md`](../ideas/finish-the-rewrite.md)). 0008–0011 came out of
@@ -33,7 +38,14 @@ suite that fails in its entirety. 0010 supplements 0006; 0011 scopes 0005; 0012 
 0013 implements 0006's pinning clause; 0014 supplements 0007 and 0008. 0015-0017 came out of
 integrating the second build sprint: 0015 extends 0009 with a stall source 0009 did not know
 existed, 0016 constrains the CI gate, and 0017 records what the newly-passing decoder
-component proof does and does not establish.
+component proof does and does not establish. 0018-0020 came out of integrating the third build
+sprint: 0018 supersedes 0016 now that required checks exist, 0019 makes the monitor sanitizer the
+place a generated-oracle defect gets repaired, and 0020 records that ADR-0006's non-perturbation
+guarantee is argued rather than proven. 0021-0023 came out of integrating the riscv-formal ladder
+port — the first time any formal check ran against the pipelined core. 0021 keeps the compressed
+checks in the ladder and records the C.JR/C.JALR decode defect they found; 0022 replaces the
+nightly's blanket failure-swallowing with an ADR-0014-style baseline; 0023 states what the run
+does and does not establish, and why M2 is not reached.
 
 ## Deferred decisions
 


### PR DESCRIPTION
Records the decisions taken while integrating the ladder port (#22) and the
`make waves` / `test-units` repair (#21), and brings `CLAUDE.md`'s ground truth
back in line with what is actually true after both landed.

Docs only — no RTL, no build, no CI config.

## What integration verification actually showed

The 55/70 headline arrived from a single agent, so it was re-run from a clean
`genchecks-local.py` sweep at integration. It reproduces exactly:

- 78 checks generated (70 `insn_*` = 45 uncompressed + 25 compressed, 2 `csrw_*`, and
  `pc_fwd` / `pc_bwd` / `liveness` / `unique` / `causal` / `reg`)
- **55 of 70 `insn_*` pass**; `pc_fwd`, `pc_bwd`, `liveness`, `unique`, `causal` pass
- `imemcheck` PASS, `dmemcheck` PASS, `cover` reaches all five goals
- `reg` inconclusive — still in the solver after 20+ minutes

Every one of the 15 failures was traced to a named assertion and then confirmed
by minimal experiment, not by argument:

| count | checks | assertion | cause |
|---|---|---|---|
| 9 | `lh` `lhu` `lw` `sh` `sw` `c_lw` `c_lwsp` `c_sw` `c_swsp` | `:198 spec_trap == trap` | `rvfi_trap` hardwired 0 until M3 (ADR-0011) |
| 2 | `c_jr` `c_jalr` | `:178` jump target | real decode defect (ADR-0021) |
| 4 | `div` `divu` `rem` `remu` | `:177 spec_rd_wdata` | ALTOPS operand-latching defect (ADR-0023) |

The trap group is self-corroborating: the failing set is exactly the accesses whose
address can be misaligned, and every byte-granularity access passes.

The harness is not vacuous or miswired. `cover` reaches the compound goal — at least
two loads *and* two stores *and* two uncompressed *and* two compressed retires in a
single trace — and `imemcheck`/`dmemcheck` tie `rvfi_insn` and `rvfi_mem_*` back to the
buses. A miswired wrapper does not produce that combination.

## The C.JR/C.JALR defect, confirmed

`rtl/decoder.v:145` folds `instr_cjr`/`instr_cjalr` into `instr_jalr`; `rtl/decoder.v:114`
routes `instr_jalr` through `i_immediate = {{20{instr[31]}}, instr[31:20]}`. For a 16-bit
instruction those bits are the adjacent halfword — `rtl/fetcher.v` passes `imem_data`
through unmasked — so the decoder adds a neighbouring instruction word to `rs1` as a
displacement. Not behind any `ifdef`.

Changing one token at line 114 (`instr_jalr` → `instr_jalr_op`) turns `insn_c_jr` and
`insn_c_jalr` green with `insn_jalr` and `insn_lb` still passing. **That fix is
deliberately not in this PR** — `rtl/` was out of scope, and it wants ADR-0003's fetch
window alongside it so the `.S` suite can execute a compressed program and test it in all
three legs.

Neither the 47-test suite nor the per-retire monitor could see this. Formal found it in
one second of solver time, on its first run.

## Rulings recorded

- **ADR-0021** — `isa rv32imc` stays. Deliberate, not a leftover: the `.S` suite assembles
  without C, so the ladder is the compressed decoder's only mechanised coverage.
- **ADR-0022** — `make -C formal check || true` is the wrong mechanism for a right posture.
  It makes 15 failures and 30 failures identical, and `check` has no `-k`, so the sub-make
  abandons the ladder at the first failure and the nightly reports a *partial* run as
  success. Needs `-k` plus an ADR-0014-style `formal/EXPECTED_FAIL`. Recorded rather than
  held: the nightly is new, non-required, and trivially revertible.
- **ADR-0023** — M2 is **not** reached. `reg` is inconclusive and it is the load-bearing
  check; everything ran under ALTOPS so a green `insn_mul` says nothing about
  multiplication; `equiv.sh` does not converge. Progress toward M2, not M2.

Follow-ups these name: the C.JR fix with the fetch window, the ALTOPS divide fix, the
formal baseline, and a bounded or re-engined `reg`.