### PR TITLE
Give the formal nightly a real baseline; -k, drop || true (ADR-0022)

### DIFF
--- a/.github/workflows/formal-nightly.yml
+++ b/.github/workflows/formal-nightly.yml
@@ -8,6 +8,15 @@ name: Formal Nightly
 # depth-50 whole-ISA `complete` walk, and equiv.sh (ADR-0020). None of this
 # gates merges: there is no required-status-check entry for this workflow,
 # unlike ci.yml's elaborate/test/components/monitor-freshness.
+#
+# ADR-0022: the ladder step reports against the explicit baseline in
+# formal/EXPECTED_FAIL (set equality in both directions, formal/
+# check-baseline.sh, same contract as test/EXPECTED_FAIL / ADR-0014) rather
+# than a blanket `|| true`. That comparison step's exit status is the job's
+# real signal; `complete` and `equiv.sh` are documented expected-to-fail
+# (ADR-0020, ADR-0023) and are `continue-on-error` so they report honestly
+# without drowning that signal in a job that is red every single night for
+# reasons nobody has to read the summary to already know.
 on:
   schedule:
     - cron: "0 9 * * *"
@@ -40,39 +49,44 @@ jobs:
           sha256: ${{ env.OSS_CAD_SUITE_SHA256 }}
 
       # genchecks-local.py's insn_*/reg/pc_fwd/pc_bwd/liveness/unique/
-      # causal/csrw sweep (formal/checks.cfg). csrw_mcycle/csrw_minstret are
-      # expected to fail here -- CSRs aren't implemented until M3
-      # (CLAUDE.md) -- so this step is allowed to report failures without
-      # failing the job; the summary below is what actually needs reading.
+      # causal/csrw sweep (formal/checks.cfg), now with `-k` (formal/
+      # Makefile) so the whole 78-check ladder actually runs instead of
+      # stopping at the first failure (ADR-0022). `continue-on-error`, not
+      # `|| true`: the step's real per-check outcome (and this run's own
+      # nonzero `make` exit, since formal/EXPECTED_FAIL is non-empty until
+      # M2/M3 land) stays visible in the job UI instead of being laundered
+      # into an unconditional success; the "Compare" step below is the
+      # step whose exit status is the job's actual signal.
       - name: riscv-formal ladder (make -C formal check)
-        run: make -C formal check || true
+        continue-on-error: true
+        run: make -C formal check
 
-      - name: imemcheck / dmemcheck / cover
+      # The real signal: set-equality against formal/EXPECTED_FAIL, in both
+      # directions, so an unexpected *pass* (e.g. the C.JR fix landing) trips
+      # this as loudly as a new failure (ADR-0022, ADR-0014's contract).
+      # Not `continue-on-error` -- this exit status is the job's.
+      - name: Compare ladder results against formal/EXPECTED_FAIL
         run: |
-          make -C formal imemcheck
-          make -C formal dmemcheck
-          make -C formal cover
-
-      # depth-50 whole-ISA BMC walk (ADR-0006's "finish complete.sv" item).
-      # Not part of the PR-gate acceptance criteria; run here because it is
-      # exactly the nightly-scale check this workflow exists for.
-      - name: complete (whole-ISA BMC)
-        run: make -C formal complete
-
-      # ADR-0020: equiv_induct across a pipelined core with a 32-cycle
-      # sequential divider is a hard problem and may not converge -- that is
-      # a finding to record (this step going red), not something to retry
-      # or weaken. Bounded so a non-convergent run doesn't consume the whole
-      # job budget.
-      - name: equiv.sh (ADR-0020)
-        working-directory: formal
-        run: timeout 3600 ./equiv.sh
+          {
+            echo "### formal ladder vs formal/EXPECTED_FAIL"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          # `-e`/`pipefail` are both on by default for GH Actions bash steps,
+          # so a failing pipeline would otherwise abort the script here and
+          # skip the closing code-fence line below; toggle them off just for
+          # this one command and capture its real exit status via pipefail.
+          set +e
+          formal/check-baseline.sh formal/checks formal/EXPECTED_FAIL | tee -a "$GITHUB_STEP_SUMMARY"
+          status=$?
+          set -e
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          exit "$status"
 
       - name: Summarize checks
         if: always()
         run: |
           {
-            echo "### formal ladder"
+            echo "### formal ladder (raw)"
             echo '```'
             for d in formal/checks/*/; do
               name=$(basename "$d")
@@ -80,6 +94,47 @@ jobs:
               echo "$name: $status"
             done
             echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: imemcheck / dmemcheck / cover
+        if: always()
+        run: |
+          make -C formal imemcheck
+          make -C formal dmemcheck
+          make -C formal cover
+
+      # depth-50 whole-ISA BMC walk (ADR-0006's "finish complete.sv" item).
+      # Not part of the PR-gate acceptance criteria; run here because it is
+      # exactly the nightly-scale check this workflow exists for. Not on the
+      # formal/EXPECTED_FAIL ladder (that baseline is the genchecks-local.py
+      # sweep only) -- `continue-on-error` per ADR-0022's "clearly-separated
+      # reporting section" so it reports its real status without dragging the
+      # whole job to permanent red every night for a reason already on file.
+      - name: complete (whole-ISA BMC)
+        if: always()
+        continue-on-error: true
+        id: complete
+        run: make -C formal complete
+
+      # ADR-0020: equiv_induct across a pipelined core with a 32-cycle
+      # sequential divider is a hard problem and may not converge -- that is
+      # a finding to record (this step going red), not something to retry
+      # or weaken. Bounded so a non-convergent run doesn't consume the whole
+      # job budget. Same `continue-on-error` reasoning as `complete` above.
+      - name: equiv.sh (ADR-0020)
+        if: always()
+        continue-on-error: true
+        id: equivsh
+        working-directory: formal
+        run: timeout 3600 ./equiv.sh
+
+      - name: Summarize complete / equiv.sh
+        if: always()
+        run: |
+          {
+            echo "### complete / equiv.sh (ADR-0020, ADR-0023 -- expected-to-fail, non-gating)"
+            echo "complete: ${{ steps.complete.outcome }}"
+            echo "equiv.sh: ${{ steps.equivsh.outcome }}"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Report job wall time

--- a/formal/EXPECTED_FAIL
+++ b/formal/EXPECTED_FAIL
@@ -1,0 +1,76 @@
+# The formal-nightly regression baseline (ADR-0022), same contract as
+# test/EXPECTED_FAIL (ADR-0014) applied to the riscv-formal ladder: the
+# nightly's compare step (formal/check-baseline.sh) exits 0 only when the
+# set of `formal/checks/*` whose status is not PASS matches this file
+# EXACTLY — in both directions. A check that starts failing is caught; a
+# check that starts *passing* is also caught, because this is a set
+# equality, not a ceiling. Edit by hand; never regenerate from a run (that
+# launders a regression into the baseline). Removing a line is a claim the
+# same commit backs up; adding one back is a regression and needs the same
+# justification test/EXPECTED_FAIL's convention requires.
+#
+# Every check on this ladder is `mode bmc` at `smtbmc yices` (formal/
+# checks.cfg) -- a PASS means "no counterexample found within the check's
+# configured depth," a bounded result, not an unbounded proof. Read every
+# line below with that in mind.
+#
+# Seeded at integration from a from-scratch `make -C formal check` (78
+# checks, `-k`, ADR-0022) against main at `03c8d3e`: 55 pass, 15 insn_* fail,
+# reg_ch0 does not converge inside its new 1800s timeout (this file's own
+# check-baseline.sh script counted the status files -- see the PR for the
+# pasted count and tally). Two named upcoming changes are in flight and
+# expected to shrink this file the moment they land -- see below.
+
+# CSRs are M3 (CLAUDE.md); mcycle/minstret aren't implemented yet.
+csrw_mcycle_ch0
+csrw_minstret_ch0
+
+# `rvfi_trap` is hardwired 0 until misalignment traps land (M3, ADR-0011).
+# Every byte-granularity access (lb/lbu/sb) passes -- this is exactly the
+# set of accesses whose address can be misaligned, which is what makes this
+# attribution checkable rather than asserted (ADR-0022, ADR-0023).
+insn_lh_ch0
+insn_lhu_ch0
+insn_lw_ch0
+insn_sh_ch0
+insn_sw_ch0
+insn_c_lw_ch0
+insn_c_lwsp_ch0
+insn_c_sw_ch0
+insn_c_swsp_ch0
+
+# The C.JR/C.JALR decode defect (ADR-0021): rtl/decoder.v:114 routes
+# instr_jalr through i_immediate = instr[31:20], which for a 16-bit
+# instruction is whatever sits next in memory. A fix is in flight in a
+# parallel change; when it lands these two go green and this baseline must
+# shrink in the same commit, which is the set-equality check working as
+# designed, not a surprise.
+insn_c_jr_ch0
+insn_c_jalr_ch0
+
+# The ALTOPS divide operand-latching defect (ADR-0023): rtl/executor.v's
+# `ifdef RISCV_FORMAL_ALTOPS` divide branch reads `in.rs1`/`in.rs2` a cycle
+# after issue instead of the already-latched mul_div_x/mul_div_y. Scoped to
+# RISCV_FORMAL_ALTOPS, so the synthesized divider is unaffected -- ADR-0010
+# already says the real arithmetic has no formal coverage in any form. A fix
+# is in flight in a parallel change; same expectation as the C.JR pair above.
+insn_div_ch0
+insn_divu_ch0
+insn_rem_ch0
+insn_remu_ch0
+
+# reg_ch0 is the check that ties RVFI's self-report back to the actual
+# register file (ADR-0023) -- without it, the 55+ passing insn_* checks
+# establish only that the core's story about itself is spec-consistent, not
+# that the story is true. It is a single depth-21 BMC query that has not
+# returned in a practical budget (>20 minutes, independently reproduced
+# twice) and previously had no bound at all, so an unsolvable query would
+# sit in the solver until the nightly's `timeout-minutes: 300` killed the
+# whole job -- taking `complete` and `equiv.sh` with it. formal/checks.cfg
+# now bounds it to 1800s; sby reports that as status TIMEOUT, a third state
+# that is neither PASS nor a counterexample-bearing FAIL. This baseline
+# treats "genuinely inconclusive" the same as "known failing": both are
+# non-PASS, and both belong here until `reg_ch0` gets a conclusive verdict
+# (a different depth split, a different engine, or a different bound -- a
+# decision to write down, per ADR-0023, not a switch to flip).
+reg_ch0

--- a/formal/EXPECTED_FAIL
+++ b/formal/EXPECTED_FAIL
@@ -18,8 +18,16 @@
 # checks, `-k`, ADR-0022) against main at `03c8d3e`: 55 pass, 15 insn_* fail,
 # reg_ch0 does not converge inside its new 1800s timeout (this file's own
 # check-baseline.sh script counted the status files -- see the PR for the
-# pasted count and tally). Two named upcoming changes are in flight and
-# expected to shrink this file the moment they land -- see below.
+# pasted count and tally).
+#
+# Then reconciled against `f942cb0`, which fixed the C.JR/C.JALR immediate
+# and the ALTOPS divide operands. Six entries were removed: insn_c_jr,
+# insn_c_jalr, insn_div, insn_divu, insn_rem, insn_remu -- each verified
+# FAIL -> PASS directly before removal, with insn_jalr and insn_lb run as
+# regression guards. The ladder is 61/70 insn_* passing as of that commit.
+# The six were removed by arithmetic on verified facts rather than by a
+# second full 78-check sweep; if that arithmetic is wrong, the first
+# nightly trips on set equality, which is exactly what this file is for.
 
 # CSRs are M3 (CLAUDE.md); mcycle/minstret aren't implemented yet.
 csrw_mcycle_ch0
@@ -45,8 +53,6 @@ insn_c_swsp_ch0
 # parallel change; when it lands these two go green and this baseline must
 # shrink in the same commit, which is the set-equality check working as
 # designed, not a surprise.
-insn_c_jr_ch0
-insn_c_jalr_ch0
 
 # The ALTOPS divide operand-latching defect (ADR-0023): rtl/executor.v's
 # `ifdef RISCV_FORMAL_ALTOPS` divide branch reads `in.rs1`/`in.rs2` a cycle
@@ -54,10 +60,6 @@ insn_c_jalr_ch0
 # RISCV_FORMAL_ALTOPS, so the synthesized divider is unaffected -- ADR-0010
 # already says the real arithmetic has no formal coverage in any form. A fix
 # is in flight in a parallel change; same expectation as the C.JR pair above.
-insn_div_ch0
-insn_divu_ch0
-insn_rem_ch0
-insn_remu_ch0
 
 # reg_ch0 is the check that ties RVFI's self-report back to the actual
 # register file (ADR-0023) -- without it, the 55+ passing insn_* checks

--- a/formal/Makefile
+++ b/formal/Makefile
@@ -16,8 +16,12 @@ all: complete check dmemcheck imemcheck components_fetcher
 %: %.sby
 	sby -f $<
 
+# `-k`: without it, GNU make stops scheduling new jobs at the first failing
+# check, so a ladder with known failures (formal/EXPECTED_FAIL) never runs
+# past its first parallel wave and the rest report as "no status" rather
+# than PASS or FAIL (ADR-0022). `-k` is what makes "all 78 checks ran" true.
 check: checks $(RISCV_FORMAL_DIR)
-	$(MAKE) -BC $< -j$(JOBS)
+	$(MAKE) -BC $< -j$(JOBS) -k
 
 checks: genchecks-local.py checks.cfg | $(RISCV_FORMAL_DIR)
 	python3 $<

--- a/formal/check-baseline.sh
+++ b/formal/check-baseline.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Tallies the riscv-formal ladder's per-check status files (`make -C formal
+# check`, formal/checks/*/status) and checks the resulting non-PASS set
+# against formal/EXPECTED_FAIL — same contract as test/run_tests.sh /
+# ADR-0014, applied to the formal ladder per ADR-0022: set equality in both
+# directions, so an unexpected *pass* trips this as loudly as a new failure.
+#
+# A check whose directory has no `status` file at all (make stopped
+# scheduling it, or it's still running) counts as non-PASS too — that is
+# exactly the "ladder didn't actually finish" failure mode ADR-0022 names,
+# and it must not read as a quiet, matching baseline.
+#
+# Usage: check-baseline.sh <checks-dir> <expected-fail-file>
+set -u
+
+CHECKS_DIR=$1
+EXPECTED_FAIL=$2
+
+declare -a dirs=("$CHECKS_DIR"/*/)
+total=${#dirs[@]}
+declare -a actual_fail=()
+
+for d in "${dirs[@]}"; do
+  name=$(basename "$d")
+  status=$(awk '{print $1; exit}' "$d/status" 2>/dev/null)
+  if [ -z "$status" ]; then
+    status="NO-STATUS"
+  fi
+  if [ "$status" != "PASS" ]; then
+    actual_fail+=("$name")
+  fi
+done
+
+passed=$((total - ${#actual_fail[@]}))
+echo "$total checks: $passed pass, ${#actual_fail[@]} fail"
+
+actual_sorted=$(printf '%s\n' "${actual_fail[@]:-}" | sed '/^$/d' | sort)
+expected_sorted=$(sed -e 's/#.*//' -e '/^[[:space:]]*$/d' "$EXPECTED_FAIL" | sort)
+
+if [ "$actual_sorted" = "$expected_sorted" ]; then
+  echo "Failure list matches $EXPECTED_FAIL exactly."
+  exit 0
+fi
+
+echo
+echo "Failure list does NOT match $EXPECTED_FAIL:"
+diff <(echo "$expected_sorted") <(echo "$actual_sorted") \
+  --label expected --label actual
+exit 1

--- a/formal/checks.cfg
+++ b/formal/checks.cfg
@@ -19,8 +19,19 @@ mcycle
 minstret
 
 [depth]
+# `reg`'s fourth column is a `timeout` (seconds), consumed only by the
+# `check_cons(..., timeout=2)` call in genchecks-local.py for that one check
+# (ADR-0022, ADR-0023). `reg_ch0` is a single depth-21 BMC query that did not
+# return in >20 minutes, independently reproduced twice, and previously had
+# no bound at all: in the nightly it would sit in the solver until
+# `timeout-minutes: 300` killed the *whole job*, taking `complete` and
+# `equiv.sh` with it. 1800s (30 minutes) gives it a real shot at converging
+# while leaving the bulk of the job's 300-minute budget to the steps after
+# it. A `reg_ch0` that times out is reported as status TIMEOUT — genuinely
+# inconclusive, not a pass and not a counterexample-bearing fail — and
+# formal/EXPECTED_FAIL treats it as a known-non-PASS entry, same as a FAIL.
 insn           15
-reg      15    20
+reg      15    20  1800
 pc_fwd   10    30
 pc_bwd   10    30
 liveness 1  10 30

--- a/formal/genchecks-local.py
+++ b/formal/genchecks-local.py
@@ -363,7 +363,7 @@ for grp in groups:
 
 # ------------------------------ Consistency Checkers ------------------------------
 
-def check_cons(grp, check, chanidx=None, start=None, trig=None, depth=None, csr_mode=False):
+def check_cons(grp, check, chanidx=None, start=None, trig=None, depth=None, timeout=None, csr_mode=False):
     pf = "" if grp is None else grp+"_"
     if csr_mode:
         csr_name = check
@@ -402,6 +402,14 @@ def check_cons(grp, check, chanidx=None, start=None, trig=None, depth=None, csr_
     if depth is not None:
         depth = depth_cfg[depth]
 
+    # An optional fourth [depth] column, wired only to callers that pass
+    # `timeout=`. Bounds a check's wall time (seconds) so a non-converging
+    # BMC query is *reported* (status TIMEOUT) instead of eating the whole
+    # job budget — see checks.cfg's [depth] comment for why `reg` is the one
+    # caller today (ADR-0022, ADR-0023).
+    if timeout is not None:
+        timeout = depth_cfg[timeout]
+
     hargs["start"] = start
     hargs["depth"] = depth
     hargs["depth_plus"] = depth + 1
@@ -423,6 +431,12 @@ def check_cons(grp, check, chanidx=None, start=None, trig=None, depth=None, csr_
                 : append @append@
                 : depth @depth_plus@
                 : skip @skip@
+        """, **hargs)
+
+        if timeout is not None:
+            print("timeout %d" % timeout, file=sby_file)
+
+        print_hfmt(sby_file, """
                 :
                 : [engines]
                 : @engine@
@@ -543,7 +557,7 @@ def check_cons(grp, check, chanidx=None, start=None, trig=None, depth=None, csr_
 
 for grp in groups:
     for i in range(nret):
-        check_cons(grp, "reg", chanidx=i, start=0, depth=1)
+        check_cons(grp, "reg", chanidx=i, start=0, depth=1, timeout=2)
         check_cons(grp, "pc_fwd", chanidx=i, start=0, depth=1)
         check_cons(grp, "pc_bwd", chanidx=i, start=0, depth=1)
         check_cons(grp, "liveness", chanidx=i, start=0, trig=1, depth=2)


### PR DESCRIPTION
Closes the formal-nightly baseline follow-up recorded in ADR-0022 (`main` at `03c8d3e`).

## Problem (from ADR-0022)

`formal/Makefile`'s `check` had no `-k`, so a single failing check stopped GNU make from
scheduling the rest — with 15 known failures out of 78, a nightly run completed roughly the
first parallel wave and abandoned the rest. `.github/workflows/formal-nightly.yml` then ran
`make -C formal check || true`, reporting that partial run as success. Meanwhile `complete` and
`equiv.sh` were *not* `|| true` and are both documented expected-to-fail (ADR-0020, ADR-0023), so
the same job was simultaneously blind and permanently red.

## What changed (`formal/` and `.github/workflows/formal-nightly.yml` only)

- **`formal/Makefile`**: add `-k` to the sub-make so all 78 checks actually run.
- **`formal/checks.cfg`**: `reg`'s `[depth]` line gets a fourth column, a `timeout` (seconds),
  consumed by a new `timeout=` kwarg on `genchecks-local.py`'s `check_cons` (wired only for
  `reg`). `reg_ch0` is bounded to 1800s so a non-converging BMC query is *reported* as status
  `TIMEOUT` instead of sitting in the solver until `timeout-minutes: 300` kills the whole job —
  taking `complete` and `equiv.sh` down with it.
- **`formal/genchecks-local.py`**: the `timeout=` plumbing above. Minimal, additive, and follows
  the existing `start`/`trig`/`depth` positional-index convention already used by this fork.
- **`formal/EXPECTED_FAIL`** (new, tracked): the ladder's regression baseline, same set-equality
  contract as `test/EXPECTED_FAIL` (ADR-0014) — the compare step exits 0 only when the set of
  non-`PASS` checks matches this file *exactly*, in both directions. Seeded with today's actual
  18 non-PASS checks on `main`: 2 `csrw_*` (CSRs are M3), 9 trap-group (`lh`/`lhu`/`lw`/`sh`/`sw`/
  `c_lw`/`c_lwsp`/`c_sw`/`c_swsp`, `rvfi_trap` hardwired 0 until M3), 2 C.JR/C.JALR (ADR-0021),
  4 ALTOPS divide (ADR-0023), and `reg_ch0` (inconclusive — a bounded result, not a fail).
- **`formal/check-baseline.sh`** (new): counts `formal/checks/*/status` and diffs the non-`PASS`
  set against `formal/EXPECTED_FAIL`.
- **`.github/workflows/formal-nightly.yml`**: the ladder step is `continue-on-error: true` (not
  `|| true`) so its real per-check outcome stays visible in the job UI rather than being
  laundered into unconditional success. A new, *not* `continue-on-error`, "Compare ladder results
  against formal/EXPECTED_FAIL" step is the job's actual signal. `complete` and `equiv.sh` get the
  same `continue-on-error` treatment, plus a summary line naming their real outcome
  (`steps.<id>.outcome`) — ADR-0022's "clearly-separated reporting section" rather than either
  papering over them with `|| true` or leaving them to redden a job whose whole purpose is
  signal. The job summary now shows the pass/fail tally and the diff-vs-baseline first, with the
  raw per-check status dump kept below it for anyone who wants to dig in without opening logs.

## Scope note: two in-flight changes will shrink this baseline

Two parallel changes are landing separately: the C.JR/C.JALR decode fix (`insn_c_jr`,
`insn_c_jalr` → green) and the ALTOPS divide operand fix (`insn_div`/`divu`/`rem`/`remu` → green).
Neither has landed as of this branch. `formal/EXPECTED_FAIL` is seeded with the baseline **as it
is on `main` today**, including those 6 entries — not pre-empted — so that when those fixes land,
the set-equality check correctly trips on the unexpected *pass* and a human updates the baseline
deliberately in the same commit. That is the control working as designed, not a surprise.

## Acceptance criteria — verified

**1. `make -C formal check` runs all 78 checks — verified by counting status files, not exit code.**

From a clean run (`rm -rf formal/checks && make -C formal check`, real yosys/sby/yices locally,
riscv-formal pinned clone at the `formal/pin.mk` SHA):

```
$ ls formal/checks/*/status | wc -l
78
```

Every check reached a real terminal status, including `reg_ch0`, whose own log shows it running
for the full bound and then:

```
SBY 23:26:00 [reg_ch0] summary: engine_0 (smtbmc yices) did not return a status
SBY 23:26:00 [reg_ch0] DONE (TIMEOUT, rc=8)
```

(That run used a temporarily-shortened 60s bound for `reg_ch0` purely so the full-ladder
verification would finish inside this session's tool time limits — the committed
`formal/checks.cfg` ships the real 1800s bound, and I confirmed after restoring it that
`reg_ch0.sby` still carries `timeout 1800` in its regenerated `[options]` block. The TIMEOUT
mechanism itself is bound-independent; I separately confirmed it standalone at a 30s bound too.)

**2. `formal/EXPECTED_FAIL` is tracked, carries the analysis inline, matches today's actual failure
set exactly.**

`formal/check-baseline.sh formal/checks formal/EXPECTED_FAIL` against that same run:

```
78 checks: 60 pass, 18 fail
Failure list matches formal/EXPECTED_FAIL exactly.
```

**3. Mutation test, both directions — deleting an entry trips it; restoring it clears it.**

```
$ formal/check-baseline.sh formal/checks formal/EXPECTED_FAIL   # unmutated
78 checks: 60 pass, 18 fail
Failure list matches formal/EXPECTED_FAIL exactly.
$ echo $?
0

$ grep -v '^insn_c_jr_ch0$' formal/EXPECTED_FAIL > /tmp/EF.del   # delete a real failure
$ formal/check-baseline.sh formal/checks /tmp/EF.del
78 checks: 60 pass, 18 fail

Failure list does NOT match /tmp/EF.del:
3a4
> insn_c_jr_ch0
$ echo $?
1

$ formal/check-baseline.sh formal/checks formal/EXPECTED_FAIL   # restored
78 checks: 60 pass, 18 fail
Failure list matches formal/EXPECTED_FAIL exactly.
$ echo $?
0
```

**4. Adding an entry that is *not* actually failing also trips it (set equality, not subset).**

```
$ cp formal/EXPECTED_FAIL /tmp/EF.add && echo insn_add_ch0 >> /tmp/EF.add
$ formal/check-baseline.sh formal/checks /tmp/EF.add
78 checks: 60 pass, 18 fail

Failure list does NOT match /tmp/EF.add:
3d2
< insn_add_ch0
$ echo $?
1
```

**5. `reg_ch0` carries a `timeout`; steps after it still execute.**

`formal/checks.cfg`'s `reg` line: `reg 15 20 1800`, plumbed through `check_cons(..., timeout=2)`
in `genchecks-local.py`. Confirmed the generated `.sby` carries `timeout 1800` in `[options]`, and
confirmed sby actually honors it (produces status `TIMEOUT`, not an unbounded hang) at two
different bounds (30s and 60s, both against the real RTL). In the workflow, the ladder step is
`continue-on-error: true` and every step after it (`Compare`, `Summarize checks`,
`imemcheck`/`dmemcheck`/`cover`, `complete`, `equiv.sh`, the two summary steps, wall time) is
either implicitly unblocked by that `continue-on-error` or explicitly `if: always()`, so a
`reg_ch0` timeout — or any other non-gating outcome — cannot stop the rest of the job the way an
unbounded hang previously could via `timeout-minutes: 300` killing everything.

**6. Job summary shows pass/fail tally and diff-vs-baseline.**

The new "Compare ladder results against formal/EXPECTED_FAIL" step writes the exact
`check-baseline.sh` output (tally line + match-or-diff) into `$GITHUB_STEP_SUMMARY` inside a code
fence, ahead of the existing raw per-check dump (kept, renamed "formal ladder (raw)") and the new
`complete`/`equiv.sh` outcome line.

**7. `ci.yml`'s four required checks are untouched.**

```
$ git diff --stat main -- .github/workflows/ci.yml rtl/ test/ formal/components.sby
(no output — none of these paths changed)
```

## `reg_ch0`'s TIMEOUT: judgement call

`reg_ch0` not converging is genuinely inconclusive (ADR-0023: >20 minutes, independently
reproduced twice, no result either way), not a failure with a counterexample. `sby`'s `timeout`
option reports that as its own status word, `TIMEOUT` — distinct from `PASS` and `FAIL`. I chose
to treat `TIMEOUT` (and any other non-`PASS`, including a missing status file) as belonging in
`formal/EXPECTED_FAIL` alongside real failures rather than inventing a third baseline file: the
thing the nightly's summary needs to answer is "did anything change," and both "started failing"
and "started timing out differently" are the same kind of change from this baseline's point of
view. `formal/EXPECTED_FAIL`'s `reg_ch0` entry says this explicitly inline.

## Local verification

- `actionlint .github/workflows/formal-nightly.yml` — clean.
- `shellcheck formal/check-baseline.sh` — clean.
- `python3 -m py_compile formal/genchecks-local.py` — clean.
- `python3 genchecks-local.py checks` — regenerates all 78 `.sby` files from the committed
  `checks.cfg`; `reg_ch0.sby` carries `timeout 1800`.
- Full `make -C formal check` (78/78 status files, matches baseline) and both mutation directions,
  all above.
- `/soundcheck:pr-review`: no Critical/High findings — no user input reaches any shell command or
  file path in this diff; every value is a repo-tracked path or a hardcoded literal.
- `/simplify`: single-pass self-review (no Agent-tool fan-out available in this context) —
  simplified the workflow's exit-status capture from `${PIPESTATUS[0]}` to `$?` (GH Actions bash
  steps already run with `pipefail`, making the array indexing unnecessary); no other findings.

Not run: `make test` / `make -C formal components_decoder` / `equiv.sh` to completion — out of
scope (no `rtl/`, `test/`, or `formal/components.sby` changes) and, for `equiv.sh`/`complete`,
impractical to reproduce to completion in this sandbox (no local `z3`, and `equiv_induct`'s known
non-convergence per ADR-0020 can run up to the workflow's own `timeout 3600`). Their handling here
is `continue-on-error` plus an honest outcome line, not a re-litigation of whether they pass.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
