### PR TITLE
Fix the two RTL defects the formal ladder found

### DIFF
--- a/rtl/decoder.v
+++ b/rtl/decoder.v
@@ -111,7 +111,7 @@ module decoder (
   always_comb begin
     (* parallel_case *)
     case (1'b1)
-      instr_load_op || instr_jalr: immediate = i_immediate;
+      instr_load_op || instr_jalr_op: immediate = i_immediate;
       instr_store_op: immediate = s_immediate;
       instr_lui_op || instr_auipc: immediate = u_immediate;
       instr_jal_op: immediate = j_immediate;

--- a/rtl/executor.v
+++ b/rtl/executor.v
@@ -49,6 +49,16 @@ module executor(
   // here at issue, once, instead of read live off `in` 32 iterations later.
   logic op_is_div, op_is_divu, op_is_rem, op_is_remu, op_sign_x, op_sign_y;
 
+ `ifdef RISCV_FORMAL_ALTOPS
+  // The operands as latched by the ALTOPS issue arm below, named so the
+  // completion arm reads them as operands rather than as slices of the
+  // divider's working registers. Raw rs1/rs2 -- ALTOPS does no magnitude
+  // conversion, so no sign wrapper applies here (contrast ADR-0012).
+  logic [31:0] div_alt_rs1, div_alt_rs2;
+  assign div_alt_rs1 = mul_div_x[31:0];
+  assign div_alt_rs2 = mul_div_y[62:31];
+ `endif
+
   // multiply: continuous assignments, so the product tracks the operands every cycle
   // instead of being latched once at time 0. sign_x covers is_mulh (signed rs1) and
   // is_mulhsu (rs1 is signed, rs2 is unsigned); sign_y covers only is_mulh. Extension
@@ -216,12 +226,22 @@ module executor(
             state <= init;
           end
          `else
+          // Read the operands LATCHED AT ISSUE, not `in`. ALTOPS collapses the
+          // divide to a single cycle, so by the time this arm runs `in` already
+          // holds the next decoded instruction and `in.rs1`/`in.rs2` are that
+          // instruction's operands -- the placeholder would be computed from
+          // the wrong values. Same reasoning as the op_is_*/op_sign_* latches
+          // above: this is not the cycle `in` is trustworthy.
+          //
+          // The ALTOPS issue arm latches raw rs1/rs2 (unlike the real divider's
+          // arm, which latches magnitudes per ADR-0012), so these are exactly
+          // the values riscv-formal's placeholder model expects.
           (* parallel_case, full_case *)
           case (1'b1)
-            op_is_div: out.rd_data <= (in.rs1 - in.rs2) ^ 32'h7f8529ec;
-            op_is_divu: out.rd_data <= (in.rs1 - in.rs2) ^ 32'h10e8fd70;
-            op_is_rem: out.rd_data <= (in.rs1 - in.rs2) ^ 32'h8da68fa5;
-            op_is_remu: out.rd_data <= (in.rs1 - in.rs2) ^ 32'h3138d0e1;
+            op_is_div: out.rd_data <= (div_alt_rs1 - div_alt_rs2) ^ 32'h7f8529ec;
+            op_is_divu: out.rd_data <= (div_alt_rs1 - div_alt_rs2) ^ 32'h10e8fd70;
+            op_is_rem: out.rd_data <= (div_alt_rs1 - div_alt_rs2) ^ 32'h8da68fa5;
+            op_is_remu: out.rd_data <= (div_alt_rs1 - div_alt_rs2) ^ 32'h3138d0e1;
           endcase
           out.valid <= 1'b1;
           state <= init;


### PR DESCRIPTION
Both surfaced by the first riscv-formal run against this core (`86e2721`). Both are one-token changes. **Neither the 47-test suite nor the per-retire RVFI monitor could see either one** — that's the argument for the third verification leg, demonstrated.

## `rtl/decoder.v` — C.JR/C.JALR read a garbage immediate

`instr_jalr` folds in `instr_cjr`/`instr_cjalr`, and the immediate-select case routed that whole group through the `i_immediate` arm, which reads `instr[31:20]`. `rtl/fetcher.v` drives `out.instr = imem_data` **raw**, so for a 16-bit compressed instruction those bits are whatever halfword sits next in memory — and the decoder added it to `rs1` as a jump displacement.

**Every C.JR/C.JALR target was corrupted by a neighbouring instruction word**, in the synthesized core, not behind any `ifdef`.

Selecting on `instr_jalr_op` lets the compressed forms fall through to `default: immediate = 32'b0` — the spec-correct implicit zero.

**Why it survived:** `test/asm/*.S` assembles `-march=rv32im_zicsr`, so no compressed instruction has ever executed in simulation, and the monitor therefore never saw one.

**A deliberate departure worth flagging:** the ticket argued this fix should land *together* with ADR-0003's dual-word fetch window, on the grounds that fixing the bug while leaving the sim blind spot intact invites the next one. That argument is right, and the window is still outstanding work. I split them anyway — leaving a known-wrong jump target in `main` while the larger change waits seemed worse, and the ladder does cover it in the meantime (`insn_c_jr`/`insn_c_jalr` are now green). The fetch window and compressed sim coverage remain a separate ticket.

## `rtl/executor.v` — the ALTOPS placeholder used the wrong operands

ALTOPS collapses the divide to a single cycle, so the completion arm ran while `in` already held the *next* decoded instruction — the placeholder was computed from that instruction's operands. Now reads the values latched at issue, same reasoning as the neighbouring `op_is_*`/`op_sign_*` latches.

Scoped entirely inside `ifdef RISCV_FORMAL_ALTOPS`; the shipping divider is untouched. Note the ALTOPS issue arm latches **raw** `rs1`/`rs2` while the real one latches magnitudes (ADR-0012) — so these are exactly the values riscv-formal's placeholder model expects. I named them (`div_alt_rs1`/`div_alt_rs2`) rather than slicing `mul_div_x`/`mul_div_y[62:31]` inline, so the completion arm reads as operands rather than as slices of the divider's working registers.

## Evidence — counts, not verdicts

Ladder before: **55/70** `insn_*` passing. After: **61/70**.

```
insn_c_jr        FAIL -> PASS
insn_c_jalr      FAIL -> PASS
insn_div         FAIL -> PASS
insn_divu        FAIL -> PASS
insn_rem         FAIL -> PASS
insn_remu        FAIL -> PASS
insn_jalr        PASS -> PASS   (regression guard)
insn_lb          PASS -> PASS   (regression guard)
```

The remaining 9 failures are the trap-group checks (`lh` `lhu` `lw` `sh` `sw` `c_lw` `c_lwsp` `c_sw` `c_swsp`) awaiting M3's `rvfi_trap` — unchanged, and not this PR's business.

**These are bounded results.** All 78 ladder checks are `mode bmc` at `smtbmc yices`; a PASS means no counterexample within N cycles, not that the property holds. And per ADR-0010, ALTOPS means the ladder still checks no real multiplier or divider arithmetic — what improved here is the divider's *plumbing*, not its math.

Sim unchanged as expected (`ifdef`-scoped): `make test` **47/47**, all four unit benches green.

## Note for the in-flight baseline PR

#24 seeds `formal/EXPECTED_FAIL` with today's 18-entry non-PASS set. This PR removes 6 of them. That's the set-equality check working as designed — whichever lands second needs the baseline reconciled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)