### PR TITLE
Delete the three vacuous component-proof tasks (JEF-631)

### DIFF
--- a/formal/Makefile
+++ b/formal/Makefile
@@ -11,7 +11,7 @@ ifeq ($(shell printf '%s' '$(JOBS)' | grep -cE '^[1-9][0-9]{0,3}$$'),0)
 override JOBS := 4
 endif
 
-all: complete check dmemcheck imemcheck components_fetcher
+all: complete check dmemcheck imemcheck components_decoder components_executor
 
 %: %.sby
 	sby -f $<
@@ -39,17 +39,14 @@ cover: cover.sby cover.sv | $(RISCV_FORMAL_DIR)
 equiv: equiv.sh
 	./$<
 
-# pipeline stages
-components_fetcher: components.sby ../rtl/fetcher.v
-	sby -f $< fetcher
+# pipeline stages. fetcher/accessor/writeback are deliberately not here: their
+# formal/components.sby tasks were deleted for carrying zero assertions
+# (ADR-0006, ADR-0017) -- a "passing" proof with nothing asserted is not a
+# result.
 components_decoder: components.sby ../rtl/decoder.v
 	sby -f $< decoder
 components_executor: components.sby ../rtl/executor.v
 	sby -f $< executor
-components_accessor: components.sby ../rtl/accessor.v
-	sby -f $< accessor
-components_writeback: components.sby ../rtl/writeback.v
-	sby -f $< writeback
 
 # The riscv-formal clone rule and its pin guard live in pin.mk, included above,
 # so this and the root Makefile cannot drift apart on it.

--- a/formal/components.sby
+++ b/formal/components.sby
@@ -1,9 +1,6 @@
 [tasks]
 executor all
 decoder all
-fetcher all
-accessor all
-writeback all
 
 [options]
 all: mode prove
@@ -16,41 +13,17 @@ decoder:
 read -sv -formal structs.v decoder.v
 prep -top decoder
 
-fetcher:
-read -sv -formal structs.v fetcher.v
-prep -top fetcher
-
 executor:
 read -formal structs.v executor.v
 prep -top executor
-
-accessor:
-read -formal structs.v accessor.v
-prep -top accessor
-
-writeback:
-read -formal structs.v writeback.v
-prep -top writeback
 --
 [files]
-fetcher:
-../rtl/fetcher.v
-../rtl/structs.v
-
 decoder:
 ../rtl/decoder.v
 ../rtl/structs.v
 
 executor:
 ../rtl/executor.v
-../rtl/structs.v
-
-accessor:
-../rtl/accessor.v
-../rtl/structs.v
-
-writeback:
-../rtl/writeback.v
 ../rtl/structs.v
 
 --

--- a/rtl/accessor.v
+++ b/rtl/accessor.v
@@ -297,13 +297,4 @@ module accessor(
     end
   end
 
- `ifdef FORMAL
-  logic clocked;
-  initial clocked = 0;
-  always_ff @(posedge clk) clocked <= 1;
-  // assume we've reset at clk 0
-  initial assume(reset);
-  always_comb if(!clocked) assume(reset);
-
- `endif
 endmodule

--- a/rtl/fetcher.v
+++ b/rtl/fetcher.v
@@ -44,13 +44,4 @@ module fetcher(
     end
   end
 
- `ifdef FORMAL
-  logic clocked;
-  initial clocked = 0;
-  always_ff @(posedge clk) clocked <= 1;
-  // assume we've reset at clk 0
-  initial assume(reset);
-  always_comb if(!clocked) assume(reset);
-
- `endif
 endmodule

--- a/rtl/writeback.v
+++ b/rtl/writeback.v
@@ -88,12 +88,4 @@ module writeback(
     else if (rvfi_valid) rvfi_order <= rvfi_order + 64'b1;
   end
  `endif
-
- `ifdef FORMAL
-  logic clocked;
-  initial clocked = 0;
-  always_ff @(posedge clk) clocked <= 1;
-  // assume we've reset at clk 0
-  initial assume(reset);
- `endif
 endmodule


### PR DESCRIPTION
## Summary

`formal/components.sby` declared `fetcher`/`accessor`/`writeback` tasks whose `ifdef FORMAL` blocks contained only `clocked`/reset-assume boilerplate — zero assertions, so their PASS meant nothing (ADR-0006 already decided this; ADR-0017 records why a green vacuous proof is worse than no proof). Since the ticket was written, `1cddcc3` touched `rtl/fetcher.v` directly and `a4662a2` added real assertions to other modules, so I re-verified each of the three blocks before deleting anything — all three still carry nothing but the boilerplate (confirmed both by reading the source and by sby's own report, see below).

- Removed the `fetcher`/`accessor`/`writeback` `[tasks]`/`[script]`/`[files]` entries from `formal/components.sby`.
- Removed the matching `components_fetcher`/`components_accessor`/`components_writeback` targets from `formal/Makefile`, and repointed `all:` at the two real proof targets (it previously named the now-deleted `components_fetcher`).
- Removed the dead `ifdef FORMAL` boilerplate (`clocked`/reset-assume, no assertions) from `rtl/accessor.v`, `rtl/fetcher.v`, and `rtl/writeback.v`. No behavioural RTL change.

`decoder` and `executor` are untouched.

## Assertion counts (the actual check, not just PASS)

From `sby -f formal/components.sby`'s own xml report (`tests` = 1 "build execution" testcase + N `ASSERT` testcases):

| Task | Before | After |
|---|---|---|
| `decoder` | PASS, 6 assertions (`tests="7"`) | PASS, 6 assertions (`tests="7"`) |
| `executor` | PASS, 16 assertions (`tests="17"`) | PASS, 16 assertions (`tests="17"`) |
| `fetcher` | PASS, **0 assertions** (`tests="0"`) | task deleted |
| `accessor` | PASS, **0 assertions** (`tests="0"`) | task deleted |
| `writeback` | PASS, **0 assertions** (`tests="0"`) | task deleted |

`make components_fetcher` now fails with "No rule to make target" as expected.

## Test plan

- [x] `sby -f formal/components.sby` (from `formal/`) now declares only `decoder` and `executor`, both PASS with non-zero assertion counts (6 and 16 respectively, verified via the sby xml report above)
- [x] `make -C formal components_fetcher` → `No rule to make target` (deleted target)
- [x] `make -C formal components_decoder` and `make -C formal components_executor` → PASS by k-induction
- [x] `make test` → 49/49, `test/EXPECTED_FAIL` match exact (unchanged, 11 entries — this change doesn't touch the riscv-formal ladder at all)
- [x] `make test-units` → all four benches PASS
- [x] `make monitor-check` → clean (no diff; RVFI logic untouched)
- [x] yosys `write_cxxrtl` elaboration of the full pipeline → zero promoted warnings
- [x] `make rvfi_macros.vh testbench.vvp` (iverilog leg) → exit 0, only the documented 20 `sorry:` notes (CLAUDE.md's known/accepted class), no warnings

Closes JEF-631
