### PR TITLE
JEF-629: prove the fetcher/decoder PC loop; cover the executor freeze branch

### DIFF
--- a/formal/components.sby
+++ b/formal/components.sby
@@ -1,6 +1,7 @@
 [tasks]
 executor all
 decoder all
+pcloop all
 
 [options]
 all: mode prove
@@ -16,6 +17,21 @@ prep -top decoder
 executor:
 read -formal structs.v executor.v
 prep -top executor
+
+pcloop:
+# The RTL is deliberately read WITHOUT -formal: -formal defines FORMAL, and
+# rtl/decoder.v's own `ifdef FORMAL` block contains `assume(in.pc == pc)` --
+# the standalone-task model of the fetcher (ADR-0017) that this composed task
+# exists to discharge. Compiled into the instance, that assume makes the echo
+# assertion circular (it is assumed inside the very design it is asserted of)
+# and turns a broken fetcher into an unreachable state instead of a
+# counterexample: mutating fetcher.v's `out.pc = pc` to `out.pc = 0` still
+# "passed" until this split, because the only traces satisfying the imported
+# assume were perpetual-stall ones. Each component's FORMAL block belongs to
+# its own task; only the harness carries proof content here.
+read -sv structs.v fetcher.v decoder.v
+read -sv -formal structs.v pcloop.sv
+prep -top pcloop
 --
 [files]
 decoder:
@@ -25,5 +41,11 @@ decoder:
 executor:
 ../rtl/executor.v
 ../rtl/structs.v
+
+pcloop:
+../rtl/fetcher.v
+../rtl/decoder.v
+../rtl/structs.v
+pcloop.sv
 
 --

--- a/formal/pcloop.sv
+++ b/formal/pcloop.sv
@@ -1,0 +1,218 @@
+// Composed fetcher + decoder proof: the PC loop, with nothing assumed about it.
+//
+// rtl/decoder.v's own component task has to `assume(in.pc == pc)` -- it stands
+// alone, so `in` is a free input and the solver would otherwise hand it a
+// fetcher_pc unrelated to what the decoder itself last drove. That assumption
+// is sound (it models rtl/fetcher.v's `out.pc = pc` plus littlecpu.v's pc->pc
+// wiring, and ADR-0017 requires it to say so) but it makes the pc-increment
+// assertions near-tautological: substitute it into `pc <= fetcher_pc + pc_inc`
+// and you get `pc <= pc + pc_inc`, which is what is being asserted.
+//
+// So this task wires the two modules together for real, the way littlecpu.v
+// does: decoder.pc drives fetcher.pc, and fetcher.out feeds decoder.in. The
+// pc-increment assertions are restated against that closed loop, and the echo
+// itself becomes an assertion rather than an assumption. Break rtl/fetcher.v's
+// `out.pc = pc` and this task fails -- which the standalone decoder task
+// cannot do, because it assumes exactly that away.
+//
+// One build-level rule makes this non-circular: components.sby reads the RTL
+// WITHOUT -formal for this task (see the note there). Compiled with it, the
+// decoder instance would carry its own standalone-task `assume(in.pc == pc)`
+// into this proof -- assuming the very echo this task asserts, and reducing a
+// broken fetcher to an unreachable state instead of a counterexample.
+//
+// Everything the decoder needs from stages this task does not instantiate
+// (reg_rs1/rs2, executor_out, the accessor's stall and pending-load slots)
+// stays a free input. reg_rs1 does reach pc arithmetic -- it is the jalr base
+// and a branch comparand -- but only on cycles the increment assertion
+// already excludes as jump/branch cycles, so leaving all of them
+// unconstrained makes the proof stronger, not weaker.
+`default_nettype none
+
+module pcloop (
+    input logic clk,
+    input logic reset,
+    input logic [31:0] imem_data,
+    input logic [31:0] imem_data2,
+    input logic [31:0] reg_rs1,
+    input logic [31:0] reg_rs2,
+    input executor_output executor_out,
+    input logic divider_stall,
+    input logic accessor_stall,
+    input logic accessor_pending_valid,
+    input logic [4:0] accessor_pending_rd
+);
+  logic [31:0] pc;
+  logic [31:0] imem_addr, imem_addr2;
+  fetcher_output fetcher_out;
+  decoder_output decoder_out;
+  logic [4:0] rs1, rs2;
+
+  fetcher fetcher (
+    .clk(clk),
+    .reset(reset),
+    .pc(pc),
+    .imem_addr(imem_addr),
+    .imem_data(imem_data),
+    .imem_addr2(imem_addr2),
+    .imem_data2(imem_data2),
+    .out(fetcher_out)
+  );
+
+  decoder decoder (
+    .clk(clk),
+    .reset(reset),
+    .in(fetcher_out),
+    .reg_rs1(reg_rs1),
+    .reg_rs2(reg_rs2),
+    .executor_out(executor_out),
+    .divider_stall(divider_stall),
+    .accessor_stall(accessor_stall),
+    .accessor_pending_valid(accessor_pending_valid),
+    .accessor_pending_rd(accessor_pending_rd),
+    .pc(pc),
+    .rs1(rs1),
+    .rs2(rs2),
+    .out(decoder_out)
+  );
+
+ `ifdef FORMAL
+  logic clocked;
+  initial clocked = 0;
+  always_ff @(posedge clk) clocked <= 1;
+
+  // Reset is a once-at-the-start pulse everywhere in this design -- the same
+  // assumption rtl/decoder.v and rtl/executor.v make in their own tasks, for
+  // the same reason: without it the solver can reassert reset between the two
+  // cycles these assertions compare and force pc back to 0 in between.
+  initial assume(reset);
+  always_comb if (!clocked) assume(reset);
+  always_comb if (clocked) assume(!reset);
+
+  // Every guard signal below is re-derived HERE, from pcloop's own ports and
+  // wires -- never by hierarchical reference into the decoder instance.
+  // yosys's Verilog frontend does not resolve `decoder.uncompressed`-style
+  // references: it implicitly declares a fresh, undriven wire of that dotted
+  // name in this module (the build log warned twice -- "Identifier
+  // `\decoder.uncompressed' is implicitly declared", then "Wire
+  // pcloop.\decoder.uncompressed is used but has no driver") and the solver
+  // then drives the phantom wire freely. An earlier revision of this file
+  // sampled those phantoms and got a "counterexample" in which pc correctly
+  // stepped 0 -> 4 for an uncompressed word while its sampled history
+  // claimed the instruction was compressed.
+  //
+  // Re-deriving is also the honest formulation: the width and jump guards
+  // become an independent restatement of the fetched word's decode, so the
+  // assertion compares the DUT against the instruction stream itself rather
+  // than against the decoder's own opinion of it.
+
+  // Width and control-flow facts of the word the fetcher presents this
+  // cycle. Field positions mirror rtl/decoder.v (quadrant = instr[1:0],
+  // opcode = instr[6:2], funct3 = instr[14:12], cfunct3 = instr[15:13]).
+  // decoder.v's upper-half masking cannot make these disagree with the
+  // decoder's view: every uncompressed match below requires quadrant ==
+  // 2'b11, where the mask is the identity, and every compressed match reads
+  // only instr[15:0], which the mask preserves.
+  logic [31:0] f_instr;
+  assign f_instr = fetcher_out.instr;
+  logic f_uncompressed;
+  assign f_uncompressed = f_instr[1:0] == 2'b11;
+  // Exactly the instructions whose case arm in rtl/decoder.v's publish block
+  // may write a non-sequential pc: jal/jalr, the six branches, and their
+  // compressed forms (c.j, c.jal, c.jr, c.jalr, c.beqz, c.bnez). A branch
+  // opcode with funct3 2'b01x matches none of the six instr_b* flags, takes
+  // no case arm, and falls through to the sequential pc -- so it is
+  // deliberately NOT excluded here.
+  logic f_jump_branch;
+  assign f_jump_branch =
+      // jal / jalr (rtl/decoder.v instr_jal_op / instr_jalr_op)
+      (f_uncompressed && f_instr[6:2] == 5'b11011) ||
+      (f_uncompressed && f_instr[6:2] == 5'b11001 && f_instr[14:12] == 3'b000) ||
+      // beq/bne/blt/bge/bltu/bgeu (instr_branch_op, the six real funct3s)
+      (f_uncompressed && f_instr[6:2] == 5'b11000 &&
+         f_instr[14:12] != 3'b010 && f_instr[14:12] != 3'b011) ||
+      // c.j / c.jal / c.beqz / c.bnez (quadrant 01)
+      (f_instr[1:0] == 2'b01 && (f_instr[15:13] == 3'b101 || f_instr[15:13] == 3'b001 ||
+                                 f_instr[15:13] == 3'b110 || f_instr[15:13] == 3'b111)) ||
+      // c.jr / c.jalr (quadrant 10, cfunct3 100, rs2 field 0, rs1 field != 0;
+      // instr[12] only picks jr vs jalr, so the union drops it)
+      (f_instr[1:0] == 2'b10 && f_instr[15:13] == 3'b100 && f_instr[6:2] == 5'b0 &&
+         f_instr[11:7] != 5'b0);
+
+  // A cycle on which the decoder may legitimately hold pc. Deliberately an
+  // OVER-approximation of rtl/decoder.v's `stall`: the real hazard also
+  // requires that the instruction consumes rs1/rs2 as register operands
+  // (uses_rs1/uses_rs2), and restating that here would mean duplicating most
+  // of decode. Skipping a superset of the stall cycles is sound for the
+  // increment assertion (it only ever *excuses* cycles, and hazard implies
+  // this signal); what it forgoes -- proving pc holds on a RAW-hazard cycle
+  // -- is asserted where `stall` is visible, in rtl/decoder.v's own FORMAL
+  // block. Built entirely from pcloop-scope nets: rs1/rs2 and decoder_out
+  // are decoder output ports, the rest are this module's free inputs, and
+  // the producer test transcribes rtl/decoder.v's live_producer().
+  logic f_live_rs1, f_live_rs2, f_may_stall;
+  assign f_live_rs1 = rs1 != 0 &&
+      ((decoder_out.valid && decoder_out.rd == rs1) ||
+       (executor_out.valid && executor_out.rd == rs1) ||
+       (accessor_pending_valid && accessor_pending_rd == rs1));
+  assign f_live_rs2 = rs2 != 0 &&
+      ((decoder_out.valid && decoder_out.rd == rs2) ||
+       (executor_out.valid && executor_out.rd == rs2) ||
+       (accessor_pending_valid && accessor_pending_rd == rs2));
+  assign f_may_stall = divider_stall || accessor_stall || f_live_rs1 || f_live_rs2;
+
+  // Registered history, sampled at the same posedge that updates pc. That
+  // same-edge sample is the phase relationship rtl/decoder.v:442 dictates:
+  // `pc <= fetcher_pc + pc_inc` computes both addends combinationally from
+  // the PRE-edge state (fetcher_pc = pc through the fetcher's echo, pc_inc
+  // from the word the fetch window presents at that same pre-edge pc), so
+  // the width that produced the post-edge pc is `uncompressed` as it stood
+  // just before the edge -- exactly what a plain registered copy holds one
+  // cycle later. Every history bit here copies a signal that is real and
+  // driven on every non-reset cycle (fetcher_out is reset-muxed to zero, the
+  // ports are always driven), and the one garbage sample possible -- the
+  // pre-reset initial state at cycle 0 -- lands under prev_reset = 1, which
+  // every assertion below excludes.
+  logic [31:0] past_pc;
+  logic prev_reset, prev_may_stall, prev_hard_stall, prev_jump_branch, prev_uncompressed;
+  always_ff @(posedge clk) begin
+    past_pc           <= pc;
+    prev_reset        <= reset;
+    prev_may_stall    <= f_may_stall;
+    prev_hard_stall   <= divider_stall || accessor_stall;
+    prev_jump_branch  <= f_jump_branch;
+    prev_uncompressed <= f_uncompressed;
+  end
+
+  // The echo, asserted rather than assumed. This one line is what turns the
+  // standalone task's `assume(in.pc == pc)` into a proof obligation.
+  always_comb if (clocked && !reset) assert(fetcher_out.pc == pc);
+
+  // Sequential advance: on a cycle whose predecessor was quiet -- not reset,
+  // no possible stall, not a jump or branch -- pc moved by exactly the width
+  // of the word the fetcher presented, with the width judged independently
+  // from that word itself. The advance provably routed through the real
+  // fetcher: rtl/decoder.v:442 adds fetcher_pc, not its own pc, and only the
+  // echo assertion above ties fetcher_pc back to past_pc.
+  always_ff @(posedge clk)
+    if (clocked && !prev_reset && !prev_may_stall && !prev_jump_branch)
+      assert(pc == past_pc + (prev_uncompressed ? 32'd4 : 32'd2));
+
+  // Deliberately NOT asserted here: `pc_inc == (uncompressed ? 4 : 2)` is a
+  // verbatim restatement of rtl/decoder.v:343, so it would prove nothing
+  // about the loop -- and the standalone decoder task already pins pc_inc's
+  // two constants (mutating it to `uncompressed ? 4 : 4` fails there). What
+  // this task adds is that the increment reaches pc *through a real fetcher*.
+
+  // A divider/accessor freeze holds the PC (ADR-0009 / ADR-0015: upstream of
+  // a stalling stage freezes). Under-approximated to the two unconditional
+  // stall sources on purpose -- both are direct inputs here, and
+  // rtl/decoder.v's first publish arm holds pc whenever either is up,
+  // hazard or no hazard. The RAW-hazard hold is the standalone decoder
+  // task's assertion, as above.
+  always_ff @(posedge clk)
+    if (clocked && prev_hard_stall && !prev_reset) assert(pc == past_pc);
+ `endif
+endmodule
+
+`default_nettype wire

--- a/rtl/executor.v
+++ b/rtl/executor.v
@@ -274,17 +274,42 @@ module executor(
   always_comb if (clocked) assume(!reset);
 
   // This component proof stands alone (no accessor instantiated), so
-  // accessor_stall is otherwise a free input every cycle — the solver could
-  // hold it asserted forever and defeat every arithmetic assertion below via
-  // the accessor_stall freeze branch (out <= 0 every cycle, never reaching
-  // the case (state) that actually computes anything). In the real pipeline
-  // accessor_stall is a one-cycle pulse strictly caused by a load reaching
-  // the accessor, structurally unrelated to mul/div correctness (ADR-0015) —
-  // scoped out here the same way ADR-0010 already restricts this proof's
-  // divide operands, for the same reason: keep the proof about the
-  // arithmetic, not an interaction test/asm/hazard.S and the decoder's own
-  // formal task already cover.
-  always_comb assume(!accessor_stall);
+  // accessor_stall is a free input. It used to be assumed away entirely
+  // (`assume(!accessor_stall)`), which scoped the freeze branch at the top
+  // of the state machine out of this proof altogether. It is now left
+  // completely free — not even ADR-0015's at-most-one-consecutive-cycle
+  // bound is assumed, which makes this stronger than the real environment:
+  // a held stall just keeps the freeze obligations below in force. The
+  // price is a `!$past(accessor_stall)` guard on each multiply assertion
+  // further down: a frozen edge computes nothing (out is bubbled), so an
+  // ungated assertion there would be asserting arithmetic about the bubble.
+  // The divide-state invariants need no such guard (a freeze holds every
+  // register they mention), and the divide completion assertions' guard
+  // ($past(state) == divide && state == init) already implies the
+  // transition edge was not frozen — a frozen edge cannot change state.
+
+  // ADR-0015 freeze coverage: the cycle after accessor_stall is asserted,
+  // the executor emitted a bubble and held everything else — state, the
+  // divider datapath, and the op/sign latches — unchanged. This is the
+  // `else if (accessor_stall)` branch of the state machine, asserted rather
+  // than assumed out of existence. Guarded on !$past(reset) because reset
+  // wins over the freeze in the RTL (and the pre-reset initial values of
+  // the mul_div registers are free).
+  always_ff @(posedge clk)
+    if (clocked && !reset && !$past(reset) && $past(accessor_stall)) begin
+      assert(out == '0);
+      assert(state == $past(state));
+      assert(mul_div_counter == $past(mul_div_counter));
+      assert(mul_div_store == $past(mul_div_store));
+      assert(mul_div_x == $past(mul_div_x));
+      assert(mul_div_y == $past(mul_div_y));
+      assert(op_is_div == $past(op_is_div));
+      assert(op_is_divu == $past(op_is_divu));
+      assert(op_is_rem == $past(op_is_rem));
+      assert(op_is_remu == $past(op_is_remu));
+      assert(op_sign_x == $past(op_sign_x));
+      assert(op_sign_y == $past(op_sign_y));
+    end
 
   // ---- Executor arithmetic BMC (ADR-0006 component proof #2 / ADR-0010) ----
   // The *primary* guarantee for real mul/div arithmetic is the randomized
@@ -323,16 +348,16 @@ module executor(
   assign mul_ref_su_hi = mul_ref_su[63:32];
 
   always_ff @(posedge clk)
-    if (clocked && !reset && !$past(reset) && $past(state) == init && $past(in.is_mul))
+    if (clocked && !reset && !$past(reset) && !$past(accessor_stall) && $past(state) == init && $past(in.is_mul))
       assert(out.rd_data == $past(mul_ref_lo));
   always_ff @(posedge clk)
-    if (clocked && !reset && !$past(reset) && $past(state) == init && $past(in.is_mulh))
+    if (clocked && !reset && !$past(reset) && !$past(accessor_stall) && $past(state) == init && $past(in.is_mulh))
       assert(out.rd_data == $past(mul_ref_ss_hi));
   always_ff @(posedge clk)
-    if (clocked && !reset && !$past(reset) && $past(state) == init && $past(in.is_mulhu))
+    if (clocked && !reset && !$past(reset) && !$past(accessor_stall) && $past(state) == init && $past(in.is_mulhu))
       assert(out.rd_data == $past(mul_ref_uu_hi));
   always_ff @(posedge clk)
-    if (clocked && !reset && !$past(reset) && $past(state) == init && $past(in.is_mulhsu))
+    if (clocked && !reset && !$past(reset) && !$past(accessor_stall) && $past(state) == init && $past(in.is_mulhsu))
       assert(out.rd_data == $past(mul_ref_su_hi));
 
   // Divide: an end-to-end assertion unrolling the restoring divider's full


### PR DESCRIPTION
Closes JEF-629

`rtl/decoder.v`'s standalone component task assumes `in.pc == pc`. Sound — it models `rtl/fetcher.v`'s `out.pc = pc` and `littlecpu.v`'s wiring — but substitute it into `pc <= fetcher_pc + pc_inc` and you get `pc <= pc + pc_inc`, which is what the assertions assert. **The loop CLAUDE.md invariant 1 rests on was assumed, not proven.**

`formal/pcloop.sv` composes a real fetcher and a real decoder, wired as `littlecpu.v` wires them, and **asserts** the echo instead of assuming it.

## Two defects surfaced building it — the second is why this mattered

**1. Yosys does not resolve hierarchical references like `decoder.uncompressed`.** It declares them implicitly as *undriven wires*. So every guard history in the first draft was a registered copy of a phantom the solver could set at will. What looked like a phase error — `pc` 0→4 with the width flag low — was a correct pc step paired with a fabricated history; the real `uncompressed` inside the instance was 1. All guards are now re-derived from pcloop-scope nets, decoded independently from `fetcher_out.instr`. That's an *oracle restatement* rather than a sampling of the decoder's own opinion, which is strictly stronger.

**2. The composition was circular.** `components.sby` read the RTL with `-formal`, which defines `FORMAL`, which compiled `rtl/decoder.v`'s own standalone-task block — **including `assume(in.pc == pc)`** — into the composed instance. The echo was being assumed inside the design it was asserted of. Breaking the fetcher then made non-stall traces *unreachable* rather than producing a counterexample, so the proof passed while proving nothing.

Fix: the `pcloop` task reads the RTL **without** `-formal` and only `pcloop.sv` with it. Each component's FORMAL block belongs to its own task.

## Verified by mutation — the only thing distinguishing this from the circular version

| mutation | result |
|---|---|
| `out.pc = pc` → `32'b0` | **FAIL** — echo assertion, step 2 |
| `pc_inc = uncompressed ? 4 : 2` → `4 : 4` | **FAIL** — increment assertion, step 3 |
| clean RTL | **PASS** by k-induction |

Two mutations, two different assertions, two different steps: **both independently live.** All mutations reverted; `git diff` on `rtl/fetcher.v` and `rtl/decoder.v` is empty.

## Executor freeze branch (ADR-0015)

`assume(!accessor_stall)` had scoped the freeze out entirely. That assumption is **gone** — `accessor_stall` is now completely free, not even bounded to the one-cycle pulse ADR-0015 establishes, since eliminating an assumption beats naming one (ADR-0017).

The multiply assertions gained a `!$past(accessor_stall)` guard (a frozen edge computes nothing); the divide invariants need none. Twelve new assertions prove the freeze holds `state`, `mul_div_*`, and `op_*` unchanged while emitting a bubble.

Mutating the freeze to add `state <= init` **FAILs** at the state-hold assertion (`executor.v:302`, step 4). Reverted.

## The one deviation from the ticket's constraint

The ticket says "no RTL changes." The executor's proof **lives inside `rtl/executor.v`'s `ifdef FORMAL` block**, so covering the freeze branch cannot be done with `rtl/` untouched.

Every changed line (277–335) is inside that block (256–473), and the sim legs define `RISCV_FORMAL`, never `FORMAL` — so nothing synthesized or simulated changes. The constraint's *rationale* holds even though its letter doesn't. Revert `rtl/executor.v` if you want the letter; the freeze coverage goes with it.

## Regression

`decoder` PASS · `executor` PASS · `make test` **49/49** · four unit benches green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)