### PR TITLE
ADRs 0026-0030: the decisions M3 forces

### DIFF
--- a/docs/adr/0025-formal-ladder-depths-are-derived-not-inherited.md
+++ b/docs/adr/0025-formal-ladder-depths-are-derived-not-inherited.md
@@ -221,3 +221,26 @@ empirically, not the largest one that still finishes.
 - M2 is unaffected by this ADR either way — it was never blocked on depth justification, only on the
   three holes ADR-0023 named (two now closed: ADR-0021's fix and ADR-0024's engine switch; ALTOPS
   itself and `equiv.sh` remain open).
+
+## Addendum, 2026-07-31: serialization is a fourth stall reason
+
+ADR-0026 adds CSR/`mret` serialization as a fourth stall reason (bubble-flavoured, folded into the
+existing `hazard` term). The derivation above enumerates three: scoreboard 2, accessor 1, divider 1
+under ALTOPS. Serialization holds a CSR instruction in decode until execute/access/writeback drain
+— **up to 3 further cycles**.
+
+That moves the single-hop floor from 8 to roughly 11, and the two-hop figure from 12 to roughly 15.
+
+Consequences for the configured depths:
+
+- **`csrw 30` clears the new floor comfortably.** No change needed.
+- **`insn 15` currently sits above the two-hop figure with margin; after serialization lands it sits
+  on it.** That is not yet a soundness failure — a CSR instruction is not a hazard producer in the
+  ordinary sense, so the worst-case chain that reaches 15 does not obviously involve one — but the
+  margin is gone, and the empirical sweep should be repeated once the CSR RTL exists rather than
+  assumed to still hold.
+
+Traps themselves add **no** cycles: they commit in decode and the payload rides the same three
+registered stages, so the trap-group `insn_*` checks are unaffected on that count.
+
+The ALTOPS caveat above is untouched and still governs everything here.

--- a/docs/adr/0026-stalls-are-four-reasons-over-two-mechanisms.md
+++ b/docs/adr/0026-stalls-are-four-reasons-over-two-mechanisms.md
@@ -1,0 +1,61 @@
+# ADR-0026: Stalls are four reasons over two mechanisms
+
+**Status:** Accepted · 2026-07-31 · *Amends ADR-0009 and CLAUDE.md invariant 8*
+
+## Context
+
+ADR-0009 established the stall protocol and CLAUDE.md invariant 8 records it as "a single global
+broadcast with three sources — the decode scoreboard, the divider, and the accessor's one-cycle
+load-response turnaround."
+
+M3 adds a fourth reason to stall: ADR-0005 requires CSR instructions and `mret` to serialize, held
+in decode until execute/access/writeback drain. The question this ADR settles is whether that is a
+fourth *mechanism* or a fourth *reason* riding an existing one.
+
+## Decision
+
+**Four reasons, still two mechanisms.**
+
+ADR-0009's rule (a) partitions stalls by what they do to `decoder_out`:
+
+- **hold** — the divider and the accessor stall hold `decoder_out` unchanged, because the
+  instruction has already issued and downstream must not re-consume it.
+- **bubble** — the scoreboard bubbles `decoder_out`, because the hazarded instruction has *not*
+  issued and must be retried.
+
+CSR serialization is bubble-shaped: the CSR instruction has not issued yet, and the executor reads
+`in` every cycle, so holding would have it reprocess the same instruction repeatedly. It therefore
+folds into the existing `hazard` term rather than becoming new machinery:
+
+```systemverilog
+assign stall = hazard || csr_serialize || divider_stall || accessor_stall;
+```
+
+where `csr_serialize` is "this is a CSR or `mret` instruction and the pipe is not yet drained."
+
+## The gap this exposes
+
+The decoder currently sees three producer slots: its own `out`, `executor_out`, and
+`accessor_pending_{valid,rd}`. **`accessor_pending_valid` covers loads only** — see the comment at
+`rtl/decoder.v:350-354`.
+
+A genuine drain condition needs more than that. A store in flight in the accessor is not visible in
+any of those three slots, so "drained" and "no pending load" are different predicates. Computing
+`csr_serialize` from the existing signals would let a CSR instruction issue while a store is still
+in the accessor.
+
+**So the decoder gains a new input: `accessor_out.valid`, wired in `rtl/littlecpu.v`.**
+
+That is easy to miss, and missing it produces a `minstret` that is off by one only when a store
+happens to be in flight — an intermittent, load-dependent wrong answer.
+
+## Consequences
+
+- CLAUDE.md invariant 8 is restated as four reasons over two mechanisms, with the hold/bubble
+  partition as the thing that actually matters.
+- The decoder's port list grows by one input. That is a `rtl/littlecpu.v` change and touches the
+  component-proof harnesses that instantiate the decoder (`formal/components.sby`'s `decoder` task
+  and `formal/pcloop.sv`).
+- ADR-0025's depth derivation gains a fourth term — see ADR-0029.
+- Nothing about ADR-0009's freeze-upstream/drain-downstream rule changes. This is a new customer
+  for an existing mechanism, not a new mechanism.

--- a/docs/adr/0027-minstret-counts-non-trapping-issues.md
+++ b/docs/adr/0027-minstret-counts-non-trapping-issues.md
@@ -1,0 +1,55 @@
+# ADR-0027: `minstret` counts non-trapping issues; serialization buys exactness, not hazard safety
+
+**Status:** Accepted · 2026-07-31 · *Amends ADR-0005*
+
+## Context
+
+ADR-0005 made two claims about CSR handling that were correct when written and are not correct
+after M3 lands traps in decode.
+
+## Amendment 1 — the `minstret` rule
+
+ADR-0005 says `minstret` "increments at issue (equivalent to retire because post-decode nothing
+faults)."
+
+The parenthetical was the justification, and **M3 invalidates it: decode itself now faults.** A
+trapping instruction issues, and retires in RVFI with `rvfi_trap = 1`, but per the RISC-V spec it
+must not increment `minstret` — a trapped instruction did not retire.
+
+**The rule becomes: increment at issue, for non-trapping issues only.**
+
+This is a one-line change to the implementation and a silent correctness bug if missed. It is also
+invisible to the riscv-formal ladder: `rvfi_csrw_check.sv` checks that a CSR *write* lands, not that
+a counter's *increment* semantics are right, and the `csrc_*` checks that would catch it are
+unreachable at the current pin (upstream split `rvfi_csrc_check.sv` into six files after the pinned
+SHA). The only mechanised check of this rule anywhere will be the component proof in ADR-0031's
+ticket.
+
+## Amendment 2 — what serialization actually buys
+
+ADR-0005 justifies serializing CSR instructions and `mret` on the grounds that it "eliminates every
+CSR/pipeline interaction corner."
+
+On inspection there are no such corners to eliminate. CSRs are read and written entirely in decode;
+nothing downstream touches them; and the CSR read result reaches `rd` through the existing
+`is_add` pass-through, where the ordinary ADR-0004 scoreboard already covers RAW. Remove the
+serialization and no hazard appears.
+
+**What serialization actually buys is `minstret` exactness.** Without it, `csrr minstret` reads a
+count inflated by the two or three instructions in flight behind it, and the value a program reads
+depends on pipeline occupancy rather than on architectural state.
+
+That is still worth the ≤3 cycles, on a core that optimises for readability over throughput, and it
+gives the sprint its sharpest test — a `csrr`/`nop`×3/`csrr`/`sub` sequence whose difference is
+exactly 4 only because the stall exists.
+
+**Keep the serialization; fix the stated reason.** The reason matters because a future reader
+looking to reclaim CPI will read "eliminates hazard corners," verify there are no hazard corners,
+and delete a stall that was load-bearing for something else entirely.
+
+## Consequences
+
+- ADR-0005's CSR section is amended in both particulars; the design it describes is unchanged.
+- The `minstret` rule needs a test that would fail if it regressed, and the ladder cannot provide
+  one — so it belongs in a component proof and in a `.S` test that traps deliberately and checks
+  the counter did not advance.

--- a/docs/adr/0028-the-rvfi-convention-for-a-trapping-retire.md
+++ b/docs/adr/0028-the-rvfi-convention-for-a-trapping-retire.md
@@ -1,0 +1,70 @@
+# ADR-0028: The RVFI convention for a trapping retire
+
+**Status:** Accepted · 2026-07-31 · *Supplements ADR-0006*
+
+## Context
+
+riscv-formal's `rvfi_insn_check.sv` ends like this:
+
+```systemverilog
+if (!spec_trap) begin
+    ...   // rd_addr, rd_wdata, pc_wdata, and every mem_* assertion
+end
+assert(spec_trap == trap);
+```
+
+**Under `spec_trap`, the only surviving assertion is the flag comparison.** `pc_wdata`, `rd_addr`,
+`rd_wdata` and the memory masks are entirely unconstrained. The ladder cannot distinguish a core
+that traps correctly from one that traps *and also* corrupts `rd`, writes memory, and redirects
+somewhere arbitrary. It does not care where you trap to.
+
+So the repo has to state what it drives on a trapping retire, and hold itself to it, because the
+oracle will not.
+
+## Decision
+
+**On a trapping retire this core drives:**
+
+| field | value |
+|---|---|
+| `rvfi_trap` | 1 |
+| `rvfi_rd_addr` | 0 |
+| `rvfi_rd_wdata` | 0 |
+| `rvfi_mem_rmask` / `rvfi_mem_wmask` | 0 |
+| `rvfi_pc_wdata` | `mtvec` |
+| `rvfi_valid` | 1 — a trapping instruction *does* retire |
+
+The instruction retires. It just retires having architecturally done nothing except redirect.
+
+## Which existing checks enforce which parts, indirectly
+
+This is the load-bearing part of the ADR, because none of it is obvious and CI would not notice if
+a future change broke the reasoning:
+
+- **`dmemcheck` catches a trapping store that still reaches the bus.** `formal/dmemcheck.sv:61-68`
+  builds its environment shadow from the **real** `mem_wstrb`/`mem_wdata`, while `rvfi_dmem_check`
+  builds its shadow purely from `rvfi_mem_*`. A store that is architecturally suppressed but still
+  strobes the bus desynchronises the two, and a later load fails at the RVFI level.
+- **`reg` catches a trapping instruction that still writes `rd`.** `rvfi_reg_check` runs on the RVFI
+  stream, but `rvfi_rs1_rdata`/`rs2_rdata` are captured from the *real* regfile in decode — so a
+  corrupted `rd` surfaces as a later instruction's read disagreeing with the shadow model.
+- **`pc_fwd`/`pc_bwd` catch a dishonest or untaken redirect.** They assert
+  `pc_wdata(N) == pc_rdata(N+1)` with **no trap special case**, so the reported target must be the
+  one actually taken. Note they are satisfied by *any* target, including `mtvec == 0`.
+
+**What nothing in the ladder enforces: that the target is `mtvec`, and that `mepc`, `mcause`, and
+`mstatus` are correct.** That gap is why the trap commit path gets its own component proof.
+
+## Consequences
+
+- The convention above is a repo commitment, not a spec requirement discovered by tooling. It must
+  be restated in `rtl/writeback.v` at the drive site, because a reader of that code has no other way
+  to learn that the ladder is silent here.
+- Any future change to trap reporting must be checked against the three indirect guards above by
+  hand — they are not named in any check's title and the connection is not discoverable from CI
+  output.
+- The top-level `trap` port on `rtl/littlecpu.v` is **redefined, not deleted**: it becomes a
+  one-cycle "trap entry committed this cycle" pulse. Deleting it would change the port list in
+  `formal/wrapper.v`, `formal/dmemcheck.sv`, `formal/imemcheck.sv`, `formal/cover.sv`,
+  `formal/complete.sv`, and `test/testbench.v` for no functional gain, and the harness check in
+  ADR-0029 needs the signal anyway.

--- a/docs/adr/0029-mtvec-resets-to-zero-and-a-pre-handler-trap-is-loud.md
+++ b/docs/adr/0029-mtvec-resets-to-zero-and-a-pre-handler-trap-is-loud.md
@@ -1,0 +1,45 @@
+# ADR-0029: `mtvec` resets to zero, and a pre-handler trap is made loud
+
+**Status:** Accepted · 2026-07-31 · *Supplements ADR-0005*
+
+## Context
+
+ADR-0005 specifies `mtvec` as a read/write CSR in direct mode with a WARL 4-byte-aligned base. It
+says nothing about its **reset value**, and the RISC-V spec leaves that implementation-defined.
+
+That silence is a trap of its own here. `test/asm/sections.lds` places `.text` at `0x0`. So with
+`mtvec` resetting to 0, a trap taken *before* a test installs its handler redirects to address 0 —
+which is `_start`. The program silently restarts.
+
+That failure mode is the worst kind: it looks like a livelock or a timeout, it produces no error,
+and the actual cause (a fault several instructions earlier) is nowhere in the symptom.
+
+## Decision
+
+**Reset `mtvec` to 0** — the spec permits it, and any nonzero choice is an arbitrary constant a
+reader would have to look up.
+
+**And make the resulting condition loud rather than silent.** `test/testbench.v` and
+`test/cxxrtl.cc` treat trap entry with `mtvec == 0` as a hard test failure, using the redefined
+`trap` pulse from ADR-0028.
+
+The two halves are one decision: 0 is the readable reset value *provided* the harness refuses to
+let a jump to it pass as normal execution.
+
+## Rationale
+
+The alternative — resetting `mtvec` to some sentinel like `0xDEAD_0000` — makes the RTL carry a
+magic number to compensate for a harness limitation, and still produces a confusing symptom (a
+fetch from unmapped ROM) rather than a clear one.
+
+Detecting it in the harness costs a few lines, produces a named failure, and keeps the RTL honest.
+It also generalises: any future test that faults before installing a handler gets the same clear
+message, without anyone remembering this ADR exists.
+
+## Consequences
+
+- `rtl/csrs.v` resets `mtvec` to 0 with a comment pointing here.
+- Both sim legs gain a check that fires on trap-to-zero. This is a *harness* assertion, not an RTL
+  one — a real program is entitled to place a handler at 0 if it wants to, and the check would need
+  revisiting if `sections.lds` ever moved `.text`.
+- Trap tests must install `mtvec` before faulting, which is the correct discipline anyway.

--- a/docs/adr/0030-trap-cause-priority-and-why-the-causes-are-disjoint.md
+++ b/docs/adr/0030-trap-cause-priority-and-why-the-causes-are-disjoint.md
@@ -1,0 +1,53 @@
+# ADR-0030: Trap cause priority, and why the causes are currently disjoint
+
+**Status:** Accepted · 2026-07-31 · *Supplements ADR-0005*
+
+## Context
+
+ADR-0005 lists the trap causes this core implements — illegal instruction (2), breakpoint (3), load
+address misaligned (4), store address misaligned (6), environment call from M-mode (11) — but not
+their **priority**, because with all traps committed in a single decode-stage branch, something has
+to decide which cause wins if two conditions hold at once.
+
+## Decision
+
+**Priority order, highest first:** illegal instruction (2) → breakpoint (3) → environment call (11)
+→ load misaligned (4) → store misaligned (6).
+
+The reasoning is that an instruction which is not legal cannot meaningfully be said to have a
+misaligned operand: the address computation is only defined for an instruction the decoder
+recognises.
+
+## The part worth writing down: the cases cannot co-occur
+
+**In this core the priority encoder is vacuous today**, and that is the fact most likely to be lost.
+
+- Illegal instruction is raised only when `instr_valid` is false, which clears every execution flag
+  including `is_lw`/`is_sw` and friends (`rtl/decoder.v:563-573`). An illegal instruction has no
+  memory operand, so it cannot also be misaligned.
+- `ecall` and `ebreak` are distinguished by `funct12` and are mutually exclusive with each other and
+  with any load or store.
+- Load-misaligned and store-misaligned are distinguished by the access direction and cannot both
+  hold.
+
+So the order above is currently unobservable. It is recorded anyway for two reasons, and both are
+about the *next* person:
+
+1. Without the order written down, someone reading the priority encoder concludes it is dead code
+   and simplifies it away — then a later change makes the cases overlap and the behaviour is
+   whatever the simplification happened to produce.
+2. Without the **disjointness argument** written down, someone else concludes the encoder is
+   load-bearing, and "fixes" a priority that was never wrong, or adds a new cause that breaks
+   disjointness without realising disjointness was the thing making the encoder vacuous.
+
+The component proof asserts mutual exclusivity, so if a future change breaks it, the proof fails
+rather than the behaviour silently changing.
+
+## Consequences
+
+- The trap-cause selection carries a comment stating both the order and the disjointness argument.
+- The component proof asserts the causes are mutually exclusive and that the committed `mcause`
+  matches the stated order — the assertion is what keeps this ADR honest as the core grows.
+- Adding any new trap cause requires re-checking disjointness, not just appending to the encoder.
+  Interrupts in particular (deliberately out of scope, ADR-0005) would break it, since an interrupt
+  can be pending during any instruction.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -30,6 +30,11 @@ and what it costs. Reversing one is fine — write a new ADR that supersedes it.
 | [0023](0023-the-first-ladder-run-does-not-reach-m2.md) | The first ladder run does not reach M2 — three named holes | Accepted |
 | [0024](0024-the-ladders-default-bmc-engine-is-btormc.md) | The ladder's default BMC engine is `btor btormc`, not `smtbmc yices` | Accepted |
 | [0025](0025-formal-ladder-depths-are-derived-not-inherited.md) | The ladder's depths are derived from the pipeline, not inherited | Accepted |
+| [0026](0026-stalls-are-four-reasons-over-two-mechanisms.md) | Stalls are four reasons over two mechanisms | Accepted |
+| [0027](0027-minstret-counts-non-trapping-issues.md) | `minstret` counts non-trapping issues; serialization buys exactness | Accepted |
+| [0028](0028-the-rvfi-convention-for-a-trapping-retire.md) | The RVFI convention for a trapping retire | Accepted |
+| [0029](0029-mtvec-resets-to-zero-and-a-pre-handler-trap-is-loud.md) | `mtvec` resets to zero, and a pre-handler trap is made loud | Accepted |
+| [0030](0030-trap-cause-priority-and-why-the-causes-are-disjoint.md) | Trap cause priority, and why the causes are disjoint | Accepted |
 
 0001–0007 came from the design brief
 ([`docs/ideas/finish-the-rewrite.md`](../ideas/finish-the-rewrite.md)). 0008–0011 came out of


### PR DESCRIPTION
Planning M3 surfaced five decisions the existing ADRs don't cover, plus one amendment to the depth derivation. Recording them **before** the RTL work rather than after.

Docs only.

| | |
|---|---|
| **0026** | Stalls are four *reasons* over two *mechanisms* — amends ADR-0009 and invariant 8 |
| **0027** | `minstret` counts non-trapping issues; serialization buys exactness, not hazard safety — amends ADR-0005 twice |
| **0028** | The RVFI convention for a trapping retire |
| **0029** | `mtvec` resets to zero, and a pre-handler trap is made loud |
| **0030** | Trap cause priority, and why the causes are disjoint |
| **0025** | Addendum: serialization is a fourth stall reason |

## The two that surfaced real gaps

**0026** — recording serialization as a stall reason exposed that `accessor_pending_valid` **covers loads only**. So "drained" and "no pending load" are different predicates, and a genuine drain condition needs `accessor_out.valid` routed into the decoder as a new input. Without it, a CSR instruction can issue with a store still in flight — and `minstret` is off by one *only when that happens*. Intermittent, load-dependent, wrong.

**0028** — riscv-formal's `rvfi_insn_check.sv` gates everything behind `if (!spec_trap)`, so under a trap the **only** surviving assertion is the flag comparison. `pc_wdata`, `rd`, and the memory masks are unconstrained; the ladder does not care where you trap to. This ADR states what the core drives and — the load-bearing part — records which existing checks enforce which parts *indirectly*: `dmemcheck` for a suppressed-but-executed store, `reg` for a corrupted `rd`, `pc_fwd`/`pc_bwd` for the redirect. None of that is visible from CI output, and a future change could break the reasoning silently.

## Two amendments worth reading

**0027** corrects ADR-0005's stated reason for serializing CSR instructions. It claims serialization "eliminates every CSR/pipeline interaction corner" — but there are none, because CSRs live entirely in decode and the existing scoreboard already covers RAW on the pass-through. What it actually buys is `minstret` exactness. **Keep the stall, fix the reason** — otherwise someone reclaiming CPI verifies there are no hazard corners and deletes a stall that was load-bearing for something else.

**0030** records the trap-cause priority *and* the argument that the causes cannot currently co-occur — so the encoder is vacuous today. Both halves matter: without the order, someone deletes it as dead code; without the disjointness argument, someone "fixes" a priority that was never wrong.

## And a depth consequence

Serialization adds up to 3 cycles, moving ADR-0025's two-hop floor from 12 to ~15 — which leaves `insn 15` sitting *on* it rather than above it. `csrw 30` still clears comfortably. Traps themselves add no cycles (they commit in decode; the payload rides the same three registered stages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)