### PR TITLE
JEF-652: Re-vendor genchecks from the pin; only basedir differs

### DIFF
--- a/docs/adr/0022-the-formal-nightly-reports-against-an-explicit-baseline.md
+++ b/docs/adr/0022-the-formal-nightly-reports-against-an-explicit-baseline.md
@@ -60,7 +60,11 @@ Concretely, the follow-up work is:
   - `reg` — inconclusive, ADR-0023.
 - Replace `|| true` with the baseline comparison as the step's exit status.
 - Give `reg` a bounded `timeout` in `checks.cfg` so an unsolvable check is *reported* as
-  inconclusive rather than eating the job budget.
+  inconclusive rather than eating the job budget. **Retired by ADR-0031.** The `timeout=` parameter
+  this relied on existed only in this repo's forked `genchecks` copy; re-vendoring from the pin
+  removed it, and ADR-0024's engine switch removed the condition it guarded (`reg_ch0` now returns
+  in seconds). The nightly's job-level `timeout-minutes` is the remaining backstop — a real, and
+  deliberately recorded, reduction in protection.
 - The `complete` and `equiv.sh` steps are **not** `|| true` today and will therefore fail the job
   every night for reasons ADR-0023 documents as expected. Decide per step whether it belongs in the
   baseline or should be allowed to report; do not paper over either with `|| true`.

--- a/docs/adr/0024-the-ladders-default-bmc-engine-is-btormc.md
+++ b/docs/adr/0024-the-ladders-default-bmc-engine-is-btormc.md
@@ -1,6 +1,14 @@
 # ADR-0024: The ladder's default BMC engine is `btor btormc`, not `smtbmc yices`
 
-**Status:** Accepted · 2026-07-29 · *Closes one of ADR-0023's three named holes*
+**Status:** Accepted · 2026-07-29 · *Closes one of ADR-0023's three named holes · Mechanism amended
+by ADR-0031*
+
+> **ADR-0031 amends this ADR's Decision, not its measurement.** `btor btormc` is still the ladder's
+> engine, for exactly the reason measured below. But `formal/genchecks-local.py` has since been
+> re-vendored from the pin, where upstream's existing `solver` line already selects that engine —
+> so the local `engine` option, the `[engine]` per-check override section, and `reg_ch0`'s 1800s
+> `timeout` described under **Decision** no longer exist. `formal/checks.cfg` now says
+> `solver btormc`. Read the numbers here; read ADR-0031 for the mechanism.
 
 ## Context
 

--- a/docs/adr/0031-the-vendored-genchecks-copy-tracks-the-pin.md
+++ b/docs/adr/0031-the-vendored-genchecks-copy-tracks-the-pin.md
@@ -1,0 +1,111 @@
+# ADR-0031: The vendored `genchecks` copy tracks the pin, and only `basedir` differs
+
+**Status:** Accepted · 2026-07-30 · *Amends the mechanism half of ADR-0024; leaves its measurement
+intact. Also retires the per-check `timeout` ADR-0022 introduced.*
+
+## Context
+
+`formal/genchecks-local.py` is a vendored copy of riscv-formal's `checks/genchecks.py`. The header
+it carried claimed one deliberate structural difference — `basedir` resolved relative to the script,
+so the harness can live in `formal/` rather than adopting upstream's `cores/<name>/` layout
+(ADR-0006) — and then conceded that "the rest of the difference is NOT deliberate."
+
+It was not a small remainder. The fork was 654 lines against upstream's 870 at the pinned SHA, and
+the skew had started costing real work:
+
+- **We reimplemented engine selection upstream already had.** ADR-0024 measured `reg_ch0` at ~8–12s
+  under `btor btormc` versus non-convergence under `smtbmc yices`, and to act on that finding it
+  added an `engine` option and an `[engine]` per-check override section to the fork. Upstream's
+  existing `solver` line already selects between `abc bmc3`, `btor btormc`, and `smtbmc <name>`
+  from the same three spellings. The fork was simply too old to contain it.
+- **Ten checks could not be generated at all** — `fault` and nine `bus_*` checks, upstream work
+  from late 2025.
+- **The counter-CSR checks were unreachable.** The fork emitted a single `csrc_{name}` pointing at
+  `rvfi_csrc_check.sv`; upstream split that into six models (`rvfi_csrc_{any,const,hpm,inc,upcnt,
+  zero}_check.sv`), all six present at the pin. `csrc_inc_minstret` is the direct formal statement
+  of ADR-0027's minstret rule, and the *fork* was what blocked it — not upstream, and not the pin.
+
+The pin itself was never the problem. `formal/pin.mk` is at upstream HEAD; it was the fork that was
+five years stale. This is the failure mode ADR-0006 named as the "version-skew time bomb", arriving.
+
+## Decision
+
+**Re-vendor `formal/genchecks-local.py` verbatim from the SHA in `formal/pin.mk`, re-applying only
+the `basedir` change.** A `diff -u` against `formal/riscv-formal/checks/genchecks.py` must show the
+header and the two `basedir` hunks and nothing else. The second hunk is the isa-table `open()`,
+which spells the same `../..` inline; it is the same one change, not a second one.
+
+Three consequences follow, and each is a decision in its own right:
+
+**1. The local `engine` option and `[engine]` section are gone; `checks.cfg` says `solver btormc`.**
+ADR-0024's measurement stands unchanged and is not being relitigated — `btor btormc` is still the
+ladder's engine, still for the reason ADR-0024 gives, and the generated `[engines]` line is still
+`btor btormc`, verified before the fork's mechanism was deleted. What changes is only *how* the
+config asks for it. ADR-0024's decision section promised a one-line per-check override for a future
+check needing `smtbmc`-specific machinery; that promise is withdrawn. Upstream has no per-check
+override, and re-forking `genchecks` to reinstate one costs more than it buys — sby's own
+`[engines]` section remains the lever for a check run by hand.
+
+**2. `reg_ch0`'s 1800s `timeout` is gone.** ADR-0022 added it, and ADR-0024 explicitly kept it "as a
+safety net". Upstream `check_cons` has no `timeout` parameter and no way to emit the sby line, so
+keeping it means keeping a fork. The condition it existed for no longer holds: it bounded a query
+that did not converge under `smtbmc yices`, and ADR-0024 replaced that engine with one under which
+the same check at the same depth returns in ~8–12s. The nightly's job-level `timeout-minutes`
+remains the backstop. **This is the one place this ADR accepts a real reduction in protection**, and
+it is recorded as such rather than argued away: if some future check hangs, the nightly loses the
+whole job rather than one check's status, exactly as it did before ADR-0022. Restoring a per-check
+bound means either forking `genchecks` again or teaching `formal/Makefile`'s `check` target to wrap
+each `sby` invocation — the latter is the cheaper answer and the one to reach for.
+
+**3. The ten newly-generatable `fault`/`bus_*` checks are evaluated and deliberately not adopted.**
+None appears in `checks.cfg`'s `[depth]`, so `genchecks` skips all ten. **0 of 10 are applicable as
+the core stands**, for three distinct reasons, recorded in full at the point a reader would add them
+(`formal/checks.cfg`, above `[depth]`):
+
+- All nine `bus_*` need `RISCV_FORMAL_BUS` — a second RVFI interface of nine signals
+  (`bus_valid`/`insn`/`data`/`fault`/`addr`/`rmask`/`wmask`/`rdata`/`wdata`). The core drives none.
+- Every `*_fault` variant models a bus that can refuse a transaction. This core's bus cannot:
+  `imem_data`/`imem_data2`/`mem_rdata` are free every cycle with no fault line and no handshake
+  (invariant 1, ADR-0015, `formal/wrapper.v`). More decisively, a bus fault is by construction
+  detected *after* decode, and **invariant 2 says nothing faults after decode**. These check a trap
+  model this design has ruled out; they need an ADR before they need a depth.
+- The three `io` ones additionally need `rvformal_addr_io`, a distinguished MMIO region with
+  ordering semantics. ADR-0008's map has a `tohost` word, not an IO region the RTL treats
+  differently, and there is no ordering to check with one outstanding access at a time.
+
+`bus_imem` and `bus_dmem` are the only two whose property is meaningful here — and
+`formal/imemcheck.sv` and `formal/dmemcheck.sv` already check it against the real split
+`imem_addr`/`imem_addr2` interface (ADR-0003), and both pass. Adopting the `bus_*` forms would mean
+plumbing nine RVFI outputs to re-derive a result already held, and would put an `` `ifdef
+RISCV_FORMAL `` value on a path the core reads — precisely what ADR-0020's non-perturbation argument
+depends on nothing doing.
+
+**The `csrc_*` checks are now generatable and are still not on the ladder.** Adding one is a
+follow-up needing its own derived depth (ADR-0025) and `formal/EXPECTED_FAIL` entry (ADR-0022), and
+`mcycle`/`minstret` are not implemented (M3). `csrc_inc_minstret` is the one to reach for first.
+
+## Consequences
+
+The ladder is unchanged where it counts. The re-vendor reached the generated `.sby` files in exactly
+two ways, and this was measured by diffing all 79 generated files against a from-scratch baseline
+taken immediately before the change:
+
+- every check's script line reads `read -sv X.sv` where it read `read_verilog -sv X.sv` — upstream's
+  frontend-agnostic spelling, which without Verific dispatches to `read_verilog -sv`;
+- `reg_ch0.sby` lost its `timeout 1800` line.
+
+**Same 78 checks, same names, same verdicts: 67 pass, 11 non-PASS matching `formal/EXPECTED_FAIL`
+exactly.** As always, every check is `mode bmc`: a PASS means *no counterexample was found within
+that check's configured depth*, not that the property holds. The whole ladder still runs under
+`RISCV_FORMAL_ALTOPS`, so a green `insn_mul` still says nothing whatever about the real multiplier
+(ADR-0010). This ADR moves M2 no closer; it removes an obstacle in front of the checks that would.
+
+Re-syncing after a future pin bump (ADR-0013) is now a documented three-line recipe in the script's
+own header, and the acceptance test for it is mechanical: the diff against the clone must show only
+the header and the two `basedir` hunks. Anything else is drift, and drift here is what produced the
+situation this ADR exists to end.
+
+The cost is that this repo now carries upstream code paths it does not exercise — `csr_spec`,
+`buslen`, `nbus`, `abspath`, `custom_csrs`, `illegal_csrs`, `verilog-files`/`vhdl-files`. That is
+the point: keeping them unedited is what makes the file byte-comparable with upstream, and what
+makes the next re-sync a copy rather than an archaeology exercise.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -35,6 +35,7 @@ and what it costs. Reversing one is fine — write a new ADR that supersedes it.
 | [0028](0028-the-rvfi-convention-for-a-trapping-retire.md) | The RVFI convention for a trapping retire | Accepted |
 | [0029](0029-mtvec-resets-to-zero-and-a-pre-handler-trap-is-loud.md) | `mtvec` resets to zero, and a pre-handler trap is made loud | Accepted |
 | [0030](0030-trap-cause-priority-and-why-the-causes-are-disjoint.md) | Trap cause priority, and why the causes are disjoint | Accepted |
+| [0031](0031-the-vendored-genchecks-copy-tracks-the-pin.md) | The vendored `genchecks` copy tracks the pin, and only `basedir` differs | Accepted |
 
 0001–0007 came from the design brief
 ([`docs/ideas/finish-the-rewrite.md`](../ideas/finish-the-rewrite.md)). 0008–0011 came out of
@@ -53,7 +54,9 @@ port — the first time any formal check ran against the pipelined core. 0021 ke
 checks in the ladder and records the C.JR/C.JALR decode defect they found; 0022 replaces the
 nightly's blanket failure-swallowing with an ADR-0014-style baseline; 0023 states what the run
 does and does not establish, and why M2 is not reached. 0024 closes one of 0023's three named
-holes by switching the ladder's default BMC engine.
+holes by switching the ladder's default BMC engine. 0031 re-vendors the `genchecks` copy from the
+pin — retiring the local mechanism 0024 built to reach that engine, while leaving 0024's
+measurement intact — and records why none of the ten `fault`/`bus_*` checks it unlocks apply here.
 
 ## Deferred decisions
 

--- a/formal/EXPECTED_FAIL
+++ b/formal/EXPECTED_FAIL
@@ -9,11 +9,11 @@
 # same commit backs up; adding one back is a regression and needs the same
 # justification test/EXPECTED_FAIL's convention requires.
 #
-# Every check on this ladder is `mode bmc` (formal/checks.cfg's `engine`
-# option, default `btor btormc` as of the switch documented below) -- a PASS
-# means "no counterexample found within the check's configured depth," a
-# bounded result, not an unbounded proof, regardless of which engine found
-# it. Switching engines changes how fast a check converges, not what a PASS
+# Every check on this ladder is `mode bmc` (formal/checks.cfg's `solver
+# btormc`, which genchecks turns into `btor btormc`) -- a PASS means "no
+# counterexample found within the check's configured depth," a bounded
+# result, not an unbounded proof, regardless of which engine found it.
+# Switching engines changes how fast a check converges, not what a PASS
 # means. Read every line below with that in mind.
 #
 # Seeded at integration from a from-scratch `make -C formal check` (78
@@ -32,8 +32,7 @@
 # nightly trips on set equality, which is exactly what this file is for.
 #
 # Then reconciled again after switching the ladder's default engine from
-# `smtbmc yices` to `btor btormc` (ADR-0024, formal/checks.cfg's `engine`
-# option, genchecks-local.py). One entry was removed: reg_ch0 -- the same
+# `smtbmc yices` to `btor btormc` (ADR-0024). One entry was removed: reg_ch0 -- the same
 # check, at the same depth, that did not converge under smtbmc yices in >20
 # minutes now PASSes under btormc in ~8-12s. Verified by a full from-scratch
 # 78-check sweep under each engine, not by argument: 67/78 pass under btormc
@@ -83,3 +82,11 @@ insn_c_swsp_ch0
 # engine, not by argument (see this file's header). Removed, not because the
 # property changed, but because the tool that had failed to answer it was
 # replaced by one that could.
+#
+# Then re-confirmed after formal/genchecks-local.py was re-vendored from the
+# pin. That change reached the ladder in exactly two ways -- every generated
+# .sby now says `read -sv` where it said `read_verilog -sv` (upstream's
+# frontend-agnostic spelling; identical without Verific), and reg_ch0 lost the
+# per-check `timeout 1800` line, which upstream genchecks has no way to emit
+# and which btormc made moot. Same 78 checks, same names, same verdicts: 67
+# pass, the 11 below.

--- a/formal/checks.cfg
+++ b/formal/checks.cfg
@@ -1,63 +1,118 @@
 [options]
-# Kept at rv32imc, not restricted to rv32im, even though test/asm/*.S only
-# assembles rv32im_zicsr (ADR-0014: the dual-word fetch window ADR-0003
-# describes isn't built yet). That gap doesn't apply here: riscv-formal's
-# base insn_* checks (unlike formal/imemcheck.sv) never constrain how
-# imem_data arrives -- it's a free value every cycle regardless of
-# alignment (see formal/wrapper.v) -- so an insn_c_* check exercises
-# rtl/decoder.v's compressed decode path directly and isn't gated on the
-# fetch window that's missing. Running them is a real, if narrower, proof
-# of the C-extension decode logic than the `.S` suite currently gives.
+# rv32imc, matching what test/asm/*.S now assembles (-march=rv32imc_zicsr).
+# This line predates that: it used to be the *only* place the C extension was
+# exercised, back when the ladder ran ahead of the dual-word fetch window and
+# the suite was still rv32im_zicsr. That gap is closed (ADR-0003), so the two
+# legs now agree -- but they still check different things, and both are worth
+# having. riscv-formal's insn_c_* checks never constrain how imem_data
+# arrives (unlike formal/imemcheck.sv); it is a free value every cycle
+# regardless of alignment, per formal/wrapper.v. So an insn_c_* check
+# exercises rtl/decoder.v's compressed decode in isolation, while the .S
+# suite exercises decode and the fetch window together.
 isa rv32imc
-# genchecks-local.py defaults to boolector, which OSS CAD Suite ships but a
-# bare `brew install yosys` / apt toolchain does not. yices is the solver
-# available in this repo's local dev setup; kept as the fallback `smtbmc`
-# solver name (used if `engine` below is ever removed, and reachable per
-# check via `[engine]`) even though `engine` is now what picks the BMC
-# engine for every generated check.
-solver yices
-# Local fork addition to genchecks-local.py (documented at the point it's
-# read, not just here): upstream only lets `solver` name an SMT solver
-# *behind* `smtbmc`, so there was no way to ask for a different BMC engine
-# at all from this file. `reg_ch0` is why that mattered -- a single
-# depth-21 BMC query that did not converge under `smtbmc yices` in >20
-# minutes, independently reproduced twice (formal/EXPECTED_FAIL's prior
-# entry), and passes under `btor btormc` in ~8 seconds -- same check, same
-# depth, only the engine differs. `btor btormc` is now the default engine
-# for every generated check; `[engine]` below is a per-check override by
-# regex against the full check name (e.g. `reg_ch0`), so `smtbmc yices` (or
-# anything else sby's [engines] section accepts) stays reachable for a
-# check that wants it without editing genchecks-local.py again. Verified
-# against the full 78-check ladder on both engines -- see ADR-0024 for the
-# side-by-side tally and wall time.
-engine btor btormc
-
-[engine]
-# No overrides today: the full-ladder comparison found btormc converges
-# every check smtbmc yices did, verdict-for-verdict (ADR-0024 -- including a
-# caveat on how machine-dependent the wall-time gap turned out to be, worth
-# reading before citing "8 seconds" as universal). Kept as an empty,
-# documented section rather than deleted so the next check that needs a
-# different engine (a solver-specific feature like --dumpsmt2, or a future
-# non-converging BMC query) has a one-line fix instead of a
-# genchecks-local.py change. Example: `reg_ch0 smtbmc yices`.
+# `solver` is genchecks' engine selector, not merely an SMT solver name: the
+# three spellings it special-cases are `bmc3` -> `abc bmc3`, `btormc` ->
+# `btor btormc`, and anything else -> `smtbmc <that>`. So `btormc` here puts
+# `btor btormc` in every generated .sby's [engines] section.
+#
+# btormc is the measured choice, not the default one (genchecks defaults to
+# `boolector`, which OSS CAD Suite ships but a bare `brew install yosys` /
+# apt toolchain does not). `reg_ch0` is why: a single depth-21 BMC query that
+# did not converge under `smtbmc yices` in >20 minutes, independently
+# reproduced twice, and passes under `btor btormc` in ~8-12s -- same check,
+# same depth, only the engine differs. Verified against the full 78-check
+# ladder on both engines; see ADR-0024 for the side-by-side tally and wall
+# time, including a caveat on how machine-dependent that gap turned out to be.
+#
+# ADR-0024 reached that conclusion through a local `engine` option added to
+# this repo's vendored genchecks copy, which had drifted far enough from
+# upstream to be missing the `solver` handling above. The measurement stands;
+# the mechanism was redundant and is gone. To pin one check to a different
+# engine, sby's own [engines] section is the lever -- there is no per-check
+# override here, and adding one back means forking genchecks again.
+solver btormc
 
 [csrs]
+# Bare names, so genchecks generates csrw_* only. Upstream also accepts a
+# per-CSR test list here (`minstret inc`, `mvendorid const`, `mstatus
+# zero_mask=...`), which turns on the csrc_* counter checks -- csrc_inc,
+# csrc_const, csrc_zero, csrc_any, csrc_upcnt, csrc_hpm, all six models
+# present at the pin. Re-vendoring made those generatable; this ladder still
+# does not ask for them, because mcycle/minstret are not implemented (M3,
+# CLAUDE.md) and because each new check needs a derived depth (ADR-0025) and
+# a formal/EXPECTED_FAIL entry (ADR-0022) of its own. `csrc_inc_minstret` is
+# the one to reach for first when they are: it is the direct formal statement
+# of ADR-0027's minstret rule.
 mcycle
 minstret
 
+# ------------------------------------------------------------------------
+# The ten checks upstream generates that this ladder deliberately omits.
+#
+# genchecks calls check_cons for `fault` and for nine `bus_*` checks. None
+# appears below in [depth], so genchecks silently skips all ten. That is a
+# decision, not an oversight, and it is not a depth problem -- it is an
+# interface problem this core does not have the ports to solve:
+#
+#   fault                       needs rvfi_mem_fault + rvfi_mem_fault_rmask/
+#                               wmask, and asserts mcause == 1/5/7. The core
+#                               drives none of the three, rvfi_trap is
+#                               hardwired 0, and mcause does not exist (M3).
+#
+#   bus_imem, bus_imem_fault    all nine need `RISCV_FORMAL_BUS`, i.e. a
+#   bus_dmem, bus_dmem_fault    second RVFI interface: bus_valid, bus_insn,
+#   bus_dmem_io_read(_fault)    bus_data, bus_fault, bus_addr, bus_rmask,
+#   bus_dmem_io_write(_fault)   bus_wmask, bus_rdata, bus_wdata. The core
+#   bus_dmem_io_order           drives zero of them.
+#
+# Three separate reasons they are not simply "future work with a depth line":
+#
+# 1. Every `*_fault` variant models a bus that can refuse a transaction.
+#    This core's bus cannot: imem_data/imem_data2/mem_rdata are free every
+#    cycle with no fault line and no handshake (invariant 1, ADR-0015,
+#    formal/wrapper.v). Worse, a bus fault is by construction detected
+#    *after* decode, and invariant 2 says nothing faults after decode. So
+#    fault, bus_imem_fault, bus_dmem_fault, bus_dmem_io_read_fault and
+#    bus_dmem_io_write_fault are not merely unimplemented -- they check a
+#    trap model this design has ruled out. They need an ADR before they need
+#    a depth.
+#
+# 2. The three io ones (bus_dmem_io_read, bus_dmem_io_write,
+#    bus_dmem_io_order) additionally need `rvformal_addr_io` -- a
+#    distinguished MMIO region with ordering semantics. ADR-0008's map has a
+#    tohost word, not an IO region the RTL treats differently, and there is
+#    no ordering to check with one outstanding access at a time.
+#
+# 3. bus_imem and bus_dmem are the only two whose *property* is meaningful
+#    here -- and formal/imemcheck.sv and formal/dmemcheck.sv already check
+#    it, against the real split imem_addr/imem_addr2 interface (ADR-0003),
+#    and both pass. Adopting the bus_* forms would mean plumbing nine RVFI
+#    outputs to re-derive a result already held, and would put an `ifdef
+#    RISCV_FORMAL` value on a path the core reads -- exactly the thing
+#    ADR-0020's non-perturbation argument depends on nothing doing.
+#
+# Summary: 0 of 10 are applicable as the core stands. bus_imem/bus_dmem are
+# the only two worth revisiting, and only if the bus interface grows a fault
+# or handshake line; the other eight need M3 traps, an MMIO region, or a
+# trap model invariant 2 forbids.
+# ------------------------------------------------------------------------
+
 [depth]
-# `reg`'s fourth column is a `timeout` (seconds), consumed only by the
-# `check_cons(..., timeout=2)` call in genchecks-local.py for that one check
-# (ADR-0022, ADR-0023). `reg_ch0` is a single depth-21 BMC query that did not
-# return in >20 minutes, independently reproduced twice, and previously had
-# no bound at all: in the nightly it would sit in the solver until
-# `timeout-minutes: 300` killed the *whole job*, taking `complete` and
-# `equiv.sh` with it. 1800s (30 minutes) gives it a real shot at converging
-# while leaving the bulk of the job's 300-minute budget to the steps after
-# it. A `reg_ch0` that times out is reported as status TIMEOUT — genuinely
-# inconclusive, not a pass and not a counterexample-bearing fail — and
-# formal/EXPECTED_FAIL treats it as a known-non-PASS entry, same as a FAIL.
+# `reg` used to carry a fourth column here, a per-check wall-clock `timeout`
+# in seconds, read by a `timeout=` parameter this repo had added to its
+# vendored genchecks copy. Upstream genchecks has no such parameter, and
+# re-vendoring from the pin (ADR-0013 -- the pin is current; it was the fork
+# that was stale) dropped it. That is deliberate and the column is gone:
+# ADR-0022 added the bound because `reg_ch0` under `smtbmc yices` would sit
+# in the solver until the nightly's `timeout-minutes: 300` killed the *whole
+# job*, and ADR-0024 then replaced that engine with `btor btormc`, under
+# which the same check at the same depth converges in ~8-12s. The condition
+# the bound existed for no longer holds. The nightly's own job-level
+# `timeout-minutes` is still the backstop; if a check ever needs a real
+# per-check bound again, sby's `[options] timeout` is the place, and getting
+# genchecks to emit it means forking genchecks again -- which is the cost
+# this re-vendor was paying down, so weigh it accordingly.
+#
 # Depths are DERIVED, not inherited -- see ADR-0025 for the full argument and
 # the empirical sweep that confirmed it. Summary, so a reader can sanity-check
 # the numbers without opening the ADR:
@@ -85,7 +140,7 @@ minstret
 # the real divider holds executor_out.valid for 32 cycles, the single-hop
 # floor becomes ~38, and every number here must be re-derived.
 insn           15
-reg      15    20  1800
+reg      15    20
 pc_fwd   10    30
 pc_bwd   10    30
 liveness 1  10 30

--- a/formal/genchecks-local.py
+++ b/formal/genchecks-local.py
@@ -1,37 +1,35 @@
 #!/usr/bin/env python3
 #
-# This is a vendored fork of upstream riscv-formal's checks/genchecks.py.
+# Vendored copy of riscv-formal's checks/genchecks.py, taken verbatim from the
+# SHA in formal/pin.mk.
 #
-# Two differences are deliberate and structural:
+# EXACTLY ONE thing differs from upstream, and it is structural: `basedir`.
+# Upstream computes `basedir = f"{os.getcwd()}/../.."` because it expects to be
+# run from riscv-formal/cores/<name>/. This repo does not adopt that layout --
+# the harness lives in formal/ and the pinned clone is a gitignored
+# subdirectory of it (ADR-0006) -- so `basedir` is resolved relative to this
+# script instead. The isa-table open a few hundred lines down spells the same
+# "../.." inline; it is rewritten to `{basedir}/insns/...` for the same reason
+# and is part of the same one change, not a second one.
 #
-# - Upstream computes `basedir = f"{os.getcwd()}/../.."`, which assumes it
-#   runs from riscv-formal/cores/<name>/; this fork resolves `basedir`
-#   relative to the script itself (see below) so the harness can live in
-#   formal/ instead of adopting riscv-formal's cores/ layout. Adopting
-#   cores/ is a much larger change with no payoff for this repo — see
-#   ADR-0006.
-# - Upstream's `solver` option only ever names an SMT solver behind
-#   `smtbmc` (the "bmc3"/"btormc" spellings below are upstream's, not this
-#   fork's, but they're the only way upstream lets a checks.cfg pick a
-#   different engine, and nothing lets a single check override it). This
-#   fork adds an `engine` option (verbatim sby [engines] line, defaults
-#   every check to it) and a `[engine]` section (regex-matched per-check
-#   override) — see where `engine_opt` and `get_engine()` are defined below.
-#   `reg_ch0` is why: a single depth-21 BMC query that did not converge
-#   under `smtbmc yices` in >20 minutes, independently reproduced twice, and
-#   passes under `btor btormc` in ~8 seconds.
+# Nothing else is edited. Options this repo does not use (csr_spec, buslen,
+# nbus, abspath, custom_csrs, illegal_csrs, verilog-files/vhdl-files) are kept
+# so the file stays byte-comparable with upstream, and so the checks they gate
+# -- notably the six csrc_* counter checks and the fault/bus_* family -- are
+# generatable the moment formal/checks.cfg asks for them.
 #
-# The rest of the difference is NOT deliberate, and this comment previously
-# claimed otherwise. This copy was vendored from a much older upstream (note
-# the pre-2021 copyright line below), and diffs ~450 lines against
-# checks/genchecks.py at the SHA in formal/pin.mk — it is missing upstream's
-# csr_spec/buslen/nbus/abspath options and its isa-string parser. That skew is
-# the "version-skew time bomb" ADR-0006 names. Do not read the size of the
-# diff as evidence the fork is intentional: re-vendoring from the pinned SHA
-# and re-applying only the basedir change is open work (tracked as a follow-up),
-# not a settled decision.
+# TO RE-SYNC after bumping formal/pin.mk:
 #
-# Copyright (C) 2017  Clifford Wolf <clifford@symbioticeda.com>
+#   cp formal/riscv-formal/checks/genchecks.py formal/genchecks-local.py
+#   # re-apply the two `basedir` hunks above, then restore this header
+#   diff -u formal/riscv-formal/checks/genchecks.py formal/genchecks-local.py
+#
+# The diff must show only this header and the two basedir hunks. Anything else
+# is drift, and drift here is how this repo previously ended up carrying a
+# pre-2021 copy that had independently reinvented an engine-selection option
+# upstream already had (see formal/checks.cfg's `solver` line and ADR-0024).
+#
+# Copyright (C) 2017  Claire Xenia Wolf <claire@yosyshq.com>
 #
 # Permission to use, copy, modify, and/or distribute this software for any
 # purpose with or without fee is hereby granted, provided that the above
@@ -46,12 +44,19 @@
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 import os, sys, shutil, re
+from functools import reduce
 
 nret = 1
 isa = "rv32i"
 ilen = 32
 xlen = 32
+buslen = 32
+nbus = 1
 csrs = set()
+custom_csrs = set()
+illegal_csrs = set()
+csr_tests = {}
+csr_spec = None
 compr = False
 
 depths = list()
@@ -63,21 +68,17 @@ basedir = os.path.abspath(os.path.join(os.path.dirname(os.path.realpath(__file__
 corename = os.getcwd().split("/")[-1]
 solver = "boolector"
 dumpsmt2 = False
+abspath = False
 sbycmd = "sby"
 config = dict()
 mode = "bmc"
-# Local fork addition (not upstream -- see the fork-provenance comment atop
-# this file): the default engine for every generated check, and the escape
-# hatch for a per-check override. See the `[options] engine` / `elif line[0]
-# == "engine"` handling and `get_engine()` below for what this does and why.
-engine_opt = None
 
 if len(sys.argv) > 1:
     assert len(sys.argv) == 2
     cfgname = sys.argv[1]
 
-print("Reading %s.cfg." % cfgname)
-with open("%s.cfg" % cfgname, "r") as f:
+print(f"Reading {cfgname}.cfg.")
+with open(f"{cfgname}.cfg", "r") as f:
     cfgsection = None
     cfgsubsection = None
     for line in f:
@@ -98,7 +99,7 @@ with open("%s.cfg" % cfgname, "r") as f:
             if cfgsubsection is None:
                 if cfgsection not in config:
                     config[cfgsection] = ""
-                config[cfgsection] += line + "\n"
+                config[cfgsection] += f"{line}\n"
             else:
                 if cfgsection not in config:
                     config[cfgsection] = []
@@ -127,56 +128,173 @@ if "options" in config:
             assert len(line) == 2
             solver = line[1]
 
-        elif line[0] == "engine":
-            # Local fork addition: takes the rest of the line verbatim as an
-            # sby [engines] line (e.g. "btor btormc", "smtbmc yices"), unlike
-            # `solver` above which only ever names an SMT solver for smtbmc
-            # (or the two upstream special-cased spellings "bmc3"/"btormc"
-            # below). Overrides the solver-derived default for every check;
-            # `[engine]` (see get_engine()) overrides this per check.
-            assert len(line) >= 2
-            engine_opt = " ".join(line[1:])
-
         elif line[0] == "dumpsmt2":
             assert len(line) == 1
             dumpsmt2 = True
 
+        elif line[0] == "abspath":
+            assert len(line) == 1
+            abspath = True
+
         elif line[0] == "mode":
             assert len(line) == 2
-            assert(line[1] in ("bmc", "prove"))
+            assert(line[1] in ("bmc", "prove", "cover"))
             mode = line[1]
+
+        elif line[0] == "buslen":
+            assert len(line) == 2
+            buslen = int(line[1])
+
+        elif line[0] == "nbus":
+            assert len(line) == 2
+            nbus = int(line[1])
+
+        elif line[0] == "csr_spec":
+            assert len(line) == 2
+            csr_spec = line[1]
 
         else:
             print(line)
             assert 0
 
-if "csrs" in config:
-    for line in config["csrs"].split("\n"):
-        for item in line.split():
-            csrs.add(item)
+# parse isa string
+isa_regex = re.compile(r"^rv(?P<width>\d+)(?P<base>[ie])(?P<ext>[a-v]*)(?P<multi>_?[SZX]\w+)?$", re.I)
+try:
+    isa_dict = isa_regex.match(isa).groupdict()
+except AttributeError:
+    print(f"Unable to parse isa string '{isa}'")
+    exit(1)
 
-if "64" in isa:
+isa_mods: list[str] = [isa_dict["base"].lower(), isa_dict["width"]]
+for mod in (isa_dict["ext"] or ""):
+    isa_mods.append(mod.lower())
+for mod in (isa_dict["multi"] or "").split("_"):
+    if mod:
+        isa_mods.append(mod.title())
+
+if isa_dict["width"] == "64":
     xlen = 64
 
-if "c" in isa:
+if "c" in isa_mods:
     compr = True
+
+def add_csr_tests(name, test_str):
+    # use regex to split by spaces, unless those spaces are inside quotation marks
+    # e.g. const="32'h dead_beef" is one match not two
+    #      const="32'h 0"_mask="32'h dead_beef" is also one match
+    tests = re.findall(r"((?:\S*?\"[^\"]*\")+|\S+)", test_str)
+    csr_tests[name] = tests
+
+def add_csr(csr_str):
+    try:
+        (name, tests) = csr_str.split(maxsplit=1)
+        add_csr_tests(name, tests)
+    except ValueError: # no tests
+        name = csr_str.strip()
+    csrs.add(name)
+    return name
+
+def mask_bits(test: str, bits: "list[int]", mask_len: int, invert=False):
+    mask = reduce(lambda x, y: x | 1<<y, bits, 0)
+    fstring = f"{test}_mask={'~' if invert else ''}{mask_len}'b{{:0{mask_len}b}}"
+    return fstring.format(mask)
+
+if csr_spec == "1.12":
+    spec_csrs = {
+        "mvendorid"     : ["const"],
+        "marchid"       : ["const"],
+        "mimpid"        : ["const"],
+        "mhartid"       : ["const"],
+        "mconfigptr"    : ["const"],
+        # All reserved bits should be 0
+        "mstatus"       : [mask_bits("zero", 
+                                     [0, 2, 4, *range(23, 31)] + ([31, *range(38, 63)] if xlen==64 else []), 
+                                     xlen)],
+        "misa"          : [mask_bits("zero", 
+                                     [6, 10, 11, 14, 17, 19, 22, 24, 25, *range(26, xlen-2)], 
+                                     xlen)],
+        "mie"           : None,
+        "mtvec"         : None,
+        "mscratch"      : ["any"],
+        "mepc"          : None,
+        "mcause"        : None,
+        "mtval"         : None,
+        "mip"           : None,
+        "mcycle"        : ["inc"],
+        "minstret"      : ["inc"],
+    }
+    spec_csrs.update({f"mhpmcounter{i}" : None for i in range(3, 32)})
+    spec_csrs.update({f"mhpmevent{i}" : None for i in range(3, 32)})
+
+    restricted_csrs = {
+        "medeleg"       : ("s",  "302", None),
+        "mideleg"       : ("s",  "303", None),
+        "mcounteren"    : ("u",  "306", None),
+        "mstatush"      : ("32", "310", [mask_bits("zero", [4, 5], xlen, invert=True)]),
+        "mtinst"        : ("h",  "34A", None),
+        "mtval2"        : ("h",  "34B", None),
+        "menvcfg"       : ("u",  "30A", None),
+        "menvcfgh"      : ("u",  "31A", None),  # u-mode only *and* 32bit only
+    }
+    for (name, data) in restricted_csrs.items():
+        if data[0] in isa_mods:
+            spec_csrs[name] = data[2]
+        else:
+            illegal_csrs.add(
+                (data[1], "m", "rw"),
+            )
+
+    for (name, tests) in spec_csrs.items():
+        csrs.add(name)
+        if tests:
+            csr_tests[name] = tests
+
+if "csrs" in config:
+    for line in config["csrs"].split("\n"):
+        if line:
+            add_csr(line)
+
+if "custom_csrs" in config:
+    for line in config["custom_csrs"].split("\n"):
+        try:
+            (addr, levels, csr_str) = line.split(maxsplit=2)
+        except ValueError: # no csr
+            continue
+        name = add_csr(csr_str)
+        custom_csrs.add((name, int(addr, base=16), levels))
+
+if "illegal_csrs" in config:
+    for line in config["illegal_csrs"].split("\n"):
+        line = tuple(line.split())
+
+        if len(line) == 0:
+            continue
+
+        assert len(line) == 3
+        illegal_csrs.add(line)
 
 if "groups" in config:
     groups += config["groups"].split()
 
-print("Creating %s directory." % cfgname)
+print(f"Creating {cfgname} directory.")
 shutil.rmtree(cfgname, ignore_errors=True)
 os.mkdir(cfgname)
 
-def print_hfmt(f, text, **kwargs):
+def hfmt(text, **kwargs):
+    lines = []
     for line in text.split("\n"):
         match = re.match(r"^\s*: ?(.*)", line)
         if match:
             line = match.group(1)
         elif line.strip() == "":
             continue
-        print(re.sub(r"@([a-zA-Z0-9_]+)@",
-                lambda match: str(kwargs[match.group(1)]), line), file=f)
+        lines.append(re.sub(r"@([a-zA-Z0-9_]+)@",
+                lambda match: str(kwargs[match.group(1)]), line))
+    return lines
+
+def print_hfmt(f, text, **kwargs):
+    for line in hfmt(text, **kwargs):
+        print(line, file=f)
 
 hargs = dict()
 hargs["basedir"] = basedir
@@ -184,6 +302,8 @@ hargs["core"] = corename
 hargs["nret"] = nret
 hargs["xlen"] = xlen
 hargs["ilen"] = ilen
+hargs["buslen"] = buslen
+hargs["nbus"] = nbus
 hargs["append"] = 0
 hargs["mode"] = mode
 
@@ -195,36 +315,13 @@ consistency_checks = set()
 
 if solver == "bmc3":
     hargs["engine"] = "abc bmc3"
-    hargs["ilang_file"] = corename + "-gates.il"
+    hargs["ilang_file"] = f"{corename}-gates.il"
 elif solver == "btormc":
     hargs["engine"] = "btor btormc"
-    hargs["ilang_file"] = corename + "-hier.il"
+    hargs["ilang_file"] = f"{corename}-hier.il"
 else:
-    hargs["engine"] = "smtbmc %s%s" % ("--dumpsmt2 " if dumpsmt2 else "", solver)
-    hargs["ilang_file"] = corename + "-hier.il"
-
-# `engine` in [options] (checks.cfg) overrides the solver-derived default
-# above -- this is the "engine is configurable, defaulting to btor btormc"
-# knob (a measured fix: `reg_ch0` did not converge under `smtbmc yices` in
-# >20 min, twice, and passes under `btor btormc` in ~8s -- same check, same
-# depth). `default_engine` feeds `get_engine()`, which every generated
-# check's .sby consults so a specific check can still be pinned back to
-# `smtbmc yices` (or anything else) via the `[engine]` section below without
-# touching this file again.
-default_engine = engine_opt if engine_opt is not None else hargs["engine"]
-
-def get_engine(check):
-    engine = default_engine
-    if "engine" in config:
-        for line in config["engine"].split("\n"):
-            line = line.strip()
-            if not line:
-                continue
-            pat, _, eng = line.partition(" ")
-            eng = eng.strip()
-            if eng and re.fullmatch(pat, check):
-                engine = eng
-    return engine
+    hargs["engine"] = f"smtbmc {'--dumpsmt2 ' if dumpsmt2 else ''}{solver}"
+    hargs["ilang_file"] = f"{corename}-hier.il"
 
 def test_disabled(check):
     if "filter-checks" in config:
@@ -248,16 +345,54 @@ def get_depth_cfg(patterns):
                     ret = [int(s) for s in line[1:]]
     return ret
 
+def print_custom_csrs(sby_file):
+    fstrings = {
+        "inputs": "  ,input [`RISCV_FORMAL_NRET * `RISCV_FORMAL_XLEN - 1 : 0] rvfi_csr_{csr}_{signal} \\",
+        "wires": "  (* keep *) wire [`RISCV_FORMAL_NRET * `RISCV_FORMAL_XLEN - 1 : 0] rvfi_csr_{csr}_{signal}; \\",
+        "conn": "  ,.rvfi_csr_{csr}_{signal} (rvfi_csr_{csr}_{signal}) \\",
+        "channel": "  wire [`RISCV_FORMAL_XLEN - 1 : 0] csr_{csr}_{signal} = rvfi_csr_{csr}_{signal} [(_idx)*(`RISCV_FORMAL_XLEN) +: `RISCV_FORMAL_XLEN]; \\",
+        "signals": "`RISCV_FORMAL_CHANNEL_SIGNAL(`RISCV_FORMAL_NRET, `RISCV_FORMAL_XLEN, csr_{csr}_{signal}) \\",
+        "outputs": "  ,output [`RISCV_FORMAL_NRET * `RISCV_FORMAL_XLEN - 1 : 0] rvfi_csr_{csr}_{signal} \\",
+        "indices": "  localparam [11:0] csr_{level}index_{name} = 12'h{index:03X}; \\"
+    }
+    for (macro, fstring) in fstrings.items():
+        if macro == "channel":
+            print(f"`define RISCV_FORMAL_CUSTOM_CSR_{macro.upper()}(_idx) \\" , file=sby_file)
+        else:
+            print(f"`define RISCV_FORMAL_CUSTOM_CSR_{macro.upper()} \\", file=sby_file)
+        for custom_csr in custom_csrs:
+            name = custom_csr[0]
+            addr = custom_csr[1]
+            levels = custom_csr[2]
+            if macro == "indices":
+                for level in ["m", "s", "u"]:
+                    if level in levels:
+                        macro_string = fstring.format(level=level, name=name, index=addr)
+                    else:
+                        macro_string = fstring.format(level=level, name=name, index=0xfff)
+                    print(macro_string, file=sby_file)
+            else:
+                for signal in ["rmask", "wmask", "rdata", "wdata"]:
+                    macro_string = fstring.format(csr=name, signal=signal)
+                    print(macro_string, file=sby_file)
+        print("", file=sby_file)
+
 # ------------------------------ Instruction Checkers ------------------------------
 
-def check_insn(grp, insn, chanidx, csr_mode=False):
+def check_insn(grp, insn, chanidx, csr_mode=False, illegal_csr=False):
     pf = "" if grp is None else grp+"_"
-    if csr_mode:
-        check = "%scsrw_%s_ch%d" % (pf, insn, chanidx)
-        depth_cfg = get_depth_cfg(["%scsrw" % (pf,), "%scsrw_ch%d" % (pf, chanidx), "%scsrw_%s" % (pf, insn), "%scsrw_%s_ch%d" % (pf, insn, chanidx)])
+    if illegal_csr:
+        (ill_addr, ill_modes, ill_rw) = insn
+        insn = f"12'h{int(ill_addr, base=16):03X}"
+        check = f"{pf}csr_ill_{ill_addr}_ch{chanidx:d}"
+        depth_cfg = get_depth_cfg([f"{pf}csr_ill", f"{pf}csr_ill_ch{chanidx:d}", f"{pf}csr_ill_{ill_addr}", f"{pf}csr_ill_{ill_addr}_ch{chanidx:d}"])
     else:
-        check = "%sinsn_%s_ch%d" % (pf, insn, chanidx)
-        depth_cfg = get_depth_cfg(["%sinsn" % (pf,), "%sinsn_ch%d" % (pf, chanidx), "%sinsn_%s" % (pf, insn), "%sinsn_%s_ch%d" % (pf, insn, chanidx)])
+        if csr_mode:
+            check = "csrw"
+        else:
+            check = "insn"
+        depth_cfg = get_depth_cfg([f"{pf}{check}", f"{pf}{check}_ch{chanidx:d}", f"{pf}{check}_{insn}", f"{pf}{check}_{insn}_ch{chanidx:d}"])
+        check = f"{pf}{check}_{insn}_ch{chanidx:d}"
 
     if depth_cfg is None: return
     assert len(depth_cfg) == 1
@@ -267,13 +402,12 @@ def check_insn(grp, insn, chanidx, csr_mode=False):
 
     hargs["insn"] = insn
     hargs["checkch"] = check
-    hargs["channel"] = "%d" % chanidx
+    hargs["channel"] = f"{chanidx:d}"
     hargs["depth"] = depth_cfg[0]
     hargs["depth_plus"] = depth_cfg[0] + 1
     hargs["skip"] = depth_cfg[0]
-    hargs["engine"] = get_engine(check)
 
-    with open("%s/%s.sby" % (cfgname, check), "w") as sby_file:
+    with open(f"{cfgname}/{check}.sby", "w") as sby_file:
         print_hfmt(sby_file, """
                 : [options]
                 : mode @mode@
@@ -291,7 +425,19 @@ def check_insn(grp, insn, chanidx, csr_mode=False):
         if "script-defines" in config:
             print_hfmt(sby_file, config["script-defines"], **hargs)
 
-        print("read_verilog -sv %s.sv" % check, file=sby_file)
+        sv_files = [f"{check}.sv"]
+        if "verilog-files" in config:
+            sv_files += hfmt(config["verilog-files"], **hargs)
+
+        vhdl_files = []
+        if "vhdl-files" in config:
+            vhdl_files += hfmt(config["vhdl-files"], **hargs)
+
+        if len(sv_files):
+            print(f"read -sv {' '.join(sv_files)}", file=sby_file)
+
+        if len(vhdl_files):
+            print(f"read -vhdl {' '.join(vhdl_files)}", file=sby_file)
 
         if "script-sources" in config:
             print_hfmt(sby_file, config["script-sources"], **hargs)
@@ -312,7 +458,11 @@ def check_insn(grp, insn, chanidx, csr_mode=False):
                 : @basedir@/checks/rvfi_testbench.sv
         """, **hargs)
 
-        if csr_mode:
+        if illegal_csr:
+            print_hfmt(sby_file, """
+                    : @basedir@/checks/rvfi_csr_ill_check.sv
+            """, **hargs)
+        elif csr_mode:
             print_hfmt(sby_file, """
                     : @basedir@/checks/rvfi_csrw_check.sv
             """, **hargs)
@@ -341,12 +491,27 @@ def check_insn(grp, insn, chanidx, csr_mode=False):
             print("`define RISCV_FORMAL_UNBOUNDED", file=sby_file)
 
         for csr in sorted(csrs):
-            print("`define RISCV_FORMAL_CSR_%s" % csr.upper(), file=sby_file)
+            print(f"`define RISCV_FORMAL_CSR_{csr.upper()}", file=sby_file)
 
         if csr_mode and insn in ("mcycle", "minstret"):
             print("`define RISCV_FORMAL_CSRWH", file=sby_file)
 
-        if csr_mode:
+        if illegal_csr:
+            print_hfmt(sby_file, """
+                    : `define RISCV_FORMAL_CHECKER rvfi_csr_ill_check
+                    : `define RISCV_FORMAL_ILL_CSR_ADDR @insn@
+            """, **hargs)
+            if 'm' in ill_modes:
+                print("`define RISCV_FORMAL_ILL_MMODE", file=sby_file)
+            if 's' in ill_modes:
+                print("`define RISCV_FORMAL_ILL_SMODE", file=sby_file)
+            if 'u' in ill_modes:
+                print("`define RISCV_FORMAL_ILL_UMODE", file=sby_file)
+            if 'r' in ill_rw:
+                print("`define RISCV_FORMAL_ILL_READ", file=sby_file)
+            if 'w' in ill_rw:
+                print("`define RISCV_FORMAL_ILL_WRITE", file=sby_file)
+        elif csr_mode:
             print_hfmt(sby_file, """
                     : `define RISCV_FORMAL_CHECKER rvfi_csrw_check
                     : `define RISCV_FORMAL_CSRW_NAME @insn@
@@ -356,6 +521,9 @@ def check_insn(grp, insn, chanidx, csr_mode=False):
                     : `define RISCV_FORMAL_CHECKER rvfi_insn_check
                     : `define RISCV_FORMAL_INSN_MODEL rvfi_insn_@insn@
             """, **hargs)
+
+        if custom_csrs:
+            print_custom_csrs(sby_file)
 
         if blackbox:
             print("`define RISCV_FORMAL_BLACKBOX_REGS", file=sby_file)
@@ -375,7 +543,11 @@ def check_insn(grp, insn, chanidx, csr_mode=False):
                 : `include "rvfi_testbench.sv"
         """, **hargs)
 
-        if csr_mode:
+        if illegal_csr:
+            print_hfmt(sby_file, """
+                    : `include "rvfi_csr_ill_check.sv"
+            """, **hargs)
+        elif csr_mode:
             print_hfmt(sby_file, """
                     : `include "rvfi_csrw_check.sv"
             """, **hargs)
@@ -403,39 +575,80 @@ def check_insn(grp, insn, chanidx, csr_mode=False):
                     print(line, file=sby_file)
 
 for grp in groups:
-    with open("riscv-formal/insns/isa_%s.txt" % isa) as isa_file:
-        for insn in isa_file:
-            for chanidx in range(nret):
-                check_insn(grp, insn.strip(), chanidx)
+    try:
+        with open(f"{basedir}/insns/isa_{isa}.txt", "r") as isa_file:
+            for insn in isa_file:
+                for chanidx in range(nret):
+                    check_insn(grp, insn.strip(), chanidx)
+    except FileNotFoundError:
+        print(f"Current isa string '{isa}' not supported, skipping instruction checks.", file=sys.stderr)
 
     for csr in sorted(csrs):
         for chanidx in range(nret):
             check_insn(grp, csr, chanidx, csr_mode=True)
 
+    for ill_csr in sorted(illegal_csrs, key=lambda csr: csr[0]):
+        for chanidx in range(nret):
+            check_insn(grp, ill_csr, chanidx, illegal_csr=True)
+
 # ------------------------------ Consistency Checkers ------------------------------
 
-def check_cons(grp, check, chanidx=None, start=None, trig=None, depth=None, timeout=None, csr_mode=False):
+def check_cons(grp, check, chanidx=None, start=None, trig=None, depth=None, csr_mode=False, csr_test=None, bus_mode=False):
     pf = "" if grp is None else grp+"_"
     if csr_mode:
         csr_name = check
-        check = pf + "csrc_" + csr_name
-        hargs["check"] = "csrc"
-
-        if chanidx is not None:
-            depth_cfg = get_depth_cfg(["%scsrc" % (pf,), check, "%scsrc_ch%d" % (pf, chanidx), "%s_ch%d" % (check, chanidx)])
-            hargs["channel"] = "%d" % chanidx
-            check += "_ch%d" % chanidx
+        if csr_test is not None:
+            # Check for provided mask
+            mask_idx = csr_test.find("_mask")
+            if mask_idx >= 0:
+                try:
+                    csr_mask = str(csr_test[mask_idx:]).split('=', maxsplit=1)[1].strip('"')
+                except IndexError: # no value provided
+                    print(csr_test)
+                    assert 0
+                csr_test = csr_test[:mask_idx]
+            if csr_test.startswith("const"):
+                try:
+                    constval = str(csr_test).split('=', maxsplit=1)[1].strip('"')
+                except IndexError: # no value provided
+                    constval = "rdata_shadow"
+                check = f"{pf}csrc_const_{csr_name}"
+                check_name = f"csrc_const"
+            elif csr_test.startswith("hpm"):
+                try:
+                    hpmevent = str(csr_test).split('=', maxsplit=1)[1].strip('"')
+                except IndexError: # no value provided
+                    pass
+                hpmcounter = str(csr_name).replace("event", "counter")
+                if hpmcounter not in csrs:
+                    csrs.add(hpmcounter)
+                check = f"{pf}csrc_hpm_{csr_name}"
+                check_name = f"csrc_hpm"
+            else:
+                check = f"{pf}csrc_{csr_test}_{csr_name}"
+                check_name =f"csrc_{csr_test}"
 
         else:
-            depth_cfg = get_depth_cfg(["csrc", check])
+            check = f"{pf}csrc_{csr_name}"
+            check_name = "csrc"
+
+        hargs["check"] = check_name
+
+        if chanidx is not None:
+            depth_cfg = get_depth_cfg([f"{pf}{check_name}", check, f"{pf}{check_name}_ch{chanidx:d}", f"{check}_ch{chanidx:d}"])
+            hargs["channel"] = f"{chanidx:d}"
+            check = f"{check}_ch{chanidx:d}"
+
+        else:
+            depth_cfg = get_depth_cfg([f"{check_name}", check])
     else:
         hargs["check"] = check
         check = pf + check
 
         if chanidx is not None:
-            depth_cfg = get_depth_cfg([check, "%s_ch%d" % (check, chanidx)])
-            hargs["channel"] = "%d" % chanidx
-            check += "_ch%d" % chanidx
+            depth_cfg = get_depth_cfg([check, f"{check}_ch{chanidx:d}"])
+            hargs["channel"] = f"{chanidx:d}"
+            check = f"{check}_ch{chanidx:d}"
 
         else:
             depth_cfg = get_depth_cfg([check])
@@ -453,14 +666,6 @@ def check_cons(grp, check, chanidx=None, start=None, trig=None, depth=None, time
     if depth is not None:
         depth = depth_cfg[depth]
 
-    # An optional fourth [depth] column, wired only to callers that pass
-    # `timeout=`. Bounds a check's wall time (seconds) so a non-converging
-    # BMC query is *reported* (status TIMEOUT) instead of eating the whole
-    # job budget — see checks.cfg's [depth] comment for why `reg` is the one
-    # caller today (ADR-0022, ADR-0023).
-    if timeout is not None:
-        timeout = depth_cfg[timeout]
-
     hargs["start"] = start
     hargs["depth"] = depth
     hargs["depth_plus"] = depth + 1
@@ -469,14 +674,12 @@ def check_cons(grp, check, chanidx=None, start=None, trig=None, depth=None, time
     hargs["checkch"] = check
 
     hargs["xmode"] = hargs["mode"]
-    if check == "cover": hargs["xmode"] = "cover"
+    if check == "cover" or "csrc_hpm" in check: hargs["xmode"] = "cover"
 
     if test_disabled(check): return
     consistency_checks.add(check)
 
-    hargs["engine"] = get_engine(check)
-
-    with open("%s/%s.sby" % (cfgname, check), "w") as sby_file:
+    with open(f"{cfgname}/{check}.sby", "w") as sby_file:
         print_hfmt(sby_file, """
                 : [options]
                 : mode @xmode@
@@ -484,12 +687,6 @@ def check_cons(grp, check, chanidx=None, start=None, trig=None, depth=None, time
                 : append @append@
                 : depth @depth_plus@
                 : skip @skip@
-        """, **hargs)
-
-        if timeout is not None:
-            print("timeout %d" % timeout, file=sby_file)
-
-        print_hfmt(sby_file, """
                 :
                 : [engines]
                 : @engine@
@@ -500,12 +697,22 @@ def check_cons(grp, check, chanidx=None, start=None, trig=None, depth=None, time
         if "script-defines" in config:
             print_hfmt(sby_file, config["script-defines"], **hargs)
 
-        if ("script-defines %s" % hargs["check"]) in config:
-            print_hfmt(sby_file, config["script-defines %s" % hargs["check"]], **hargs)
+        if (f"script-defines {hargs['check']}") in config:
+            print_hfmt(sby_file, config[f"script-defines {hargs['check']}"], **hargs)
 
-        print_hfmt(sby_file, """
-                : read_verilog -sv @checkch@.sv
-        """, **hargs)
+        sv_files = [f"{check}.sv"]
+        if "verilog-files" in config:
+            sv_files += hfmt(config["verilog-files"], **hargs)
+
+        vhdl_files = []
+        if "vhdl-files" in config:
+            vhdl_files += hfmt(config["vhdl-files"], **hargs)
+
+        if len(sv_files):
+            print(f"read -sv {' '.join(sv_files)}", file=sby_file)
+
+        if len(vhdl_files):
+            print(f"read -vhdl {' '.join(vhdl_files)}", file=sby_file)
 
         if "script-sources" in config:
             print_hfmt(sby_file, config["script-sources"], **hargs)
@@ -546,12 +753,26 @@ def check_cons(grp, check, chanidx=None, start=None, trig=None, depth=None, time
             print("`define RISCV_FORMAL_UNBOUNDED", file=sby_file)
 
         for csr in sorted(csrs):
-            print("`define RISCV_FORMAL_CSR_%s" % csr.upper(), file=sby_file)
+            print(f"`define RISCV_FORMAL_CSR_{csr.upper()}", file=sby_file)
 
         if csr_mode:
-            if csr_name in ("mcycle", "minstret"):
-                print("`define RISCV_FORMAL_CSRC_UPCNT", file=sby_file)
-            print("`define RISCV_FORMAL_CSRC_NAME " + csr_name, file=sby_file)
+            localdict = locals()
+            csr_defs = [
+                ("RISCV_FORMAL_CSRC_CONSTVAL", "constval"),
+                ("RISCV_FORMAL_CSRC_HPMEVENT", "hpmevent"),
+                ("RISCV_FORMAL_CSRC_HPMCOUNTER", "hpmcounter"),
+                ("RISCV_FORMAL_CSRC_MASK", "csr_mask"),
+            ]
+            for key, val  in csr_defs:
+                try:
+                    print(f"`define {key} {localdict[val]}", file=sby_file)
+                except KeyError:
+                    # no val for key
+                    pass
+            print(f"`define RISCV_FORMAL_CSRC_NAME {csr_name}", file=sby_file)
+
+        if custom_csrs:
+            print_custom_csrs(sby_file)
 
         if blackbox and hargs["check"] != "liveness":
             print("`define RISCV_FORMAL_BLACKBOX_ALU", file=sby_file)
@@ -560,10 +781,17 @@ def check_cons(grp, check, chanidx=None, start=None, trig=None, depth=None, time
             print("`define RISCV_FORMAL_BLACKBOX_REGS", file=sby_file)
 
         if chanidx is not None:
-            print("`define RISCV_FORMAL_CHANNEL_IDX %d" % chanidx, file=sby_file)
+            print(f"`define RISCV_FORMAL_CHANNEL_IDX {chanidx:d}", file=sby_file)
 
         if trig is not None:
-            print("`define RISCV_FORMAL_TRIG_CYCLE %d" % trig, file=sby_file)
+            print(f"`define RISCV_FORMAL_TRIG_CYCLE {trig:d}", file=sby_file)
+
+        if bus_mode:
+            print_hfmt(sby_file, """
+                    : `define RISCV_FORMAL_BUS
+                    : `define RISCV_FORMAL_NBUS @nbus@
+                    : `define RISCV_FORMAL_BUSLEN @buslen@
+            """, **hargs)
 
         if hargs["check"] in ("liveness", "hang"):
             print("`define RISCV_FORMAL_FAIRNESS", file=sby_file)
@@ -571,8 +799,8 @@ def check_cons(grp, check, chanidx=None, start=None, trig=None, depth=None, time
         if "defines" in config:
             print_hfmt(sby_file, config["defines"], **hargs)
 
-        if ("defines %s" % hargs["check"]) in config:
-            print_hfmt(sby_file, config["defines %s" % hargs["check"]], **hargs)
+        if (f"defines {hargs['check']}") in config:
+            print_hfmt(sby_file, config[f"defines {hargs['check']}"], **hargs)
 
         print_hfmt(sby_file, """
                 : `include "rvfi_macros.vh"
@@ -610,20 +838,34 @@ def check_cons(grp, check, chanidx=None, start=None, trig=None, depth=None, time
 
 for grp in groups:
     for i in range(nret):
-        check_cons(grp, "reg", chanidx=i, start=0, depth=1, timeout=2)
+        check_cons(grp, "reg", chanidx=i, start=0, depth=1)
         check_cons(grp, "pc_fwd", chanidx=i, start=0, depth=1)
         check_cons(grp, "pc_bwd", chanidx=i, start=0, depth=1)
         check_cons(grp, "liveness", chanidx=i, start=0, trig=1, depth=2)
         check_cons(grp, "unique", chanidx=i, start=0, trig=1, depth=2)
         check_cons(grp, "causal", chanidx=i, start=0, depth=1)
+        check_cons(grp, "causal_mem", chanidx=i, start=0, depth=1)
+        check_cons(grp, "causal_io", chanidx=i, start=0, depth=1)
         check_cons(grp, "ill", chanidx=i, depth=0)
+        check_cons(grp, "fault", chanidx=i, depth=0)
+
+        check_cons(grp, "bus_imem", chanidx=i, start=0, depth=1, bus_mode=True)
+        check_cons(grp, "bus_imem_fault", chanidx=i, start=0, depth=1, bus_mode=True)
+        check_cons(grp, "bus_dmem", chanidx=i, start=0, depth=1, bus_mode=True)
+        check_cons(grp, "bus_dmem_fault", chanidx=i, start=0, depth=1, bus_mode=True)
+        check_cons(grp, "bus_dmem_io_read", chanidx=i, start=0, depth=1, bus_mode=True)
+        check_cons(grp, "bus_dmem_io_read_fault", chanidx=i, start=0, depth=1, bus_mode=True)
+        check_cons(grp, "bus_dmem_io_write", chanidx=i, start=0, depth=1, bus_mode=True)
+        check_cons(grp, "bus_dmem_io_write_fault", chanidx=i, start=0, depth=1, bus_mode=True)
+        check_cons(grp, "bus_dmem_io_order", chanidx=i, start=0, depth=1, bus_mode=True)
 
     check_cons(grp, "hang", start=0, depth=1)
     check_cons(grp, "cover", start=0, depth=1)
 
     for csr in sorted(csrs):
         for chanidx in range(nret):
-            check_cons(grp, csr, chanidx, start=0, depth=1, csr_mode=True)
+            for csr_test in csr_tests.get(csr, [None]):
+                check_cons(grp, csr, chanidx, start=0, depth=1, csr_mode=True, csr_test=csr_test)
 
 # ------------------------------ Makefile ------------------------------
 
@@ -631,24 +873,27 @@ def checks_key(check):
     if "sort" in config:
         for index, line in enumerate(config["sort"].split("\n")):
             if re.fullmatch(line.strip(), check):
-                return "%04d-%s" % (index, check)
+                return f"{index:04d}-{check}"
     if check.startswith("insn_"):
-        return "9999-%s" % check
-    return "9998-%s" % check
+        return f"9999-{check}"
+    return f"9998-{check}"
 
-with open("%s/makefile" % cfgname, "w") as mkfile:
+with open(f"{cfgname}/makefile", "w") as mkfile:
     print("all:", end="", file=mkfile)
 
     checks = list(sorted(consistency_checks | instruction_checks, key=checks_key))
 
     for check in checks:
-        print(" %s" % check, end="", file=mkfile)
+        print(f" {check}", end="", file=mkfile)
     print(file=mkfile)
 
     for check in checks:
-        print("%s: %s/status" % (check, check), file=mkfile)
-        print("%s/status:" % check, file=mkfile)
-        print("\t%s %s.sby" % (sbycmd, check), file=mkfile)
-        print(".PHONY: %s" % check, file=mkfile)
+        print(f"{check}: {check}/status", file=mkfile)
+        print(f"{check}/status:", file=mkfile)
+        if abspath:
+            print(f"\t{sbycmd} $(shell pwd)/{check}.sby", file=mkfile)
+        else:
+            print(f"\t{sbycmd} {check}.sby", file=mkfile)
+        print(f".PHONY: {check}", file=mkfile)
 
-print("Generated %d checks." % (len(consistency_checks) + len(instruction_checks)))
+print(f"Generated {len(consistency_checks) + len(instruction_checks)} checks.")


### PR DESCRIPTION
Closes JEF-652

`formal/genchecks-local.py` was a copy of riscv-formal's `checks/genchecks.py` taken from a pre-2021 upstream — **654 lines against 870** at the SHA in `formal/pin.mk`. The pin was never stale; the fork was. Re-vendored verbatim from the pin, re-applying only `basedir`.

**Do not read any PASS below as "the property holds."** Every ladder check is `mode bmc` — a PASS means *no counterexample was found within that check's configured depth*. The whole ladder still runs under `RISCV_FORMAL_ALTOPS`, so a green `insn_mul` still says nothing whatever about the real multiplier (ADR-0010). This PR moves M2 no closer; it removes an obstacle in front of the checks that would.

---

## AC1 — differs from upstream by only the `basedir` change

`diff -u formal/riscv-formal/checks/genchecks.py formal/genchecks-local.py`, with the new header hunk elided (it is the ticket's "rewrite the header" item; full text in the file):

```diff
@@ -35,7 +64,7 @@
 blackbox = False
 
 cfgname = "checks"
-basedir = f"{os.getcwd()}/../.."
+basedir = os.path.abspath(os.path.join(os.path.dirname(os.path.realpath(__file__)), "riscv-formal"))
 corename = os.getcwd().split("/")[-1]
 solver = "boolector"
 dumpsmt2 = False
@@ -547,7 +576,7 @@
 
 for grp in groups:
     try:
-        with open(f"../../insns/isa_{isa}.txt", "r") as isa_file:
+        with open(f"{basedir}/insns/isa_{isa}.txt", "r") as isa_file:
             for insn in isa_file:
                 for chanidx in range(nret):
                     check_insn(grp, insn.strip(), chanidx)
```

Two hunks. The second is the isa-table `open()`, which spells the same `../..` inline — upstream's `../../insns/` *is* `basedir/insns`, so it is the same one change, not a second one. The header carries a three-line re-sync recipe whose acceptance test is exactly this diff.

Options this repo does not use (`csr_spec`, `buslen`, `nbus`, `abspath`, `custom_csrs`, `illegal_csrs`, `verilog-files`/`vhdl-files`) are kept unedited so the file stays byte-comparable with upstream — that is what makes the next re-sync a copy rather than archaeology.

## AC2 — same 78 checks, same verdicts

The re-vendor reached the generated `.sby` files in **exactly two ways**. Measured, not asserted: all 79 generated files diffed against a from-scratch baseline taken immediately before the change.

```
$ diff -r checks-baseline checks | grep -E '^[<>]' | sed -E 's/<check>/…/' | sort | uniq -c
  78 > read -sv <CHECK>.sv
  78 < read_verilog -sv <CHECK>.sv
   1 < timeout 1800
```

`read -sv` is upstream's frontend-agnostic spelling; without Verific yosys dispatches it to `read_verilog -sv`. Check-name set is byte-identical (78 + makefile). No yosys read/elaboration errors in any of the 78 logs.

```
$ make -C formal check          # -k, from scratch
make -C formal check  471.73s user 68.97s system 214% cpu 4:11.70 total

$ ./check-baseline.sh checks EXPECTED_FAIL
78 checks: 67 pass, 11 fail
Failure list matches EXPECTED_FAIL exactly.
check-baseline.sh exit: 0
```

The 11 non-PASS, unchanged from baseline — 2 = the M3 CSR gap, 9 = the M3 trap gap:

```
csrw_mcycle_ch0    insn_lh_ch0    insn_lw_ch0   insn_c_lw_ch0     insn_c_sw_ch0
csrw_minstret_ch0  insn_lhu_ch0   insn_sh_ch0   insn_c_lwsp_ch0   insn_c_swsp_ch0
                                  insn_sw_ch0
```

<details><summary>Full 78-check tally, verbatim</summary>

```
causal_ch0               PASS
csrw_mcycle_ch0          ERROR
csrw_minstret_ch0        ERROR
insn_add_ch0             PASS
insn_addi_ch0            PASS
insn_and_ch0             PASS
insn_andi_ch0            PASS
insn_auipc_ch0           PASS
insn_beq_ch0             PASS
insn_bge_ch0             PASS
insn_bgeu_ch0            PASS
insn_blt_ch0             PASS
insn_bltu_ch0            PASS
insn_bne_ch0             PASS
insn_c_add_ch0           PASS
insn_c_addi_ch0          PASS
insn_c_addi16sp_ch0      PASS
insn_c_addi4spn_ch0      PASS
insn_c_and_ch0           PASS
insn_c_andi_ch0          PASS
insn_c_beqz_ch0          PASS
insn_c_bnez_ch0          PASS
insn_c_j_ch0             PASS
insn_c_jal_ch0           PASS
insn_c_jalr_ch0          PASS
insn_c_jr_ch0            PASS
insn_c_li_ch0            PASS
insn_c_lui_ch0           PASS
insn_c_lw_ch0            ERROR
insn_c_lwsp_ch0          ERROR
insn_c_mv_ch0            PASS
insn_c_or_ch0            PASS
insn_c_slli_ch0          PASS
insn_c_srai_ch0          PASS
insn_c_srli_ch0          PASS
insn_c_sub_ch0           PASS
insn_c_sw_ch0            ERROR
insn_c_swsp_ch0          ERROR
insn_c_xor_ch0           PASS
insn_div_ch0             PASS
insn_divu_ch0            PASS
insn_jal_ch0             PASS
insn_jalr_ch0            PASS
insn_lb_ch0              PASS
insn_lbu_ch0             PASS
insn_lh_ch0              ERROR
insn_lhu_ch0             ERROR
insn_lui_ch0             PASS
insn_lw_ch0              ERROR
insn_mul_ch0             PASS
insn_mulh_ch0            PASS
insn_mulhsu_ch0          PASS
insn_mulhu_ch0           PASS
insn_or_ch0              PASS
insn_ori_ch0             PASS
insn_rem_ch0             PASS
insn_remu_ch0            PASS
insn_sb_ch0              PASS
insn_sh_ch0              ERROR
insn_sll_ch0             PASS
insn_slli_ch0            PASS
insn_slt_ch0             PASS
insn_slti_ch0            PASS
insn_sltiu_ch0           PASS
insn_sltu_ch0            PASS
insn_sra_ch0             PASS
insn_srai_ch0            PASS
insn_srl_ch0             PASS
insn_srli_ch0            PASS
insn_sub_ch0             PASS
insn_sw_ch0              ERROR
insn_xor_ch0             PASS
insn_xori_ch0            PASS
liveness_ch0             PASS
pc_bwd_ch0               PASS
pc_fwd_ch0               PASS
reg_ch0                  PASS
unique_ch0               PASS
```
</details>

**Finding (pre-existing, not caused by this change, not patched here).** The 11 report status `ERROR`, not `FAIL`. `btormc` *does* find the counterexample in all 11 — `found 1 reachable ... bad state properties at bound k = 15` — and `sby` then errors only because `btorsim` (trace rendering) is not installed on this machine (`btorsim: command not found`, rc=16). Verified for all 11 individually. `check-baseline.sh` only distinguishes PASS from non-PASS, so the tally is correct either way. But it means **on a box without `btorsim` a genuine harness ERROR is indistinguishable from an expected baseline FAIL** — both land in the same bucket and read as a matching baseline. Worth a follow-up; out of scope here.

## AC3 — `reg_ch0` passes in seconds, via upstream's `solver`

```
$ sed -n '/\[engines\]/,/^$/p' formal/checks/reg_ch0.sby
[engines]
btor btormc

$ grep -n timeout formal/checks/reg_ch0.sby
(none -- upstream genchecks emits no timeout)

$ cat formal/checks/reg_ch0/status
PASS 0 16
```
```
SBY [reg_ch0] summary: Elapsed clock time [H:MM:SS (secs)]: 0:00:34 (34)
SBY [reg_ch0] summary: Elapsed process time [H:MM:SS (secs)]: 0:00:16 (16)
SBY [reg_ch0] summary: engine_0 (btor btormc) returned pass
SBY [reg_ch0] DONE (PASS, rc=0)
```

16s process time (34s wall, under contention from 78 parallel checks) — from `solver btormc` in `checks.cfg`, which upstream turns into `btor btormc`. All 78 `.sby` files carry that engine line. The engine line was verified **before** the fork's `engine` option was deleted.

## AC4 — `csrc_*` are now generatable (and deliberately NOT added to the ladder)

Demonstrated in a scratch config (`csrcdemo.cfg`, deleted after; `checks.cfg` untouched) that gives `mcycle`/`minstret` upstream's `inc` test and a `csrc_inc` depth:

```
$ python3 genchecks-local.py csrcdemo
Generated 80 checks.
$ ls csrcdemo/ | grep csrc
csrc_inc_mcycle_ch0.sby
csrc_inc_minstret_ch0.sby

$ grep -nE 'rvfi_csrc|RISCV_FORMAL_CSRC' csrcdemo/csrc_inc_minstret_ch0.sby
29:.../formal/riscv-formal/checks/rvfi_csrc_inc_check.sv
36:`define RISCV_FORMAL_CHECKER rvfi_csrc_inc_check
41:`define RISCV_FORMAL_CSRC_NAME minstret
51:`include "rvfi_csrc_inc_check.sv"

EXISTS  .../formal/riscv-formal/checks/rvfi_csrc_inc_check.sv
```

All six models present at the pin: `rvfi_csrc_{any,const,hpm,inc,upcnt,zero}_check.sv`. **Not added to the ladder** — each needs its own derived depth (ADR-0025) and `EXPECTED_FAIL` entry (ADR-0022), and `mcycle`/`minstret` are not implemented (M3). `csrc_inc_minstret` is flagged in `checks.cfg` as the one to reach for first: it is the direct formal statement of ADR-0027's minstret rule, and **the fork was what blocked it** — not upstream, and not the pin.

## AC5 — assessment of the ten `fault`/`bus_*` checks

**0 of 10 are applicable as the core stands.** Recorded durably in `formal/checks.cfg` above `[depth]` (where someone would go to add them) and in ADR-0031.

| Check | Applicable? | Why |
|---|---|---|
| `fault` | No | Needs `rvfi_mem_fault` + `rvfi_mem_fault_rmask`/`wmask`; asserts `mcause` ∈ {1,5,7}. Core drives none of the three, `rvfi_trap` is hardwired 0, `mcause` does not exist (M3). |
| `bus_imem` | No (property already covered) | Needs `RISCV_FORMAL_BUS`. `formal/imemcheck.sv` already checks this against the real split `imem_addr`/`imem_addr2` interface (ADR-0003), and passes. |
| `bus_dmem` | No (property already covered) | Same; `formal/dmemcheck.sv` already covers it. |
| `bus_imem_fault` | No — architecturally | Models a bus that can refuse a transaction. |
| `bus_dmem_fault` | No — architecturally | Same. |
| `bus_dmem_io_read_fault` | No — architecturally | Same, plus MMIO. |
| `bus_dmem_io_write_fault` | No — architecturally | Same, plus MMIO. |
| `bus_dmem_io_read` | No | Needs `rvformal_addr_io`. |
| `bus_dmem_io_write` | No | Needs `rvformal_addr_io`. |
| `bus_dmem_io_order` | No | Needs `rvformal_addr_io`; nothing to order with one outstanding access. |

Three distinct reasons, not one:

1. **All nine `bus_*` need a second RVFI interface** — `RISCV_FORMAL_BUS` requires nine signals (`bus_valid`, `bus_insn`, `bus_data`, `bus_fault`, `bus_addr`, `bus_rmask`, `bus_wmask`, `bus_rdata`, `bus_wdata`). `rtl/littlecpu.v` drives **zero** of them.
2. **Every `*_fault` variant checks a trap model this design has ruled out.** This core's bus cannot refuse a transaction: `imem_data`/`imem_data2`/`mem_rdata` are free every cycle, no fault line, no handshake (invariant 1, ADR-0015, `formal/wrapper.v`). More decisively — a bus fault is by construction detected **after** decode, and **invariant 2 says nothing faults after decode**. These five need an ADR before they need a depth line.
3. **The three `io` ones need `rvformal_addr_io`** — a distinguished MMIO region with ordering semantics. ADR-0008's map has a `tohost` word, not a region the RTL treats differently.

And adopting `bus_imem`/`bus_dmem` would mean plumbing nine RVFI outputs to re-derive a result already held — putting an `` `ifdef RISCV_FORMAL `` value on a path the core reads, precisely what ADR-0020's non-perturbation argument depends on nothing doing.

## AC6 — sim gates

```
$ make test
49/49 passed
Failure list matches test/EXPECTED_FAIL exactly.

$ make test-units
== exec_tb ==     PASSED: 10000 randomized vectors per op (mul/mulh/mulhu/mulhsu/div/divu/rem/remu), 0 mismatches
== mem_tb ==      PASSED: memory.v read-after-write and out-of-range checks
== decoder_tb ==  PASSED: decode vectors (xori immediate, ebreak/mret/wfi)
== regfile_tb ==  PASSED: regfile combinational read / write-through bypass / x0 semantics

$ make monitor-check          # silent = no diff at the pin
$ make -C formal components_decoder components_executor
[components_decoder]  DONE (PASS, rc=0)     # basecase + induction
[components_executor] DONE (PASS, rc=0)     # basecase + induction
```

---

## Scope, and the one judgement call

`formal/` only, plus ADRs. `rtl/`, `test/` and the pin are untouched (`formal/pin.mk` still `c992aa61`; the clone is clean at that SHA and nothing in it was modified or staged).

**DECISION NEEDED — `reg_ch0` lost its per-check 1800s `timeout`.** This is the one place the re-vendor reduces protection, and it is recorded as such rather than argued away.

ADR-0022 added the bound so a non-converging check is *reported* as `TIMEOUT` instead of sitting in the solver until the nightly's `timeout-minutes: 300` kills the whole job (taking `complete` and `equiv.sh` with it). ADR-0024 then explicitly kept it "as a safety net." But it was read by a `timeout=` parameter that exists **only in the fork** — upstream `check_cons` has no such parameter and no way to emit the `sby` line — so keeping it means keeping a fork, which is what AC1 forbids. The condition it guarded is also gone: it bounded a query that did not converge under `smtbmc yices`, and ADR-0024 replaced that engine with one that answers the same check at the same depth in 16s.

I dropped it, per AC1, and amended ADR-0022 and ADR-0024 in place so neither still promises a mechanism that no longer exists. **If you would rather keep a per-check bound, the cheaper answer than re-forking `genchecks` is to have `formal/Makefile`'s `check` target wrap each `sby` invocation** — say the word and I will do that instead.

Also amended: ADR-0024's Decision section promised a one-line `[engine]` per-check override for a future check needing `smtbmc`-specific machinery. That promise is withdrawn; upstream has no per-check override. **ADR-0024's measurement is untouched and not relitigated** — `btor btormc` is still the engine, for exactly the reason it gives. Only *how* the config asks for it changed.

One stale comment corrected in passing: `checks.cfg`'s `isa rv32imc` note claimed the dual-word fetch window "isn't built yet". It landed (ADR-0003) and the suite now assembles `-march=rv32imc_zicsr`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
