### PR TITLE
JEF-651 Spike: lockstep co-simulation against the Sail RISC-V model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,13 @@ obj_dir/
 rtl/rom.mem
 sim
 sim.dSYM/
+# The Sail co-simulation spike (docs/adr/0031): a second cxxrtl binary and
+# the prebuilt sail-riscv release `make sail-setup` unpacks. Both are build
+# artifacts; neither is on `make test`'s path.
+cosim
+cosim.dSYM/
+tools/sail
+tools/sail.tmp
 test/a.out.dSYM/
 # Swarm agent worktrees (.claude/tracker.json stays tracked).
 .claude/worktrees/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,17 @@ iverilog leg (`testbench.vvp`) instead of the cxxrtl runner, matching the verifi
 and produces a real `waves.vcd`. CI (`.github/workflows/ci.yml`) runs elaborate / test / components
 / monitor-freshness on every PR.
 
+**A Sail co-simulation spike measured what the existing oracles structurally cannot see**
+(ADR-0031). Both the RVFI monitor and every `insn_*` ladder check read the core's *self-report*;
+`reg_ch0` is the one check that ties that report back to `rtl/regfile.v`, and it is a single
+`mode bmc` query at depth 21. An injected extra architectural write outside the retiring
+instruction's `rd` (`regs[31] <= wdata` alongside `regs[waddr]`) was **missed by all 49 `.S` tests
+with the per-retire monitor live**, caught by `reg_ch0` — and then, gated to fire only after cycle
+40, **missed by the entire 78-check ladder** (67 pass / 11 fail, matching `formal/EXPECTED_FAIL`
+exactly) while the co-sim reported it in 0.6s with instruction number, PC and both values. The
+class is *architectural state no retiring instruction names, corrupted past the BMC bound*. The
+mutation was reverted; `rtl/` is untouched by that change.
+
 **`86e2721` ports the riscv-formal ladder to `littlecpu`** — the first time any riscv-formal
 check has run against the pipelined core since the 2021 teardown. `formal/wrapper.v` speaks the
 real bus (no handshake: `imem_data`/`mem_rdata` are free every cycle, per invariant 1 and
@@ -160,6 +171,9 @@ make monitor-check  # regenerate test/monitor.v at the pin and diff
 
 make -C formal components_decoder   # component proofs
 make -C formal check                # the riscv-formal ladder (78 checks; see ADR-0023)
+
+make sail-setup     # once: fetch the pinned sail-riscv release into tools/sail/
+make cosim-run      # Sail co-simulation on ONE program (PROG=add.S). Opt-in; see ADR-0031
 ```
 
 Toolchain: macOS `brew install riscv64-elf-gcc`; Linux `apt install gcc-riscv64-unknown-elf`.
@@ -177,6 +191,14 @@ no multilib or newlib is needed. Formal needs a pinned YosysHQ OSS CAD Suite.
 **riscv-formal runs with `RISCV_FORMAL_ALTOPS`, so it never checks the real multiplier or divider.**
 That arithmetic is covered only by the `.S` suite and the executor component proof. Do not assume a
 green formal ladder means the ALU is correct.
+
+**There is a fourth thing you can run, and it is deliberately not a leg** (ADR-0031). `make
+cosim-run` diffs the core's *real* `regs` array — read through cxxrtl `debug_items` by
+`test/cosim.cc`, which touches no `rvfi_*` signal at all — against the Sail RISC-V model. All 49
+programs agree (24s for the suite, against 7.3s for `make test`). It is **not** on `make test`'s
+path and **not** a CI gate, on purpose: `make test` must keep working on a machine with no Sail
+installed. Do not wire it in without reading ADR-0031's consequences first — the `tohost`/HTIF
+overlap it works around is real and the fix belongs in shared test infrastructure.
 
 `test/monitor.v` rides along in both sim legs (`b2dafcc`), so every run is self-checking per-retire —
 a test that corrupts state transiently but converges to the right final registers fails loudly, not
@@ -238,12 +260,13 @@ wording is "re-proves everything the serialized core proved", and 15 red checks 
 ## Pointers
 
 - Design brief: [`docs/ideas/finish-the-rewrite.md`](docs/ideas/finish-the-rewrite.md)
-- Decisions: [`docs/adr/`](docs/adr/) — twenty-three accepted ADRs, plus a deferred list
+- Decisions: [`docs/adr/`](docs/adr/) — thirty-one accepted ADRs, plus a deferred list
 - Reference text from the old core: `git show 1709433^:rtl/riscv.v` (RVFI retire block),
   `git show e67875c^:rtl/alu.v` (arithmetic)
 - Work is tracked in Linear, project **Little CPU** (team JEF). Named here so you know where the
   queue is — but nothing in this repo should depend on it, and no ticket ID belongs in the code.
 
 **Deferred behind future ADRs** — forwarding network, radix-4 divider, negedge-BRAM regfile, FPGA
-timing closure, interrupts, Spike co-sim. Each trades away simplicity the current design depends
-on; none are safe to build while the core is unverified.
+timing closure, interrupts. Each trades away simplicity the current design depends on; none are
+safe to build while the core is unverified. (Sail co-sim came off this list in ADR-0031: the
+harness exists, opt-in; wiring it into `make test` or CI has not been decided.)

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,67 @@ sim: test/cxxrtl.cc test/rtl.cc
 	clang++ -O2 -DNDEBUG -std=c++17 -Wall -Wextra -Werror \
 	  -isystem $$(yosys-config --datdir)/include/backends/cxxrtl/runtime $< -o $@
 
+# ---------------------------------------------------------------------------
+# Sail co-simulation (docs/adr/0031) -- a SPIKE, deliberately opt-in.
+#
+# Nothing below is reachable from `make test`, `make test-units` or CI. The
+# whole point of keeping it off the default path is that `make test` must
+# still work on a machine with no Sail installed, and a time-boxed experiment
+# must not quietly become a merge gate. Run it by hand:
+#
+#     make sail-setup     # once: fetch the pinned sail-riscv release
+#     make cosim          # build the architectural-state tracer
+#     make cosim-run      # run it on one program (PROG=add.S by default)
+# ---------------------------------------------------------------------------
+
+# The sail-riscv release this spike was run against. Pinned for the same
+# reason formal/pin.mk pins riscv-formal: an oracle that moves under you is
+# not an oracle. Unlike that pin this one is NOT an enforced supply-chain
+# control -- no code is executed out of the tarball at build time, and
+# `make test` does not depend on it -- so it is a plain variable, overridable
+# for a bisect.
+SAIL_RISCV_VERSION ?= 0.13.1
+SAIL_RISCV_DIR     := tools/sail
+
+# Prebuilt, first-party release binaries from github.com/riscv/sail-riscv.
+# Building the model from source needs opam + OCaml + the Sail compiler
+# (there is no `brew install sail-riscv`; homebrew's `sail` formula is an
+# unrelated WordPress deploy tool). The upstream release ships a macOS arm64
+# and two Linux tarballs, which covers every machine this repo is developed
+# and CI'd on, so the source build is not worth its cost here.
+.PHONY: sail-setup
+sail-setup: $(SAIL_RISCV_DIR)/bin/sail_riscv_sim
+$(SAIL_RISCV_DIR)/bin/sail_riscv_sim:
+	@case "$$(uname -s)/$$(uname -m)" in \
+	  Darwin/arm64)  asset=sail-riscv-Mac-arm64 ;; \
+	  Linux/x86_64)  asset=sail-riscv-Linux-x86_64 ;; \
+	  Linux/aarch64) asset=sail-riscv-Linux-aarch64 ;; \
+	  *) echo "no prebuilt sail-riscv for $$(uname -s)/$$(uname -m);" >&2; \
+	     echo "build it from https://github.com/riscv/sail-riscv and set" >&2; \
+	     echo "SAIL_RISCV_SIM to the resulting sail_riscv_sim." >&2; exit 1 ;; \
+	esac; \
+	url=https://github.com/riscv/sail-riscv/releases/download/$(SAIL_RISCV_VERSION)/$$asset.tar.gz; \
+	echo "fetching $$url"; \
+	rm -rf $(SAIL_RISCV_DIR).tmp && mkdir -p $(SAIL_RISCV_DIR).tmp && \
+	curl -fsSL "$$url" | tar xz -C $(SAIL_RISCV_DIR).tmp --strip-components=1 && \
+	test -x $(SAIL_RISCV_DIR).tmp/bin/sail_riscv_sim && \
+	rm -rf $(SAIL_RISCV_DIR) && mv $(SAIL_RISCV_DIR).tmp $(SAIL_RISCV_DIR)
+	@$@ --version
+
+# The co-simulation runner: a SECOND cxxrtl binary, not a change to `sim`.
+# It reads the real `uut regfile regs` array through debug_items and reads no
+# rvfi_* signal at all; see the header comment in test/cosim.cc for why that
+# distinction is the entire value of this leg. Shares test/rtl.cc with `sim`,
+# so it costs one extra compile and no extra elaboration.
+cosim: test/cosim.cc test/rtl.cc
+	clang++ -O2 -DNDEBUG -std=c++17 -Wall -Wextra -Werror \
+	  -isystem $$(yosys-config --datdir)/include/backends/cxxrtl/runtime $< -o $@
+
+PROG ?= add.S
+.PHONY: cosim-run
+cosim-run: cosim
+	./test/cosim.py $(PROG)
+
 # test/monitor.sim.v is a build-time-only, gitignored derivative of the
 # tracked test/monitor.v (ADR-0019). test/monitor.v itself stays
 # pristine and tracked (CLAUDE.md invariant 7); regenerate this file, never
@@ -186,12 +247,17 @@ clean:
 	rm -f pll.v
 	rm -f waves.vcd
 	rm -rf sim sim.dSYM
+	rm -rf cosim cosim.dSYM
 	rm -f testbench.vvp testbench.vcd
 	rm -f test/rtl.cc
 	rm -f test/monitor.sim.v
 	rm -f rvfi_macros.vh
 	@# NOT rtl/rom.mem: gitignored, untracked, and nothing regenerates real
 	@# contents for it, so `clean` deleting it is unrecoverable data loss.
+	@# NOT tools/sail either: it is a multi-megabyte network fetch that nothing
+	@# on `make test`'s path needs, so blowing it away on every `clean` costs a
+	@# download to get back something `clean` was never asked to rebuild.
+	@# `rm -rf tools/sail` by hand, or bump SAIL_RISCV_VERSION, to re-fetch.
 
 # The riscv-formal clone rule and its pin guard live in formal/pin.mk, included
 # above, so the root and formal/ Makefiles cannot drift apart on it.

--- a/docs/adr/0031-sail-co-simulation-is-worth-building-and-stays-opt-in.md
+++ b/docs/adr/0031-sail-co-simulation-is-worth-building-and-stays-opt-in.md
@@ -1,0 +1,159 @@
+# ADR-0031: Sail co-simulation is worth building, and stays opt-in
+
+**Status:** Accepted · 2026-07-30 · *Replaces the "Spike or Sail co-simulation" deferred item in
+[`docs/adr/README.md`](README.md)*
+
+## Context
+
+The deferred list said "riscv-formal is the oracle. Revisit only if formal and simulation ever
+disagree." That test is the wrong one, because it can only fire on a bug **both** legs can see. The
+question worth asking is what neither leg can see at all.
+
+Both existing oracles read the core's **self-report**. `test/monitor.v` and every `insn_*` check on
+the riscv-formal ladder evaluate a spec model on `rvfi_insn` / `rvfi_rs1_rdata` / `rvfi_rs2_rdata`
+and compare the result to `rvfi_rd_wdata`. Nothing in that loop touches `rtl/regfile.v`. A core that
+mis-reports a value and computes with that same mis-reported value tells an internally consistent
+story and satisfies both. `reg_ch0` is the one check that ties the report back to the register file,
+and it is a single `mode bmc` query at depth 21 (`formal/checks/reg_ch0.sby`, ADR-0024, ADR-0025).
+
+There is also a documented history of hand-maintained models being wrong in ways that cost real
+time: ADR-0019's `monitor_insn_div`/`monitor_insn_rem` signedness defect, ADR-0024's hardcoded
+engine, ADR-0023's inconclusive `reg`. Every one of those was found by checking rather than
+assuming. RISC-V International's Sail model is the spec's executable definition and is maintained by
+the people who write the spec, which is a different and better failure mode than a generated
+Verilog monitor.
+
+This ADR records a **time-boxed spike**, not an integration: build the thing, get a verdict on one
+program, try to break it, and decide.
+
+## Decision
+
+**Build the co-simulation harness, keep it entirely off `make test` and off CI, and record the
+integration work as a follow-up rather than doing it here.**
+
+Three files and three Makefile targets, none of them on any existing path:
+
+- `test/sail/memory-map.json` — a `--config-override` placing Sail's MainMemory at `0x0` so
+  ADR-0008's two-region link map is executable and loadable, and restating the CLINT window the
+  model's config validator demands.
+- `test/cosim.cc` — a **second** cxxrtl runner beside `test/cxxrtl.cc`, sharing the same
+  `test/rtl.cc`. It reads `uut regfile regs` through `debug_items` and **no `rvfi_*` signal at
+  all**, printing a `CS ` line every time the real 32×32 register file changes.
+- `test/cosim.py` — assembles one `test/asm/*.S`, runs both, reduces each side to the sequence of
+  **distinct architectural register-file states**, and reports the first divergence with
+  instruction number, PC, disassembly, and both values.
+- `make sail-setup` / `make cosim` / `make cosim-run`.
+
+`make sail-setup` fetches upstream's **prebuilt release tarball** (pinned, `SAIL_RISCV_VERSION`,
+0.13.1) rather than building the model. There is no `brew install sail-riscv`; homebrew's `sail`
+formula is an unrelated WordPress deploy tool, and a source build needs opam + OCaml + the Sail
+compiler. Upstream ships macOS-arm64 and two Linux tarballs, which covers every machine this repo is
+developed or CI'd on. The pin is a plain variable, not an enforced control like `formal/pin.mk` —
+nothing executes out of the tarball at build time and nothing on `make test`'s path depends on it.
+
+**Comparing states rather than write events** is a deliberate reduction. A write of a value a
+register already holds is architecturally invisible; Sail traces it and a state snapshot does not.
+Reducing both sides to distinct states makes them agree on what counts as an event without either
+having to special-case it, and makes writes to `x0` a non-issue on both sides.
+
+## Rationale — the spike's actual results
+
+**It agrees, on the whole suite, not just the one program the spike promised.** 49/49 programs
+AGREE, 24s wall for the lot on an M-series laptop:
+
+```
+AGREE=49 NOT-AGREE=0 wall=24s over 49 programs
+```
+
+`add.S` — the named program — matches on all **218** architectural register-file changes, in order
+and in value. That is the first time anything in this repo has compared the core's real register
+file against an external spec.
+
+**A deliberately-introduced defect is caught, and the measurement is more interesting than a bare
+"yes."** The mutation is an extra architectural write outside the retiring instruction's `rd`
+(`rtl/regfile.v`, reverted before commit): `regs[31] <= wdata` alongside `regs[waddr]`. RVFI's
+per-retire contract is exactly one `rd`, so anything else the core writes is outside what the
+monitor and the ladder can describe, by construction; the `.S` suite sees it only if a test program
+happens to read that register back, and none of these 49 read `x31`.
+
+| Leg | Mutation A: clobber on every write | Mutation B: same, gated to fire only after cycle 40 |
+|---|---|---|
+| `make test` — 49 `.S` under cxxrtl, per-retire RVFI monitor live in both sim legs, plus `regfile_tb` | **49/49 PASS — misses it** | **49/49 PASS — misses it** |
+| riscv-formal ladder, 78 checks | `reg_ch0` **catches it** (`bad state property 0 reachable at bound k = 20 SATISFIABLE`) | **67 pass / 11 fail — exactly `formal/EXPECTED_FAIL`. Misses it.** |
+| Sail co-sim | **catches it** at architectural change #0 | **catches it** at architectural change #18 |
+
+Mutation B is the one that settles the question. It is the same defect, made to fire later than
+`reg_ch0`'s 21-cycle window — the shape of any defect whose trigger is a counter rollover, a rarely
+taken FSM path, or a specific instruction history. The full ladder run against it is
+indistinguishable from a clean one:
+
+```
+78 checks: 67 pass, 11 fail
+Failure list matches formal/EXPECTED_FAIL exactly.
+```
+
+while the co-sim reports:
+
+```
+DIVERGENCE at architectural change #18
+  sail instruction #27  pc=0x0000004a  add x14, x1, x2
+  sail : x14=0x80000000
+  core : x14=0x80000000 x31=0x80000000   (cycle 44, decode pc=0x00000054)
+```
+
+**So the class this leg catches that the others structurally cannot is: architectural state that no
+retiring instruction names, corrupted beyond the bound of a BMC query.** Not "a wrong answer" — the
+existing legs are good at wrong answers. Wrong *state*, at a depth the ladder cannot reach and in a
+register the test programs never read.
+
+**It also found a defect in this repo's own test infrastructure**, which is the ADR-0019 pattern
+repeating. Sail auto-detects HTIF from the ELF's `tohost` symbol and claims the whole **doubleword**
+at that address as an IO window. ADR-0008 puts `tohost` at the base of RAM and `test/asm/riscv_test.h`
+emits it as a 32-bit `.word`, so every load/store test's `TEST_DATA` starts four bytes later, *inside*
+that window. Sail answered every `lw` from `0x10004` with zero (`--trace-mem`:
+`htif[0x000010004] -> 0x0`) and eight programs "diverged" for a reason that was entirely the
+harness's fault. The spike works around it by stripping `tohost` from a throwaway ELF copy. The real
+fix — padding `tohost` to a full doubleword, as upstream riscv-tests does, which would also buy a
+clean HTIF exit instead of `--inst-limit` plus a spin-loop check — changes shared test infrastructure
+both existing legs read, and belongs in the integration ticket.
+
+## Consequences
+
+- **The "Spike or Sail co-simulation" deferred item is resolved as *yes, eventually*, not *now*.**
+  The `docs/adr/README.md` bullet is replaced by a pointer here.
+- **This does not become a merge gate, and `make test` does not learn about it.** That is the
+  constraint the spike was run under and it holds afterwards: a time-boxed experiment that quietly
+  becomes a required check is unplanned maintenance. `make test` works unchanged on a machine with
+  no Sail installed; `test/cosim.py` fails with a message naming `make sail-setup` rather than
+  breaking a build.
+- **Cost, measured, on this machine.** `sail_riscv_sim` on `add.S` with full instruction+GPR
+  tracing: **0.17s**. The `cosim` binary: **0.01s**, same as `sim`. One end-to-end `cosim.py`
+  invocation: **0.6s**, dominated by `riscv64-elf-gcc` and Sail, not by simulation. Whole suite:
+  **24s**, against **7.3s** for `make test`. So a whole-suite co-sim leg costs roughly 3–4× `make
+  test` — real, but nowhere near the formal ladder's 75s, and it parallelises per-program trivially.
+- **What integrating it across the suite would take**, in rough order of cost: (1) fix `tohost` to a
+  doubleword in `riscv_test.h`/`sections.lds` so the HTIF workaround and the `--inst-limit` +
+  spin-loop convergence check both go away — this is the only change that touches what the existing
+  legs read, and it needs the whole suite re-run on both; (2) a `run_cosim.sh` in the shape of
+  `test/run_tests.sh`, with a `test/COSIM_EXPECTED_FAIL` baseline per ADR-0014's set-equality
+  contract; (3) a nightly job, not a PR gate, with `sail-setup` cached — the ladder's nightly
+  (ADR-0022) is the precedent; (4) extending the comparison to **memory**, which this spike does
+  not do at all: Sail has `--dump-memory` and the runner already holds the RAM array, so an
+  end-of-run image diff is cheap and would cover stores, which today are checked only by
+  `dmemcheck` (bounded) and by whatever the test program asserts.
+- **What it will still not catch.** Co-sim runs the programs it is given. It inherits the `.S`
+  suite's coverage exactly, so it says nothing about instructions or operand patterns those 49
+  programs never reach — including the real multiplier and divider on untested operands, which
+  ADR-0010 already flags as covered by nothing else either (the ladder runs under
+  `RISCV_FORMAL_ALTOPS`). It is not a proof and does not become one; it makes the programs already
+  being run check vastly more per run.
+- **It does not read `rvfi_*`, and that must stay true.** The moment `test/cosim.cc` samples an
+  RVFI signal to align its trace, it stops being independent of the oracle it exists to
+  cross-check, and the mutation table above stops holding. The retire *sequencing* is derived from
+  the register file changing, not from `rvfi_valid`.
+- **The prebuilt-binary route is what makes this affordable**, and it is the fragile part. If
+  upstream stops shipping a macOS arm64 tarball, this leg costs an opam/OCaml toolchain to keep. The
+  `SAIL_RISCV_VERSION` pin is what makes that a scheduled problem rather than a surprise.
+- Sail's version, the model's own config schema, and `--config-override`'s merge semantics
+  (`memory.regions` is **replaced**, not merged) are all things a version bump can move.
+  `test/sail/memory-map.json` says so at the point it matters.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -35,6 +35,7 @@ and what it costs. Reversing one is fine — write a new ADR that supersedes it.
 | [0028](0028-the-rvfi-convention-for-a-trapping-retire.md) | The RVFI convention for a trapping retire | Accepted |
 | [0029](0029-mtvec-resets-to-zero-and-a-pre-handler-trap-is-loud.md) | `mtvec` resets to zero, and a pre-handler trap is made loud | Accepted |
 | [0030](0030-trap-cause-priority-and-why-the-causes-are-disjoint.md) | Trap cause priority, and why the causes are disjoint | Accepted |
+| [0031](0031-sail-co-simulation-is-worth-building-and-stays-opt-in.md) | Sail co-simulation is worth building, and stays opt-in | Accepted |
 
 0001–0007 came from the design brief
 ([`docs/ideas/finish-the-rewrite.md`](../ideas/finish-the-rewrite.md)). 0008–0011 came out of
@@ -53,7 +54,9 @@ port — the first time any formal check ran against the pipelined core. 0021 ke
 checks in the ladder and records the C.JR/C.JALR decode defect they found; 0022 replaces the
 nightly's blanket failure-swallowing with an ADR-0014-style baseline; 0023 states what the run
 does and does not establish, and why M2 is not reached. 0024 closes one of 0023's three named
-holes by switching the ladder's default BMC engine.
+holes by switching the ladder's default BMC engine. 0031 came out of a time-boxed spike against the
+Sail RISC-V model and resolves the "Spike or Sail co-simulation" item that used to sit in the
+deferred list below.
 
 ## Deferred decisions
 
@@ -69,5 +72,8 @@ trades away simplicity the current design depends on.
 - **FPGA timing closure / nextpnr flow** — including ADR-0003's second ROM read becoming interleaved
   16-bit banks. Post-M4.
 - **Interrupts** (`mie`/`mip` real rather than read-only zero) — no interrupt sources exist.
-- **Spike or Sail co-simulation** — riscv-formal is the oracle. Revisit only if formal and
-  simulation ever disagree.
+- ~~**Spike or Sail co-simulation**~~ — **resolved by [ADR-0031](0031-sail-co-simulation-is-worth-building-and-stays-opt-in.md).**
+  The old test ("revisit only if formal and simulation ever disagree") could only fire on a bug both
+  legs can see; a spike measured what neither can. The harness exists and is deliberately opt-in —
+  `make cosim-run`, never `make test`, never CI. Integrating it across the whole suite is
+  still future work, scoped in that ADR's consequences.

--- a/test/cosim.cc
+++ b/test/cosim.cc
@@ -1,0 +1,247 @@
+// The co-simulation runner: a second cxxrtl runner (alongside test/cxxrtl.cc)
+// whose only job is to emit the core's REAL architectural register-file state
+// as it changes, so test/cosim.py can diff it against the Sail RISC-V model.
+//
+// This is a spike, not a fourth verification leg. `make test` does not build
+// or run it; `make cosim` does. See docs/adr/0031.
+//
+// WHY A SEPARATE BINARY, AND WHY IT READS `regs` RATHER THAN RVFI.
+//
+// The RVFI monitor (test/monitor.v) and the riscv-formal ladder both check
+// what the core SAYS it did: rvfi_rd_wdata against a spec model evaluated on
+// rvfi_rs1_rdata / rvfi_rs2_rdata / rvfi_insn. A core that mis-reports a
+// value and then computes with that same mis-reported value tells an
+// internally consistent story and passes both. This runner never reads a
+// single rvfi_* signal. It samples the `uut regfile regs` array -- the actual
+// 32x32 memory in rtl/regfile.v -- once per cycle and prints a line whenever
+// it changes.
+//
+// Comparing STATE, not WRITE EVENTS, is deliberate. A write of a value a
+// register already holds is architecturally invisible, and Sail traces it
+// while a state snapshot does not; comparing the sequence of distinct
+// register-file states makes both sides agree on what counts as an event
+// without either having to special-case that.
+//
+// The PC is printed as diagnostic context only, and is deliberately NOT
+// compared: `uut decoder pc` is the PC of the instruction currently in
+// DECODE, several stages ahead of the write retiring this cycle, so it is a
+// pipeline landmark rather than an architectural fact. test/cosim.py reports
+// the Sail-side PC as the authoritative location of a divergence.
+//
+// Output format, one line per architectural change (stdout):
+//     CS <change-index> <cycle> x<n>=<hex> [x<n>=<hex> ...] @pc=<hex>
+// followed by exactly one terminator line:
+//     CS END PASS <cycle> | CS END FAIL <testnum> <cycle> | CS END TIMEOUT
+//
+// The `CS ` prefix exists because test/testbench.v $displays a line or two
+// per cycle (ifetch/read/write chatter) onto the same stdout, and cxxrtl
+// implements $display natively. Prefixing is what lets test/cosim.py treat
+// an unrecognised `CS ` line as a hard error instead of having to guess
+// which unparseable lines were the bench talking.
+//
+// Exit codes match test/cxxrtl.cc where they overlap: 0 = ran to a tohost
+// verdict (PASS or FAIL -- either is a successful TRACE, and cosim.py, not
+// this runner, decides whether the trace matches), 2 = cycle-limit timeout,
+// 3 = usage/setup error.
+#include "rtl.cc"
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <map>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+
+namespace {
+
+// Kept in sync with test/cxxrtl.cc, test/testbench.v and test/asm/sections.lds
+// (ADR-0008).
+constexpr uint32_t kRamBase = 0x00010000;
+
+using HexImage = std::map<uint32_t, uint32_t>;
+
+bool parse_verilog_hex(const std::string &path, HexImage &image) {
+  std::ifstream in(path);
+  if (!in) {
+    std::fprintf(stderr, "error: cannot open %s\n", path.c_str());
+    return false;
+  }
+  uint32_t addr = 0;
+  std::string line;
+  while (std::getline(in, line)) {
+    size_t start = line.find_first_not_of(" \t\r\n");
+    if (start == std::string::npos)
+      continue;
+    if (line[start] == '@') {
+      addr = std::strtoul(line.c_str() + start + 1, nullptr, 16);
+      continue;
+    }
+    std::istringstream words(line);
+    std::string word;
+    while (words >> word)
+      image[addr++] = std::strtoul(word.c_str(), nullptr, 16);
+  }
+  return true;
+}
+
+bool load_image(cxxrtl::debug_items &items, const std::string &name,
+                const HexImage &image, uint32_t base_words) {
+  const cxxrtl::debug_item &item = items.at(name).at(0);
+  if (item.type != cxxrtl::debug_item::MEMORY) {
+    std::fprintf(stderr, "error: debug item %s is not a memory\n", name.c_str());
+    return false;
+  }
+  uint32_t *data = item.curr;
+  for (const auto &[addr, word] : image) {
+    if (addr < base_words || addr - base_words >= item.depth) {
+      std::fprintf(stderr,
+                   "error: %s image address 0x%08x is outside the simulated "
+                   "%s (%zu words at base 0x%08x)\n",
+                   name.c_str(), addr * 4, name.c_str(), item.depth,
+                   base_words * 4);
+      return false;
+    }
+    data[addr - base_words] = word;
+  }
+  return true;
+}
+
+struct Args {
+  std::string rom_path;
+  std::string ram_path;
+  long cycles = 0;
+};
+
+bool parse_args(int argc, char **argv, Args &args) {
+  for (int i = 1; i < argc; ++i) {
+    std::string arg = argv[i];
+    auto next = [&](const char *flag) -> const char * {
+      if (i + 1 >= argc) {
+        std::fprintf(stderr, "error: %s requires an argument\n", flag);
+        return nullptr;
+      }
+      return argv[++i];
+    };
+    if (arg == "--rom") {
+      const char *v = next("--rom");
+      if (!v) return false;
+      args.rom_path = v;
+    } else if (arg == "--ram") {
+      const char *v = next("--ram");
+      if (!v) return false;
+      args.ram_path = v;
+    } else if (arg == "--cycles") {
+      const char *v = next("--cycles");
+      if (!v) return false;
+      args.cycles = std::strtol(v, nullptr, 10);
+    } else {
+      std::fprintf(stderr, "error: unrecognized argument '%s'\n", arg.c_str());
+      return false;
+    }
+  }
+  if (args.rom_path.empty() || args.ram_path.empty() || args.cycles <= 0) {
+    std::fprintf(stderr, "usage: cosim --rom <hex> --ram <hex> --cycles N\n");
+    return false;
+  }
+  return true;
+}
+
+} // namespace
+
+int main(int argc, char **argv) {
+  Args args;
+  if (!parse_args(argc, argv, args))
+    return 3;
+
+  HexImage rom_image, ram_image;
+  if (!parse_verilog_hex(args.rom_path, rom_image))
+    return 3;
+  if (!parse_verilog_hex(args.ram_path, ram_image))
+    return 3;
+
+  cxxrtl_design::p_testbench top;
+  cxxrtl::debug_items all_debug_items;
+  top.debug_info(&all_debug_items, nullptr, "");
+
+  if (!load_image(all_debug_items, "rom", rom_image, 0))
+    return 3;
+  if (!load_image(all_debug_items, "memory", ram_image, kRamBase / 4))
+    return 3;
+
+  const cxxrtl::debug_item &memory_item = all_debug_items.at("memory").at(0);
+  uint32_t *ram_data = memory_item.curr;
+
+  // The real register file inside rtl/regfile.v. `hierarchy -top testbench`
+  // flattens the instance path to a space-separated debug-item name, the same
+  // convention test/cxxrtl.cc uses for "monitor errcode".
+  const cxxrtl::debug_item *regs_item = nullptr;
+  const cxxrtl::debug_item *pc_item = nullptr;
+  try {
+    regs_item = &all_debug_items.at("uut regfile regs").at(0);
+    pc_item = &all_debug_items.at("uut decoder pc").at(0);
+  } catch (const std::out_of_range &) {
+    std::fprintf(stderr,
+                 "error: 'uut regfile regs' / 'uut decoder pc' not found in "
+                 "the simulated design -- did the RTL hierarchy change?\n");
+    return 3;
+  }
+  if (regs_item->type != cxxrtl::debug_item::MEMORY || regs_item->depth != 32) {
+    std::fprintf(stderr, "error: 'uut regfile regs' is not a 32-word memory\n");
+    return 3;
+  }
+  const uint32_t *regs = regs_item->curr;
+
+  uint32_t shadow[32];
+  std::memset(shadow, 0, sizeof(shadow));
+
+  top.p_reset.set(true);
+  top.step();
+  // The regfile has no reset, so its power-on contents are whatever cxxrtl
+  // zero-initialised them to. Seed the shadow from the post-reset state so
+  // the first printed change is a real one and not the initialisation.
+  std::memcpy(shadow, regs, sizeof(shadow));
+
+  long change_index = 0;
+  int verdict = -1; // 0 = PASS, >0 = FAIL testnum
+  long verdict_cycle = 0;
+
+  for (long cycle = 0; cycle < args.cycles; ++cycle) {
+    if (cycle == 0)
+      top.p_reset.set(false);
+    top.p_clk.set<bool>(false);
+    top.step();
+    top.p_clk.set<bool>(true);
+    top.step();
+
+    if (std::memcmp(shadow, regs, sizeof(shadow)) != 0) {
+      std::printf("CS %ld %ld", change_index, cycle);
+      for (int r = 0; r < 32; ++r) {
+        if (shadow[r] != regs[r])
+          std::printf(" x%d=%08x", r, regs[r]);
+      }
+      std::printf(" @pc=%08x\n", pc_item->curr[0]);
+      std::memcpy(shadow, regs, sizeof(shadow));
+      ++change_index;
+    }
+
+    uint32_t tohost = ram_data[0];
+    if (tohost != 0) {
+      verdict = (tohost == 1) ? 0 : static_cast<int>(tohost >> 1);
+      verdict_cycle = cycle;
+      break;
+    }
+  }
+
+  if (verdict < 0) {
+    std::printf("CS END TIMEOUT\n");
+    return 2;
+  }
+  if (verdict == 0)
+    std::printf("CS END PASS %ld\n", verdict_cycle);
+  else
+    std::printf("CS END FAIL %d %ld\n", verdict, verdict_cycle);
+  return 0;
+}

--- a/test/cosim.py
+++ b/test/cosim.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+"""Lockstep co-simulation of this core against the Sail RISC-V model.
+
+A spike, not a fourth verification leg: `make test` neither builds nor runs
+this, and CI does not gate on it. See docs/adr/0031 for what it is for and
+what it costs.
+
+WHAT IS ACTUALLY COMPARED
+-------------------------
+The core's REAL architectural register file -- `uut regfile regs`, read
+through cxxrtl `debug_items` by test/cosim.cc -- against the register file of
+RISC-V International's own executable specification.  No rvfi_* signal is read
+on either side.  That is the whole point: test/monitor.v and the riscv-formal
+ladder both check the core's SELF-REPORT (rvfi_rd_wdata against a spec model
+evaluated on rvfi_rs1_rdata / rvfi_rs2_rdata / rvfi_insn), so a core that
+mis-reports a value and computes with that same mis-reported value satisfies
+both.  This compares state that neither side got to describe.
+
+Both sides are reduced to the same canonical form: the sequence of DISTINCT
+architectural register-file states.  A write of a value the register already
+holds is architecturally invisible; Sail traces it and a state snapshot does
+not, so comparing states rather than write events makes the two agree on what
+counts as an event without special-casing.  Writes to x0 are dropped on the
+Sail side for the same reason -- rtl/regfile.v guards them and the ISA makes
+them unobservable.
+
+HTIF HAS TO BE DISABLED, AND THAT IS A REAL FINDING
+---------------------------------------------------
+Sail auto-detects HTIF from the ELF's `tohost` symbol and then claims the
+whole DOUBLEWORD at that address as an IO window.  ADR-0008 puts `tohost` at
+the base of the RAM region and test/asm/riscv_test.h emits it as a 32-bit
+`.word`, so `.data` -- every load/store test's TEST_DATA -- starts four bytes
+later, INSIDE that window.  Left alone, Sail answers every `lw` from 0x10004
+with zero (`--trace-mem` shows `htif[0x000010004] -> 0x0` ahead of the read)
+and eight of this suite's programs "diverge" for a reason that is entirely
+the harness's fault.
+
+It also does not help on the other side: HTIF acts on a 64-bit doubleword
+write, and RVTEST_PASS stores with `sw`, so the run does not terminate on the
+verdict either (`--trace-htif` logs the write and keeps going).
+
+So the ELF handed to Sail gets its `tohost` symbol stripped -- a harness-side
+`objcopy` on a throwaway copy, changing nothing about what either existing
+sim leg builds or how ADR-0008's protocol works.  The reference run is then
+bounded with `--inst-limit` and confirmed to have reached the pass/fail spin
+loop by checking that its last instructions are a self-loop at one PC.
+
+The alternative -- padding `tohost` to a full doubleword in riscv_test.h so
+it stops overlapping test data, which is what upstream riscv-tests does -- is
+the better long-term fix and would buy a clean HTIF exit as well.  It is a
+change to shared test infrastructure that both existing legs read, so it
+belongs in the integration ticket, not in a spike.
+"""
+
+import argparse
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+ASM_DIR = os.path.join(REPO, "test", "asm")
+MEMORY_MAP = os.path.join(REPO, "test", "sail", "memory-map.json")
+
+# `[123] [M]: 0x00000006 (0x00208733) add x14, x1, x2      test_2+4`
+INSN_RE = re.compile(
+    r"^\[(?P<idx>\d+)\]\s+\[\w+\]:\s+0x(?P<pc>[0-9A-Fa-f]+)\s+"
+    r"\((?P<insn>0x[0-9A-Fa-f]+)\)\s+(?P<disasm>.*?)\s*$"
+)
+# `x14 <- 0x0000000A`
+GPR_RE = re.compile(r"^x(?P<reg>\d+)\s+<-\s+0x(?P<val>[0-9A-Fa-f]+)\s*$")
+# `CS 0 41 x14=0000000a @pc=00000012`. The `CS ` prefix separates the runner's
+# records from test/testbench.v's per-cycle $display chatter, which cxxrtl
+# emits onto the same stdout; see test/cosim.cc.
+DUT_RE = re.compile(
+    r"^CS\s+(?P<idx>\d+)\s+(?P<cycle>\d+)\s+(?P<writes>(?:x\d+=[0-9a-f]{8}\s+)+)"
+    r"@pc=(?P<pc>[0-9a-f]{8})\s*$"
+)
+
+
+class Fatal(Exception):
+    pass
+
+
+def find_cross_compiler():
+    for cc in ("riscv64-elf-gcc", "riscv64-unknown-elf-gcc"):
+        if shutil.which(cc):
+            return cc
+    raise Fatal(
+        "no RISC-V cross compiler found (tried riscv64-elf-gcc, "
+        "riscv64-unknown-elf-gcc). Run 'make setup'."
+    )
+
+
+def find_sail(explicit):
+    """Locate sail_riscv_sim: --sail, $SAIL_RISCV_SIM, tools/sail, then PATH.
+
+    Opt-in by construction (the ticket's constraint, and ADR-0031's): nothing
+    in `make test` reaches this function, and when the binary is absent the
+    message names the target that installs it rather than a build failure.
+    """
+    for candidate in (
+        explicit,
+        os.environ.get("SAIL_RISCV_SIM"),
+        os.path.join(REPO, "tools", "sail", "bin", "sail_riscv_sim"),
+    ):
+        if candidate and os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+            return candidate
+    found = shutil.which("sail_riscv_sim")
+    if found:
+        return found
+    raise Fatal(
+        "sail_riscv_sim not found. Run 'make sail-setup' to install the pinned "
+        "release into tools/sail/, or set SAIL_RISCV_SIM to an existing build."
+    )
+
+
+def assemble(cc, src, outdir):
+    """Assemble one test/asm/*.S exactly as test/run_tests.sh does, and emit
+    the ELF (for Sail) plus the two objcopy images (for the cxxrtl runner)."""
+    base = os.path.splitext(os.path.basename(src))[0]
+    elf = os.path.join(outdir, base + ".elf")
+    rom = os.path.join(outdir, base + ".rom.hex")
+    ram = os.path.join(outdir, base + ".ram.hex")
+    objcopy = cc[: -len("gcc")] + "objcopy"
+    log = subprocess.run(
+        [cc, "-march=rv32imc_zicsr", "-mabi=ilp32", "-nostdlib", "-I", ASM_DIR,
+         "-T", os.path.join(ASM_DIR, "sections.lds"), src, "-o", elf],
+        capture_output=True, text=True,
+    )
+    if log.returncode != 0:
+        raise Fatal(f"assembling {src} failed:\n{log.stdout}{log.stderr}")
+    for args, out in (
+        (["--only-section=.text"], rom),
+        (["--remove-section=.text"], ram),
+    ):
+        subprocess.run(
+            [objcopy, "-O", "verilog", "--verilog-data-width=4", *args, elf, out],
+            check=True, capture_output=True,
+        )
+    # A throwaway copy with `tohost` removed from the symbol table, so Sail
+    # does not auto-detect HTIF and shadow the test data that ADR-0008's
+    # memory map places immediately after it. See the module docstring.
+    sail_elf = os.path.join(outdir, base + ".sail.elf")
+    subprocess.run([objcopy, "--strip-symbol=tohost", elf, sail_elf],
+                   check=True, capture_output=True)
+    return sail_elf, rom, ram
+
+
+def run_sail(sail, elf, inst_limit, outdir):
+    """Run the reference model and return its list of distinct register-file
+    states, each tagged with the instruction that produced it."""
+    trace = os.path.join(outdir, "sail.trace")
+    proc = subprocess.run(
+        [sail, "--rv32", "--config-override", MEMORY_MAP,
+         "--inst-limit", str(inst_limit), "--trace-instr", "--trace-gpr",
+         "--trace-output", trace, elf],
+        capture_output=True, text=True,
+    )
+    if not os.path.exists(trace):
+        raise Fatal(f"sail produced no trace:\n{proc.stdout}{proc.stderr}")
+
+    regs = [0] * 32
+    records = []       # (change_index, sail_idx, pc, disasm, {reg: val})
+    tail_pcs = []
+    current = None     # (idx, pc, disasm)
+    pending = {}
+
+    def flush():
+        nonlocal current, pending
+        if current is None:
+            return
+        changed = {r: v for r, v in pending.items() if regs[r] != v}
+        for r, v in changed.items():
+            regs[r] = v
+        if changed:
+            records.append((len(records), current[0], current[1], current[2], changed))
+        current, pending = None, {}
+
+    with open(trace) as fh:
+        for line in fh:
+            m = INSN_RE.match(line)
+            if m:
+                flush()
+                current = (int(m.group("idx")), int(m.group("pc"), 16),
+                           m.group("disasm"))
+                tail_pcs.append(current[1])
+                if len(tail_pcs) > 8:
+                    tail_pcs.pop(0)
+                continue
+            m = GPR_RE.match(line)
+            if m and current is not None:
+                reg = int(m.group("reg"))
+                if reg != 0:  # x0 is hardwired; rtl/regfile.v guards it too
+                    pending[reg] = int(m.group("val"), 16)
+    flush()
+
+    if not tail_pcs:
+        raise Fatal(f"sail traced no instructions:\n{proc.stdout}{proc.stderr}")
+    # riscv_test.h's RVTEST_PASS/RVTEST_FAIL both end in `1: j 1b`, so a run
+    # that reached a verdict is parked on one PC. If it is not, --inst-limit
+    # cut the reference short and any length mismatch below would be an
+    # artefact of this harness rather than a finding.
+    converged = len(set(tail_pcs)) == 1 and len(tail_pcs) == 8
+    return records, converged, tail_pcs[-1]
+
+
+def run_dut(binary, rom, ram, cycles):
+    proc = subprocess.run(
+        [binary, "--rom", rom, "--ram", ram, "--cycles", str(cycles)],
+        capture_output=True, text=True,
+    )
+    records = []   # (change_index, cycle, {reg: val}, pc)
+    verdict = None
+    for line in proc.stdout.splitlines():
+        if not line.startswith("CS "):
+            continue  # test/testbench.v's $display chatter
+        if line.startswith("CS END "):
+            verdict = line[len("CS END "):].strip()
+            continue
+        m = DUT_RE.match(line)
+        if not m:
+            raise Fatal(f"unparseable cosim record line: {line!r}")
+        writes = {}
+        for w in m.group("writes").split():
+            reg, val = w.split("=")
+            writes[int(reg[1:])] = int(val, 16)
+        records.append((int(m.group("idx")), int(m.group("cycle")), writes,
+                        int(m.group("pc"), 16)))
+    if verdict is None:
+        raise Fatal(
+            f"cosim produced no `CS END` line (exit {proc.returncode}):\n{proc.stderr}"
+        )
+    return records, verdict
+
+
+def fmt(writes):
+    return " ".join(f"x{r}=0x{v:08x}" for r, v in sorted(writes.items()))
+
+
+def compare(sail_records, dut_records):
+    """Return (ok, list_of_report_lines). Reports the FIRST divergence with
+    instruction number, PC and both values, per the spike's acceptance
+    criteria."""
+    out = []
+    for i in range(min(len(sail_records), len(dut_records))):
+        _, sidx, spc, sdis, swrites = sail_records[i]
+        _, cycle, dwrites, dpc = dut_records[i]
+        if swrites != dwrites:
+            out.append(f"DIVERGENCE at architectural change #{i}")
+            out.append(f"  sail instruction #{sidx}  pc=0x{spc:08x}  {sdis}")
+            out.append(f"  sail : {fmt(swrites)}")
+            out.append(f"  core : {fmt(dwrites)}   (cycle {cycle}, "
+                       f"decode pc=0x{dpc:08x})")
+            return False, out
+    if len(sail_records) != len(dut_records):
+        n = min(len(sail_records), len(dut_records))
+        out.append(
+            f"DIVERGENCE in length: sail made {len(sail_records)} "
+            f"architectural register-file changes, the core made "
+            f"{len(dut_records)}"
+        )
+        longer, label = ((sail_records, "sail") if len(sail_records) > n
+                         else (dut_records, "core"))
+        extra = longer[n]
+        if label == "sail":
+            out.append(f"  first unmatched ({label}): instruction #{extra[1]} "
+                       f"pc=0x{extra[2]:08x} {extra[3]} -> {fmt(extra[4])}")
+        else:
+            out.append(f"  first unmatched ({label}): cycle {extra[1]} "
+                       f"-> {fmt(extra[2])} (decode pc=0x{extra[3]:08x})")
+        return False, out
+    return True, out
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("program", nargs="?", default="add.S",
+                    help="a test/asm/*.S file name (default: add.S)")
+    ap.add_argument("--cosim-binary", default=os.path.join(REPO, "cosim"))
+    ap.add_argument("--sail", default=None, help="path to sail_riscv_sim")
+    ap.add_argument("--cycles", type=int, default=5000,
+                    help="cxxrtl cycle budget (test/run_tests.sh uses 5000)")
+    ap.add_argument("--inst-limit", type=int, default=20000,
+                    help="sail instruction budget")
+    ap.add_argument("--quiet", action="store_true")
+    args = ap.parse_args()
+
+    try:
+        cc = find_cross_compiler()
+        sail = find_sail(args.sail)
+        if not os.path.isfile(args.cosim_binary):
+            raise Fatal(f"{args.cosim_binary} not built. Run 'make cosim'.")
+        src = args.program
+        if not os.path.isabs(src):
+            src = os.path.join(ASM_DIR, os.path.basename(src))
+        if not os.path.isfile(src):
+            raise Fatal(f"no such test program: {src}")
+
+        with tempfile.TemporaryDirectory(prefix="littlecpu-cosim.") as outdir:
+            elf, rom, ram = assemble(cc, src, outdir)
+            sail_records, converged, last_pc = run_sail(
+                sail, elf, args.inst_limit, outdir)
+            dut_records, verdict = run_dut(
+                args.cosim_binary, rom, ram, args.cycles)
+    except Fatal as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 3
+
+    name = os.path.basename(src)
+    if not args.quiet:
+        print(f"program            : {name}")
+        print(f"sail               : {sail}")
+        print(f"sail changes       : {len(sail_records)}  "
+              f"(spin-loop reached: {converged}, last pc=0x{last_pc:08x})")
+        print(f"core changes       : {len(dut_records)}   (tohost: {verdict})")
+
+    if not converged:
+        print(f"INCONCLUSIVE {name}: sail hit --inst-limit "
+              f"{args.inst_limit} without reaching the pass/fail spin loop; "
+              f"raise it.", file=sys.stderr)
+        return 3
+    if verdict.startswith("TIMEOUT"):
+        print(f"INCONCLUSIVE {name}: the core hit its {args.cycles}-cycle "
+              f"budget without a tohost verdict.", file=sys.stderr)
+        return 3
+
+    ok, report = compare(sail_records, dut_records)
+    if ok:
+        print(f"AGREE {name}: {len(sail_records)} architectural register-file "
+              f"changes, identical in order and value.")
+        return 0
+    print(f"DISAGREE {name}")
+    for line in report:
+        print(line)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/sail/memory-map.json
+++ b/test/sail/memory-map.json
@@ -1,0 +1,92 @@
+// Sail RISC-V configuration override for this repo's test memory map
+// (ADR-0008). Passed to `sail_riscv_sim --rv32 --config-override`, so it
+// only has to restate what differs from the model's default RV32 config;
+// everything else (extensions, mtvec, PMP, ...) is inherited.
+//
+// The default RV32 config puts MainMemory at 0x8000_0000. test/asm/sections.lds
+// links `.text` at 0x0000_0000 and `.data`/`.bss` at 0x0001_0000, so nothing
+// this suite builds is executable or loadable under that map. The override
+// replaces the region list with one MainMemory region covering both.
+//
+// `memory.regions` is REPLACED, not merged, so the CLINT region has to be
+// restated here too -- the model refuses a config whose `platform.clint`
+// (0x0200_0000) falls outside every declared region. The default map's third
+// region, an unwritable IOMemory window at 0x0000_1000, is deliberately NOT
+// restated: it overlaps `.text` and the model rejects overlapping regions.
+// Nothing needs it, because the PC is taken from the ELF entry point rather
+// than from a reset vector in that window.
+//
+// The model detects HTIF from the ELF's `tohost` symbol and reports
+// "HTIF located at 0x10000", but does not terminate on this suite's write:
+// test/asm/riscv_test.h's `tohost` is a 32-bit `.word` and the write is an
+// `sw`, which is not the 64-bit doubleword HTIF acts on. That is fine here --
+// test/cosim.py bounds the reference run with `--inst-limit` and truncates
+// both traces at their last architectural change instead (see the "why not
+// HTIF" note there).
+{
+  "memory": {
+    "regions": [
+      {
+        // test/asm/sections.lds: rom at 0x0 (16K) + ram at 0x10000 (4K),
+        // rounded up to a flat 1MB so the linker script can grow without
+        // this file having to.
+        "base": { "len": 64, "value": "0x0000_0000" },
+        "size": { "len": 64, "value": "0x0010_0000" },
+        "attributes": {
+          "mem_type": "MainMemory",
+          "cacheable": true,
+          "coherent": true,
+          "executable": true,
+          "readable": true,
+          "writable": true,
+          "read_idempotent": true,
+          "write_idempotent": true,
+          "misaligned_exceptions": {
+            "load_store": { "None": null },
+            "vector": { "None": null },
+            "amo": "AccessFault"
+          },
+          "atomic_support": "AMOCASQ",
+          "misaligned_atomicity_granule_size_exp": 4,
+          "vector_misaligned_atomicity_granule_size_exp": 4,
+          "reservability": "RsrvEventual",
+          "supports_cbo_zero": true,
+          "supports_pte_read": true,
+          "supports_pte_write": true
+        },
+        "include_in_device_tree": true
+      },
+      {
+        // Restated verbatim from the default RV32 config: `platform.clint`
+        // and `platform.simple_interrupt_generator` both live in here and
+        // config validation fails without it. This core has no CLINT and
+        // never touches the window.
+        "base": { "len": 64, "value": "0x0200_0000" },
+        "size": { "len": 64, "value": "0x1000_0000" },
+        "attributes": {
+          "mem_type": "IOMemory",
+          "cacheable": false,
+          "coherent": true,
+          "executable": false,
+          "readable": true,
+          "writable": true,
+          "read_idempotent": false,
+          "write_idempotent": false,
+          "misaligned_exceptions": {
+            "load_store": { "None": null },
+            "vector": { "None": null },
+            "amo": "AccessFault"
+          },
+          "atomic_support": "AMONone",
+          "misaligned_atomicity_granule_size_exp": 0,
+          "vector_misaligned_atomicity_granule_size_exp": 0,
+          "reservability": "RsrvNone",
+          "supports_cbo_zero": false,
+          "supports_pte_read": false,
+          "supports_pte_write": false
+        },
+        "include_in_device_tree": false
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Closes JEF-651

**Time-boxed spike. Prove or disprove the concept on one program, then stop.** The verdict is
**prove** — with a more interesting measurement than a bare yes.

## The question

Both existing oracles read the core's **self-report**. `test/monitor.v` and every `insn_*` check on
the riscv-formal ladder evaluate a spec model on `rvfi_insn` / `rvfi_rs1_rdata` / `rvfi_rs2_rdata`
and compare the result to `rvfi_rd_wdata`. Nothing in that loop touches `rtl/regfile.v`. `reg_ch0`
is the one check that ties the report back to the register file, and it is a single `mode bmc`
query at depth 21.

This spike compares the core's **real `regs` array** — read through cxxrtl `debug_items`, touching
no `rvfi_*` signal on either side — against RISC-V International's executable spec.

## Acceptance criteria

**1. `sail-riscv` builds locally, steps written down.** `make sail-setup` fetches upstream's
**prebuilt release tarball** (`SAIL_RISCV_VERSION`, pinned at 0.13.1) rather than building from
source. There is no `brew install sail-riscv` — homebrew's `sail` formula is an unrelated WordPress
deploy tool — and a source build needs opam + OCaml + the Sail compiler. Upstream ships macOS-arm64
and two Linux tarballs, covering every machine this repo is developed or CI'd on. A Makefile target
rather than a script, so it sits next to `make setup` and inherits the pin as a variable.

**2. One named program produces a verdict.** `add.S` agrees on all **218** architectural
register-file changes, in order and value. It was cheap to run the rest, so:

```
AGREE=49 NOT-AGREE=0 wall=24s over 49 programs
```

**3. A deliberately-introduced RTL bug is caught.** The mutation (reverted; `git diff` against
`main` shows **no `rtl/` change**) is an extra architectural write outside the retiring
instruction's `rd`: `regs[31] <= wdata` alongside `regs[waddr]`. RVFI's per-retire contract is
exactly one `rd`, so anything else the core writes is outside what the monitor and the ladder can
describe, and the `.S` suite sees it only if a test program reads that register back.

| Leg | Mutation A: clobber on every write | Mutation B: same, gated to fire only after cycle 40 |
|---|---|---|
| `make test` — 49 `.S` under cxxrtl, per-retire RVFI monitor live in both sim legs, plus `regfile_tb` | **49/49 PASS — misses it** | **49/49 PASS — misses it** |
| riscv-formal ladder, 78 checks | `reg_ch0` **catches it** — `bad state property 0 reachable at bound k = 20 SATISFIABLE` | **67 pass / 11 fail = `formal/EXPECTED_FAIL` exactly. Misses it.** |
| Sail co-sim | **catches it** at architectural change #0 | **catches it** at architectural change #18 |

Mutation B settles it. Same defect, made to fire past `reg_ch0`'s 21-cycle window — the shape of any
defect whose trigger is a counter rollover, a rarely taken FSM path, or a specific instruction
history. The full ladder against it is indistinguishable from a clean run, while the co-sim says:

```
DIVERGENCE at architectural change #18
  sail instruction #27  pc=0x0000004a  add x14, x1, x2
  sail : x14=0x80000000
  core : x14=0x80000000 x31=0x80000000   (cycle 44, decode pc=0x00000054)
```

**The class this leg catches that the others structurally cannot: architectural state that no
retiring instruction names, corrupted beyond the bound of a BMC query.** Not "a wrong answer" — the
existing legs are good at wrong answers. Wrong *state*, at a depth the ladder cannot reach, in a
register the test programs never read.

**4. Written assessment.** In `docs/adr/0031`, including measured cost, what whole-suite integration
would take (in cost order), and — stated plainly — what this leg will still not catch: it runs the
programs it is given and inherits the `.S` suite's coverage exactly, so it says nothing about
operand patterns those 49 programs never reach.

**5. `make test` still passes and this adds a leg without disturbing the existing three.** 49/49,
verified both with and without Sail installed. `make -C formal check` is at baseline (67/11).

## It found a defect in this repo's own test infrastructure

The ADR-0019 pattern repeating. Sail auto-detects HTIF from the ELF's `tohost` symbol and claims the
whole **doubleword** at that address as an IO window. ADR-0008 puts `tohost` at the base of RAM and
`riscv_test.h` emits it as a 32-bit `.word`, so every load/store test's `TEST_DATA` starts four bytes
later, *inside* that window. Sail answered every `lw` from `0x10004` with zero
(`htif[0x000010004] -> 0x0` under `--trace-mem`) and eight programs "diverged" for a reason that was
entirely the harness's fault. Worked around harness-side by stripping `tohost` from a throwaway ELF
copy. The real fix — padding `tohost` to a doubleword, as upstream riscv-tests does, which would also
buy a clean HTIF exit — changes shared test infrastructure both existing legs read, and belongs in
the integration ticket.

## Scope discipline

- **Not integrated into `make test`, not a CI check.** `make sail-setup` / `make cosim` /
  `make cosim-run` only. Verified: `make test` is 49/49 with `tools/sail` moved aside, and
  `test/cosim.py` then exits 3 with a message naming `make sail-setup`.
- **No `rtl/` change.** `git diff main -- rtl/` is empty.
- **No build artifacts committed.** `cosim` and `tools/` are gitignored; `make clean` removes
  `cosim` but deliberately not `tools/sail` (a multi-megabyte fetch nothing on `make test`'s path
  needs).
- **`test/cosim.cc` reads no `rvfi_*` signal, and that has to stay true.** The moment it samples one
  to align its trace, it stops being independent of the oracle it exists to cross-check and the
  table above stops holding.

## Cost, measured on an M-series laptop

| | |
|---|---|
| `sail_riscv_sim`, `add.S`, full instr+GPR trace | 0.17s |
| `cosim` binary | 0.01s (same as `sim`) |
| one end-to-end `cosim.py` | 0.6s — dominated by `riscv64-elf-gcc` and Sail, not simulation |
| whole suite co-sim | 24s |
| `make test` for comparison | 7.3s |
| `make -C formal check` for comparison | 75s |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
