### PR TITLE
JEF-646: Teach the sim harness to trap and recover; add the monitor's missing !spec_trap gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,10 +115,13 @@ jobs:
   # The ADR-0007/ADR-0008 cxxrtl regression gate: builds `sim`, runs
   # test-units (the iverilog RTL-level benches), then every test/asm/*.S
   # under `sim` and checks the pass/fail table against test/EXPECTED_FAIL
-  # (ADR-0014's M1 baseline). Since `a4662a2` that baseline is empty
-  # and the suite is 47/47 green, so this is now a plain all-pass gate --
-  # ADR-0014's set-equality check still runs in both directions, so a test
-  # that starts passing unexpectedly is caught alongside one that regresses.
+  # (ADR-0014's baseline). `a4662a2` took that baseline to empty; it now
+  # carries three M3 tests (csr.S, minstret.S, trap.S) written ahead of the
+  # RTL that pays them off, so the gate is 49 pass / 3 expected-fail rather
+  # than a plain all-pass. ADR-0014's set-equality check runs in both
+  # directions, so one of those three starting to pass -- which is exactly
+  # what each M3 RTL change is supposed to cause -- fails the gate until its
+  # line comes out of the baseline in the same commit.
   test:
     name: test
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,9 +20,10 @@ The README is the project's voice and is deliberately left as-is. **Ground truth
 
 **M1 is reached** (`a4662a2`). `rtl/regfile.v` is combinational-read with write-through
 bypass, every inter-stage struct carries a `valid` bit, and decode runs a stall-only hazard
-scoreboard (ADR-0004 / ADR-0009 / ADR-0015). `make test` is **47/47** and `test/EXPECTED_FAIL` is
-empty, so it is a plain all-pass gate — ADR-0014's set-equality check still runs in both directions,
-so an unexpected *pass* is caught too. The same change fixed three datapath defects found on the way:
+scoreboard (ADR-0004 / ADR-0009 / ADR-0015). `make test` was **47/47** at that commit with
+`test/EXPECTED_FAIL` empty (it is seeded with M3 debt now — see below); ADR-0014's set-equality
+check runs in both directions, so an unexpected *pass* is caught too. The same change fixed three
+datapath defects found on the way:
 AUIPC computed `reg_rs1 + reg_rs2` instead of `pc + immediate`, `mem_wdata` was registered a cycle
 behind `mem_addr`/`mem_wstrb`, and SLL/SRL/SRA did not mask the shift amount to `rs2[4:0]`.
 
@@ -34,9 +35,10 @@ one-cycle load-response latch); `rtl/writeback.v` drives `rvfi_valid`/`rvfi_orde
 retiring `accessor_output`, exactly where invariant 3 below says retire happens. `trap`/`halt`/
 `intr`/`mode`/`ixl`/the CSR fields are hardwired constants in `rtl/littlecpu.v` (no traps or CSRs
 exist yet — M3). `test/monitor.v` stays pristine and tracked; a gitignored, build-time-derived
-`test/monitor.sim.v` (Makefile) carries the two build-time fixes it needs — stripping the
-`$time`-in-`$display` yosys can't elaborate, and ADR-0019's DIV/REM signedness repair — and **both**
-legs read it, so they cannot drift into checking different specs. `make test` is now per-retire
+`test/monitor.sim.v` (`test/sanitize_monitor.py`) carries the build-time repairs it needs —
+originally two, stripping the `$time`-in-`$display` yosys can't elaborate and ADR-0019's DIV/REM
+signedness fix, now three with the `!spec_trap` gate below — and **both** legs read it, so they
+cannot drift into checking different specs. `make test` is now per-retire
 self-checking in both legs, not merely end-state-checking via `tohost`.
 
 **The generated monitor's DIV/REM spec model is defective, and the sanitizer fixes it**
@@ -66,6 +68,38 @@ happened not to compress anything. `formal/imemcheck.sv` — the check that mode
 granularity, per ADR-0003's own consequences section — is re-pointed at the split
 `imem_addr`/`imem_addr2` interface and still passes. `misa`'s C bit is no longer an untested claim.
 
+**The harness can trap and recover, and the monitor no longer lies about trapping retires.**
+Three things landed together, all of them test-side — no `rtl/` file changed. (1)
+`test/asm/riscv_test.h` gains **opt-in** trap macros: a `.align 2` handler that records
+`mcause`/`mepc`/a trap counter into RAM and resumes at `mepc+4`, a fatal variant that fails the
+test from inside the handler, and an installer for `mtvec`. `RVTEST_CODE_BEGIN` is byte-identical
+(verified with `gcc -E`), so the 49 existing tests do not start executing CSR instructions before
+the CSR RTL exists. The handler **cannot read the faulting instruction** — Harvard buses,
+ADR-0008 — so it cannot tell a 2-byte fault from a 4-byte one, and every trapping instruction in a
+resuming test must be wrapped in `.option norvc`. (2) The sanitizer moved from an inline `sed`
+chain to `test/sanitize_monitor.py` and gained a **third rule**: gate the monitor's spec-value
+checks on `!ch0_spec_trap`, mirroring riscv-formal's own `checks/rvfi_insn_check.sv`, which the
+monitor generator never emits. Without it a misaligned `lw` — where the spec model reports the
+loaded value and `pc+4` while a correct core writes nothing and redirects to `mtvec` (ADR-0028) —
+reports errors 104/105/106/111-113 in both sim legs **on correct hardware**. Same situation as
+ADR-0019's DIV/REM defect and the same remedy; the script now also asserts a site count per rule,
+so a pin bump that changes the generator fails loudly instead of silently shipping an unapplied
+sanitizer. (3) `test/monitor_tb.v` joins `make test-units`, driving the sanitized monitor directly
+with hand-built trapping and non-trapping RVFI vectors — including a deliberately wrong one, so a
+gate that disabled all spec checking could not pass.
+
+`test/EXPECTED_FAIL` is **no longer empty**: `csr.S`, `minstret.S` and `trap.S` are seeded there
+ahead of the RTL that pays them off, which is the direction ADR-0014's burn-down contract was
+designed for. `make test` is **49 pass / 3 expected-fail** and still exits 0 only on set equality.
+`test/run_tests.sh` also grew a `MONITOR-ERROR` label for runner exit 4, which used to fall into
+`RUNNER-ERROR` and read as "the sim would not start" when it actually means the per-retire oracle
+disagreed with the core mid-run. **Nothing here checks M3 semantics against an oracle**:
+riscv-formal ships no spec model for `csrr*`/`ecall`/`ebreak`/`mret` at the pinned SHA, so
+`spec_valid` is 0 for every one of them and the monitor's whole semantic block is skipped. The
+trap and CSR tests assert on values their own handler recorded. Error 133 ("expected intr after
+trap") stays unreachable in this single-channel config — `shadow_pc_valid <= !rvfi_trap` gates 130
+and 133 off for the retire after a trap — so `rvfi_intr` hardwired to 0 does not break anything.
+
 What does not work right now:
 
 - **The ALTOPS divide branch reads stale operands.** `rtl/executor.v:221-224` reads `in.rs1`/
@@ -94,11 +128,13 @@ What does not work right now:
   them for deletion. A green run of one of those is not a result.
 
 What does work: `yosys ... write_cxxrtl` elaborates the current RTL cleanly with zero warnings, the
-cxxrtl binary builds and runs, the full `.S` suite passes under it, `make test-units` passes (four
-benches: `exec_tb`, `mem_tb`, `decoder_tb`, and `regfile_tb` — the last covers the write-through
-bypass and x0 semantics), and the decoder and executor component proofs pass by k-induction (see
-ADR-0017 for what the decoder proof does and does not establish). `make waves` now runs the
-iverilog leg (`testbench.vvp`) instead of the cxxrtl runner, matching the verification table below,
+cxxrtl binary builds and runs, the `.S` suite passes under it except the three M3 tests seeded in
+`test/EXPECTED_FAIL`, `make test-units` passes (five benches: `exec_tb`, `mem_tb`, `decoder_tb`,
+`regfile_tb` — which covers the write-through bypass and x0 semantics — and `monitor_tb`, which
+checks the oracle itself rather than the core), and the decoder and executor component proofs pass
+by k-induction (see ADR-0017 for what the decoder proof does and does not establish). `make waves`
+now runs the iverilog leg (`testbench.vvp`) instead of the cxxrtl runner, matching the verification
+table below,
 and produces a real `waves.vcd`. CI (`.github/workflows/ci.yml`) runs elaborate / test / components
 / monitor-freshness on every PR.
 

--- a/Makefile
+++ b/Makefile
@@ -48,27 +48,19 @@ sim: test/cxxrtl.cc test/rtl.cc
 # pristine and tracked (CLAUDE.md invariant 7); regenerate this file, never
 # hand-edit it, and never commit it. BOTH sim legs read this file, so they
 # cannot drift into checking different specs -- and it is therefore
-# load-bearing for correctness, not just elaboration: changing a rule below
-# changes the oracle. Two rules, each anchored tightly enough that it cannot
-# match anywhere it wasn't meant to. `diff test/monitor.v test/monitor.sim.v`
-# is six lines; if it stops being readable at a glance, fix the generator
-# upstream instead.
+# load-bearing for correctness, not just elaboration: changing a rule in the
+# sanitizer changes the oracle.
 #
-#   1. yosys's AST_AUTOWIRE elaboration bug trips on `$time` used as a bare
-#      $display argument (four call sites -- iverilog handles it fine, yosys
-#      does not). Strips the timestamp from the error banner; the iverilog
-#      leg loses a diagnostic nicety, not a check.
-#   2. ADR-0019: monitor_insn_div/monitor_insn_rem compute signed division as
-#      a conditional whose other branches are unsigned, so IEEE 1800
-#      sign-context propagation silently evaluates the division UNSIGNED --
-#      wrong answers for negative operands only, which is exactly what
-#      div.S/rem.S exercise. Wrapping the arithmetic in $signed() makes it
-#      self-determined, so the enclosing conditional can no longer downgrade
-#      it. Two lines change (DIV `/` and REM `%`).
-test/monitor.sim.v: test/monitor.v
-	sed -E -e 's/ at time %0t --------", ([A-Za-z0-9_]+), \$$time\)/ --------", \1)/' \
-	       -e 's/\$$signed\((rvfi_rs1_rdata)\) ([\/%]) \$$signed\((rvfi_rs2_rdata)\);/$$signed($$signed(\1) \2 $$signed(\3));/' \
-	       $< > $@
+# The three rules, and why each exists, live in test/sanitize_monitor.py.
+# They were an inline `sed` chain here until the third one (the !spec_trap
+# gate) arrived: that rule is a structural insert across a 45-line span, not
+# a line substitution, and the script additionally asserts a site count per
+# rule so a pin bump that changes the generator's output fails loudly instead
+# of silently shipping an unapplied sanitizer. `diff test/monitor.v
+# test/monitor.sim.v` is eight lines; if it stops being readable at a glance,
+# fix the generator upstream instead.
+test/monitor.sim.v: test/monitor.v test/sanitize_monitor.py
+	python3 test/sanitize_monitor.py $< > $@
 
 # $(RISCV_FORMAL_MACROS) turns on the rvfi_* ports and their driving logic
 # throughout rtl/ and test/testbench.v's `monitor` instance (ADR-0006);
@@ -114,19 +106,24 @@ else
 	@echo "  sudo apt-get install gcc-riscv64-unknown-elf"
 endif
 
-# Four small benches that landed in `eb18320` and `a4662a2` with no runner
+# Five small benches. Four landed in `eb18320` and `a4662a2` with no runner
 # (rtl/executor.v, rtl/memory.v, rtl/decoder.v, rtl/regfile.v respectively —
 # regfile_tb.v covers the write-through bypass and x0 semantics, the single
 # most load-bearing change in the project, and was verified by hand via
-# iverilog+vvp before this rule existed to run it in CI). Compiled and run
-# straight through iverilog/vvp; each bench $fatal(1)s on a mismatch and
-# $finish (exit 0) on success, so vvp's own exit code is the pass/fail
-# signal — no output-parsing needed. A separate target from `test` (that one
-# is the ADR-0007 cxxrtl regression gate over test/asm/*.S; these are
-# RTL-level unit benches with their own, unrelated pass/fail mechanism) but
-# `test` depends on it so one `make test` still catches everything.
+# iverilog+vvp before this rule existed to run it in CI). The fifth,
+# monitor_tb, is not an RTL bench at all: it drives the sanitized monitor
+# (test/monitor.sim.v) directly with hand-built RVFI retires, because that
+# file is the oracle both sim legs check against and nothing else exercises
+# it on inputs whose correct verdict is known independently of the core
+# (ADR-0019). Compiled and run straight through iverilog/vvp; each bench
+# $fatal(1)s on a mismatch and $finish (exit 0) on success, so vvp's own exit
+# code is the pass/fail signal — no output-parsing needed. A separate target
+# from `test` (that one is the ADR-0007 cxxrtl regression gate over
+# test/asm/*.S; these are unit benches with their own, unrelated pass/fail
+# mechanism) but `test` depends on it so one `make test` still catches
+# everything.
 .PHONY: test-units
-test-units:
+test-units: test/monitor.sim.v
 	@tmp=$$(mktemp -d "$${TMPDIR:-/tmp}/test-units.XXXXXX"); \
 	trap 'rm -rf "$$tmp"' EXIT; \
 	set -e; \
@@ -141,7 +138,10 @@ test-units:
 	vvp $$tmp/decoder_tb.vvp; \
 	echo "== regfile_tb =="; \
 	iverilog -I./rtl/ -g2012 -o $$tmp/regfile_tb.vvp rtl/regfile.v test/regfile_tb.v; \
-	vvp $$tmp/regfile_tb.vvp
+	vvp $$tmp/regfile_tb.vvp; \
+	echo "== monitor_tb =="; \
+	iverilog -g2012 -o $$tmp/monitor_tb.vvp test/monitor.sim.v test/monitor_tb.v; \
+	vvp $$tmp/monitor_tb.vvp
 
 # Assembles every test/asm/*.S (rv32im_zicsr, -nostdlib, ADR-0008's memory
 # map), runs each under `sim`, and checks the pass/fail table against

--- a/test/EXPECTED_FAIL
+++ b/test/EXPECTED_FAIL
@@ -19,3 +19,36 @@
 # this core, and ADR-0019 fixes it in the build-time sanitizer instead. The
 # file stays empty. See ADR-0019 before ever adding a line back for a
 # monitor-side problem.
+#
+# The three lines below are the M3 debt, added deliberately and ahead of the
+# RTL that pays it off — this is the direction the burn-down contract was
+# designed for. Each names behaviour ADR-0005 / ADR-0027 / ADR-0028 /
+# ADR-0030 specify and no `rtl/` file implements yet: there is no CSR file,
+# no mtvec, no trap commit. They are NOT monitor-side problems (ADR-0019's
+# case) and NOT regressions; they are tests written before their feature, so
+# that each M3 RTL change has a checkable simulation acceptance criterion
+# instead of an argument. Remove them one at a time, in the commit that makes
+# each pass.
+#
+#   csr.S       — Zicsr access semantics and the CSR set of ADR-0005:
+#                 round-trip, CSRRW's old value, the CSRRS/CSRRC rs1==x0 and
+#                 immediate forms, the read-only identification CSRs,
+#                 mie/mip/mtval reading zero, and the mstatus.MPP / mepc[0]
+#                 WARL fields. Fails today at test 2 (mscratch does not exist).
+#   minstret.S  — ADR-0027's two counter rules: `csrr minstret` is exact
+#                 because CSR instructions serialize, and a trapping
+#                 instruction does not increment it. The ladder cannot check
+#                 either (rvfi_csrw_check checks that a write lands, not
+#                 increment semantics; the csrc_* checks are unreachable at
+#                 the pinned SHA), so simulation is the only mechanised check
+#                 short of the component proof.
+#   trap.S      — every implemented trap cause (ADR-0005 / ADR-0030) taken
+#                 deliberately, plus ADR-0028's convention that a trapping
+#                 instruction writes no register and no memory. Reports
+#                 MONITOR-ERROR rather than FAIL today: with no trap logic the
+#                 core completes the misaligned load, and the per-retire
+#                 monitor catches the disagreement before `tohost` is ever
+#                 written.
+csr.S
+minstret.S
+trap.S

--- a/test/asm/csr.S
+++ b/test/asm/csr.S
@@ -1,0 +1,135 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# csr.S
+#-----------------------------------------------------------------------------
+#
+# The Zicsr access semantics and the CSR set of ADR-0005, checked in band.
+# riscv-formal has no spec model for csrr*/mret at the pinned SHA, so the
+# per-retire monitor reports nothing about any instruction in this file (see
+# riscv_test.h) — every claim here is asserted by the test itself.
+#
+# No trap is expected anywhere in this file, so it installs the *fatal* handler:
+# an unexpected fault reports the live test number instead of restarting the
+# program from mtvec = 0 (ADR-0029).
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  RVTEST_INSTALL_TRAP_HANDLER
+
+  #-------------------------------------------------------------
+  # A read/write CSR round-trips.
+  #-------------------------------------------------------------
+
+  TEST_CASE( 2, a1, 0x1234, \
+    li a0, 0x1234; \
+    csrw mscratch, a0; \
+    csrr a1, mscratch; )
+
+  #-------------------------------------------------------------
+  # CSRRW returns the old value and installs the new one.
+  #-------------------------------------------------------------
+
+  TEST_CASE( 3, a1, 0x1234, \
+    li a0, 0x5678; \
+    csrrw a1, mscratch, a0; )
+
+  TEST_CASE( 4, a1, 0x5678, csrr a1, mscratch; )
+
+  #-------------------------------------------------------------
+  # CSRRS with rs1 == x0 suppresses the write entirely (ADR-0005), so it is
+  # legal against a read-only CSR — if it raised illegal-instruction instead,
+  # the fatal handler below would report this test number.
+  #-------------------------------------------------------------
+
+  TEST_CASE( 5, a0, 0x40001104, csrrs a0, misa, x0; )
+  TEST_CASE( 6, a1, 0x5678, csrrs a0, mscratch, x0; csrr a1, mscratch; )
+
+  #-------------------------------------------------------------
+  # The immediate forms operate on a 5-bit zimm, not on rs1.
+  #-------------------------------------------------------------
+
+  TEST_CASE( 7, a1, 0x567f, csrrsi a0, mscratch, 0x1f; csrr a1, mscratch; )
+  TEST_CASE( 8, a1, 0x5670, csrrci a0, mscratch, 0x0f; csrr a1, mscratch; )
+
+  # ...and the value returned is the one from before the update: mscratch is
+  # 0x5670 on entry and 0x5673 on exit, so only the pre-update read passes.
+  TEST_CASE( 9, a0, 0x5670, csrrsi a0, mscratch, 0x03; )
+
+  #-------------------------------------------------------------
+  # The read-only identification CSRs (ADR-0005).
+  #-------------------------------------------------------------
+
+  TEST_CASE( 10, a0, 0x40001104, csrr a0, misa; )
+  TEST_CASE( 11, a0, 0, csrr a0, mvendorid; )
+  TEST_CASE( 12, a0, 0, csrr a0, marchid; )
+  TEST_CASE( 13, a0, 0, csrr a0, mimpid; )
+  TEST_CASE( 14, a0, 0, csrr a0, mhartid; )
+
+  # No interrupt sources and no mtval: all three read as zero, forever.
+  TEST_CASE( 15, a2, 0, \
+    csrr a0, mie; \
+    csrr a1, mip; \
+    or   a2, a0, a1; \
+    csrr a0, mtval; \
+    or   a2, a2, a0; )
+
+  # ...and a write to them does not stick.
+  TEST_CASE( 16, a1, 0, \
+    li a0, -1; \
+    csrw mie, a0; \
+    csrr a1, mie; )
+
+  #-------------------------------------------------------------
+  # mtvec reads back the handler this test installed.
+  #-------------------------------------------------------------
+
+test_17:
+  csrr  a0, mtvec
+  la    x29, trap_handler
+  li    TESTNUM, 17
+  bne   a0, x29, fail
+
+  #-------------------------------------------------------------
+  # WARL fields. MPP is hardwired to M-mode, so it survives a zero write
+  # (ADR-0005), and mepc's bit 0 is always clear — only bit 0, because C makes
+  # 2-byte targets legal.
+  #-------------------------------------------------------------
+
+  TEST_CASE( 18, a1, 0x1800, \
+    csrw mstatus, x0; \
+    csrr a0, mstatus; \
+    li   a2, 0x1800; \
+    and  a1, a0, a2; )
+
+  TEST_CASE( 19, a1, 0x102, \
+    li a0, 0x103; \
+    csrw mepc, a0; \
+    csrr a1, mepc; )
+
+  #-------------------------------------------------------------
+  # fence and wfi are NOPs here (ADR-0005): they retire and change nothing.
+  #-------------------------------------------------------------
+
+  TEST_CASE( 20, a1, 7, \
+    li a1, 7; \
+    fence; \
+    wfi; )
+
+  TEST_PASSFAIL
+
+  RVTEST_TRAP_HANDLER_FATAL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/test/asm/minstret.S
+++ b/test/asm/minstret.S
@@ -1,0 +1,124 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# minstret.S
+#-----------------------------------------------------------------------------
+#
+# The two counter rules that nothing else can check.
+#
+# 1. `minstret` is exact as read. CSR instructions serialize (ADR-0005), and
+#    ADR-0027 records that exactness — not hazard safety — is the whole reason
+#    that stall exists. Without it, `csrr minstret` reads a count inflated by
+#    whatever happens to be in flight behind it, and the difference between two
+#    reads separated by three nops is a function of pipeline occupancy rather
+#    than of architectural state. Here it must be exactly 4.
+#
+# 2. A trapping instruction does not increment `minstret` (ADR-0027): it issued,
+#    and it retires in RVFI with rvfi_trap = 1, but it did not retire
+#    architecturally. The riscv-formal ladder cannot see this — rvfi_csrw_check
+#    checks that a CSR write lands, not that a counter's increment semantics are
+#    right, and the csrc_* checks that would are unreachable at the pinned SHA.
+#    So this test is the simulation-side check of that rule.
+#
+# The expected count across the trap is derived from the handler's own size
+# rather than hardcoded, so editing the handler in riscv_test.h cannot silently
+# invalidate this file.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  RVTEST_INSTALL_TRAP_HANDLER
+
+  #-------------------------------------------------------------
+  # Exactness: csrr, nop, nop, nop — four instructions retire between the two
+  # reads, counting the first csrr and not the second.
+  #-------------------------------------------------------------
+
+  TEST_CASE( 2, a2, 4, \
+    csrr a0, minstret; \
+    nop; \
+    nop; \
+    nop; \
+    csrr a1, minstret; \
+    sub  a2, a1, a0; )
+
+  #-------------------------------------------------------------
+  # A trapping instruction contributes nothing. Between the two reads: the
+  # first csrr, the whole handler, and the misaligned load — which must not
+  # count. `.option norvc` because the handler resumes at mepc+4.
+  #-------------------------------------------------------------
+
+test_3:
+  la    a3, tdat
+  addi  a3, a3, 1
+
+  csrr  a0, minstret
+  .option push
+  .option norvc
+  lw    a4, 0(a3)
+  .option pop
+  csrr  a1, minstret
+  sub   a2, a1, a0
+
+  # Expected = the first csrr, plus one entry's worth of handler. The handler
+  # body is straight-line and `.option norvc`, so its instruction count is its
+  # byte span / 4. Computed at run time rather than assembled as a constant:
+  # `li` cannot take a label difference, and hardcoding the number would let an
+  # edit to riscv_test.h silently invalidate this assertion.
+  la    a5, trap_handler
+  la    a6, trap_handler_end
+  sub   a5, a6, a5
+  srli  a5, a5, 2
+  addi  x29, a5, 1
+  li    TESTNUM, 3
+  bne   a2, x29, fail
+
+  # The trap really was taken — otherwise test 3 would be asserting about a
+  # sequence that never entered the handler at all.
+  TEST_CASE( 4, a4, 1, la a3, trap_count; lw a4, 0(a3); )
+
+  #-------------------------------------------------------------
+  # mcycle advances on its own. It counts cycles, not instructions, so the only
+  # portable claim is monotonicity across a few instructions.
+  #-------------------------------------------------------------
+
+  TEST_CASE( 5, a2, 1, \
+    csrr a0, mcycle; \
+    nop; \
+    csrr a1, mcycle; \
+    sltu a2, a0, a1; )
+
+  # The high halves are separate CSRs and read as zero this early in the run.
+  TEST_CASE( 6, a2, 0, \
+    csrr a0, mcycleh; \
+    csrr a1, minstreth; \
+    or   a2, a0, a1; )
+
+  # An explicit write takes precedence over that cycle's increment (ADR-0005).
+  TEST_CASE( 7, a1, 0x100, \
+    li   a0, 0x100; \
+    csrw minstret, a0; \
+    csrr a1, minstret; )
+
+  TEST_PASSFAIL
+
+  RVTEST_TRAP_HANDLER
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+  RVTEST_TRAP_DATA
+
+  .align 2
+tdat:
+  .word 0x0ff0
+  .word 0x0ff0
+
+RVTEST_DATA_END

--- a/test/asm/riscv_test.h
+++ b/test/asm/riscv_test.h
@@ -1,12 +1,49 @@
 // Local, minimal riscv_test.h (ADR-0008).
 //
-// Unlike upstream riscv-tests' env/p/riscv_test.h, this core has no CSRs, no
-// privilege modes, no PMP, and no trap handling wired up yet (M3 work), so
-// none of that setup belongs here. RVTEST_CODE_BEGIN just establishes
-// `_start` and zeroes the test-number register; RVTEST_PASS/RVTEST_FAIL
-// write the riscv-tests `tohost` encoding (ADR-0008) to a fixed word in RAM
-// and spin. The cxxrtl runner (test/cxxrtl.cc) and the iverilog bench watch
-// that address for the magic write instead of relying on ecall/mtvec.
+// Unlike upstream riscv-tests' env/p/riscv_test.h, this core has no privilege
+// modes and no PMP, so none of that setup belongs here. RVTEST_CODE_BEGIN just
+// establishes `_start` and zeroes the test-number register;
+// RVTEST_PASS/RVTEST_FAIL write the riscv-tests `tohost` encoding (ADR-0008) to
+// a fixed word in RAM and spin. The cxxrtl runner (test/cxxrtl.cc) and the
+// iverilog bench watch that address for the magic write instead of relying on
+// ecall/mtvec.
+//
+// The trap-handler macros at the bottom are strictly opt-in and
+// RVTEST_CODE_BEGIN is deliberately untouched by them: the suite's other tests
+// must keep assembling to the same bytes, and must not start executing CSR
+// instructions before the CSR RTL exists (M3). A test opts in by invoking
+// RVTEST_TRAP_HANDLER (in .text) and RVTEST_TRAP_DATA (in .data) and then
+// installing the handler with RVTEST_INSTALL_TRAP_HANDLER.
+//
+// Three constraints on trap tests, none of them optional, all of them
+// consequences of decisions recorded elsewhere:
+//
+//   1. **The handler cannot read the faulting instruction.** This core is
+//      Harvard with physically disjoint buses (ADR-0008): no load can reach
+//      ROM. So a handler cannot inspect insn[1:0] to decide whether to resume
+//      at mepc+2 or mepc+4. The resume path here adds 4 unconditionally, which
+//      means **every trapping instruction in a resuming test must be
+//      uncompressed** -- wrap it in `.option norvc` / `.option pop`, because
+//      the assembler compresses freely at -march=rv32imc_zicsr (ADR-0014's
+//      sunset note) and would otherwise silently turn a 4-byte `lw` into a
+//      2-byte `c.lw`, after which the resume skips a whole instruction. Tests
+//      that instead terminate from inside the handler are unconstrained.
+//   2. **Install the handler before faulting.** `mtvec` resets to 0, which is
+//      `_start` (ADR-0029), so a trap taken before installation silently
+//      restarts the program. Both sim legs are supposed to make that loud, but
+//      the discipline is the actual fix.
+//   3. **Trap tests must self-check in band.** riscv-formal ships no spec model
+//      for csrr*/ecall/ebreak/mret at the pinned SHA, so `spec_valid` is 0 for
+//      all of them and the per-retire monitor -- the thing that makes every
+//      other test self-checking (ADR-0019) -- has nothing to say about the
+//      instructions these tests exist to exercise. Hence the handler records
+//      mcause/mepc/a trap count into RAM and the test body asserts on them
+//      with the ordinary TEST_CASE machinery. Do not assume a passing trap
+//      test was cross-checked against an oracle; it was checked against
+//      whatever the test itself asserts.
+//
+// The handler clobbers t0 and t1 and nothing else, so a test body must not
+// hold live values in those registers across an instruction that may trap.
 
 #ifndef __RISCV_TEST_H
 #define __RISCV_TEST_H
@@ -57,5 +94,81 @@ tohost:                                                                      \
         .align  2;
 
 #define RVTEST_DATA_END
+
+// ---------------------------------------------------------------------------
+// Opt-in trap support (M3). Nothing above this line references any of it, so a
+// test that does not invoke these macros assembles to exactly the bytes it did
+// before they existed. Read the three constraints at the top of this file
+// before writing a trap test.
+// ---------------------------------------------------------------------------
+
+// Where the handler records what it saw. Invoke inside the data section (after
+// RVTEST_DATA_BEGIN) so it lands in RAM, which is the only memory a load can
+// reach on this Harvard core (ADR-0008).
+#define RVTEST_TRAP_DATA                                                     \
+        .align  2;                                                          \
+        .global trap_count;                                                 \
+trap_count:                                                                  \
+        .word   0;                                                          \
+        .global trap_cause;                                                 \
+trap_cause:                                                                  \
+        .word   0;                                                          \
+        .global trap_epc;                                                   \
+trap_epc:                                                                    \
+        .word   0;
+
+// The recording handler: bump `trap_count`, store `mcause` and `mepc`, then
+// resume at mepc+4 via `mret`.
+//
+// +4 is unconditional because the handler cannot look at the faulting
+// instruction to find out whether it was 2 or 4 bytes (constraint 1 at the top
+// of this file) — so the trapping instruction must be uncompressed. Clobbers
+// t0 and t1.
+//
+// Invoke it in .text somewhere control cannot fall into — after TEST_PASSFAIL
+// is the convention, since both of those paths end in an infinite loop.
+// `.align 2` satisfies mtvec's 4-byte-aligned WARL base (ADR-0005).
+//
+// The body is `.option norvc` and straight-line, so every instruction in it is
+// exactly 4 bytes and `(trap_handler_end - trap_handler) / 4` is the number of
+// instructions one trap entry retires. A test that reasons about `minstret`
+// across a trap (ADR-0027) should compute that expression rather than hardcode
+// a count, so editing this macro cannot silently invalidate it.
+#define RVTEST_TRAP_HANDLER                                                  \
+        .align  2;                                                          \
+trap_handler:                                                                \
+        .option push;                                                       \
+        .option norvc;                                                      \
+        la      t0, trap_count;                                             \
+        lw      t1, 0(t0);                                                  \
+        addi    t1, t1, 1;                                                  \
+        sw      t1, 0(t0);                                                  \
+        csrr    t1, mcause;                                                 \
+        la      t0, trap_cause;                                             \
+        sw      t1, 0(t0);                                                  \
+        csrr    t1, mepc;                                                   \
+        la      t0, trap_epc;                                               \
+        sw      t1, 0(t0);                                                  \
+        addi    t1, t1, 4;                                                  \
+        csrw    mepc, t1;                                                   \
+        mret;                                                               \
+trap_handler_end:                                                            \
+        .option pop;
+
+// The alternative handler: any trap is a test failure, reported against
+// whatever test number was live when it happened. Terminates from inside the
+// handler, so it is not subject to the uncompressed-instruction constraint.
+// Define at most one of RVTEST_TRAP_HANDLER / RVTEST_TRAP_HANDLER_FATAL per
+// test — they share the `trap_handler` symbol.
+#define RVTEST_TRAP_HANDLER_FATAL                                            \
+        .align  2;                                                          \
+trap_handler:                                                                \
+        RVTEST_FAIL
+
+// Point mtvec at the handler. Direct mode: mtvec[1:0] = 0, which the handler's
+// `.align 2` guarantees. Clobbers t0.
+#define RVTEST_INSTALL_TRAP_HANDLER                                          \
+        la      t0, trap_handler;                                           \
+        csrw    mtvec, t0;
 
 #endif

--- a/test/asm/trap.S
+++ b/test/asm/trap.S
@@ -1,0 +1,148 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# trap.S
+#-----------------------------------------------------------------------------
+#
+# Every trap cause this core implements (ADR-0005 / ADR-0030), taken
+# deliberately, recorded by the opt-in handler in riscv_test.h, and asserted
+# on from the test body.
+#
+# This test self-checks in band rather than leaning on the per-retire RVFI
+# monitor, and that is not a stylistic choice: riscv-formal ships no spec model
+# for ecall/ebreak/mret/csrr* at the pinned SHA, so `spec_valid` is 0 for every
+# instruction here that matters and the monitor's whole semantic block is
+# skipped. See the constraints at the top of riscv_test.h.
+#
+# Every trapping instruction is wrapped in `.option norvc` because the handler
+# resumes at mepc+4 unconditionally — it cannot read the faulting instruction
+# to find out how long it was (Harvard buses, ADR-0008).
+#
+# The handler clobbers t0/t1, so nothing here holds a live value in either
+# across a fault.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  # mtvec resets to 0, which is _start (ADR-0029) — install before faulting.
+  RVTEST_INSTALL_TRAP_HANDLER
+
+  #-------------------------------------------------------------
+  # Load address misaligned: cause 4.
+  #-------------------------------------------------------------
+
+  la    a0, tdat
+  addi  a0, a0, 1
+  li    a1, 0x5a5
+
+mis_lw:
+  .option push
+  .option norvc
+  lw    a1, 0(a0)
+  .option pop
+
+  TEST_CASE( 2, a4, 4, la a3, trap_cause; lw a4, 0(a3); )
+  TEST_CASE( 3, a4, 1, la a3, trap_count; lw a4, 0(a3); )
+
+  # mepc holds the address of the faulting instruction, and resuming at mepc+4
+  # therefore landed on the instruction after it — which is where the code
+  # asserting this is running.
+test_4:
+  la    a3, trap_epc
+  lw    a4, 0(a3)
+  la    x29, mis_lw
+  li    TESTNUM, 4
+  bne   a4, x29, fail
+
+  # A trapping load writes no register (ADR-0028): a1 still holds its sentinel.
+  TEST_CASE( 5, a1, 0x5a5, nop; )
+
+  #-------------------------------------------------------------
+  # Store address misaligned: cause 6.
+  #-------------------------------------------------------------
+
+  la    a0, tdat
+  addi  a0, a0, 2
+
+  .option push
+  .option norvc
+  sw    a1, 0(a0)
+  .option pop
+
+  TEST_CASE(  6, a4, 6, la a3, trap_cause; lw a4, 0(a3); )
+  TEST_CASE(  7, a4, 2, la a3, trap_count; lw a4, 0(a3); )
+
+  # ...and wrote no memory: tdat is untouched.
+  TEST_CASE(  8, a4, 0x0ff0, la a3, tdat; lw a4, 0(a3); )
+
+  #-------------------------------------------------------------
+  # Environment call from M-mode: cause 11.
+  #-------------------------------------------------------------
+
+  .option push
+  .option norvc
+  ecall
+  .option pop
+
+  TEST_CASE(  9, a4, 11, la a3, trap_cause; lw a4, 0(a3); )
+
+  #-------------------------------------------------------------
+  # Breakpoint: cause 3.
+  #-------------------------------------------------------------
+
+  .option push
+  .option norvc
+  ebreak
+  .option pop
+
+  TEST_CASE( 10, a4, 3, la a3, trap_cause; lw a4, 0(a3); )
+
+  #-------------------------------------------------------------
+  # Illegal instruction: cause 2. Two flavours — an encoding that decodes to
+  # nothing (the all-zero word is illegal by definition), and a read of an
+  # unimplemented CSR (ADR-0005).
+  #-------------------------------------------------------------
+
+  .option push
+  .option norvc
+  .4byte 0
+  .option pop
+
+  TEST_CASE( 11, a4, 2, la a3, trap_cause; lw a4, 0(a3); )
+
+  # Clear the recorded cause so the next case cannot pass on a stale value.
+  la    a3, trap_cause
+  sw    x0, 0(a3)
+
+  .option push
+  .option norvc
+  csrr  a0, 0x7c0
+  .option pop
+
+  TEST_CASE( 12, a4, 2, la a3, trap_cause; lw a4, 0(a3); )
+
+  # Six traps taken, six handler entries.
+  TEST_CASE( 13, a4, 6, la a3, trap_count; lw a4, 0(a3); )
+
+  TEST_PASSFAIL
+
+  RVTEST_TRAP_HANDLER
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+  RVTEST_TRAP_DATA
+
+  .align 2
+tdat:
+  .word 0x0ff0
+  .word 0x0ff0
+
+RVTEST_DATA_END

--- a/test/monitor_tb.v
+++ b/test/monitor_tb.v
@@ -1,0 +1,244 @@
+// Unit bench for the generated RVFI monitor itself -- not for the core.
+//
+// The monitor is an oracle both sim legs read (ADR-0019), so a defect in it is
+// a defect in every `make test` result. This bench drives the `monitor` module
+// directly with hand-built RVFI retires whose correct verdict is known by
+// construction, which is the technique that pinned the DIV/REM signedness
+// defect ADR-0019 records. It is compiled against test/monitor.sim.v -- the
+// sanitized derivative, i.e. the file that actually does the checking.
+//
+// What it pins:
+//
+//   * a correct non-trapping retire is accepted (vectors 1, 3);
+//   * a correct TRAPPING retire is accepted (vectors 2, 5) -- this is the
+//     !spec_trap gate the generator omits and test/sanitize_monitor.py adds.
+//     On a misaligned `lw` the spec model still reports spec_rd_addr = the
+//     destination register, spec_rd_wdata = the loaded value, spec_pc_wdata =
+//     pc+4 and spec_mem_rmask = the byte mask, while a correct core writes no
+//     register, strobes no memory and redirects to mtvec (ADR-0028). Without
+//     the gate these vectors report errors 104/105/106/111-113 (load) and
+//     108 (store) against hardware that is behaving correctly. Run this bench
+//     against an unsanitized monitor -- or with the gate line mutated to
+//     `if (1'b1)` -- and it $fatal(1)s;
+//   * a genuinely wrong non-trapping retire is still REJECTED (vector 4).
+//     Without this the bench could pass by checking nothing, and a gate that
+//     accidentally disabled all spec checking would look identical to a
+//     correct one;
+//   * an M3 instruction with no spec model (`ecall`, vector 6) is accepted
+//     silently, because spec_valid never asserts for it. That is not the gate
+//     working, it is the monitor having nothing to say -- the reason the trap
+//     and CSR `.S` tests carry their own in-band assertions rather than
+//     leaning on the per-retire oracle. See test/asm/riscv_test.h.
+//
+// Pass/fail is vvp's exit code, like the other benches in `make test-units`:
+// $fatal(1) on a mismatch, $finish on success.
+`timescale 1ns / 1ps
+
+module monitor_tb;
+  localparam [31:0] MTVEC = 32'h0000_0100;  // where the trapping vectors redirect
+  localparam [31:0] RAM   = 32'h0001_0000;  // ADR-0008's RAM base
+
+  reg clock = 0;
+  reg reset = 1;
+
+  reg  [0:0]  rvfi_valid = 0;
+  reg  [63:0] rvfi_order = 0;
+  reg  [31:0] rvfi_insn = 0;
+  reg  [0:0]  rvfi_trap = 0;
+  reg  [0:0]  rvfi_halt = 0;
+  reg  [0:0]  rvfi_intr = 0;
+  reg  [1:0]  rvfi_mode = 2'b11;
+  reg  [4:0]  rvfi_rs1_addr = 0;
+  reg  [4:0]  rvfi_rs2_addr = 0;
+  reg  [31:0] rvfi_rs1_rdata = 0;
+  reg  [31:0] rvfi_rs2_rdata = 0;
+  reg  [4:0]  rvfi_rd_addr = 0;
+  reg  [31:0] rvfi_rd_wdata = 0;
+  reg  [31:0] rvfi_pc_rdata = 0;
+  reg  [31:0] rvfi_pc_wdata = 0;
+  reg  [31:0] rvfi_mem_addr = 0;
+  reg  [3:0]  rvfi_mem_rmask = 0;
+  reg  [3:0]  rvfi_mem_wmask = 0;
+  reg  [31:0] rvfi_mem_rdata = 0;
+  reg  [31:0] rvfi_mem_wdata = 0;
+  reg  [0:0]  rvfi_mem_extamo = 0;
+
+  wire [15:0] errcode;
+
+  monitor dut (
+    .clock(clock),
+    .reset(reset),
+    .rvfi_valid(rvfi_valid),
+    .rvfi_order(rvfi_order),
+    .rvfi_insn(rvfi_insn),
+    .rvfi_trap(rvfi_trap),
+    .rvfi_halt(rvfi_halt),
+    .rvfi_intr(rvfi_intr),
+    .rvfi_mode(rvfi_mode),
+    .rvfi_rs1_addr(rvfi_rs1_addr),
+    .rvfi_rs2_addr(rvfi_rs2_addr),
+    .rvfi_rs1_rdata(rvfi_rs1_rdata),
+    .rvfi_rs2_rdata(rvfi_rs2_rdata),
+    .rvfi_rd_addr(rvfi_rd_addr),
+    .rvfi_rd_wdata(rvfi_rd_wdata),
+    .rvfi_pc_rdata(rvfi_pc_rdata),
+    .rvfi_pc_wdata(rvfi_pc_wdata),
+    .rvfi_mem_addr(rvfi_mem_addr),
+    .rvfi_mem_rmask(rvfi_mem_rmask),
+    .rvfi_mem_wmask(rvfi_mem_wmask),
+    .rvfi_mem_rdata(rvfi_mem_rdata),
+    .rvfi_mem_wdata(rvfi_mem_wdata),
+    .rvfi_mem_extamo(rvfi_mem_extamo),
+    .errcode(errcode)
+  );
+
+  always #5 clock = ~clock;
+
+  // `errcode` is a one-cycle pulse two clocks behind the retire that caused it
+  // (the per-channel code is registered, then the top-level mux registers it
+  // again), so latch it rather than sampling on a guessed cycle.
+  reg [15:0] latched = 0;
+  reg        clear_latched = 0;
+
+  always @(posedge clock) begin
+    if (clear_latched) latched <= 0;
+    else if (errcode) latched <= errcode;
+  end
+
+  integer failures = 0;
+
+  task drive_retire;
+    input [31:0] insn;
+    input        trap;
+    input [4:0]  rs1_addr;
+    input [4:0]  rs2_addr;
+    input [31:0] rs1_rdata;
+    input [31:0] rs2_rdata;
+    input [4:0]  rd_addr;
+    input [31:0] rd_wdata;
+    input [31:0] pc_rdata;
+    input [31:0] pc_wdata;
+    input [31:0] mem_addr;
+    input [3:0]  mem_rmask;
+    input [3:0]  mem_wmask;
+    input [31:0] mem_rdata;
+    input [31:0] mem_wdata;
+    begin
+      @(negedge clock);
+      rvfi_valid     <= 1;
+      rvfi_insn      <= insn;
+      rvfi_trap      <= trap;
+      rvfi_rs1_addr  <= rs1_addr;
+      rvfi_rs2_addr  <= rs2_addr;
+      rvfi_rs1_rdata <= rs1_rdata;
+      rvfi_rs2_rdata <= rs2_rdata;
+      rvfi_rd_addr   <= rd_addr;
+      rvfi_rd_wdata  <= rd_wdata;
+      rvfi_pc_rdata  <= pc_rdata;
+      rvfi_pc_wdata  <= pc_wdata;
+      rvfi_mem_addr  <= mem_addr;
+      rvfi_mem_rmask <= mem_rmask;
+      rvfi_mem_wmask <= mem_wmask;
+      rvfi_mem_rdata <= mem_rdata;
+      rvfi_mem_wdata <= mem_wdata;
+      @(negedge clock);
+      rvfi_valid <= 0;
+      rvfi_order <= rvfi_order + 1;  // the ROB requires a dense, in-order stream
+    end
+  endtask
+
+  // Drains the two-cycle errcode pipeline, compares, and clears the latch.
+  task expect_errcode;
+    input [15:0] expected;
+    input [511:0] label;  // 64 chars; $display("%0s") left-truncates past that
+    begin
+      repeat (4) @(negedge clock);
+      if (latched !== expected) begin
+        $display("FAIL: %0s: expected monitor errcode %0d, got %0d", label, expected, latched);
+        failures = failures + 1;
+      end else begin
+        $display("ok: %0s (errcode %0d)", label, latched);
+      end
+      clear_latched <= 1;
+      @(negedge clock);
+      clear_latched <= 0;
+      @(negedge clock);
+    end
+  endtask
+
+  initial begin
+    repeat (4) @(negedge clock);
+    reset <= 0;
+    @(negedge clock);
+
+    // 1. add x3, x1, x2 with x1=5, x2=7 -- correct, non-trapping. Establishes
+    //    the shadow PC at 4 and shadow x3 = 12 for the vectors that follow.
+    drive_retire(32'h0020_81b3, 1'b0,
+                 5'd1, 5'd2, 32'd5, 32'd7,
+                 5'd3, 32'd12,
+                 32'h0000_0000, 32'h0000_0004,
+                 32'd0, 4'b0000, 4'b0000, 32'd0, 32'd0);
+    expect_errcode(16'd0, "correct add retire");
+
+    // 2. lw x5, 1(x1) with x1 = RAM base -- address 0x00010001, misaligned, so
+    //    spec_trap holds. A correct core reports the ADR-0028 convention:
+    //    rd_addr/rd_wdata/mem masks all zero, pc_wdata = mtvec. The spec model
+    //    meanwhile reports rd = x5, rd_wdata = the loaded word and
+    //    pc_wdata = pc+4, so every one of those comparisons disagrees. Only
+    //    the !spec_trap gate keeps this clean.
+    drive_retire(32'h0010_a283, 1'b1,
+                 5'd1, 5'd0, RAM, 32'd0,
+                 5'd0, 32'd0,
+                 32'h0000_0004, MTVEC,
+                 32'd0, 4'b0000, 4'b0000, 32'hdead_beef, 32'd0);
+    expect_errcode(16'd0, "trapping misaligned lw retire");
+
+    // 3. addi x6, x0, 3 at mtvec -- the handler's first instruction. Proves the
+    //    monitor keeps checking normally after a trapping retire.
+    drive_retire(32'h0030_0313, 1'b0,
+                 5'd0, 5'd0, 32'd0, 32'd0,
+                 5'd6, 32'd3,
+                 MTVEC, MTVEC + 4,
+                 32'd0, 4'b0000, 4'b0000, 32'd0, 32'd0);
+    expect_errcode(16'd0, "correct addi retire after the trap");
+
+    // 4. Positive control: the same add as vector 1, but reporting 13 instead
+    //    of 12. The monitor must still reject this -- a gate that switched off
+    //    spec checking altogether would pass every vector above.
+    $display("monitor_tb: the monitor error banner below is EXPECTED (positive control)");
+    drive_retire(32'h0020_81b3, 1'b0,
+                 5'd1, 5'd2, 32'd5, 32'd7,
+                 5'd3, 32'd13,
+                 MTVEC + 4, MTVEC + 8,
+                 32'd0, 4'b0000, 4'b0000, 32'd0, 32'd0);
+    expect_errcode(16'd105, "wrong rd_wdata is still caught");
+
+    // 5. sw x2, 1(x1) with x1 = RAM base -- misaligned store. Here the spec
+    //    model reports a non-zero spec_mem_wmask while a correct core strobes
+    //    nothing, which is error 108 without the gate.
+    drive_retire(32'h0020_a0a3, 1'b1,
+                 5'd1, 5'd2, RAM, 32'hcafe_f00d,
+                 5'd0, 32'd0,
+                 MTVEC + 8, MTVEC,
+                 32'd0, 4'b0000, 4'b0000, 32'd0, 32'd0);
+    expect_errcode(16'd0, "trapping misaligned sw retire");
+
+    // 6. ecall. riscv-formal ships no spec model for it at the pinned SHA, so
+    //    spec_valid is 0 and the whole semantic block is skipped -- the monitor
+    //    is not checking this instruction at all. Recorded here so that nobody
+    //    reads a green run as evidence that M3's new instructions are covered.
+    drive_retire(32'h0000_0073, 1'b1,
+                 5'd0, 5'd0, 32'd0, 32'd0,
+                 5'd0, 32'd0,
+                 MTVEC + 12, MTVEC,
+                 32'd0, 4'b0000, 4'b0000, 32'd0, 32'd0);
+    expect_errcode(16'd0, "ecall retire (no spec model exists -- unchecked)");
+
+    if (failures != 0) begin
+      $display("monitor_tb: %0d vector(s) failed", failures);
+      $fatal(1);
+    end
+    $display("monitor_tb: all vectors passed");
+    $finish;
+  end
+endmodule

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -60,10 +60,18 @@ for src in "$ASM_DIR"/*.S; do
 
     "$SIM" --rom "$rom_hex" --ram "$ram_hex" --cycles "$CYCLES" \
       > "$tmp/$base.run.log" 2>&1
+    # The runner's exit ladder (test/cxxrtl.cc): 0 pass, 1 tohost fail, 2 cycle
+    # limit, 3 usage/setup, 4 RVFI monitor error. 4 gets its own label because
+    # it means something entirely different from the others — the per-retire
+    # oracle disagreed with the core mid-run (ADR-0019), which is a wrong-result
+    # report, not a broken harness. Lumping it into RUNNER-ERROR made it
+    # indistinguishable from "the sim could not be started at all".
     case $? in
       0) status="PASS" ;;
       1) status="FAIL $(awk '/^FAIL/{print $2}' "$tmp/$base.run.log")" ;;
       2) status="TIMEOUT" ;;
+      4) status="MONITOR-ERROR $(sed -n 's/.*RVFI monitor error \([0-9]*\).*/\1/p' \
+             "$tmp/$base.run.log" | head -1)" ;;
       *) status="RUNNER-ERROR" ;;
     esac
   fi

--- a/test/sanitize_monitor.py
+++ b/test/sanitize_monitor.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Derive test/monitor.sim.v from the tracked, generated test/monitor.v.
+
+test/monitor.v is riscv-formal's `monitor/generate.py` output at the pinned SHA
+(formal/pin.mk). It is tracked but never hand-edited (CLAUDE.md invariant 7);
+defects in it are repaired here, at build time, in a gitignored derivative that
+BOTH sim legs read -- so the two legs cannot drift into checking different specs
+(ADR-0019).
+
+This used to be a two-rule `sed` chain in the root Makefile. It moved into a
+script when the third rule arrived, because that one is a structural insert
+across a 45-line span rather than a single-line substitution, and because a
+`sed` rule that silently stops matching after a pin bump is indistinguishable
+from one that did its job. Every rule below declares how many sites it must hit
+and this script exits non-zero if the count is wrong.
+
+The diff `test/monitor.v` -> `test/monitor.sim.v` must stay small enough to read
+in full (`diff` it; it is currently eight lines). If it stops being readable at a
+glance, that is the signal to fix the generator upstream instead of adding a
+rule here.
+
+Usage: sanitize_monitor.py <monitor.v>   # sanitized source on stdout
+"""
+
+import re
+import sys
+
+# ---------------------------------------------------------------------------
+# Rule 1 -- strip `$time` from the `$display` error banners.
+#
+# yosys's AST_AUTOWIRE elaboration trips on `$time` used as a bare `$display`
+# argument (iverilog handles it fine, yosys does not), so the cxxrtl leg cannot
+# read the file as generated. The iverilog leg loses a timestamp in its error
+# banner; that is a diagnostic nicety, not a check.
+# ---------------------------------------------------------------------------
+TIME_IN_DISPLAY = (
+    re.compile(r' at time %0t --------", ([A-Za-z0-9_]+), \$time\)'),
+    r' --------", \1)',
+    4,
+)
+
+# ---------------------------------------------------------------------------
+# Rule 2 -- make signed DIV/REM self-determined (ADR-0019).
+#
+# monitor_insn_div / monitor_insn_rem compute the signed result as one branch of
+# a conditional whose other branches are unsigned. Per IEEE 1800 sign-context
+# rules the conditional's type is unsigned and that propagates down into the
+# division, which is then evaluated UNSIGNED -- silently, and wrongly, for
+# negative operands only. Wrapping the arithmetic in `$signed()` makes it
+# self-determined, so the enclosing conditional can no longer downgrade it.
+# Anchored on the exact operand names and the trailing semicolon so it cannot
+# match anywhere it was not meant to. Two sites: DIV's `/` and REM's `%`.
+# ---------------------------------------------------------------------------
+UNSIGNED_SIGNED_DIVREM = (
+    re.compile(r'\$signed\((rvfi_rs1_rdata)\) ([/%]) \$signed\((rvfi_rs2_rdata)\);'),
+    r'$signed($signed(\1) \2 $signed(\3));',
+    2,
+)
+
+# ---------------------------------------------------------------------------
+# Rule 3 -- gate the spec-value checks on `!spec_trap`.
+#
+# riscv-formal's own checker (checks/rvfi_insn_check.sv) puts rs1_addr,
+# rs2_addr, rd_addr, rd_wdata, pc_wdata and every mem_* assertion inside
+# `if (!spec_trap)`, leaving only `assert(spec_trap == trap)` outside. The
+# monitor generator never emits that gate: it runs all of those comparisons
+# unconditionally once spec_valid holds.
+#
+# On a trapping instruction the spec model still reports what the instruction
+# WOULD have done -- for a misaligned `lw`, spec_rd_addr is the destination
+# register, spec_rd_wdata is the loaded value, spec_pc_wdata is pc+4 and
+# spec_mem_rmask is the byte mask. A correct core writes no register, strobes no
+# memory and redirects to `mtvec` (ADR-0028). So the ungated monitor reports
+# errors 104/105/106 and 110-113 on correct hardware, in both sim legs, for
+# every trapping retire. That is a defect in the generated oracle, and per
+# ADR-0019 it is repaired here rather than parked in test/EXPECTED_FAIL.
+#
+# The span wrapped runs from the rs1_addr comparison (error 102) through the
+# mem_addr comparison (error 107) -- i.e. everything the generator emits inside
+# `if (chN_spec_valid)` except the trap-flag comparison (error 101), which is
+# exactly the partition upstream's checker uses. Two lines are inserted and
+# nothing is reindented, so the diff stays readable.
+# ---------------------------------------------------------------------------
+TRAP_GATE_SPAN = re.compile(
+    r'(?P<indent>[ ]*)if \((?P<ch>ch\d+)_rvfi_rs1_addr != (?P=ch)_spec_rs1_addr\b.*?'
+    r'(?P=ch)_handle_error\(\d+, "mismatch in mem_addr"\);\n[ ]*end\n',
+    re.DOTALL,
+)
+
+
+def _wrap_in_trap_gate(match):
+    indent = match.group('indent')
+    channel = match.group('ch')
+    return (
+        f'{indent}if (!{channel}_spec_trap) begin\n'
+        f'{match.group(0)}'
+        f'{indent}end\n'
+    )
+
+
+TRAP_GATE = (TRAP_GATE_SPAN, _wrap_in_trap_gate, 1)
+
+
+RULES = [
+    ('strip $time from $display banners', *TIME_IN_DISPLAY),
+    ('make signed DIV/REM self-determined', *UNSIGNED_SIGNED_DIVREM),
+    ('gate spec-value checks on !spec_trap', *TRAP_GATE),
+]
+
+
+def main(argv):
+    if len(argv) != 2:
+        sys.stderr.write(f'usage: {argv[0]} <monitor.v>\n')
+        return 2
+
+    with open(argv[1]) as handle:
+        text = handle.read()
+
+    failures = []
+    for name, pattern, replacement, expected in RULES:
+        text, count = pattern.subn(replacement, text)
+        if count != expected:
+            failures.append(f'  rule "{name}": matched {count} site(s), expected {expected}')
+
+    if failures:
+        sys.stderr.write(
+            f'{argv[0]}: the generated monitor no longer looks the way these rules\n'
+            f'expect. A riscv-formal pin bump (formal/pin.mk) may have changed the\n'
+            f'generator output -- re-read each rule against {argv[1]} and either fix\n'
+            f'or delete it. Do NOT ship a silently-unapplied sanitizer: both sim legs\n'
+            f'read this output as their oracle (ADR-0019).\n'
+            + '\n'.join(failures) + '\n'
+        )
+        return 1
+
+    sys.stdout.write(text)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
Closes JEF-646

M3 groundwork, **no `rtl/` file touched**. Three test-side blockers, each of which stands between M3's RTL tickets and any checkable *simulation* acceptance criterion.

## 1. The harness can trap and recover

`test/asm/riscv_test.h` gains **opt-in** trap macros — `RVTEST_TRAP_HANDLER` (record `mcause`/`mepc`/a trap counter into RAM, resume at `mepc+4`), `RVTEST_TRAP_HANDLER_FATAL` (any trap fails the test, from inside the handler), `RVTEST_TRAP_DATA`, and `RVTEST_INSTALL_TRAP_HANDLER`.

`RVTEST_CODE_BEGIN` is left byte-identical, which is what lets this land ahead of the CSR RTL: the 49 existing tests do not start executing CSR instructions. Verified with `riscv64-elf-gcc -E` over five of them, comparing the old and new header at the same include path:

```
add.S: -E output BYTE-IDENTICAL
lw.S: -E output BYTE-IDENTICAL
sw.S: -E output BYTE-IDENTICAL
rvc.S: -E output BYTE-IDENTICAL
simple.S: -E output BYTE-IDENTICAL
```

Three constraints are written into the header as constraints, not folklore:

- **The handler cannot read the faulting instruction.** Harvard buses, no load reaches ROM (ADR-0008), so it cannot inspect `insn[1:0]` to choose `mepc+2` vs `mepc+4`. It resumes at +4 unconditionally, and every trapping instruction in a resuming test is wrapped in `.option norvc` — the assembler compresses freely at `-march=rv32imc_zicsr` and would otherwise turn a 4-byte `lw` into a 2-byte `c.lw`, after which the resume skips an instruction.
- **Install `mtvec` before faulting** — it resets to 0, which is `_start` (ADR-0029).
- **Trap tests self-check in band**, because the oracle has nothing to say about them (see §3).

The handler body is `.option norvc` and straight-line, so `(trap_handler_end - trap_handler) / 4` is exactly one trap entry's instruction count. `minstret.S` computes that at run time rather than hardcoding it, so editing the handler cannot silently invalidate the assertion.

## 2. The monitor's missing `!spec_trap` gate

riscv-formal's own `checks/rvfi_insn_check.sv` puts `rs1_addr`, `rs2_addr`, `rd_addr`, `rd_wdata`, `pc_wdata` and every `mem_*` assertion inside `if (!spec_trap)`, leaving only `assert(spec_trap == trap)` outside. `monitor/generate.py` never emits that gate — it runs every comparison unconditionally once `spec_valid` holds.

So on a misaligned `lw`, where the spec model reports `spec_rd_addr` = the destination register, `spec_rd_wdata` = the loaded value, `spec_pc_wdata` = pc+4 and `spec_mem_rmask` = the byte mask, while a correct core writes nothing and redirects to `mtvec` (ADR-0028), the monitor reports errors 104/105/106/111-113 **in both sim legs, on correct hardware**.

This is ADR-0019's situation exactly, and gets ADR-0019's remedy: fixed in the build-time sanitizer, never in the tracked `test/monitor.v` (invariant 7 — `make monitor-check` stays green) and never as an `EXPECTED_FAIL` line.

The sanitizer moves from the Makefile's inline `sed` chain to **`test/sanitize_monitor.py`**. The ticket's bar for that promotion — "if the diff stops being readable at a glance" — is met by this rule being a structural insert across a 45-line span rather than a substitution. The script also asserts a **site count per rule**, so a pin bump that changes the generator's output now fails loudly instead of silently shipping an unapplied sanitizer. Rules 1 and 2 produce byte-identical output to the old `sed`; `diff test/monitor.v test/monitor.sim.v` goes from six lines to eight:

```
132a133
>         if (!ch0_spec_trap) begin
177a179
>         end
```

## 3. `test/monitor_tb.v`, and the M3 semantic hole

`grep -c -i csr test/monitor.v` is 0: riscv-formal ships no `insn_csrr*`/`insn_ecall`/`insn_ebreak`/`insn_mret` model and no `isa_*zicsr*.txt` at the pinned SHA, so `spec_valid` is 0 for every M3 instruction and the monitor's whole semantic block is skipped. CLAUDE.md's "every run is self-checking per-retire" quietly stops being true for exactly the code M3 adds — hence the in-band assertions in the new `.S` tests, and a vector in the bench that records the hole rather than papering over it.

`test/monitor_tb.v` joins `make test-units` and drives the sanitized monitor directly with hand-built RVFI vectors (the technique ADR-0019 used to pin the DIV/REM defect), including a deliberately **wrong** non-trapping retire so that a gate which disabled spec checking altogether could not pass.

**Acceptance criterion 1 — the mutation run.** With the gate:

```
=== WITH the trap gate ===
vvp exit=0
ok: correct add retire (errcode 0)
ok: trapping misaligned lw retire (errcode 0)
ok: correct addi retire after the trap (errcode 0)
ok: wrong rd_wdata is still caught (errcode 105)
ok: trapping misaligned sw retire (errcode 0)
ok: ecall retire (no spec model exists -- unchecked) (errcode 0)
monitor_tb: all vectors passed
```

With it removed (`if (!ch0_spec_trap)` → `if (1'b1)`, a one-line mutation that preserves block structure):

```
133c133
<         if (!ch0_spec_trap) begin
---
>         if (1'b1) begin
vvp exit=1
ok: correct add retire (errcode 0)
FAIL: trapping misaligned lw retire: expected monitor errcode 0, got 113
ok: correct addi retire after the trap (errcode 0)
ok: wrong rd_wdata is still caught (errcode 105)
FAIL: trapping misaligned sw retire: expected monitor errcode 0, got 108
ok: ecall retire (no spec model exists -- unchecked) (errcode 0)
monitor_tb: 2 vector(s) failed
```

113 is `mem_rmask[3]` on the trapping load and 108 is `mem_wmask` on the trapping store — both against a core reporting exactly what ADR-0028 says it should.

## 4. `EXPECTED_FAIL` seeded, and `MONITOR-ERROR`

`test/asm/{trap,csr,minstret}.S` are new and listed in `test/EXPECTED_FAIL` with per-file justification — ADR-0014's burn-down contract used in the direction it was designed for. They cover ADR-0005's CSR set and access semantics, ADR-0030's trap causes, ADR-0028's "a trapping instruction writes no register and no memory", and ADR-0027's two counter rules (which the ladder cannot check at all: `rvfi_csrw_check` checks that a write lands, not increment semantics, and the `csrc_*` checks are unreachable at the pinned SHA).

`test/run_tests.sh` gives runner exit 4 its own `MONITOR-ERROR` label. It used to fall into `RUNNER-ERROR`, indistinguishable from exit 3 (usage/setup) — i.e. "the per-retire oracle disagreed with the core mid-run" read as "the sim would not start".

**Acceptance criterion 5**, demonstrated two ways. `trap.S` produces it naturally today (no trap logic, so the core completes the misaligned load and the monitor catches it):

```
trap.S           MONITOR-ERROR 101
```

and by mutating one line of RTL (`rtl/writeback.v:74`, `in.rd_data` → `in.rd_data + 1`; reverted, `rtl/writeback.v` is untouched in this PR):

```
add.S            MONITOR-ERROR 105
addi.S           MONITOR-ERROR 105
and.S            MONITOR-ERROR 105
...
make test exit=2
```

## Gates

```
$ make test          # from clean
49/52 passed
Failure list matches test/EXPECTED_FAIL exactly.
make test exit=0

$ make test-units
== exec_tb ==
== mem_tb ==
== decoder_tb ==
== regfile_tb ==
== monitor_tb ==
monitor_tb: all vectors passed
test-units exit=0

$ make monitor-check
monitor-check exit=0        # tracked test/monitor.v byte-identical to the pin
```

iverilog `sorry:` notes: **20**, the documented pre-existing set from `rtl/executor.v`, unchanged (no RTL touched). yosys warnings: **1**, "Deep recursion in AST simplifier", confirmed identical between the old `sed`-sanitized monitor and the new script-sanitized one. `monitor_tb` compiles with zero diagnostics.

## Notes for review

- **Error 133 ("expected intr after trap") is unreachable** in this single-channel config — `shadow_pc_valid <= !rvfi_trap` gates both 130 and 133 off for the retire following a trap — so `rvfi_intr` staying hardwired 0 does not break the monitor. Stated in CLAUDE.md so nobody "fixes" it.
- **The upstream issue about the missing `!spec_trap` gate is deliberately not filed** — outward-facing, maintainer's call. The defect is in `monitor/generate.py` at the pinned SHA; per ADR-0019 the sanitizer rule should be deleted if a future pin bump fixes the codegen (the site-count assertion will fail loudly at that point, which is the signal).
- `fence.i` is **not** used anywhere here, so `-march` did not need `_zifencei`. `fence` and `wfi` do assemble at `rv32imc_zicsr` and are exercised in `csr.S`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
