### PR TITLE
JEF-654: Harden the monitor sanitizer's trap-gate rule against generator drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,7 +213,9 @@ jobs:
   # (CLAUDE.md invariant 7: generated but tracked, never hand-edited).
   # ADR-0013 asks CI to run this from a from-scratch clone, which is what a
   # fresh runner gives for free -- no oss-cad-suite needed here, just
-  # python3 and git, both preinstalled.
+  # python3 and git, both preinstalled. The job then reuses that same clone to
+  # check the repo's other vendored-from-the-pin file, formal/genchecks-local.py
+  # (ADR-0031); see the second step.
   monitor-freshness:
     name: monitor-freshness
     runs-on: ubuntu-latest
@@ -226,6 +228,17 @@ jobs:
 
       - name: make monitor-check
         run: make monitor-check
+
+      # The same control for the repo's OTHER vendored generated artifact.
+      # formal/genchecks-local.py is a copy of the pinned riscv-formal's
+      # checks/genchecks.py and may differ from it only by this repo's header
+      # and `basedir` (ADR-0031) -- a rule that until now lived only in a
+      # hand-run recipe in the script's own header, which nothing enforced.
+      # Runs here rather than in its own job because the step above has already
+      # paid for the from-scratch clone at the pin that this needs too, and
+      # like monitor-check it wants nothing but python3 and git.
+      - name: make -C formal genchecks-check
+        run: make -C formal genchecks-check
 
       - name: Report job wall time
         if: always()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,30 @@ sanitizer. (3) `test/monitor_tb.v` joins `make test-units`, driving the sanitize
 with hand-built trapping and non-trapping RVFI vectors — including a deliberately wrong one, so a
 gate that disabled all spec checking could not pass.
 
+**A site count proves a sanitizer rule fired, not what it swallowed.** Rule 3 selects its ~45-line
+span by *position* — first anchor (`rs1_addr`) to last (`mem_addr`) — so a pin bump that moved the
+trap comparison (`handle_error(101, "mismatch in trap")`) between those anchors would keep the count
+at 1, keep the diff at eight lines, and silently gate off the one assertion riscv-formal's
+`checks/rvfi_insn_check.sv` deliberately keeps live under `spec_trap`. A core that failed to trap on
+a misaligned load would then retire clean in **both** sim legs. So rule 3 now also asserts on
+*contents*: two forbidden literals in the span, the exact multiset of `handle_error` codes it
+encloses (derived from the current output — re-derive it after a pin bump, never edit it to silence
+a failure), and a post-check that error 101 survives into the sanitized output at all. All three
+were confirmed by mutation; the pre-change sanitizer accepted every one of them at exit 0.
+`test/monitor_tb.v` carries the simulation-side half (vector 7: a retire claiming `rvfi_trap = 0`
+where the spec model says it must trap — the existing wrong-retire control is non-trapping and
+passes happily without error 101). `trap.S` sits in `test/EXPECTED_FAIL` as `MONITOR-ERROR 101`
+today, which is that check doing its job against the missing M3 trap logic.
+
+**`make -C formal genchecks-check` is the drift control for the repo's other vendored generated
+file.** ADR-0031 permits `formal/genchecks-local.py` to differ from the pin's
+`checks/genchecks.py` by this repo's header and `basedir` and nothing else — but that rule lived
+only in a hand-run `cp` + `diff -u` recipe in the script's own header, which nothing enforced, and
+unenforced drift there is exactly what produced the five-year-stale fork ADR-0031 exists to end.
+`formal/check-genchecks.py` undoes those two documented edits and then requires byte equality with
+the clone, so any residual diff is drift by construction and is printed. It runs in CI in the
+`monitor-freshness` job, which has already paid for the from-scratch clone at the pin.
+
 `test/EXPECTED_FAIL` is **no longer empty**: `csr.S`, `minstret.S` and `trap.S` are seeded there
 ahead of the RTL that pays them off, which is the direction ADR-0014's burn-down contract was
 designed for. `make test` is **49 pass / 3 expected-fail** and still exits 0 only on set equality.

--- a/formal/Makefile
+++ b/formal/Makefile
@@ -26,6 +26,16 @@ check: checks $(RISCV_FORMAL_DIR)
 checks: genchecks-local.py checks.cfg | $(RISCV_FORMAL_DIR)
 	python3 $<
 
+# genchecks-local.py is vendored from the pin and may differ from it only by
+# this repo's header and `basedir` (ADR-0031). That rule used to be enforced by
+# a `cp` + `diff -u` recipe in the script's own header, run by hand or not at
+# all -- the same gap `make monitor-check` already closes for test/monitor.v,
+# the repo's other vendored generated artifact. Drift here is what produced the
+# five-year-stale fork ADR-0031 exists to end.
+.PHONY: genchecks-check
+genchecks-check: $(RISCV_FORMAL_DIR)/checks/genchecks.py genchecks-local.py | $(RISCV_FORMAL_DIR)
+	python3 check-genchecks.py $^
+
 dmemcheck: dmemcheck.sby dmemcheck.sv | $(RISCV_FORMAL_DIR)
 imemcheck: imemcheck.sby imemcheck.sv | $(RISCV_FORMAL_DIR)
 complete: complete.sby complete.sv | $(RISCV_FORMAL_DIR)

--- a/formal/check-genchecks.py
+++ b/formal/check-genchecks.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Fail if formal/genchecks-local.py has drifted from the pinned riscv-formal.
+
+genchecks-local.py is a vendored copy of riscv-formal's checks/genchecks.py at
+the SHA in formal/pin.mk. ADR-0031 says exactly two things may differ: this
+repo's header block, and `basedir` (spelled in two places -- the assignment and
+the isa-table open -- which are one change, not two).
+
+Until now the only control on that was a `cp` + `diff -u` recipe written in
+genchecks-local.py's own header, run by hand or not at all. Nothing failed when
+it was skipped. That is how this repo previously ended up carrying a pre-2021
+fork that had independently reinvented an engine-selection option upstream
+already had, could not generate ten upstream checks, and blocked the six csrc_*
+models outright (ADR-0031). The repo already solves this for the other vendored
+generated artifact -- `make monitor-check` regenerates test/monitor.v from a
+clone at the pin and diffs it -- and this is the same control for this file.
+
+Rather than diffing and eyeballing the result, this UNDOES the two documented
+edits and then requires byte equality with the clone. A residual diff is drift
+by construction, and it is printed.
+
+Usage: check-genchecks.py <upstream genchecks.py> <vendored genchecks-local.py>
+"""
+
+import difflib
+import sys
+
+# The header this repo prepends, delimited by text that exists in both files:
+# everything between the shebang's trailing bare `#` and upstream's copyright
+# line. Upstream has nothing there, so removing it should leave the two equal.
+HEADER_START = '#!/usr/bin/env python3\n#\n'
+HEADER_END = '# Copyright (C) 2017'
+
+# The `basedir` change, in both the places ADR-0031 accounts for. Each must
+# appear exactly once: a re-vendor that forgets one leaves genchecks resolving
+# paths against the caller's cwd, which fails in a way that looks like a broken
+# clone rather than a botched re-sync.
+BASEDIR_EDITS = (
+    (
+        'basedir assignment',
+        'basedir = os.path.abspath(os.path.join('
+        'os.path.dirname(os.path.realpath(__file__)), "riscv-formal"))',
+        'basedir = f"{os.getcwd()}/../.."',
+    ),
+    (
+        'isa-table open',
+        'open(f"{basedir}/insns/isa_{isa}.txt", "r")',
+        'open(f"../../insns/isa_{isa}.txt", "r")',
+    ),
+)
+
+
+def strip_header(text, path):
+    """Remove this repo's header block, returning upstream-shaped text."""
+    if not text.startswith(HEADER_START):
+        raise SystemExit(
+            f'{path}: does not start with the shebang and bare `#` both files\n'
+            f'share, so the vendored header cannot be located. Re-sync from the\n'
+            f'pin per this file\'s docstring.'
+        )
+    start = len(HEADER_START)
+    end = text.find(HEADER_END, start)
+    if end < 0:
+        raise SystemExit(
+            f'{path}: no {HEADER_END!r} line found. This is upstream\'s own\n'
+            f'copyright banner; its absence means the file is not a copy of\n'
+            f'checks/genchecks.py at all.'
+        )
+    header = text[start:end]
+    # Guard the delete: only comment lines may be removed this way. Code hidden
+    # in the header region would otherwise be stripped before the comparison and
+    # so would never show up as drift.
+    stray = [line for line in header.splitlines() if line and not line.startswith('#')]
+    if stray:
+        raise SystemExit(
+            f'{path}: the header region above the copyright banner contains\n'
+            f'non-comment lines, which this check will not silently drop:\n'
+            + '\n'.join(f'    {line}' for line in stray)
+        )
+    return text[:start] + text[end:]
+
+
+def main(argv):
+    if len(argv) != 3:
+        sys.stderr.write(f'usage: {argv[0]} <upstream> <vendored>\n')
+        return 2
+
+    upstream_path, vendored_path = argv[1], argv[2]
+    with open(upstream_path) as handle:
+        upstream = handle.read()
+    with open(vendored_path) as handle:
+        vendored = handle.read()
+
+    normalized = strip_header(vendored, vendored_path)
+    for name, ours, theirs in BASEDIR_EDITS:
+        count = normalized.count(ours)
+        if count != 1:
+            sys.stderr.write(
+                f'{argv[0]}: {vendored_path}: the documented "{name}" change appears\n'
+                f'{count} time(s), expected 1. ADR-0031 says this is one of exactly two\n'
+                f'permitted differences from the pin; re-apply it, or -- if upstream has\n'
+                f'restructured this code -- update BASEDIR_EDITS in {argv[0]} and say so\n'
+                f'in the ADR.\n'
+            )
+            return 1
+        normalized = normalized.replace(ours, theirs)
+
+    if normalized == upstream:
+        print(f'genchecks-check: {vendored_path} matches {upstream_path} at the pin '
+              f'(header + basedir only)')
+        return 0
+
+    sys.stderr.write(
+        f'{argv[0]}: {vendored_path} has DRIFTED from {upstream_path}.\n'
+        f'ADR-0031 permits exactly two differences -- this repo\'s header and the\n'
+        f'`basedir` change -- and both are undone before the comparison below, so\n'
+        f'everything shown is drift. Re-sync per the recipe in the vendored file\'s\n'
+        f'header; do not hand-patch upstream code in place.\n\n'
+    )
+    sys.stderr.writelines(difflib.unified_diff(
+        upstream.splitlines(keepends=True),
+        normalized.splitlines(keepends=True),
+        fromfile=f'{upstream_path} (at the pin)',
+        tofile=f'{vendored_path} (header and basedir normalized away)',
+    ))
+    return 1
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/test/monitor_tb.v
+++ b/test/monitor_tb.v
@@ -24,6 +24,13 @@
 //     Without this the bench could pass by checking nothing, and a gate that
 //     accidentally disabled all spec checking would look identical to a
 //     correct one;
+//   * a retire that FAILS TO TRAP when the spec model says it must is still
+//     REJECTED (vector 7, error 101). Vector 4 does not cover this: its wrong
+//     retire is non-trapping, so it passes just as happily with the trap
+//     comparison switched off. Error 101 is the one check upstream's
+//     checks/rvfi_insn_check.sv keeps live under spec_trap, which makes it the
+//     one the sanitizer's gate could swallow without changing a site count --
+//     see test/sanitize_monitor.py's rule 3;
 //   * an M3 instruction with no spec model (`ecall`, vector 6) is accepted
 //     silently, because spec_valid never asserts for it. That is not the gate
 //     working, it is the monitor having nothing to say -- the reason the trap
@@ -233,6 +240,36 @@ module monitor_tb;
                  MTVEC + 12, MTVEC,
                  32'd0, 4'b0000, 4'b0000, 32'd0, 32'd0);
     expect_errcode(16'd0, "ecall retire (no spec model exists -- unchecked)");
+
+    // 7. Positive control for the trap comparison ITSELF (error 101) -- the one
+    //    check riscv-formal's checks/rvfi_insn_check.sv deliberately keeps live
+    //    under spec_trap, and that test/sanitize_monitor.py's third rule must
+    //    therefore leave OUTSIDE the `!spec_trap` gate it inserts.
+    //
+    //    Vector 4's wrong retire is non-trapping, so it stays green even if the
+    //    trap comparison is disabled: nothing above would notice a sanitizer
+    //    that swallowed error 101 into its own gate. That is the silent failure
+    //    the span-contents assertions in test/sanitize_monitor.py exist to
+    //    prevent, and this vector is the simulation-side half of the same
+    //    check. It is the misaligned `lw` of vector 2 again, except the core
+    //    claims it completed normally -- rvfi_trap = 0, x5 written, pc_wdata =
+    //    pc+4, read mask strobed -- while the spec model reports spec_trap = 1.
+    //    A core that failed to trap on a misaligned load looks exactly like
+    //    this. Only 101 may fire: every other comparison sits inside the gate
+    //    and spec_trap holds, so they are switched off.
+    //
+    //    Deliberately last. It is the only vector reporting trap = 0 on a
+    //    trapping instruction, so it leaves the shadow PC valid and pointing at
+    //    an address no handler would resume from; anything appended after it
+    //    would report error 130 for reasons that have nothing to do with what
+    //    it is testing.
+    $display("monitor_tb: the monitor error banner below is EXPECTED (positive control)");
+    drive_retire(32'h0010_a283, 1'b0,
+                 5'd1, 5'd0, RAM, 32'd0,
+                 5'd5, 32'hdead_beef,
+                 MTVEC + 16, MTVEC + 20,
+                 RAM + 1, 4'b1111, 4'b0000, 32'hdead_beef, 32'd0);
+    expect_errcode(16'd101, "failure to trap on a misaligned lw is still caught");
 
     if (failures != 0) begin
       $display("monitor_tb: %0d vector(s) failed", failures);

--- a/test/sanitize_monitor.py
+++ b/test/sanitize_monitor.py
@@ -14,6 +14,13 @@ across a 45-line span rather than a single-line substitution, and because a
 from one that did its job. Every rule below declares how many sites it must hit
 and this script exits non-zero if the count is wrong.
 
+A site count proves a rule FIRED. It says nothing about WHAT it matched, and for
+rule 3 -- which selects a ~45-line span by position, from a first anchor to a
+last one -- that gap is the whole risk: a generator change that moves another
+check between the anchors keeps the count at 1 while quietly disabling that
+check. So rule 3 also asserts on the contents of its span, and this script
+re-checks the finished output. See rule 3's comment for the three layers.
+
 The diff `test/monitor.v` -> `test/monitor.sim.v` must stay small enough to read
 in full (`diff` it; it is currently eight lines). If it stops being readable at a
 glance, that is the signal to fix the generator upstream instead of adding a
@@ -80,6 +87,23 @@ UNSIGNED_SIGNED_DIVREM = (
 # `if (chN_spec_valid)` except the trap-flag comparison (error 101), which is
 # exactly the partition upstream's checker uses. Two lines are inserted and
 # nothing is reindented, so the diff stays readable.
+#
+# The span is selected by POSITION -- first anchor to last anchor -- so the site
+# count alone only proves the rule fired, not what it swallowed. That is not
+# enough. `assert(spec_trap == trap)` (error 101) is the one comparison
+# upstream's checker deliberately keeps live under `spec_trap`; if a pin bump
+# emitted it anywhere between the two anchors, the count would still read 1, the
+# diff would still be eight lines, and "did the core trap when the spec says it
+# should" would become vacuous on every trapping retire -- in BOTH sim legs,
+# silently, exactly as M3 starts producing trapping retires. So the rule also
+# asserts on the CONTENTS of what it is about to wrap, in three layers:
+#
+#   1. two literal markers that must not appear inside the span;
+#   2. the exact list of handle_error codes enclosed, which catches a relocated
+#      check however its comparison is spelled -- 101 is not on the list;
+#   3. after all rules run, that the trap comparison still exists in the output
+#      (see _check_trap_comparison_survives), which catches the generator
+#      dropping it rather than moving it.
 # ---------------------------------------------------------------------------
 TRAP_GATE_SPAN = re.compile(
     r'(?P<indent>[ ]*)if \((?P<ch>ch\d+)_rvfi_rs1_addr != (?P=ch)_spec_rs1_addr\b.*?'
@@ -87,13 +111,71 @@ TRAP_GATE_SPAN = re.compile(
     re.DOTALL,
 )
 
+# Layer 1. Both spellings of the trap comparison the generator emits today. A
+# match means the generator relocated it inside the span and gating it would
+# disable it.
+TRAP_GATE_FORBIDDEN = (
+    '"mismatch in trap"',
+    '_rvfi_trap != ',
+)
+
+# Layer 2. DERIVED, not chosen: this is the exact multiset of handle_error codes
+# the generator emits between the two anchors, read off test/monitor.v at the
+# SHA in formal/pin.mk. Compared sorted, so a harmless reordering inside the
+# span does not trip it but an added, removed or duplicated check does.
+#
+# After a pin bump, RE-DERIVE this from the new test/monitor.v -- read what the
+# generator now emits inside `if (chN_spec_valid)` and confirm each code belongs
+# under `!spec_trap` per riscv-formal's checks/rvfi_insn_check.sv. Do NOT edit it
+# to make a failure go away: a code appearing here that upstream keeps outside
+# the gate is precisely the silent-oracle failure this list exists to catch.
+TRAP_GATE_ENCLOSED_CODES = sorted(
+    [102, 103, 104, 105, 106, 108, 110, 120, 111, 121, 112, 122, 113, 123, 107]
+)
+
+# Layer 3. The generated monitor is `generate.py -c 1` (one retire channel, see
+# the root Makefile's MONITOR_GEN), so exactly one channel emits the check.
+TRAP_COMPARISON = re.compile(r'ch\d+_handle_error\(101, "mismatch in trap"\)')
+TRAP_COMPARISON_SITES = 1
+
+
+class SanitizerError(Exception):
+    """A rule matched, but not the text it was written to match."""
+
 
 def _wrap_in_trap_gate(match):
     indent = match.group('indent')
     channel = match.group('ch')
+    span = match.group(0)
+
+    for marker in TRAP_GATE_FORBIDDEN:
+        if marker in span:
+            raise SanitizerError(
+                f'  rule "gate spec-value checks on !spec_trap": the span it is about\n'
+                f'  to wrap contains {marker!r}, i.e. the generator now emits the\n'
+                f'  trap-flag comparison BETWEEN the rs1_addr and mem_addr anchors.\n'
+                f'  Gating it would silently disable the one check riscv-formal\n'
+                f'  (checks/rvfi_insn_check.sv) deliberately keeps live under\n'
+                f'  spec_trap. Re-anchor the span so the trap comparison stays\n'
+                f'  outside the gate; do not widen the anchors to swallow it.'
+            )
+
+    codes = sorted(int(c) for c in re.findall(
+        rf'{channel}_handle_error\((\d+),', span))
+    if codes != TRAP_GATE_ENCLOSED_CODES:
+        raise SanitizerError(
+            f'  rule "gate spec-value checks on !spec_trap": the span encloses\n'
+            f'  handle_error codes {codes}, expected\n'
+            f'  {TRAP_GATE_ENCLOSED_CODES}. The generator has moved a check into or\n'
+            f'  out of the gated region. Re-read each code against riscv-formal\'s\n'
+            f'  checks/rvfi_insn_check.sv to decide whether it belongs under\n'
+            f'  !spec_trap, then re-derive TRAP_GATE_ENCLOSED_CODES from the new\n'
+            f'  test/monitor.v -- do not edit the list to silence this.'
+        )
+
     return (
         f'{indent}if (!{channel}_spec_trap) begin\n'
-        f'{match.group(0)}'
+        f'{span}'
         f'{indent}end\n'
     )
 
@@ -108,6 +190,24 @@ RULES = [
 ]
 
 
+def _check_trap_comparison_survives(text):
+    """Layer 3: the trap comparison must still be in the sanitized output.
+
+    Layers 1 and 2 catch the generator MOVING error 101 inside the gate. Neither
+    notices it disappearing altogether -- the enclosed-code list would still
+    match and the site count would still be 1, while the sanitized oracle no
+    longer checks whether the core traps at all.
+    """
+    found = len(TRAP_COMPARISON.findall(text))
+    if found != TRAP_COMPARISON_SITES:
+        raise SanitizerError(
+            f'  post-check "the trap comparison survives": found {found} site(s) of\n'
+            f'  handle_error(101, "mismatch in trap") in the sanitized output,\n'
+            f'  expected {TRAP_COMPARISON_SITES}. Without it neither sim leg checks\n'
+            f'  whether the core traps when the spec model says it must.'
+        )
+
+
 def main(argv):
     if len(argv) != 2:
         sys.stderr.write(f'usage: {argv[0]} <monitor.v>\n')
@@ -117,10 +217,15 @@ def main(argv):
         text = handle.read()
 
     failures = []
-    for name, pattern, replacement, expected in RULES:
-        text, count = pattern.subn(replacement, text)
-        if count != expected:
-            failures.append(f'  rule "{name}": matched {count} site(s), expected {expected}')
+    try:
+        for name, pattern, replacement, expected in RULES:
+            text, count = pattern.subn(replacement, text)
+            if count != expected:
+                failures.append(f'  rule "{name}": matched {count} site(s), expected {expected}')
+        if not failures:
+            _check_trap_comparison_survives(text)
+    except SanitizerError as error:
+        failures.append(str(error))
 
     if failures:
         sys.stderr.write(


### PR DESCRIPTION
Closes JEF-654

One riscv-formal pin bump could silence both simulation oracles at once with every gate still green. Three weaknesses composed; this closes all three.

## 1. The sanitizer's trap-gate rule asserted on position, not contents

`test/sanitize_monitor.py`'s third rule (ADR-0019) picks a ~45-line span of the generated monitor with a DOTALL regex anchored on the first check (`rs1_addr`) and the last (`"mismatch in mem_addr"`), and wraps it in `if (!chN_spec_trap)`. Its site-count assertion proves the rule **fired** and says nothing about **what it swallowed**.

`ch0_handle_error(101, "mismatch in trap")` is the one comparison riscv-formal's own `checks/rvfi_insn_check.sv` deliberately keeps live under `spec_trap`. If a pin bump emitted it between the two anchors, the count would still read 1, the sanitized diff would still be 8 lines, and "did the core trap when the spec says it should" would go vacuous — in **both** sim legs, silently, exactly as the M3 trap work starts producing trapping retires.

Three layers now assert on contents:

1. two forbidden literals inside the span (`"mismatch in trap"`, `_rvfi_trap != `);
2. the exact multiset of enclosed `handle_error` codes — catches a relocated check however its comparison is spelled, since 101 is not on the list. **Derived from the current output, not guessed**; the comment says to re-derive after a pin bump rather than edit it to silence a failure;
3. a post-check that error 101 survives into the sanitized output at all — catches the generator *dropping* it rather than moving it.

**Sanitizer output on the real `test/monitor.v` is byte-identical to before.** This changes what the sanitizer *detects*, not what it *produces*.

### Mutation evidence (acceptance criterion 1)

Three hand-built monitors: trap check relocated inside the span; relocated with its message and operator respelled so the literals miss; deleted outright.

```
################ relocated: NEW sanitizer ################
  rule "gate spec-value checks on !spec_trap": the span it is about
  to wrap contains '"mismatch in trap"', i.e. the generator now emits the
  trap-flag comparison BETWEEN the rs1_addr and mem_addr anchors.
  Gating it would silently disable the one check riscv-formal
  (checks/rvfi_insn_check.sv) deliberately keeps live under
  spec_trap. Re-anchor the span so the trap comparison stays
  outside the gate; do not widen the anchors to swallow it.
EXIT: 1

################ disguised: NEW sanitizer ################
  rule "gate spec-value checks on !spec_trap": the span encloses
  handle_error codes [101, 102, 103, 104, 105, 106, 107, 108, 110, 111, 112, 113, 120, 121, 122, 123], expected
  [102, 103, 104, 105, 106, 107, 108, 110, 111, 112, 113, 120, 121, 122, 123]. ...
EXIT: 1

################ deleted: NEW sanitizer ################
  post-check "the trap comparison survives": found 0 site(s) of
  handle_error(101, "mismatch in trap") in the sanitized output,
  expected 1. Without it neither sim leg checks
  whether the core traps when the spec model says it must.
EXIT: 1

################ OLD sanitizer against all three ################
  old sanitizer, relocated: EXIT 0 (0 = shipped a silenced oracle)
  old sanitizer, disguised: EXIT 0 (0 = shipped a silenced oracle)
  old sanitizer, deleted:   EXIT 0 (0 = shipped a silenced oracle)
```

## 2. `monitor_tb` had no vector that would fail if the trap comparison were disabled

Its negative control (vector 4) drives a wrong **non-trapping** retire, so it passes just as happily with error 101 removed. New **vector 7**: a misaligned `lw` where the core claims `rvfi_trap = 0` while the spec model reports `spec_trap = 1` — what a core that failed to trap actually looks like. Only 101 may fire; every other comparison is inside the gate.

Placed last deliberately: it is the only vector reporting `trap = 0` on a trapping instruction, so it leaves the shadow PC valid and anything appended after it would report error 130 for unrelated reasons.

### Mutation evidence (acceptance criterion 2)

Removing the 3-line trap comparison from `test/monitor.sim.v`:

```
ok: correct add retire (errcode 0)
ok: trapping misaligned lw retire (errcode 0)
ok: correct addi retire after the trap (errcode 0)
ok: wrong rd_wdata is still caught (errcode 105)
ok: trapping misaligned sw retire (errcode 0)
ok: ecall retire (no spec model exists -- unchecked) (errcode 0)
FAIL: failure to trap on a misaligned lw is still caught: expected monitor errcode 101, got 0
monitor_tb: 1 vector(s) failed
MUTATED monitor_tb VVP EXIT: 1
```

Every pre-existing vector still passes under the mutation — vector 7 is the only thing that catches it. Unmutated: `UNMUTATED monitor_tb VVP EXIT: 0`, all vectors passed.

## 3. `genchecks-local.py` had no mechanical drift check

ADR-0031 permits it to differ from the pin's `checks/genchecks.py` by this repo's header and `basedir` and nothing else — but that rule lived only in a hand-run `cp` + `diff -u` recipe in the script's own header. No target, no CI job. Unenforced drift there is exactly what produced the five-year-stale fork ADR-0031 exists to end.

`formal/check-genchecks.py` **undoes** the two documented edits and then requires byte equality with the clone, so any residual diff is drift by construction and is printed. Runs in CI in the `monitor-freshness` job, which has already paid for the from-scratch clone at the pin.

### Evidence (acceptance criterion 3)

```
$ make -C formal genchecks-check
genchecks-check: genchecks-local.py matches riscv-formal/checks/genchecks.py at the pin (header + basedir only)
EXIT: 0
```

Edited vendored copy (`solver = "boolector"` -> `"btormc"`):

```
check-genchecks.py: genchecks-local.py has DRIFTED from riscv-formal/checks/genchecks.py.
...
-solver = "boolector"
+solver = "btormc"
make: *** [genchecks-check] Error 1
```

Dropped `basedir` hunk:

```
check-genchecks.py: genchecks-local.py: the documented "isa-table open" change appears
0 time(s), expected 1. ...
make: *** [genchecks-check] Error 1
```

## Gates (acceptance criterion 4)

| gate | result |
|---|---|
| `make test` | **exit 0** — 49/52, "Failure list matches test/EXPECTED_FAIL exactly" |
| `make test-units` | **exit 0** — all five benches; `monitor_tb` 7/7 |
| `make monitor-check` | **exit 0**, `test/monitor.v` untouched (invariant 7) |
| `make -C formal genchecks-check` | **exit 0** |
| iverilog `sorry:` notes | **20** (the documented `executor.v` set) |
| `git diff origin/main -- rtl/` | **empty** |

Incidentally: `trap.S` sits in `test/EXPECTED_FAIL` reporting `MONITOR-ERROR 101` today. That is this very check doing its job against the missing M3 trap logic — a live, in-suite demonstration that error 101 is load-bearing right now, not just after M3.

## Scope and risk

No `rtl/`. No ADR needed — ADR-0019 and ADR-0031 already govern; this hardens the existing mechanisms rather than deciding anything new. CLAUDE.md's description of the sanitizer was left incomplete by the site-count-only story and is updated.

The one judgement call: the enclosed-code list is compared **sorted**, so a harmless reordering inside the span does not trip it while an added, removed or duplicated check does. A stricter emission-order comparison would be more brittle for no safety gain.

Edits to `.github/workflows/ci.yml` (two steps in the `monitor-freshness` job) and `formal/Makefile` (one additive target) are kept minimal for the concurrent work on the `elaborate` job and the root Makefile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)