### PR TITLE
JEF-655: Hold sail-setup to formal/pin.mk's standard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,33 +51,51 @@ sim: test/cxxrtl.cc test/rtl.cc
 # still work on a machine with no Sail installed, and a time-boxed experiment
 # must not quietly become a merge gate. Run it by hand:
 #
-#     make sail-setup     # once: fetch the pinned sail-riscv release
+#     make sail-setup     # once: fetch, verify and unpack the pinned release
 #     make cosim          # build the architectural-state tracer
 #     make cosim-run      # run it on one program (PROG=add.S by default)
 # ---------------------------------------------------------------------------
 
-# The sail-riscv release this spike was run against. Pinned for the same
-# reason formal/pin.mk pins riscv-formal: an oracle that moves under you is
-# not an oracle.
+# The sail-riscv release this spike was run against, pinned the way
+# formal/pin.mk pins riscv-formal and for the same reason (ADR-0013): an oracle
+# that moves under you is not an oracle -- and this one is EXECUTED, by the
+# `--version` probe at the end of the fetch below and by every `make cosim-run`
+# after it, via test/cosim.py.
 #
-# It is NOT the same KIND of pin, and the difference is worth being exact
-# about. formal/pin.mk pins a 40-hex commit SHA with `override`,
-# verifies HEAD after checkout, and fails closed; ci.yml SHA256-verifies the
-# oss-cad-suite tarball. This is a plain variable naming a GitHub release
-# asset, fetched over `curl | tar xz` with no checksum and no signature --
-# and release assets are mutable, so the tag pins a NAME, not BYTES. The
-# unpacked binary IS executed: immediately below (`--version`) and on every
-# `cosim-run`. What keeps that acceptable for now is scope, not the fetch:
-# nothing on `make test`'s path or in any CI workflow reaches this target, so
-# it runs only when a maintainer types `make sail-setup` by hand. Wiring
-# co-sim into `make test` or CI (ADR-0032's integration item) means fixing
-# this first -- pin.mk is the shape to copy: a checksum over the tarball,
-# verified before anything out of it is executed.
+# A GitHub release asset is MUTABLE, so a version on its own pins a FILENAME,
+# not BYTES. The SHA-256 beside each asset name below is what pins the bytes,
+# and it is checked before anything is extracted, let alone run. Bumping the
+# version therefore means re-pinning all three digests; that friction is the
+# point, exactly as it is for RISCV_FORMAL_SHA.
 #
-# Overridable for a bisect; note that bumping it does NOT re-fetch, because
-# the rule below keys on the binary existing. `rm -rf tools/sail` first.
-SAIL_RISCV_VERSION ?= 0.13.1
-SAIL_RISCV_DIR     := tools/sail
+# An attempt to set the version from outside is REJECTED rather than ignored:
+# `override` alone would make `make SAIL_RISCV_VERSION=...` silently do
+# nothing, which reads as a working knob. This is a supply-chain control, not
+# a knob.
+#
+# ADR-0033 gap 4 recorded the unverified fetch as accepted-because-opt-in, with
+# "give it pin.mk's treatment" as the precondition for ever putting co-sim on
+# `make test` or CI. That precondition is met here. It is the only one: the
+# rest of ADR-0032's integration list (the `tohost` doubleword, a
+# COSIM_EXPECTED_FAIL baseline, a nightly job) is untouched, and co-simulation
+# stays off every default path.
+ifneq ($(filter command line environment,$(origin SAIL_RISCV_VERSION)),)
+$(error SAIL_RISCV_VERSION cannot be set from the command line or the \
+  environment: it pins bytes this repo executes. Change it in the Makefile, \
+  together with the SHA-256 digests below it)
+endif
+override SAIL_RISCV_VERSION := 0.13.1
+
+# Three-part, so a branch name, `latest`, or one of upstream's rolling
+# date-and-SHA tags (`2026-07-27-9901550`) cannot be written here by accident.
+# Upstream also ships two-part tags (`0.13`, `0.12`): bumping to one means
+# widening this regex deliberately, in the same commit as the new digests,
+# rather than discovering at fetch time that the guard was never the control.
+# The digests are.
+ifeq ($(shell printf '%s' '$(SAIL_RISCV_VERSION)' | grep -cE '^[0-9]+\.[0-9]+\.[0-9]+$$'),0)
+$(error SAIL_RISCV_VERSION must be a three-part release version like 0.13.1, \
+  not a branch, a moving tag or a range: '$(SAIL_RISCV_VERSION)')
+endif
 
 # Prebuilt, first-party release binaries from github.com/riscv/sail-riscv.
 # Building the model from source needs opam + OCaml + the Sail compiler
@@ -85,24 +103,127 @@ SAIL_RISCV_DIR     := tools/sail
 # unrelated WordPress deploy tool). The upstream release ships a macOS arm64
 # and two Linux tarballs, which covers every machine this repo is developed
 # and CI'd on, so the source build is not worth its cost here.
+#
+# Digests are `shasum -a 256` over all three 0.13.1 assets, downloaded fresh
+# and cross-checked against the per-asset digest the GitHub releases API
+# reports. All three are pinned deliberately: a host whose asset has no digest
+# here must fail closed rather than fetch something unverifiable, so the
+# recipe below refuses to run rather than skipping the check for one platform.
+SAIL_SHA256_sail-riscv-Mac-arm64     := 53d0c6fd84edd898728e7ba01c1575e66e5f17efd098847c5273690abbbd0737
+SAIL_SHA256_sail-riscv-Linux-x86_64  := ee052f64494a2f5f071afd9c2cb4aa5eaae4ba84753e4f77e442b4f83f2e9469
+SAIL_SHA256_sail-riscv-Linux-aarch64 := 3cd33a323d6749aec4667e54f71d2bf8e8e6e220a4e4bafd9083440f9a7e55f0
+
+SAIL_ASSET_Darwin_arm64   := sail-riscv-Mac-arm64
+SAIL_ASSET_Linux_x86_64   := sail-riscv-Linux-x86_64
+SAIL_ASSET_Linux_aarch64  := sail-riscv-Linux-aarch64
+
+SAIL_RISCV_DIR := tools/sail
+SAIL_SIM_BIN   := $(SAIL_RISCV_DIR)/bin/sail_riscv_sim
+SAIL_ASSET     := $(SAIL_ASSET_$(shell uname -s)_$(shell uname -m))
+SAIL_SHA256    := $(SAIL_SHA256_$(SAIL_ASSET))
+
+# tools/sail/.sail-pin, written only after the digest check passes. Line 1 is
+# the pin the tree was fetched under; line 2 is the SHA-256 of the unpacked
+# sail_riscv_sim, which is what test/cosim.py checks the binary against before
+# executing it. Line 1 is what makes a version bump re-fetch instead of
+# silently reusing whatever landed first -- the old rule keyed on the binary
+# merely existing, so the first binary to arrive was executed forever.
+SAIL_STAMP := $(SAIL_RISCV_DIR)/.sail-pin
+SAIL_PIN   := $(SAIL_RISCV_VERSION) $(SAIL_ASSET) $(SAIL_SHA256)
+
+# Fail closed, the way formal/pin.mk's HEAD check does: a tree on disk at
+# anything other than the pin stops the target that would execute it, rather
+# than being silently reused. `sail-setup` is exempt because it is the way out
+# of this state (pin.mk exempts `clean` for the same reason) -- it re-fetches
+# on a pin mismatch.
+#
+# Scoped to the goals that actually run the binary. A stale tools/sail must not
+# break `make test`: co-simulation is opt-in (ADR-0032) and a guard on it that
+# could fail the suite would have made it a gate by the back door.
+ifneq ($(filter cosim-run,$(MAKECMDGOALS)),)
+ifneq ($(wildcard $(SAIL_SIM_BIN)),)
+SAIL_PIN_ON_DISK := $(shell sed -n 1p $(SAIL_STAMP) 2>/dev/null)
+ifneq ($(SAIL_PIN_ON_DISK),$(SAIL_PIN))
+$(error $(SAIL_RISCV_DIR) was fetched under '$(SAIL_PIN_ON_DISK)', not the pin \
+  '$(SAIL_PIN)'. Re-fetch it with: make sail-setup)
+endif
+endif
+endif
+
+# Download to a file, verify the digest, audit the member paths, and only then
+# extract -- the previous recipe piped curl straight into tar, so bytes from
+# the network were unpacked before anything could reject them. `--version` runs
+# last, after verification, which is the order the comment above claims.
 .PHONY: sail-setup
-sail-setup: $(SAIL_RISCV_DIR)/bin/sail_riscv_sim
-$(SAIL_RISCV_DIR)/bin/sail_riscv_sim:
-	@case "$$(uname -s)/$$(uname -m)" in \
-	  Darwin/arm64)  asset=sail-riscv-Mac-arm64 ;; \
-	  Linux/x86_64)  asset=sail-riscv-Linux-x86_64 ;; \
-	  Linux/aarch64) asset=sail-riscv-Linux-aarch64 ;; \
-	  *) echo "no prebuilt sail-riscv for $$(uname -s)/$$(uname -m);" >&2; \
-	     echo "build it from https://github.com/riscv/sail-riscv and set" >&2; \
-	     echo "SAIL_RISCV_SIM to the resulting sail_riscv_sim." >&2; exit 1 ;; \
-	esac; \
-	url=https://github.com/riscv/sail-riscv/releases/download/$(SAIL_RISCV_VERSION)/$$asset.tar.gz; \
+sail-setup:
+	@set -e; \
+	if [ -z '$(SAIL_ASSET)' ]; then \
+	  echo "no prebuilt sail-riscv for $$(uname -s)/$$(uname -m);" >&2; \
+	  echo "build it from https://github.com/riscv/sail-riscv and set" >&2; \
+	  echo "SAIL_RISCV_SIM to the resulting sail_riscv_sim." >&2; \
+	  exit 1; \
+	fi; \
+	if [ -z '$(SAIL_SHA256)' ]; then \
+	  echo "no SHA-256 pinned for $(SAIL_ASSET) at $(SAIL_RISCV_VERSION);" >&2; \
+	  echo "add one beside the others in the Makefile. Fetching an asset this" >&2; \
+	  echo "repo cannot verify is not an option this target offers." >&2; \
+	  exit 1; \
+	fi; \
+	if command -v shasum >/dev/null 2>&1; then sha='shasum -a 256'; \
+	elif command -v sha256sum >/dev/null 2>&1; then sha='sha256sum'; \
+	else \
+	  echo "neither shasum nor sha256sum is on PATH; refusing to unpack a" >&2; \
+	  echo "tarball this machine cannot check." >&2; \
+	  exit 1; \
+	fi; \
+	if [ -x $(SAIL_SIM_BIN) ] && \
+	   [ "$$(sed -n 1p $(SAIL_STAMP) 2>/dev/null)" = '$(SAIL_PIN)' ]; then \
+	  want=$$(sed -n 2p $(SAIL_STAMP)); \
+	  got=$$($$sha $(SAIL_SIM_BIN) | cut -d ' ' -f 1); \
+	  if [ "$$want" != "$$got" ]; then \
+	    echo "$(SAIL_SIM_BIN) is not the binary its stamp was written for:" >&2; \
+	    echo "  recorded : $$want" >&2; \
+	    echo "  on disk  : $$got" >&2; \
+	    echo "the tree changed after it was verified. Start over with:" >&2; \
+	    echo "  rm -rf $(SAIL_RISCV_DIR) && make sail-setup" >&2; \
+	    exit 1; \
+	  fi; \
+	  echo "sail-riscv $(SAIL_RISCV_VERSION) already verified in $(SAIL_RISCV_DIR)"; \
+	  exit 0; \
+	fi; \
+	url=https://github.com/riscv/sail-riscv/releases/download/$(SAIL_RISCV_VERSION)/$(SAIL_ASSET).tar.gz; \
+	tmp=$(SAIL_RISCV_DIR).tmp; tgz=$$tmp/$(SAIL_ASSET).tar.gz; \
+	rm -rf $$tmp; mkdir -p $$tmp; \
 	echo "fetching $$url"; \
-	rm -rf $(SAIL_RISCV_DIR).tmp && mkdir -p $(SAIL_RISCV_DIR).tmp && \
-	curl -fsSL "$$url" | tar xz -C $(SAIL_RISCV_DIR).tmp --strip-components=1 && \
-	test -x $(SAIL_RISCV_DIR).tmp/bin/sail_riscv_sim && \
-	rm -rf $(SAIL_RISCV_DIR) && mv $(SAIL_RISCV_DIR).tmp $(SAIL_RISCV_DIR)
-	@$@ --version
+	curl -fsSL -o $$tgz "$$url"; \
+	got=$$($$sha $$tgz | cut -d ' ' -f 1); \
+	if [ "$$got" != '$(SAIL_SHA256)' ]; then \
+	  echo "sail-riscv tarball SHA-256 MISMATCH -- refusing to extract:" >&2; \
+	  echo "  asset    : $(SAIL_ASSET).tar.gz at $(SAIL_RISCV_VERSION)" >&2; \
+	  echo "  expected : $(SAIL_SHA256)" >&2; \
+	  echo "  actual   : $$got" >&2; \
+	  rm -rf $$tmp; \
+	  exit 1; \
+	fi; \
+	echo "sha256 ok: $$got"; \
+	tar tzf $$tgz | awk -v top='$(SAIL_ASSET)/' ' \
+	  index($$0, top) != 1 { print "member outside " top ": " $$0 > "/dev/stderr"; bad = 1 } \
+	  /(^|\/)\.\.(\/|$$)/  { print "traversal in member: " $$0 > "/dev/stderr"; bad = 1 } \
+	  END { exit bad ? 1 : 0 }' \
+	  || { echo "refusing to extract $(SAIL_ASSET).tar.gz" >&2; rm -rf $$tmp; exit 1; }; \
+	tar tvzf $$tgz | awk ' \
+	  substr($$1, 1, 1) !~ /^[-d]$$/ { print "not a file or directory: " $$0 > "/dev/stderr"; bad = 1 } \
+	  END { exit bad ? 1 : 0 }' \
+	  || { echo "refusing to extract $(SAIL_ASSET).tar.gz" >&2; rm -rf $$tmp; exit 1; }; \
+	tar xzf $$tgz -C $$tmp --strip-components=1 \
+	  --no-same-owner --no-same-permissions; \
+	rm -f $$tgz; \
+	test -x $$tmp/bin/sail_riscv_sim; \
+	printf '%s\n' '$(SAIL_PIN)' > $$tmp/.sail-pin; \
+	$$sha $$tmp/bin/sail_riscv_sim | cut -d ' ' -f 1 >> $$tmp/.sail-pin; \
+	rm -rf $(SAIL_RISCV_DIR); \
+	mv $$tmp $(SAIL_RISCV_DIR)
+	@$(SAIL_SIM_BIN) --version
 
 # The co-simulation runner: a SECOND cxxrtl binary, not a change to `sim`.
 # It reads the real `uut regfile regs` array through debug_items and reads no
@@ -271,7 +392,10 @@ clean:
 	@# NOT tools/sail either: it is a multi-megabyte network fetch that nothing
 	@# on `make test`'s path needs, so blowing it away on every `clean` costs a
 	@# download to get back something `clean` was never asked to rebuild.
-	@# `rm -rf tools/sail` by hand, or bump SAIL_RISCV_VERSION, to re-fetch.
+	@# Bumping SAIL_RISCV_VERSION and re-running `make sail-setup` re-fetches
+	@# on its own now -- the pin is recorded in tools/sail/.sail-pin and
+	@# compared, so this comment is no longer the only thing making that true.
+	@# `rm -rf tools/sail` still works as the blunt instrument.
 
 # The riscv-formal clone rule and its pin guard live in formal/pin.mk, included
 # above, so the root and formal/ Makefiles cannot drift apart on it.

--- a/test/cosim.py
+++ b/test/cosim.py
@@ -53,6 +53,7 @@ belongs in the integration ticket, not in a spike.
 """
 
 import argparse
+import hashlib
 import os
 import re
 import shutil
@@ -63,6 +64,12 @@ import tempfile
 REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 ASM_DIR = os.path.join(REPO, "test", "asm")
 MEMORY_MAP = os.path.join(REPO, "test", "sail", "memory-map.json")
+SAIL_DIR = os.path.join(REPO, "tools", "sail")
+SAIL_BIN = os.path.join(SAIL_DIR, "bin", "sail_riscv_sim")
+# Written by `make sail-setup` after it verifies the release tarball's SHA-256:
+# line 1 is the pin (version, asset, tarball digest), line 2 is the digest of
+# the unpacked sail_riscv_sim. See the Makefile's sail-setup target.
+SAIL_STAMP = os.path.join(SAIL_DIR, ".sail-pin")
 
 # `[123] [M]: 0x00000006 (0x00208733) add x14, x1, x2      test_2+4`
 INSN_RE = re.compile(
@@ -94,23 +101,90 @@ def find_cross_compiler():
     )
 
 
-def find_sail(explicit):
-    """Locate sail_riscv_sim: --sail, $SAIL_RISCV_SIM, tools/sail, then PATH.
+def sha256(path):
+    h = hashlib.sha256()
+    with open(path, "rb") as fh:
+        for chunk in iter(lambda: fh.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
 
-    Opt-in by construction (the ticket's constraint, and ADR-0032's): nothing
-    in `make test` reaches this function, and when the binary is absent the
-    message names the target that installs it rather than a build failure.
+
+def read_pin():
+    """(pin_line, binary_sha256) from tools/sail/.sail-pin, or (None, None)."""
+    try:
+        with open(SAIL_STAMP) as fh:
+            lines = [ln.strip() for ln in fh.read().splitlines() if ln.strip()]
+    except OSError:
+        return None, None
+    if len(lines) < 2:
+        return None, None
+    return lines[0], lines[1].split()[0]
+
+
+def find_sail(explicit):
+    """Locate sail_riscv_sim and check it against the pin before running it.
+
+    Returns (path, provenance). Two sources, in order:
+
+    1. `--sail` / `$SAIL_RISCV_SIM` -- a build a human named on purpose. This
+       is the documented escape hatch for a host with no prebuilt release
+       asset (the Makefile's sail-setup names it), so it is honoured even when
+       it does not match the pin -- but never silently: an unmatched binary is
+       announced on stderr with its digest.
+    2. `tools/sail/bin/sail_riscv_sim` -- must match the SHA-256 that
+       `make sail-setup` recorded in tools/sail/.sail-pin after verifying the
+       release tarball. A mismatch is fatal, not a warning: nobody named this
+       path, so an unexpected binary here is a substituted one, and tools/sail
+       is gitignored so it never shows up in `git status` or in review.
+
+    There is deliberately no bare PATH fallback. It executed whatever
+    `sail_riscv_sim` happened to be first on PATH, with no version or digest
+    check and nobody having asked for that particular build; naming it in
+    SAIL_RISCV_SIM is one environment variable away and is then a choice.
+
+    What this does NOT establish: the stamp is checked against the binary, not
+    against the Makefile. A whole tools/sail tree substituted along with its
+    stamp passes here. `make cosim-run` catches that -- the Makefile compares
+    line 1 of the stamp to its own `override` pin before running anything --
+    so the two checks are complementary and a direct ./test/cosim.py
+    invocation only gets this one.
+
+    Opt-in by construction (ADR-0032): nothing in `make test` reaches this
+    function, and when the binary is absent the message names the target that
+    installs it rather than a build failure.
     """
-    for candidate in (
-        explicit,
-        os.environ.get("SAIL_RISCV_SIM"),
-        os.path.join(REPO, "tools", "sail", "bin", "sail_riscv_sim"),
-    ):
-        if candidate and os.path.isfile(candidate) and os.access(candidate, os.X_OK):
-            return candidate
-    found = shutil.which("sail_riscv_sim")
-    if found:
-        return found
+    pin, want = read_pin()
+
+    named = explicit or os.environ.get("SAIL_RISCV_SIM")
+    if named:
+        if not (os.path.isfile(named) and os.access(named, os.X_OK)):
+            raise Fatal(f"{named} is not an executable file")
+        got = sha256(named)
+        if want is not None and got == want:
+            return named, f"pinned: {pin}"
+        print(f"warning: {named} was named explicitly and does not match the "
+              f"pin recorded in {SAIL_STAMP}; running it unverified "
+              f"(sha256 {got})", file=sys.stderr)
+        return named, f"unverified, named explicitly (sha256 {got})"
+
+    if os.path.isfile(SAIL_BIN) and os.access(SAIL_BIN, os.X_OK):
+        if want is None:
+            raise Fatal(
+                f"{SAIL_BIN} exists but {SAIL_STAMP} does not record the "
+                "digest it was verified against, so it was not installed by "
+                "the current 'make sail-setup'. Re-run it: "
+                f"rm -rf {SAIL_DIR} && make sail-setup"
+            )
+        got = sha256(SAIL_BIN)
+        if got != want:
+            raise Fatal(
+                f"{SAIL_BIN} does not match the digest recorded when it was "
+                f"verified.\n  recorded : {want}\n  on disk  : {got}\n"
+                "Refusing to execute it. Start over with: "
+                f"rm -rf {SAIL_DIR} && make sail-setup"
+            )
+        return SAIL_BIN, f"pinned: {pin}"
+
     raise Fatal(
         "sail_riscv_sim not found. Run 'make sail-setup' to install the pinned "
         "release into tools/sail/, or set SAIL_RISCV_SIM to an existing build."
@@ -290,7 +364,7 @@ def main():
 
     try:
         cc = find_cross_compiler()
-        sail = find_sail(args.sail)
+        sail, sail_provenance = find_sail(args.sail)
         if not os.path.isfile(args.cosim_binary):
             raise Fatal(f"{args.cosim_binary} not built. Run 'make cosim'.")
         src = args.program
@@ -313,6 +387,7 @@ def main():
     if not args.quiet:
         print(f"program            : {name}")
         print(f"sail               : {sail}")
+        print(f"sail provenance    : {sail_provenance}")
         print(f"sail changes       : {len(sail_records)}  "
               f"(spin-loop reached: {converged}, last pc=0x{last_pc:08x})")
         print(f"core changes       : {len(dut_records)}   (tohost: {verdict})")


### PR DESCRIPTION
Closes JEF-655

`make sail-setup` piped a GitHub release tarball into `tar xz` with no checksum and no signature, then executed the unpacked binary immediately (`--version`) and again on every `cosim-run` via `test/cosim.py`. Release assets are mutable, so `SAIL_RISCV_VERSION` pinned a filename, not bytes.

This repo already implements the control twice — `formal/pin.mk` (ADR-0013) and `.github/actions/setup-oss-cad-suite` — so the deviation was unexplained rather than reasoned. ADR-0033 gap 4 records it and names *"give this fetch pin.mk's treatment"* as the precondition for ever putting co-simulation on `make test` or CI. **That precondition is now met. Nothing else changes**: co-sim stays off `make test`, off `test-units` and off every CI workflow, and the rest of ADR-0032's integration list is untouched.

Scope: root `Makefile` (sail targets + the `clean` comment) and `test/cosim.py`. No `rtl/`, no `test/asm/`, no `formal/`, no `.gitignore` change needed (`tools/sail` was already ignored).

## What changed

- **Per-asset SHA-256 for all three release assets**, downloaded fresh and cross-checked against the digest the GitHub releases API reports. Download to a file, verify, *then* extract. A host whose asset has no pinned digest fails closed rather than skipping verification for one platform; so does a machine with neither `shasum` nor `sha256sum`.
- **`override` + three-part format guard**, and an attempt to set the version from the command line or the environment is *rejected*, not ignored — `override` alone makes `make SAIL_RISCV_VERSION=…` silently do nothing, which reads as a working knob.
- **`tools/sail/.sail-pin`**: line 1 the pin the tree was fetched under, line 2 the digest of the unpacked binary, written only after verification. The old rule keyed on the binary merely *existing*, so a version bump did not re-fetch (contradicting `clean`'s own comment) and the first binary to land was executed forever. Now `sail-setup` re-fetches on a pin mismatch, `cosim-run` fails closed on one, and a binary that changed after verification is a hard error on both paths.
- **Extraction hardening**: `--no-same-owner --no-same-permissions`, and member paths audited first — every entry must sit under the expected top directory, contain no `..` component, and be a regular file or directory.
- **`find_sail` verifies the binary against the pin.** The bare PATH fallback is gone. `--sail` / `$SAIL_RISCV_SIM` remain the escape hatch for a host with no prebuilt asset, but an unmatched binary there is announced with its digest instead of run quietly.

## Demonstrations

**1. Tampered tarball, correct filename — rejected before extraction.** (`curl` shadowed by a stub that serves mutated bytes for the same URL, i.e. a mutated release asset.)

```
fetching https://github.com/riscv/sail-riscv/releases/download/0.13.1/sail-riscv-Mac-arm64.tar.gz
[stub curl] serving tampered bytes to tools/sail.tmp/sail-riscv-Mac-arm64.tar.gz
sail-riscv tarball SHA-256 MISMATCH -- refusing to extract:
  asset    : sail-riscv-Mac-arm64.tar.gz at 0.13.1
  expected : 53d0c6fd84edd898728e7ba01c1575e66e5f17efd098847c5273690abbbd0737
  actual   : f8a584b6f480a3879e6d0f7b53950e1706e276c47b2410cece34794b46c213ba
make: *** [sail-setup] Error 1
--- did anything get extracted? ---
total 0        (tools/ is empty; the .tmp dir is removed)
```

**2a. Bumping the version re-fetches** (bumped to a deliberately nonexistent `0.13.2` — the point is it fetches instead of reporting "already verified"; the 404 is upstream's):

```
=== after bumping SAIL_RISCV_VERSION to 0.13.2, make sail-setup ===
fetching https://github.com/riscv/sail-riscv/releases/download/0.13.2/sail-riscv-Mac-arm64.tar.gz
curl: (56) The requested URL returned error: 404
```

**2b. A stale tree is a hard error, not silent reuse:**

```
$ make cosim-run
Makefile:140: *** tools/sail was fetched under '0.13.1 sail-riscv-Mac-arm64 53d0c6…0737',
not the pin '0.13.2 sail-riscv-Mac-arm64 53d0c6…0737'. Re-fetch it with: make sail-setup.  Stop.
```

**2c. And the re-fetch succeeds and rewrites the stamp** (stamp set to an older pin — the exact on-disk state a bump produces):

```
=== make sail-setup (pin on disk != Makefile pin) ===
fetching https://github.com/riscv/sail-riscv/releases/download/0.13.1/sail-riscv-Mac-arm64.tar.gz
sha256 ok: 53d0c6fd84edd898728e7ba01c1575e66e5f17efd098847c5273690abbbd0737
0.13.1
=== stamp after ===
0.13.1 sail-riscv-Mac-arm64 53d0c6fd84edd898728e7ba01c1575e66e5f17efd098847c5273690abbbd0737
8890af1f7c7fa7bcb01b4033b1d16013eeaff59e6c55851459007c8d9ee3cbba
=== make sail-setup again (now matching) ===
sail-riscv 0.13.1 already verified in tools/sail
```

**3. Overriding the version from outside is rejected:**

```
$ make SAIL_RISCV_VERSION=0.13 sail-setup
Makefile:76: *** SAIL_RISCV_VERSION cannot be set from the command line or the environment:
it pins bytes this repo executes. Change it in the Makefile, together with the SHA-256 digests below it.  Stop.

$ SAIL_RISCV_VERSION=main make sail-setup      # same error
$ make SAIL_RISCV_VERSION=latest test          # same error — no goal escapes it
```

And the format guard on the in-file value:

```
Makefile:89: *** SAIL_RISCV_VERSION must be a three-part release version like 0.13.1,
not a branch, a moving tag or a range: 'main'.  Stop.
```

**Swapped binary — caught on both paths:**

```
$ make sail-setup
tools/sail/bin/sail_riscv_sim is not the binary its stamp was written for:
  recorded : 8890af1f…cbba
  on disk  : 6f186352…23d8

$ ./test/cosim.py add.S      (exit 3)
error: …/tools/sail/bin/sail_riscv_sim does not match the digest recorded when it was verified.
```

**Member audit, against crafted archives** (traversal, absolute path, symlink):

```
traversal in member: sail-riscv-Mac-arm64/../../../../tmp/pwned
member outside sail-riscv-Mac-arm64/: /etc/cron.d/pwned
not a file or directory: lrw-r--r-- … sail-riscv-Mac-arm64/evil-link -> /etc/passwd
```

**5. `make test` still green with no Sail installed** (`tools/sail` moved aside, `tools/` empty):

```
$ ./test/cosim.py add.S
error: sail_riscv_sim not found. Run 'make sail-setup' to install the pinned release
into tools/sail/, or set SAIL_RISCV_SIM to an existing build.
EXIT=3

$ make test
49/52 passed
Failure list matches test/EXPECTED_FAIL exactly.
make test EXIT=0
```

And end-to-end afterwards, unchanged from ADR-0032's numbers:

```
$ make cosim-run
sail provenance    : pinned: 0.13.1 sail-riscv-Mac-arm64 53d0c6fd…0737
AGREE add.S: 218 architectural register-file changes, identical in order and value.
```

## Judgement calls worth a reviewer's eye

- **The `cosim-run` guard is a *scoped* parse-time error**, not a global one like `pin.mk`'s. A stale `tools/sail` must not be able to fail `make test` — a security guard on an opt-in leg that could break the suite would have made it a gate by the back door (ADR-0032). `sail-setup` is exempt because it is the way out, the way `clean` is for `pin.mk`.
- **Three-part format guard as specified, and upstream also ships two-part tags** (`0.13`, `0.12`). Bumping to one means widening the regex deliberately in the same commit as the new digests. The comment says so at the point a bumper would hit it; the digests, not the regex, are the byte pin.
- **The digest variables are keyed by asset, not by version.** Bumping the version without re-pinning digests therefore fails loudly at the checksum step rather than passing silently — the friction is intended, but it is worth knowing that is where it lands.
- **What the stamp does not establish**, stated in `find_sail`'s docstring rather than left implied: it binds the binary to the tree's own stamp, not to the Makefile. A whole `tools/sail` substituted *along with* its stamp passes `find_sail`; `make cosim-run` catches it, a direct `./test/cosim.py` does not. The two checks are complementary and neither is claimed to be the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
