### PR TITLE
ADR-0034: what the CSR ladder checks cannot see, and the decisions the CSR file forced

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -315,18 +315,26 @@ the oracle (ADR-0019).
 
 - **Compiler and elaboration warnings are errors.** Fix them; don't silence them.
   **One documented exception**, and only this one: iverilog emits `sorry: constant selects in
-  always_* processes are not fully supported` for every struct-field read inside an `always_*`
-  block — 20 of them, all from `rtl/executor.v`'s `in.is_*` flags. It cannot build a precise
-  sensitivity entry for a constant part-select, so it falls back to whole-struct sensitivity.
+  always_* processes are not fully supported` for every struct-field read inside an
+  **`always_comb`** block — 20 of them, all from `rtl/writeback.v`, against
+  `in[311:0]` (`accessor_output`). It cannot build a precise sensitivity entry for a constant
+  part-select, so it falls back to whole-struct sensitivity.
   **That fallback is provably safe**: over-sensitivity re-evaluates redundantly and can never
   yield a stale value; only *under*-sensitivity is a correctness bug. Everywhere the select was
   cheap to hoist into a named continuous assign it has been (`rtl/decoder.v`'s register-index
-  fields, `rtl/accessor.v`'s payload fields, `test/testbench.v`'s ROM index) — that silenced 17
-  of 37 and reads better besides. `rtl/executor.v` keeps the `in.` form because its body is one
-  `case (1'b1)` over 39 flags, and hoisting all of them would add ~80 lines of plumbing to the
-  module whose legibility matters most. Copying the struct to a local does not help (still a
-  constant select); `always @(in)` would, but trades away `always_comb`'s latch checking for
-  exactly the sensitivity iverilog already infers. Do not add new ones outside `executor.v`.
+  fields, `rtl/accessor.v`'s payload fields, `test/testbench.v`'s ROM index, and
+  `rtl/writeback.v`'s twelve CSR payload reads) — and it reads better besides.
+  `rtl/writeback.v` keeps the `in.` form in its two `always_comb` blocks because hoisting all
+  30 reads would add more plumbing than it removes. Copying the struct to a local does not help
+  (still a constant select); `always @(in)` would, but trades away `always_comb`'s latch
+  checking for exactly the sensitivity iverilog already infers.
+  **The diagnostic is specific to `always_comb`**, where the sensitivity list is *inferred*.
+  `rtl/executor.v` emits **zero** of these despite its `case (1'b1)` over 39 `in.is_*` flags,
+  because that body sits in `always_ff @(posedge clk)`, whose sensitivity is written out.
+  Compile any module alone to attribute them (`iverilog -g2012 -s <mod> rtl/structs.v
+  rtl/<mod>.v`). **Do not add new ones outside `rtl/writeback.v`**, and prefer a continuous
+  assign for any new struct-field read in an `always_comb` — that is what holds the count at 20
+  (ADR-0034; this bullet named `rtl/executor.v` until then, which was measurably wrong).
 - **Every non-trivial change adds or updates tests and runs the full suite** before being declared
   done. Elaboration succeeding is not a substitute for tests passing.
 - **Never commit build artifacts.** `test/rtl.cc`, `sim`, `*.vvp`, `*.vcd`, `rvfi_macros.vh`, and

--- a/docs/adr/0034-what-the-csr-ladder-checks-cannot-see.md
+++ b/docs/adr/0034-what-the-csr-ladder-checks-cannot-see.md
@@ -1,0 +1,139 @@
+# ADR-0034: What the CSR ladder checks cannot see, and the decisions the CSR file forced
+
+**Status:** Accepted · 2026-07-31 · *Recorded at integration. Amends ADR-0005's decode-side field
+list and ADR-0027's note on the `h` halves; supplements ADR-0028 and ADR-0033 on what a green
+ladder does not establish; corrects a `CLAUDE.md` engineering rule.*
+
+## Context
+
+The CSR file (`rtl/csrs.v`) landed as a sibling of the decoder, with `csrw_mcycle_ch0`,
+`csrw_minstret_ch0` and `csrw_mscratch_ch0` all passing and `formal/EXPECTED_FAIL` matching
+exactly at 79 checks / 70 pass / 9 fail. Four questions came up during that work that the
+existing ADRs did not answer, and one measurement contradicted a rule `CLAUDE.md` states as a
+documented exception. All five are recorded here rather than left in a review thread, which is
+the treatment ADR-0033 established for this shape of finding.
+
+## Decision
+
+### 1. `decoder_output` loses the three Zicsr op flags; `csr_addr`/`is_csr_imm` stay, with a sunset condition
+
+`is_csrrw`/`is_csrrs`/`is_csrrc` are **gone, and their removal is forced rather than cosmetic.**
+ADR-0005 prescribes that the CSR read result rides the `is_add` pass-through. `rtl/executor.v`'s
+op select is a single `(* parallel_case *) case (1'b1)`, so an instruction that set both `is_add`
+and a CSR flag would make two arms match at once — under `parallel_case` that is an assertion to
+synthesis that cannot happen, i.e. a lie, not mere redundancy. The executor's own `$onehot0` over
+the flag set says the same thing. They could not coexist with ADR-0005's own prescription.
+
+`csr_addr` and `is_csr_imm` were added as ADR-0005 specifies and **have no downstream consumer
+today** — a CSR access is read, computed and committed entirely in decode, so nothing after decode
+needs either. They are **kept**, for one reason: without `RISCV_FORMAL` there is no `rvfi.insn` in
+the struct, so they are the only place a waveform reader on the iverilog leg can tell a CSR access
+apart from the add it is disguised as. That leg is load-bearing (`CLAUDE.md`'s verification table).
+
+**The sunset condition is explicit, so this cannot rot quietly: if the trap-entry change lands
+without either field acquiring a consumer, strike them both in that change.** Thirteen bits of
+`decoder_output` is not worth carrying indefinitely on a debuggability argument alone, and a
+struct field nothing reads is exactly the incidental machinery this project's stated goal warns
+against.
+
+### 2. ADR-0027's trapping-`minstret` rule belongs in `trap.S`, not `minstret.S`
+
+ADR-0027 states two counter rules. They have different preconditions and the partition follows
+that, rather than following the file names:
+
+- **exactness** (`csrr`/`nop`×3/`csrr`/`sub` differs by exactly 4 only because the stall exists)
+  needs no trap, and stays in `test/asm/minstret.S`, which passes today;
+- **a trapping instruction does not increment `minstret`** needs a *takeable* trap, which does not
+  exist until trap entry lands. It is written and waiting as `test/asm/trap.S` tests 14 and 15,
+  and `trap.S` stays baselined in `test/EXPECTED_FAIL`.
+
+**Confirmed as correct.** Splitting a single ADR's rules across two files is the right call when
+one rule's precondition is a feature that does not exist yet: the alternative is either baselining
+`minstret.S` wholesale — losing the exactness check that *does* pass — or writing the assertion
+nowhere and rediscovering it later. Test 15 re-reads `trap_count` so test 14 cannot pass against a
+sequence that never entered the handler.
+
+### 3. `genchecks` defines `RISCV_FORMAL_CSRWH` itself, so the `h` halves are exercised
+
+The assumption going in was that the ladder would not reach `mcycleh`/`minstreth`. **That was
+wrong, and the correction matters.** `formal/genchecks-local.py` does
+
+```python
+    if csr_mode and insn in ("mcycle", "minstret"):
+        print("`define RISCV_FORMAL_CSRWH", file=sby_file)
+```
+
+unconditionally for exactly those two. With it defined, `checks/rvfi_csrw_check.sv` admits the
+`h` address in its `assume`, and asserts `csr_insn_changed_full[31:0] == 0` on a high-half write
+and `[63:32] == 0` on a low-half one.
+
+So `rtl/csrs.v` reporting **per-half masks** (`{{32{wr_mcycleh}}, {32{wr_mcycle}}}`) is not merely
+a tidy choice — it is **required**. A uniform 64-bit mask across both halves would fail that
+assertion on an otherwise correct core. ADR-0027's remark that the `h` halves are out of reach is
+amended accordingly.
+
+### 4. `csrw_mscratch_ch0` cannot see the CSRRS/CSRRC `rs1 == x0` write suppression
+
+Measured, not assumed. Deleting that suppression from `rtl/decoder.v` leaves `csrw_mscratch_ch0`
+**PASSing**. `rvfi_csrw_check` reasons entirely over reported masks and data, and a
+suppressed-write-that-fires computes `rdata | 0` — the same value, with `smask` and `cmask` both
+zero — so no assertion in the check can distinguish it. The rule only becomes architecturally
+observable once an illegal write to a read-only CSR raises a trap.
+
+`test/decoder_tb.v` **does** fail on that mutation, which is the layered defence working as
+designed rather than a defect in either layer.
+
+For the record, a mutation the ladder check **does** catch: making CSRRC compute `rdata | arg`
+instead of `rdata & ~arg` gives `bad state property 11 reachable at bound k = 30 SATISFIABLE`.
+Both mutations were reverted; the finding is recorded beside the `[csrs]` list in
+`formal/checks.cfg`.
+
+**This is the same species as ADR-0028's "which existing checks enforce which parts, indirectly"
+and ADR-0033's audit of the machinery M2 is measured by.** A green `csrw_*` is a statement about
+the reported CSR interface, not about the decode-side suppression rules that feed it.
+
+Relatedly, and already recorded beside that list: `mtvec`, `mepc`, `mcause` and `mstatus` are
+deliberately **off** `[csrs]`, because `rvfi_csrw_check.sv` has no WARL model and would fail them
+on a *correct* core. Those are checked field-by-field in `test/csr_tb.v`.
+
+### 5. `CLAUDE.md`'s `sorry:` attribution was wrong, and the rule it carries pointed at the wrong file
+
+The engineering-rules bullet said the 20 iverilog `sorry: constant selects in always_* processes`
+notes were "all from `rtl/executor.v`'s `in.is_*` flags", and closed with "do not add new ones
+outside `executor.v`".
+
+**Measured: `rtl/executor.v` emits zero. All 20 come from `rtl/writeback.v`**, against
+`in[311:0]` (`accessor_output`):
+
+```
+iverilog -g2012 -s executor  rtl/structs.v rtl/executor.v    ->  0
+iverilog -g2012 -s writeback rtl/structs.v rtl/writeback.v   -> 20
+```
+
+The reason is principled rather than a toolchain accident: the diagnostic is about an **inferred**
+sensitivity list, so it is specific to `always_comb`. `rtl/executor.v`'s `case (1'b1)` over 39
+flags sits inside `always_ff @(posedge clk)`, whose sensitivity is written out and needs no
+inference. `rtl/writeback.v`'s two `always_comb` blocks are the real source.
+
+This is load-bearing misinformation in a clause whose whole purpose is to bound an accepted
+warning: as written it forbade adding notes in the one file that has none, and licensed them in
+the file that has all of them. `CLAUDE.md` is corrected, and now states the `always_comb`
+mechanism and the one-line command that attributes them, so the next reader can check rather than
+inherit the claim.
+
+## Consequences
+
+- The count stays **exactly 20**. The CSR change kept it there by driving `rtl/writeback.v`'s
+  twelve new CSR payload reads as continuous assigns rather than adding them to the `always_comb`
+  block — which is now the documented pattern for any new struct-field read.
+- `fence` and `wfi` are **still unrecognised instructions** rather than the NOPs ADR-0005
+  specifies. `instr_ecall`/`instr_ebreak` require `funct12` of exactly 0 and 1, and `fence`'s
+  opcode is not in `instr_valid` at all. This is harmless today — an unrecognised instruction has
+  its execution flags suppressed and no trap is taken — but it becomes **wrong the moment trap
+  entry makes "unrecognised" mean illegal-instruction**, at which point a legal `fence` faults.
+  Recorded here because that is the change that must fix it.
+- `formal/complete` was already failing for retiring `ecall`/`ebreak`/unrecognised instructions;
+  CSR instructions join that set. It is not on any gate, and ADR-0022/ADR-0023 already record it.
+- Nothing here changes the M2 signal. Every ladder check is `mode bmc`, so PASS means "no
+  counterexample within the configured depth", and everything still runs under
+  `RISCV_FORMAL_ALTOPS` (ADR-0010).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -38,6 +38,7 @@ and what it costs. Reversing one is fine — write a new ADR that supersedes it.
 | [0031](0031-the-vendored-genchecks-copy-tracks-the-pin.md) | The vendored `genchecks` copy tracks the pin, and only `basedir` differs | Accepted |
 | [0032](0032-sail-co-simulation-is-worth-building-and-stays-opt-in.md) | Sail co-simulation is worth building, and stays opt-in | Accepted |
 | [0033](0033-what-the-green-ladder-does-not-cover.md) | What a green ladder does not cover — three assurance gaps, named | Accepted |
+| [0034](0034-what-the-csr-ladder-checks-cannot-see.md) | What the CSR ladder checks cannot see, and the decisions the CSR file forced | Accepted |
 
 0001–0007 came from the design brief
 ([`docs/ideas/finish-the-rewrite.md`](../ideas/finish-the-rewrite.md)). 0008–0011 came out of
@@ -62,7 +63,10 @@ measurement intact — and records why none of the ten `fault`/`bus_*` checks it
 0032 came out of a time-boxed spike against the Sail RISC-V model and resolves the "Spike or Sail
 co-simulation" item that used to sit in the deferred list below. 0033 came out of integrating those
 three together: it audits the machinery M2 is *measured* by rather than the core it measures, and
-records what a green ladder and a matching baseline do not, on their own, establish.
+records what a green ladder and a matching baseline do not, on their own, establish. 0034 came out of
+integrating the CSR file: it records the two decode-side decisions ADR-0005's field list left open,
+corrects ADR-0027 on the counter `h` halves, measures what the `csrw_*` checks cannot see, and fixes
+a `CLAUDE.md` engineering rule that named the wrong file.
 
 ## Deferred decisions
 


### PR DESCRIPTION
Recorded at integration of the CSR file, the sanitizer hardening and the sail-setup pinning.

Five things, all of which came out of that integration and none of which the existing ADRs answered:

1. **`decoder_output`'s Zicsr fields.** The three op flags (`is_csrrw`/`is_csrrs`/`is_csrrc`) had to go — they cannot coexist with ADR-0005's own `is_add` pass-through under the executor's `(* parallel_case *)` select, where two matching arms are a lie to synthesis. `csr_addr`/`is_csr_imm` were added per ADR-0005 and have no downstream consumer today; they are kept for the iverilog leg (without `RISCV_FORMAL` there is no `rvfi.insn`, so they are the only way a waveform tells a CSR access from the add it is disguised as) **with an explicit sunset condition** — if the trap-entry change does not give them a consumer, strike them there.
2. **ADR-0027's trapping-`minstret` rule lives in `trap.S`.** It needs a takeable trap; the exactness rule does not, and stays in `minstret.S`, which passes today. Confirmed as the right partition.
3. **`genchecks` defines `RISCV_FORMAL_CSRWH` itself** for `mcycle`/`minstret`. The assumption that it would not was wrong, and it matters: the `h` halves are exercised, and `rtl/csrs.v`'s per-half masks are **required** rather than merely tidy — a uniform 64-bit mask would fail `csr_insn_changed_full` on a correct core. Amends ADR-0027.
4. **`csrw_mscratch_ch0` cannot see the CSRRS/CSRRC `rs1 == x0` write suppression.** Measured: deleting the suppression leaves the check PASSing, because a suppressed-write-that-fires computes `rdata | 0` with `smask` and `cmask` both zero. `test/decoder_tb.v` does catch it. Same species as ADR-0028's indirect-enforcement section and ADR-0033's audit.
5. **`CLAUDE.md`'s `sorry:` attribution was wrong.** It said all 20 notes come from `rtl/executor.v`. Measured, per-module:

   ```
   iverilog -g2012 -s executor  rtl/structs.v rtl/executor.v    ->  0
   iverilog -g2012 -s writeback rtl/structs.v rtl/writeback.v   -> 20
   ```

   All 20 are `rtl/writeback.v`, against `in[311:0]` (`accessor_output`). The reason is principled: the diagnostic is about an *inferred* sensitivity list, so it is specific to `always_comb`; `executor.v`'s 39-flag `case (1'b1)` sits in `always_ff @(posedge clk)`, whose sensitivity is written out. The bullet is a documented-exception clause, so as written it forbade adding notes in the one file that has none and licensed them in the file that has all of them. Corrected, with the attribution command inline so the next reader can check rather than inherit the claim.

Also records that `fence`/`wfi` are still unrecognised rather than the NOPs ADR-0005 specifies — harmless today, wrong the moment trap entry makes "unrecognised" mean illegal-instruction — placed where the trap change will see it.

Docs only; no `rtl/` change. The count stays at exactly 20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)