### PR TITLE
JEF-656: harden the test gate — an assembler or objcopy failure must not be able to report PASS

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,7 +115,12 @@ the clone, so any residual diff is drift by construction and is printed. It runs
 `test/EXPECTED_FAIL` is **no longer empty**: `csr.S`, `minstret.S` and `trap.S` were seeded there
 ahead of the RTL that pays them off, which is the direction ADR-0014's burn-down contract was
 designed for. Two of the three are paid off (below); `trap.S` remains, so `make test` is
-**51 pass / 1 expected-fail** and still exits 0 only on set equality.
+**51 pass / 1 expected-fail** and still exits 0 only on set equality. That equality is now over
+**name-and-status pairs** (ADR-0035) — the baselined entry is `trap.S      MONITOR-ERROR 101`, so a
+baselined test that starts failing some *other* way (a broken assembly, a `TIMEOUT`, an unstartable
+runner) is a red gate rather than a match. The same change made every build step's exit status
+checked and `mktemp` fatal: an unchecked `objcopy` that emitted an **empty** RAM image used to make
+`tohost` read zero and every data-independent test still report `PASS`.
 `test/run_tests.sh` also grew a `MONITOR-ERROR` label for runner exit 4, which used to fall into
 `RUNNER-ERROR` and read as "the sim would not start" when it actually means the per-retire oracle
 disagreed with the core mid-run. **Nothing here checks M3 semantics against an oracle**:

--- a/Makefile
+++ b/Makefile
@@ -472,11 +472,17 @@ lint-setup:
 # test/asm/*.S; these are unit benches with their own, unrelated pass/fail
 # mechanism) but `test` depends on it so one `make test` still catches
 # everything.
+#
+# `set -e` comes FIRST, before mktemp and before the trap (ADR-0035). The
+# other order installed the cleanup trap on an unchecked $$tmp: a failed
+# mktemp left it empty, every -o path collapsed to the filesystem root, and
+# the trap then removed nothing.
 .PHONY: test-units
 test-units: test/monitor.sim.v
-	@tmp=$$(mktemp -d "$${TMPDIR:-/tmp}/test-units.XXXXXX"); \
+	@set -e; \
+	tmp=$$(mktemp -d "$${TMPDIR:-/tmp}/test-units.XXXXXX"); \
+	test -n "$$tmp" -a -d "$$tmp"; \
 	trap 'rm -rf "$$tmp"' EXIT; \
-	set -e; \
 	echo "== exec_tb =="; \
 	iverilog -I./rtl/ -g2012 -o $$tmp/exec_tb.vvp rtl/structs.v rtl/executor.v test/exec_tb.v; \
 	vvp $$tmp/exec_tb.vvp; \

--- a/docs/adr/0035-the-baseline-pins-the-failure-mode.md
+++ b/docs/adr/0035-the-baseline-pins-the-failure-mode.md
@@ -1,0 +1,128 @@
+# ADR-0035: `test/EXPECTED_FAIL` pins the failure mode, not just the file name
+
+**Status:** Accepted · 2026-07-31 · *Amends ADR-0014. Same shape as ADR-0033's "a check that can
+stop checking without anything going red."*
+
+## Context
+
+`test/run_tests.sh` is the merge gate. `make test` calls it, CI's `test` job calls `make test`, and
+its exit status is what decides whether a change lands. A gate that reports success without having
+tested anything is therefore the failure mode that matters here — more than any bug it might miss,
+because a false green disables every other check downstream of it at once.
+
+A review of the script found three ways it could do exactly that, plus a fourth smaller one. None
+is exploitable — this repo has no service, no secrets, no untrusted input, and read-only CI — so
+this is ordinary robustness, recorded because the machinery is load-bearing.
+
+**1. The objcopy exit status was discarded.** The script set no error-exit option, and the next
+thing to read an exit code was the `case` over the simulator's status. Both `objcopy` calls (ADR-0008's
+two images) ran unchecked. A failing objcopy — a binutils without `--verilog-data-width`, a full
+disk, a `--only-section` filter matching nothing — left no image or a truncated one, and the
+simulator ran against it anyway, with its verdict reported as if it were about the CPU.
+
+The worst case is specific and quiet: **an empty RAM image**. The hex parser accepts an empty file,
+the `tohost` word reads zero, and every test with no data dependency still executes to
+`RVTEST_PASS` and exits 0. The gate prints PASS for a test that never received its data image. The
+objcopy error text landed in the build log, but the log was printed only for tests that *failed* —
+so on a false PASS the diagnostic was discarded too.
+
+**2. The failure set recorded only the test name.** ADR-0014's contract is a set equality against
+`test/EXPECTED_FAIL`, in both directions, so an unexpected pass is caught as well as an unexpected
+failure. But the set's elements were bare filenames, so the comparison was blind to *why* a test
+failed. `trap.S` is baselined for a precise reason — `MONITOR-ERROR 101`, "mismatch in trap", the
+one spec-value check ADR-0033 gap 2 deliberately keeps live under `spec_trap`. If it instead began
+reporting `ASSEMBLE-ERROR` (someone breaks the assembly, or the assembler regresses),
+`TIMEOUT`, or `RUNNER-ERROR` (the sim binary will not start), the name was still in the failure set
+and the gate exited 0. A broken test and a broken *harness* were both laundered into a green merge
+gate. An assembler error passing silently also defeats the project's warnings-are-errors rule,
+which the `ASSEMBLE-WARNING` label exists to enforce.
+
+**3. The temp directory creation was unchecked.** With no error-exit option, a failed `mktemp` left
+`$tmp` empty and every artifact path collapsed to the filesystem root (`/add.elf`, `/add.rom.hex`).
+The cleanup trap then removed nothing. On a CI container running as root those writes succeed, so a
+later run whose objcopy also failed could pick up the *previous* run's stale image and report PASS
+from an image the current build never produced. It also moved the images out of `mktemp`'s private
+0700 directory onto fixed, predictable paths. The same trap-before-`set -e` ordering was in the
+Makefile's `test-units` recipe.
+
+**4.** The baseline file itself was read with no existence check. A missing or mistyped path yielded
+an empty expected set, and against an all-passing suite the gate printed "Failure list matches
+`test/EXPECTED_FAIL` exactly" having compared nothing.
+
+## Decision
+
+**The gate checks every step that produces the thing it tests, and the baseline pins the failure
+mode.**
+
+### The baseline format grows a second field — this is the ADR-0014 amendment
+
+`test/EXPECTED_FAIL` entries are now `<test>.S <STATUS>`:
+
+```
+trap.S      MONITOR-ERROR 101
+```
+
+The status is the exact label the table prints, including its numeric suffix where it has one.
+Whitespace between the fields is free (both sides are normalised before comparison). A line with
+only a name — the old format — is **rejected with an error naming the format**, not half-matched:
+silently accepting it would make every baselined entry unmatchable in a way that reads like a
+regression.
+
+This is the natural extension of ADR-0014's contract rather than a departure from it. That contract
+already catches an unexpected *pass*, because it is a set equality and not a ceiling; it should
+equally catch a test that fails for a new reason. Everything else in ADR-0014 stands unchanged: the
+file is still edited by hand and never regenerated from a run, lines still come out one at a time in
+the commit that makes that test pass, and adding one back is still a regression that needs
+justifying in the PR. **Changing an existing line's status is the same kind of claim as removing the
+line**, and needs the same justification — that is the whole point of the second field.
+
+### The build steps are checked, and the simulator is gated on them
+
+- `set -euo pipefail` is on. Every place a nonzero status is *expected* handles it at its own call
+  site (`if ! cmd`), so error-exit stays live everywhere else. The simulator's status is captured
+  explicitly rather than read from `$?` at a distance, and it is the **one** site where error-exit
+  is lifted (`set +e` … `set -e`) rather than guarded with `|| sim_status=$?`. That is not a style
+  choice: **bash 3.2 — macOS `/bin/bash`, the interpreter in this script's shebang — rewrites a
+  127 "command not found" to 1 while `set -e` is in force.** An unstartable runner would then land
+  in the `1` arm and be reported as `FAIL`, a verdict about the CPU. Measured on the way in, not
+  assumed; it now reports `RUNNER-ERROR 127`. Adding `set -e` to a script is not free, and this is
+  the shape of what it costs.
+- Each objcopy is checked separately and carries its own status label with the region that failed:
+  **`OBJCOPY-ERROR rom|ram`** for a nonzero exit, **`OBJCOPY-EMPTY rom|ram`** for the zero-exit
+  empty-output case. The empty case gets its own label because it is the one that used to produce a
+  false PASS rather than a visible error; the two are diagnosed differently and should read
+  differently. All 52 programs in the suite produce non-empty images in both regions today (the
+  smallest RAM image is 21 bytes), so the emptiness check has no legitimate case to reject.
+- The simulator runs only when the assemble step and both objcopy steps succeeded.
+- `RUNNER-ERROR` carries the unexpected exit status, so "the sim crashed" and "the sim exited 5"
+  are distinguishable in the table.
+- The failure log is a single per-test build log covering the assembler and both objcopy calls.
+
+### The setup probes and the temp directory are fatal
+
+- `objcopy` is probed with `command -v` alongside the compiler probe, rather than derived blind from
+  the compiler's path and assumed to exist. A half-installed toolchain says so once, up front,
+  instead of appearing as 52 identical per-test build failures.
+- `mktemp -d` failing is fatal, and its output is additionally checked for emptiness and
+  directory-ness before the trap is installed.
+- The baseline path is checked for existence and readability **before the suite runs**, so a
+  mistyped path fails in a second rather than after a full run.
+- The Makefile's `test-units` recipe enables `set -e` **before** `mktemp` and before installing its
+  trap, and asserts the directory exists.
+
+## Consequences
+
+- `test/EXPECTED_FAIL`'s format changed. Any future line must carry a status; the script says so if
+  one does not. Nothing else in the repo reads this file.
+- The gate is strictly harder to satisfy than it was: every path added here can only turn a PASS
+  into a failure, never the reverse. Each was demonstrated failing — a forced objcopy failure, a
+  baselined test changed to a different failure mode, an unwritable `TMPDIR`, a missing baseline —
+  rather than argued.
+- A toolchain or environment problem now stops the run instead of being scored as a CPU verdict.
+  That is a behaviour change for anyone running on a broken setup: they get an error, where before
+  they got a table.
+- `OBJCOPY-ERROR` / `OBJCOPY-EMPTY` join the label set that `test/EXPECTED_FAIL` may contain. Nothing
+  should ever be baselined under them — they describe a broken build, not a known-red property —
+  but the format admits them, and a line under either is a review flag.
+- This does not make the gate *correct*, only harder to fool. The classes ADR-0032 measured — state
+  no retiring instruction names — are untouched by any of it, and so is everything in ADR-0023.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -39,6 +39,7 @@ and what it costs. Reversing one is fine — write a new ADR that supersedes it.
 | [0032](0032-sail-co-simulation-is-worth-building-and-stays-opt-in.md) | Sail co-simulation is worth building, and stays opt-in | Accepted |
 | [0033](0033-what-the-green-ladder-does-not-cover.md) | What a green ladder does not cover — three assurance gaps, named | Accepted |
 | [0034](0034-what-the-csr-ladder-checks-cannot-see.md) | What the CSR ladder checks cannot see, and the decisions the CSR file forced | Accepted |
+| [0035](0035-the-baseline-pins-the-failure-mode.md) | `test/EXPECTED_FAIL` pins the failure mode, not just the file name | Accepted |
 
 0001–0007 came from the design brief
 ([`docs/ideas/finish-the-rewrite.md`](../ideas/finish-the-rewrite.md)). 0008–0011 came out of
@@ -66,7 +67,9 @@ three together: it audits the machinery M2 is *measured* by rather than the core
 records what a green ladder and a matching baseline do not, on their own, establish. 0034 came out of
 integrating the CSR file: it records the two decode-side decisions ADR-0005's field list left open,
 corrects ADR-0027 on the counter `h` halves, measures what the `csrw_*` checks cannot see, and fixes
-a `CLAUDE.md` engineering rule that named the wrong file.
+a `CLAUDE.md` engineering rule that named the wrong file. 0035 amends 0014 and applies 0033's lens
+to the *simulation* gate: `test/run_tests.sh` had three ways to report success without having tested
+anything, so the failure set now records name **and** status and every build step is checked.
 
 ## Deferred decisions
 

--- a/test/EXPECTED_FAIL
+++ b/test/EXPECTED_FAIL
@@ -6,6 +6,23 @@
 # wholesale from a run (that would launder a regression into the baseline);
 # edit it by hand, and justify any line added back in the PR that adds it.
 #
+# FORMAT — two fields, not one (ADR-0035):
+#
+#     <test>.S  <STATUS>
+#
+# The status is the exact label test/run_tests.sh prints in its table:
+# ASSEMBLE-ERROR, ASSEMBLE-WARNING, OBJCOPY-ERROR <region>,
+# OBJCOPY-EMPTY <region>, FAIL <n>, TIMEOUT, MONITOR-ERROR <n>, or
+# RUNNER-ERROR <n>. Whitespace between the fields is free; a line with only a
+# name is rejected rather than half-matched.
+#
+# The status is here because matching on the name alone made the gate blind to
+# *why* a test failed. A baselined entry stayed matched if its assembly broke
+# (ASSEMBLE-ERROR), if the sim binary would not start (RUNNER-ERROR) or if it
+# hung (TIMEOUT) — a broken harness and a broken test both laundered into a
+# green gate. Changing the status is the same kind of claim as removing the
+# line: it needs the same justification in the PR that does it.
+#
 # ADR-0004/ADR-0009 (`a4662a2`): combinational-read regfile + write-through
 # bypass, valid bits, the stall-only hazard interlock, and the divider's
 # stall wired up for real) took this to empty: all 47 tests in the suite
@@ -41,5 +58,9 @@
 #                 MONITOR-ERROR rather than FAIL today: with no trap logic the
 #                 core completes the misaligned load, and the per-retire
 #                 monitor catches the disagreement before `tohost` is ever
-#                 written.
-trap.S
+#                 written. Error 101 is "mismatch in trap" — the check
+#                 ADR-0033 gap 2 keeps live under `spec_trap`. Pinning that
+#                 number here is the point of the status field: if trap.S
+#                 starts failing some other way, it is a new failure, not this
+#                 one.
+trap.S      MONITOR-ERROR 101

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -1,15 +1,49 @@
 #!/bin/bash
 # Assembles every test/asm/*.S file, runs it under the cxxrtl runner (`sim`),
 # and checks the resulting pass/fail table against test/EXPECTED_FAIL — the
-# sprint-1 baseline (ADR-0007, ADR-0008). Invoked by `make test`.
+# sprint-1 baseline (ADR-0007, ADR-0008, ADR-0014). Invoked by `make test`.
 #
 # Usage: run_tests.sh <sim-binary> <asm-dir> <expected-fail-file>
-set -u
+#
+# This script is the merge gate, so the failure mode that matters is a FALSE
+# GREEN — reporting success without having tested anything. Three properties
+# below exist only for that (ADR-0035):
+#
+#   * every build step's exit status is checked, and the simulator runs only
+#     when the image it would read was actually produced. An unchecked objcopy
+#     that emits an empty RAM image makes `tohost` read zero, which every test
+#     with no data dependency still turns into a PASS;
+#   * the failure set records NAME AND STATUS, not just the name, so the
+#     set-equality check against test/EXPECTED_FAIL pins the failure *mode*.
+#     A baselined test that starts failing for a new reason — a broken
+#     assembly, a crashing runner, a timeout — is a red gate, not a match;
+#   * `set -e` is on and mktemp is fatal. Without it a failed mktemp leaves
+#     $tmp empty, every artifact path collapses to the filesystem root, and a
+#     later run can pick up the previous run's stale image.
+#
+# Any nonzero exit that is *expected* is handled at its own call site (`if !`,
+# `|| status=$?`) so that error-exit stays on everywhere else.
+set -euo pipefail
+
+if [ "$#" -ne 3 ]; then
+  echo "usage: run_tests.sh <sim-binary> <asm-dir> <expected-fail-file>" >&2
+  exit 1
+fi
 
 SIM=$1
 ASM_DIR=$2
 EXPECTED_FAIL=$3
 CYCLES=5000
+
+# Read before running anything: a mistyped or missing baseline path used to
+# yield an empty expected set, and with an all-passing suite the gate then
+# printed "Failure list matches ... exactly" having compared nothing. Fail
+# here, in a second, rather than after the whole suite has run.
+if [ ! -f "$EXPECTED_FAIL" ] || [ ! -r "$EXPECTED_FAIL" ]; then
+  echo "error: baseline '$EXPECTED_FAIL' does not exist or is not readable." >&2
+  echo "The gate compares the failure set against it; without it there is no gate." >&2
+  exit 1
+fi
 
 # Toolchain: brew's riscv64-elf-gcc on macOS, apt's gcc-riscv64-unknown-elf
 # (binary name riscv64-unknown-elf-gcc) on Linux. See `make setup`.
@@ -25,12 +59,31 @@ if [ -z "$CC" ]; then
   echo "Run 'make setup' to install one." >&2
   exit 1
 fi
-OBJCOPY=${CC%gcc}objcopy
 
-tmp=$(mktemp -d "${TMPDIR:-/tmp}/littlecpu-test.XXXXXX")
+# objcopy is derived from the compiler's name but probed like the compiler,
+# rather than assumed to exist because gcc did. A half-installed toolchain is
+# a setup problem and should say so once, up front, instead of surfacing as 52
+# identical per-test build failures.
+OBJCOPY=${CC%gcc}objcopy
+if ! command -v "$OBJCOPY" >/dev/null 2>&1; then
+  echo "error: found $CC but not its matching $OBJCOPY." >&2
+  echo "Run 'make setup' to install a complete toolchain." >&2
+  exit 1
+fi
+
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/littlecpu-test.XXXXXX") || {
+  echo "error: could not create a temporary directory under ${TMPDIR:-/tmp}." >&2
+  exit 1
+}
+# Belt and braces: an mktemp that exits 0 with empty output would otherwise
+# collapse every artifact path to /<base>.hex and defeat the trap below.
+if [ -z "$tmp" ] || [ ! -d "$tmp" ]; then
+  echo "error: mktemp -d produced no usable directory under ${TMPDIR:-/tmp}." >&2
+  exit 1
+fi
 trap 'rm -rf "$tmp"' EXIT
 
-declare -a failed_tests=()
+declare -a failures=()
 declare -a table=()
 passed=0
 
@@ -38,51 +91,84 @@ for src in "$ASM_DIR"/*.S; do
   name=$(basename "$src")
   base=${name%.S}
   elf="$tmp/$base.elf"
-  asm_log="$tmp/$base.asm.log"
+  build_log="$tmp/$base.build.log"
+  rom_hex="$tmp/$base.rom.hex"
+  ram_hex="$tmp/$base.ram.hex"
 
   status="PASS"
   if ! "$CC" -march=rv32imc_zicsr -mabi=ilp32 -nostdlib -I "$ASM_DIR" \
-       -T "$ASM_DIR/sections.lds" "$src" -o "$elf" > "$asm_log" 2>&1; then
+       -T "$ASM_DIR/sections.lds" "$src" -o "$elf" > "$build_log" 2>&1; then
     status="ASSEMBLE-ERROR"
-  elif [ -s "$asm_log" ]; then
+  elif [ -s "$build_log" ]; then
     # Any assembler output (warnings included) on an otherwise-successful
     # build is still a defect per criterion 7 — zero assembler warnings.
     status="ASSEMBLE-WARNING"
   fi
 
+  # ADR-0008's two images. Both statuses are checked: a failing objcopy
+  # (a binutils without --verilog-data-width, a full disk) used to leave the
+  # previous file — or no file — in place and let the simulator run against
+  # it, reporting its verdict as if it were about the CPU. The empty case is
+  # the dangerous one and gets its own label: an empty RAM image parses fine,
+  # `tohost` reads zero, and every test with no data dependency still reaches
+  # RVTEST_PASS.
   if [ "$status" = "PASS" ]; then
-    rom_hex="$tmp/$base.rom.hex"
-    ram_hex="$tmp/$base.ram.hex"
-    "$OBJCOPY" -O verilog --verilog-data-width=4 --only-section=.text \
-      "$elf" "$rom_hex" 2>>"$asm_log"
-    "$OBJCOPY" -O verilog --verilog-data-width=4 --remove-section=.text \
-      "$elf" "$ram_hex" 2>>"$asm_log"
+    for region in rom ram; do
+      if [ "$region" = rom ]; then
+        section_flag="--only-section=.text"
+        image=$rom_hex
+      else
+        section_flag="--remove-section=.text"
+        image=$ram_hex
+      fi
+      rm -f "$image"
+      if ! "$OBJCOPY" -O verilog --verilog-data-width=4 "$section_flag" \
+           "$elf" "$image" >> "$build_log" 2>&1; then
+        status="OBJCOPY-ERROR $region"
+        break
+      fi
+      if [ ! -s "$image" ]; then
+        status="OBJCOPY-EMPTY $region"
+        break
+      fi
+    done
+  fi
 
+  if [ "$status" = "PASS" ]; then
+    # The one place error-exit is lifted, and it is lifted rather than guarded
+    # with `|| sim_status=$?` because bash 3.2 (macOS /bin/bash) rewrites a
+    # 127 "command not found" to 1 while `set -e` is in force — which would
+    # report an unstartable runner as a `FAIL`, i.e. as a verdict about the
+    # CPU. Measured, not assumed. Restored immediately after.
+    set +e
     "$SIM" --rom "$rom_hex" --ram "$ram_hex" --cycles "$CYCLES" \
       > "$tmp/$base.run.log" 2>&1
+    sim_status=$?
+    set -e
     # The runner's exit ladder (test/cxxrtl.cc): 0 pass, 1 tohost fail, 2 cycle
     # limit, 3 usage/setup, 4 RVFI monitor error. 4 gets its own label because
     # it means something entirely different from the others — the per-retire
     # oracle disagreed with the core mid-run (ADR-0019), which is a wrong-result
     # report, not a broken harness. Lumping it into RUNNER-ERROR made it
     # indistinguishable from "the sim could not be started at all".
-    case $? in
+    case $sim_status in
       0) status="PASS" ;;
-      1) status="FAIL $(awk '/^FAIL/{print $2}' "$tmp/$base.run.log")" ;;
+      1) num=$(awk '/^FAIL/{print $2; exit}' "$tmp/$base.run.log")
+         status="FAIL${num:+ $num}" ;;
       2) status="TIMEOUT" ;;
-      4) status="MONITOR-ERROR $(sed -n 's/.*RVFI monitor error \([0-9]*\).*/\1/p' \
-             "$tmp/$base.run.log" | head -1)" ;;
-      *) status="RUNNER-ERROR" ;;
+      4) code=$(awk '/RVFI monitor error/{print $4; exit}' "$tmp/$base.run.log")
+         status="MONITOR-ERROR${code:+ $code}" ;;
+      *) status="RUNNER-ERROR $sim_status" ;;
     esac
   fi
 
   if [ "$status" = "PASS" ]; then
     passed=$((passed + 1))
   else
-    failed_tests+=("$name")
-    if [ -s "$asm_log" ]; then
-      echo "--- $name assembler output ---" >&2
-      cat "$asm_log" >&2
+    failures+=("$name $status")
+    if [ -s "$build_log" ]; then
+      echo "--- $name build output ---" >&2
+      cat "$build_log" >&2
     fi
   fi
   table+=("$(printf '%-16s %s' "$name" "$status")")
@@ -92,16 +178,34 @@ printf '%s\n' "${table[@]}"
 echo
 echo "$passed/${#table[@]} passed"
 
-actual_sorted=$(printf '%s\n' "${failed_tests[@]:-}" | sed '/^$/d' | sort)
-expected_sorted=$(sed -e 's/#.*//' -e '/^[[:space:]]*$/d' "$EXPECTED_FAIL" | sort)
+# Both sides are name-and-status pairs, whitespace-normalised so the baseline
+# can stay readable. `NF` must gate the rebuild rather than follow it: awk
+# forces NF to 1 when $1 is assigned, so `{$1=$1} NF` would resurrect every
+# blank and comment-only line as an empty entry.
+# ADR-0035 amends ADR-0014: matching on the name alone let a baselined test
+# change failure mode — ASSEMBLE-ERROR, TIMEOUT, RUNNER-ERROR instead of the
+# baselined MONITOR-ERROR — and still satisfy set equality.
+actual_sorted=$(printf '%s\n' "${failures[@]:-}" | awk 'NF { $1=$1; print }' | sort)
+expected_sorted=$(sed -e 's/#.*//' "$EXPECTED_FAIL" | awk 'NF { $1=$1; print }' | sort)
+
+# A one-field line is the pre-ADR-0035 format. Silently accepting it would
+# make every baselined entry unmatchable for a reason that reads like a
+# regression, so name it instead.
+malformed=$(printf '%s\n' "$expected_sorted" | awk 'NF == 1 {print}')
+if [ -n "$malformed" ]; then
+  echo "error: $EXPECTED_FAIL has entries with no status (ADR-0035 format is" >&2
+  echo "'<test>.S <STATUS>', e.g. 'trap.S MONITOR-ERROR 101'):" >&2
+  printf '  %s\n' "$malformed" >&2
+  exit 1
+fi
 
 if [ "$actual_sorted" = "$expected_sorted" ]; then
-  echo "Failure list matches $EXPECTED_FAIL exactly."
+  echo "Failure list matches $EXPECTED_FAIL exactly (name and status)."
   exit 0
 fi
 
 echo
 echo "Failure list does NOT match $EXPECTED_FAIL:" >&2
 diff <(echo "$expected_sorted") <(echo "$actual_sorted") \
-  --label expected --label actual >&2
+  --label expected --label actual >&2 || true
 exit 1


### PR DESCRIPTION
Closes JEF-656

`test/run_tests.sh` is the merge gate, so the failure mode that matters is a **false green** — reporting success without having tested anything. A security review found three ways it could do that, plus a fourth smaller one. None is exploitable (no service, no secrets, read-only CI); this is ordinary robustness on machinery that decides whether code merges.

Scope is exactly `test/run_tests.sh`, `test/EXPECTED_FAIL`, the Makefile's `test-units` recipe, plus **ADR-0035** (the baseline format change amends ADR-0014's contract) and its index/CLAUDE.md pointers. **No `rtl/` change and no change to what any test asserts.**

## The four holes, each demonstrated failing

### 1. The objcopy exit status was discarded → false PASS

Both of ADR-0008's images were produced unchecked, and the simulator ran against whatever was there. The worst case is a silently **empty** RAM image: the hex parser accepts it, `tohost` reads zero, and every test with no data dependency still reaches `RVTEST_PASS`.

With an `objcopy` shim that writes an empty `add.ram.hex` and exits 0:

```
=== OLD script + OLD baseline ===
add.S            PASS
51/52 passed
Failure list matches .../old_EXPECTED_FAIL exactly.
exit=0                     <-- green gate, add.S never received its data image

=== NEW script ===
add.S            OBJCOPY-EMPTY ram
50/52 passed
Failure list does NOT match test/EXPECTED_FAIL:
> add.S OBJCOPY-EMPTY ram
exit=1
```

A nonzero objcopy gets its own label with the region that failed:

```
--- add.S build output ---
riscv64-elf-objcopy: simulated failure (no --verilog-data-width)
add.S            OBJCOPY-ERROR rom
50/52 passed
> add.S OBJCOPY-ERROR rom
exit=1
```

The simulator now runs only when the assemble step **and** both objcopy steps succeeded, and the build log is dumped for any failing test.

### 2. The failure set recorded only the name → a changed failure mode still matched

`trap.S` is baselined for a precise reason (`MONITOR-ERROR 101`, "mismatch in trap"). Appending an unrecognised opcode to `trap.S`:

```
=== OLD script + OLD baseline ===
trap.S           ASSEMBLE-ERROR
51/52 passed
Failure list matches .../old_EXPECTED_FAIL exactly.
exit=0                     <-- a broken test AND a broken harness, laundered green

=== NEW script ===
--- trap.S build output ---
trap.S:191: Error: unrecognized opcode `this_is_not_an_instruction x1,x2'
trap.S           ASSEMBLE-ERROR
51/52 passed
Failure list does NOT match test/EXPECTED_FAIL:
1c1
< trap.S MONITOR-ERROR 101
---
> trap.S ASSEMBLE-ERROR
exit=1
```

The failure set and `test/EXPECTED_FAIL` now carry **name and status** pairs. A one-field line (the old format) is rejected by name rather than half-matched:

```
error: .../nameonly_EXPECTED_FAIL has entries with no status (ADR-0035 format is
'<test>.S <STATUS>', e.g. 'trap.S MONITOR-ERROR 101'):
  trap.S
exit=1
```

### 3. Unchecked `mktemp` → artifacts at the filesystem root

```
=== NEW script, TMPDIR=/nonexistent-dir-jef/nope ===
mktemp: mkdtemp failed on /nonexistent-dir-jef/nope/littlecpu-test.YIl7LP: No such file or directory
error: could not create a temporary directory under /nonexistent-dir-jef/nope.
exit=1
(no /*.rom.hex, no /*.elf)
```

Same ordering bug in `test-units` (trap installed before `set -e`). Old ordering, reproduced:

```
would run: iverilog -o /exec_tb.vvp ...
```

New: `TMPDIR=/nonexistent-dir-jef/nope make test-units` → `make: *** [test-units] Error 1`, nothing at `/`.

### 4. Unchecked baseline path → empty comparison reported as a match

```
error: baseline 'test/NO_SUCH_BASELINE' does not exist or is not readable.
The gate compares the failure set against it; without it there is no gate.
exit=1
```

Checked **before** the suite runs, so a mistyped path fails in a second.

## One measured surprise, recorded in ADR-0035

Adding `set -e` is not free. **bash 3.2 (macOS `/bin/bash`, this script's shebang) rewrites a 127 "command not found" to 1 while `set -e` is in force.** With the obvious `|| sim_status=$?` guard, an unstartable runner landed in the `1` arm and was reported as `FAIL` — a verdict about the CPU. The simulator call lifts error-exit explicitly (`set +e` … `set -e`) instead. Verified:

```
add.S            RUNNER-ERROR 127
```

## Criterion 5 — nothing else changed

`make test`: **51/52**, one baselined failure, `make-exit=0`.

```
add.S PASS   addi.S PASS   and.S PASS   andi.S PASS   auipc.S PASS
beq.S PASS   bge.S PASS    bgeu.S PASS  blt.S PASS    bltu.S PASS
bne.S PASS   csr.S PASS    div.S PASS   divu.S PASS   hazard.S PASS
jal.S PASS   jalr.S PASS   lb.S PASS    lbu.S PASS    lh.S PASS
lhu.S PASS   lui.S PASS    lw.S PASS    minstret.S PASS
mul.S PASS   mulh.S PASS   mulhsu.S PASS mulhu.S PASS
or.S PASS    ori.S PASS    rem.S PASS   remu.S PASS   rvc.S PASS
sb.S PASS    sh.S PASS     simple.S PASS sll.S PASS   slli.S PASS
slt.S PASS   slti.S PASS   sltiu.S PASS sltu.S PASS   sra.S PASS
srai.S PASS  srl.S PASS    srli.S PASS  straddle.S PASS
sub.S PASS   sw.S PASS     xor.S PASS   xori.S PASS
trap.S       MONITOR-ERROR 101

51/52 passed
Failure list matches test/EXPECTED_FAIL exactly (name and status).
```

`make test-units` passes (all six benches, run as part of `make test`). `shellcheck test/run_tests.sh` is clean.

## Note for the architect

Every path added here can only turn a PASS into a failure, never the reverse — the gate is strictly harder to satisfy than it was. The one behaviour change for a user on a broken setup is that a toolchain problem now stops the run with an error instead of being scored as a CPU verdict.

The Makefile edit is confined to the `test-units` recipe and the comment directly above it, to stay mergeable alongside the concurrent `.svlint.toml` / `ci.yml` work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)