### PR TITLE
JEF-657: add svlint as a structural lint gate over rtl/

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,6 +208,52 @@ jobs:
             echo "wall time: ${elapsed}s"
           } >> "$GITHUB_STEP_SUMMARY"
 
+  # The structural lint gate: svlint over rtl/ with the tracked .svlint.toml.
+  #
+  # svlint parses with sv-parser -- a THIRD SystemVerilog frontend, neither
+  # yosys's nor iverilog's. It has already earned that: it cannot resolve
+  # rtl/structs.v without an explicit `-i rtl`, a parse-configuration fact
+  # neither of the other two surfaces. `make lint` runs it twice, with and
+  # without the RVFI macros, because roughly a fifth of rtl/ sits behind
+  # `ifdef RISCV_FORMAL` and svlint's preprocessor drops it otherwise.
+  #
+  # Read .svlint.toml before changing anything here: every disabled rule
+  # carries its reason and its measured finding count, and the enabled set is
+  # deliberately small so a finding means something.
+  #
+  # Needs neither oss-cad-suite nor the RISC-V cross compiler -- just the
+  # pinned svlint archive, which `make lint-setup` fetches, SHA-256-verifies
+  # and unpacks (the Makefile owns that pin, so the workflow and the local
+  # path cannot drift on which svlint they run). That makes this by far the
+  # cheapest job here and the first to report.
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Record job start
+        run: echo "JOB_START=$(date +%s)" >> "$GITHUB_ENV"
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install svlint at the pin
+        run: make lint-setup
+
+      - name: make lint
+        # Exit code is the gate. GITHUB_ACTIONS is set on every runner, so
+        # `make lint` passes --github-actions and any finding also lands as an
+        # ::error annotation on the PR diff.
+        run: make lint
+
+      - name: Report job wall time
+        if: always()
+        run: |
+          elapsed=$(( $(date +%s) - JOB_START ))
+          {
+            echo "### lint"
+            echo "wall time: ${elapsed}s"
+          } >> "$GITHUB_STEP_SUMMARY"
+
   # Regenerates test/monitor.v from a from-scratch riscv-formal clone at
   # the pin (formal/pin.mk) and diffs it against the tracked copy
   # (CLAUDE.md invariant 7: generated but tracked, never hand-edited).

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,10 @@ cosim
 cosim.dSYM/
 tools/sail
 tools/sail.tmp
+# The pinned svlint release archive `make lint-setup` unpacks (the structural
+# lint gate, .svlint.toml). A downloaded binary; never commit it.
+tools/svlint
+tools/svlint.tmp
 test/a.out.dSYM/
 # Swarm agent worktrees (.claude/tracker.json stays tracked).
 .claude/worktrees/

--- a/.svlint.toml
+++ b/.svlint.toml
@@ -1,0 +1,350 @@
+# svlint configuration -- the structural lint gate (`make lint`).
+#
+# WHY THIS EXISTS. svlint is a THIRD independent SystemVerilog frontend
+# (sv-parser), alongside yosys and iverilog. By the same reasoning CLAUDE.md's
+# verification table applies to the three simulation legs, a third parser earns
+# its place by seeing what the other two structurally cannot. It has already
+# demonstrated that: svlint cannot resolve rtl/structs.v without an explicit
+# include path (`-i rtl`), a parse-configuration fact neither yosys nor
+# iverilog surfaces.
+#
+# WHAT IT IS FOR. Almost every rule enabled below reports ZERO findings on
+# today's rtl/. That is the point, not an argument against it. Each one catches
+# a defect class that elaborates cleanly in BOTH existing frontends and that
+# neither the .S suite nor the bounded formal ladder reliably reaches:
+#
+#   - a blocking assignment in `always_ff`, or a non-blocking one in
+#     `always_comb`, is a simulation/synthesis mismatch that passes both sim
+#     legs. Measured: injecting `regs[waddr] = wdata` into rtl/regfile.v's
+#     `always_ff` is caught here and by nothing else in the repo.
+#   - a bare `always` whose sensitivity list is inferred, `===` in synthesised
+#     logic, an untyped `enum`, a missing `default_nettype none`.
+#   - this repo has already shipped a defect of that flavour: the multiplier
+#     that was a DECLARATION INITIALISER, evaluated once before time 0 and
+#     never again. It elaborated cleanly in both frontends.
+#
+# WHAT IT IS **NOT** FOR, measured rather than assumed. Latch inference from a
+# `case` in `always_comb` with no default is ALREADY a hard error in yosys:
+# injecting one into rtl/fetcher.v gives `ERROR: Latch inferred for signal
+# ... from always_comb process` and exit 1 from both `write_cxxrtl` (the
+# Makefile's test/rtl.cc recipe) and the CI elaborate job's `proc; opt_clean;
+# check`. iverilog does not report it, but yosys aborting is enough. Do not
+# reach for the `case` family below to cover that class -- read the comment on
+# those three rules for what they actually check, which is not what their
+# names suggest.
+#
+# HOUSE RULE FOR THIS FILE. Every DISABLED rule below carries a one-line reason.
+# A rule switched off without one is the failure mode this file exists to
+# avoid -- the next reader cannot tell "measured, does not apply here" from
+# "someone got tired of the noise". Rules are grouped by why they are off.
+#
+# SCOPE. rtl/ only. test/ benches use delays, `$display` and `initial` blocks
+# that these rules were never meant for. Run with:
+#
+#     make lint
+#
+# and see the Makefile's `lint` target for the two passes (with and without
+# `RISCV_FORMAL`) and why both are needed.
+
+[option]
+# rtl/littlesoc.v is dead scaffolding: it synthesises to 2 LUT4s, carries a
+# `mem_valid`/`mem_ready` handshake the current core does not use, and has a
+# `// TODO SPI mem`. It is also the ONLY file in rtl/ with a genuine finding
+# (four `inout` ports with no `tri` datakind). Deleting it is probably right,
+# but that is its own decision and must not ride in on a lint change; excluding
+# it here keeps `inout_with_tri` LIVE for any inout port added to real RTL,
+# which is the version of that rule worth having.
+exclude_paths = ["rtl/littlesoc\\.v"]
+
+# ---------------------------------------------------------------------------
+# Text rules -- all off.
+#
+# header_copyright, style_directives, style_semicolon, style_textwidth encode a
+# house style this repo has not adopted, and CLAUDE.md is explicit that this
+# project optimises for readability over conformance. Whitespace findings would
+# bury the structural rules that are the entire reason svlint is here.
+# ---------------------------------------------------------------------------
+[textrules]
+header_copyright = false   # no per-file copyright header convention in this repo
+style_directives = false   # style: indentation of `ifdef`/`endif`
+style_semicolon = false    # style: whitespace before `;`
+style_textwidth = false    # style: line length; not a structural property
+
+[syntaxrules]
+
+# ---------------------------------------------------------------------------
+# ENABLED -- assignment kind must match process kind.
+#
+# The simulation/synthesis-mismatch family. All zero findings today; all cheap
+# to violate in a future edit and invisible to both existing frontends.
+# ---------------------------------------------------------------------------
+blocking_assignment_in_always_ff = true
+blocking_assignment_in_always_at_edge = true
+blocking_assignment_in_always_latch = true
+non_blocking_assignment_in_always_comb = true
+non_blocking_assignment_in_always_no_edge = true
+eventlist_comma_always_ff = true
+
+# ---------------------------------------------------------------------------
+# ENABLED -- process kind must be stated, not inferred.
+#
+# A bare `always` whose sensitivity list the tool infers is how a combinational
+# block silently becomes a latch. CLAUDE.md invariant 1 (fetch is
+# combinational, no flush logic) depends on the comb/ff split being exactly
+# what it reads as.
+# ---------------------------------------------------------------------------
+general_always_no_edge = true
+general_always_level_sensitive = true
+procedural_continuous_assignment = true
+
+# ---------------------------------------------------------------------------
+# ENABLED -- declaration hygiene that yosys and iverilog both accept silently.
+#
+# default_nettype_none is already satisfied by all twelve files in rtl/; it is
+# enabled so a thirteenth cannot arrive without it and start inferring 1-bit
+# wires from typos.
+# ---------------------------------------------------------------------------
+default_nettype_none = true
+enum_with_type = true                 # untyped enum defaults to `int`; no enums today
+function_with_automatic = true
+function_same_as_system_function = true
+genvar_declaration_in_loop = true
+loop_variable_declaration = true
+generate_case_with_label = true
+generate_for_with_label = true
+generate_if_with_label = true
+parameter_default_value = true
+parameter_in_generate = true
+inout_with_tri = true                 # live: littlesoc.v, its only source, is excluded above
+
+# ---------------------------------------------------------------------------
+# ENABLED -- expression and statement traps.
+# ---------------------------------------------------------------------------
+operator_case_equality = true         # `===` has no synthesised equivalent
+explicit_brackets_for_confusing_precedence = true
+multiline_if_begin = true             # the dangling-else trap
+multiline_for_begin = true
+action_block_with_side_effect = true  # assertion action blocks must not drive state
+
+# ---------------------------------------------------------------------------
+# DISABLED -- safety rules measured against rtl/ and found not to apply.
+# Each line says why. Do not re-enable one without re-reading its reason.
+# ---------------------------------------------------------------------------
+
+# The `case` family: 19 findings, all on ONE safe idiom, and NONE of the three
+# rules can tell that idiom apart from the unsafe one. rtl/accessor.v assigns
+# every driven signal a default BEFORE its `case`:
+#
+#     always_comb begin
+#       mem_addr = 0;  mem_wstrb = 0;  write_request = 0;
+#       if (!reset && in_valid) begin
+#         case (1'b1)
+#
+# so no latch is inferred. MEASURED, against svlint 0.9.5, on a two-module file
+# differing only in whether `y = 0;` precedes the `case`: all three rules fire
+# IDENTICALLY on both. Only an explicit `default:` ARM satisfies them; a
+# preceding default ASSIGNMENT does not, whatever implicit_case_default's name
+# and stated rationale ("signals are never metastable") suggest. So these are
+# not latch detectors that this code happens to trip -- they are "write a
+# `default:` arm" rules, and the choice they offer is binary.
+#
+# explicit_case_default additionally fires inside `always_ff` (where there is
+# no latch to infer) and on four `case (pending_addr24)` / `case
+# (pending_addr16)` statements in rtl/accessor.v that enumerate every value of
+# their 2-bit and 1-bit selector -- provably exhaustive, flagged anyway.
+#
+# case_default is the one worth revisiting: it is always_comb-scoped (it
+# correctly skips the always_ff block) and has exactly ONE finding on rtl/ --
+# rtl/accessor.v:147, whose commented-out default ("not a load or a store this
+# cycle -- the zeroed defaults above stand") sits precisely where a
+# `default: ;` arm would go. Turning that comment into an arm is a ONE-LINE
+# rtl/ change that would let this rule come on at zero ongoing cost, and it is
+# the rule that would catch a future `case` in `always_comb` with no defaults.
+# That change is deliberately not made here (this file adds a gate; it does not
+# edit what the gate finds) and is filed as a follow-up.
+case_default = false               # 1 finding: rtl/accessor.v:147 wants a `default: ;` arm -- see above
+explicit_case_default = false      # 10 findings; 4 provably exhaustive, and it fires inside always_ff too
+implicit_case_default = false      # 8 findings; measured NOT to honour a preceding default assignment
+
+# 9 findings across accessor/csrs/decoder/memory/regfile. Requires an `else` on
+# every `if`. This RTL deliberately relies on a register holding its value when
+# the `if` does not fire (`if (wen) ...` in rtl/csrs.v and rtl/regfile.v); the
+# explicit `else x <= x;` it wants is noise on a sequential block and would be
+# an rtl/ change besides.
+explicit_if_else = false
+
+# 2-state typing (`bit`/`int` instead of `logic`). 18 + 2 + 2 findings, all on
+# CSR-address and memory-size constants. This design wants 4-state semantics:
+# X-propagation in simulation is how an undriven signal is caught, and
+# ADR-0017's component proofs read X as "unconstrained". Switching the type
+# would be an rtl/ change with a real semantic effect, not a lint fix.
+localparam_type_twostate = false   # 18 findings: rtl/csrs.v CSR-address constants
+parameter_type_twostate = false    # 2 findings: rtl/imemory.v, rtl/memory.v size parameters
+localparam_explicit_type = false   # 2 findings: rtl/executor.v; same 4-state reasoning
+
+# 5 findings, all rtl/structs.v. That file is an INCLUDE of shared typedefs
+# (``include "structs.v"``), not a `package` -- which is what lets both sim legs
+# and the formal harness pull it in with a plain `-I rtl`. Making it a package
+# is a structural change to how every module is compiled.
+package_item_not_in_package = false
+
+# 3 findings: rtl/imemory.v, rtl/memory.v, rtl/regfile.v. Memory and register
+# arrays are exactly what unpacked dimensions are for.
+unpacked_array = false
+
+# ---------------------------------------------------------------------------
+# DISABLED -- the inverse of a rule enabled above. Enabling both is a
+# contradiction that makes the gate unsatisfiable.
+# ---------------------------------------------------------------------------
+default_nettype_wire_at_end = false # contradicts default_nettype_none, enabled above
+genvar_declaration_out_loop = false # contradicts genvar_declaration_in_loop, enabled above
+
+# ---------------------------------------------------------------------------
+# DISABLED -- structural rules that encode a coding style, not a defect class.
+# Measured, so the cost of each is on the record rather than assumed.
+# ---------------------------------------------------------------------------
+input_with_var = false      # 52 findings: requires `input var` on every port; ANSI default is fine
+output_with_var = false     # 37 findings: as above
+sequential_block_in_always_comb = false  # 10 findings: forbids `begin`/`end`; this RTL is built on it
+sequential_block_in_always_ff = false    # 6 findings: as above
+sequential_block_in_always_latch = false # no always_latch in rtl/, and the rule is the same style call
+loop_statement_in_always_comb = false    # forbids `for` in comb logic; rtl/regfile.v's reset loop is correct
+loop_statement_in_always_ff = false      # as above
+loop_statement_in_always_latch = false   # as above
+parameter_explicit_type = false          # style: `parameter integer` vs `parameter`; no defect class
+parameter_in_package = false             # this repo has no packages (see package_item_not_in_package)
+interface_port_with_modport = false      # no interfaces in rtl/; rule is vacuous here
+module_ansi_forbidden = false            # rtl/ is uniformly ANSI-header; this rule forbids that
+module_nonansi_forbidden = false         # redundant: rtl/ has no non-ANSI headers to forbid
+operator_incdec = false                  # style: forbids `++`/`--`; not used in rtl/ anyway
+operator_self_assignment = false         # style: forbids `x += y`; not used in rtl/ anyway
+keyword_required_generate = false        # style: explicit `generate`/`endgenerate` wrappers
+eventlist_or = false                     # style: `or` vs `,` in event lists; no defect class
+tab_character = false                    # style: whitespace
+
+# ---------------------------------------------------------------------------
+# DISABLED -- house-style families, off wholesale.
+#
+# These forbid language keywords, impose identifier casing, or enforce name
+# prefixes/regexes. They encode a house style this repo has not adopted, and
+# CLAUDE.md is explicit that readability is the design goal. Enabling any of
+# them would produce hundreds of findings and bury the rules above, which is
+# the specific outcome this gate is meant to avoid. Listed by family rather
+# than one line each -- the reason is identical for every member.
+# ---------------------------------------------------------------------------
+
+# keyword_forbidden_*: bans `always`, `always_comb`, `always_ff`, `logic`,
+# `generate`, `priority`, `unique`, `wire`/`reg`. This design is written in
+# exactly those keywords, on purpose.
+keyword_forbidden_always = false
+keyword_forbidden_always_comb = false
+keyword_forbidden_always_ff = false
+keyword_forbidden_always_latch = false
+keyword_forbidden_generate = false
+keyword_forbidden_logic = false
+keyword_forbidden_priority = false
+keyword_forbidden_unique = false
+keyword_forbidden_unique0 = false
+keyword_forbidden_wire_reg = false
+
+# *camelcase_* / *_identifier_matches_filename: identifier-casing and
+# file-naming conventions. rtl/ is snake_case and one module per file already,
+# but by convention, not by a gate anyone agreed to.
+lowercamelcase_interface = false
+lowercamelcase_module = false
+lowercamelcase_package = false
+uppercamelcase_interface = false
+uppercamelcase_module = false
+uppercamelcase_package = false
+interface_identifier_matches_filename = false
+module_identifier_matches_filename = false
+package_identifier_matches_filename = false
+program_identifier_matches_filename = false
+
+# prefix_*: mandatory `i_`/`o_`/`b_`/`u_` name prefixes. Not this repo's style.
+prefix_inout = false
+prefix_input = false
+prefix_instance = false
+prefix_interface = false
+prefix_module = false
+prefix_output = false
+prefix_package = false
+
+# style_*: whitespace, indentation and operator spacing. See textrules above.
+style_commaleading = false
+style_indent = false
+style_keyword_0or1space = false
+style_keyword_0space = false
+style_keyword_1or2space = false
+style_keyword_1space = false
+style_keyword_1spaceornewline = false
+style_keyword_construct = false
+style_keyword_datatype = false
+style_keyword_end = false
+style_keyword_maybelabel = false
+style_keyword_new = false
+style_keyword_newline = false
+style_operator_arithmetic = false
+style_operator_arithmetic_leading_space = false
+style_operator_boolean = false
+style_operator_boolean_leading_space = false
+style_operator_integer = false
+style_operator_integer_leading_space = false
+style_operator_unary = false
+style_trailingwhitespace = false
+
+# re_required_* / re_forbidden_*: regex naming policy for every declaration
+# kind. The most opinionated family svlint has; adopting it is a separate
+# decision with its own ADR, not a side effect of adding a structural gate.
+re_forbidden_assert = false
+re_forbidden_assert_property = false
+re_forbidden_checker = false
+re_forbidden_class = false
+re_forbidden_function = false
+re_forbidden_generateblock = false
+re_forbidden_genvar = false
+re_forbidden_instance = false
+re_forbidden_interface = false
+re_forbidden_localparam = false
+re_forbidden_modport = false
+re_forbidden_module_ansi = false
+re_forbidden_module_nonansi = false
+re_forbidden_package = false
+re_forbidden_parameter = false
+re_forbidden_port_inout = false
+re_forbidden_port_input = false
+re_forbidden_port_interface = false
+re_forbidden_port_output = false
+re_forbidden_port_ref = false
+re_forbidden_program = false
+re_forbidden_property = false
+re_forbidden_sequence = false
+re_forbidden_task = false
+re_forbidden_var_class = false
+re_forbidden_var_classmethod = false
+re_required_assert = false
+re_required_assert_property = false
+re_required_checker = false
+re_required_class = false
+re_required_function = false
+re_required_generateblock = false
+re_required_genvar = false
+re_required_instance = false
+re_required_interface = false
+re_required_localparam = false
+re_required_modport = false
+re_required_module_ansi = false
+re_required_module_nonansi = false
+re_required_package = false
+re_required_parameter = false
+re_required_port_inout = false
+re_required_port_input = false
+re_required_port_interface = false
+re_required_port_output = false
+re_required_port_ref = false
+re_required_program = false
+re_required_property = false
+re_required_sequence = false
+re_required_task = false
+re_required_var_class = false
+re_required_var_classmethod = false

--- a/Makefile
+++ b/Makefile
@@ -296,11 +296,160 @@ monitor-check: $(RISCV_FORMAL_DIR)/monitor/generate.py | $(RISCV_FORMAL_DIR)
 .PHONY: setup
 setup:
 ifeq ($(shell uname -s),Darwin)
-	brew install riscv64-elf-gcc
+	brew install riscv64-elf-gcc svlint
 else
 	@echo "On Linux, install the RISC-V cross compiler with:"
 	@echo "  sudo apt-get install gcc-riscv64-unknown-elf"
+	@echo
+	@echo "svlint (the structural lint gate, \`make lint\`) is not packaged by"
+	@echo "apt. Get the pinned release archive with:"
+	@echo "  make lint-setup"
+	@echo "which fetches, SHA-256-verifies and unpacks it into $(SVLINT_DIR)/."
+	@echo "\`cargo install svlint --version $(SVLINT_VERSION)\` also works, but"
+	@echo "builds from an unpinned crates.io tarball -- prefer lint-setup."
 endif
+
+# ---------------------------------------------------------------------------
+# Structural lint (.svlint.toml) -- the THIRD SystemVerilog frontend.
+#
+# svlint parses with sv-parser, which is neither yosys's nor iverilog's
+# frontend. Read .svlint.toml's header for why this gate exists and why nearly
+# every rule it enables reports zero findings today; read the rule comments
+# there before changing any of them.
+#
+# rtl/ only. test/ benches use delays, `$display` and `initial` blocks these
+# rules were never meant for.
+# ---------------------------------------------------------------------------
+
+# Pinned the way formal/pin.mk pins riscv-formal and the sail spike above pins
+# sail-riscv, and for the same reason (ADR-0013): this fetches a 45 MB
+# EXECUTABLE off the network. A GitHub release asset is MUTABLE, so a version
+# on its own pins a FILENAME, not BYTES -- the SHA-256 beside each asset name
+# is what pins the bytes, and it is checked before anything is extracted, let
+# alone run. Bumping the version means re-pinning every digest; that friction
+# is the point.
+#
+# `override` + an origin check so this cannot be redirected from a script or a
+# CI job. A supply-chain control, not a knob.
+ifneq ($(filter command line environment,$(origin SVLINT_VERSION)),)
+$(error SVLINT_VERSION cannot be set from the command line or the environment: \
+  it pins bytes this repo executes. Change it in the Makefile, together with \
+  the SHA-256 digests below it)
+endif
+override SVLINT_VERSION := 0.9.5
+
+# Three-part, so a branch name or a moving tag cannot be written here by
+# accident.
+ifeq ($(shell printf '%s' '$(SVLINT_VERSION)' | grep -cE '^[0-9]+\.[0-9]+\.[0-9]+$$'),0)
+$(error SVLINT_VERSION must be a three-part release version like 0.9.5, not a \
+  branch, a moving tag or a range: '$(SVLINT_VERSION)')
+endif
+
+# `shasum -a 256` over each 0.9.5 asset, downloaded fresh and cross-checked
+# against the per-asset digest the GitHub releases API reports. Upstream ships
+# no Linux aarch64 build, so that host has no line here and `lint-setup` fails
+# closed on it rather than fetching something it cannot verify (use `brew` or
+# `cargo install` there).
+#
+# The version is spelled out in each variable NAME, not interpolated. That is
+# deliberate: bumping SVLINT_VERSION without re-pinning makes the lookup below
+# resolve to empty, and `lint-setup` refuses to fetch. A digest that silently
+# carried over to a new version would be a control that reads as protection
+# while providing none (ADR-0013).
+SVLINT_SHA256_svlint-v0.9.5-x86_64-lnx  := 0bbb3850b8ef604d7ccf25c2b0d2a751154ac2e18b2a12753ae1648f237a8ceb
+SVLINT_SHA256_svlint-v0.9.5-x86_64-mac  := 53838f356862b6492777347999ccf44c1b44bc78f51cb032759b9e17bd213519
+SVLINT_SHA256_svlint-v0.9.5-aarch64-mac := d032be600f0ee04130e0663daa05da3cc562d3d34bbc4305d6b70cb99310c6df
+
+SVLINT_ASSET_Linux_x86_64  := svlint-v$(SVLINT_VERSION)-x86_64-lnx
+SVLINT_ASSET_Darwin_x86_64 := svlint-v$(SVLINT_VERSION)-x86_64-mac
+SVLINT_ASSET_Darwin_arm64  := svlint-v$(SVLINT_VERSION)-aarch64-mac
+
+SVLINT_DIR   := tools/svlint
+SVLINT_ASSET := $(SVLINT_ASSET_$(shell uname -s)_$(shell uname -m))
+SVLINT_SHA256 := $(SVLINT_SHA256_$(SVLINT_ASSET))
+
+# Prefer whatever is on PATH (brew, cargo, the distro) and fall back to the
+# tree `lint-setup` unpacks, so a developer who already has svlint installed
+# never pays for the download and CI needs no extra PATH plumbing.
+SVLINT ?= $(shell command -v svlint 2>/dev/null || echo ./$(SVLINT_DIR)/bin/svlint)
+
+# TWO passes, and both are load-bearing. Roughly a fifth of rtl/ sits behind
+# `ifdef RISCV_FORMAL` (rvfi_* capture in structs/decoder/accessor/writeback);
+# svlint's preprocessor drops those blocks unless the macros are defined, so a
+# single undefined pass would leave the RVFI instrumentation unlinted --
+# exactly the code ADR-0020 says must stay write-only with respect to the core
+# and that nothing else structurally checks. Same macro list as both sim legs
+# ($(RISCV_FORMAL_MACROS), defined at the top of this file) so the three
+# cannot drift on what "RVFI is live" means.
+#
+# `-i rtl` is required, not decorative: svlint resolves `include "structs.v"`
+# relative to the include path only, and without it every module that includes
+# it fails to parse. Neither yosys nor iverilog surfaces that.
+#
+# `--github-actions` when GITHUB_ACTIONS is set turns findings into
+# ::error file=...,line=... annotations on the PR diff; plain `-1`
+# (one finding per line) otherwise.
+SVLINT_FLAGS := -c .svlint.toml -i rtl $(if $(GITHUB_ACTIONS),--github-actions,-1)
+
+.PHONY: lint
+lint:
+	@command -v $(SVLINT) >/dev/null 2>&1 || test -x $(SVLINT) || { \
+	  echo "svlint not found. Install it with 'make setup' (macOS) or" >&2; \
+	  echo "'make lint-setup' (pinned release archive)." >&2; exit 1; }
+	@echo "== svlint: rtl/, RVFI off =="
+	$(SVLINT) $(SVLINT_FLAGS) rtl/*.v
+	@echo "== svlint: rtl/, RVFI on =="
+	$(SVLINT) $(SVLINT_FLAGS) $(addprefix -D ,$(RISCV_FORMAL_MACROS)) rtl/*.v
+	@echo "svlint: clean in both passes"
+
+# Download to a file, verify the digest, audit the member paths, and only then
+# extract -- the same order `sail-setup` above uses, and for the same reason:
+# bytes from the network must not be unpacked before anything can reject them.
+# tools/svlint is gitignored; never commit the binary.
+.PHONY: lint-setup
+lint-setup:
+	@set -e; \
+	if [ -z '$(SVLINT_ASSET)' ] || [ -z '$(SVLINT_SHA256)' ]; then \
+	  echo "no svlint $(SVLINT_VERSION) release pinned for" >&2; \
+	  echo "$$(uname -s)/$$(uname -m). Install it with 'brew install svlint'" >&2; \
+	  echo "or 'cargo install svlint --version $(SVLINT_VERSION)'. Fetching an" >&2; \
+	  echo "asset this repo cannot verify is not an option this target offers." >&2; \
+	  exit 1; \
+	fi; \
+	if command -v shasum >/dev/null 2>&1; then sha='shasum -a 256'; \
+	elif command -v sha256sum >/dev/null 2>&1; then sha='sha256sum'; \
+	else \
+	  echo "neither shasum nor sha256sum is on PATH; refusing to unpack an" >&2; \
+	  echo "archive this machine cannot check." >&2; \
+	  exit 1; \
+	fi; \
+	tmp=$(SVLINT_DIR).tmp; zip=$$tmp/$(SVLINT_ASSET).zip; \
+	url=https://github.com/dalance/svlint/releases/download/v$(SVLINT_VERSION)/$(SVLINT_ASSET).zip; \
+	rm -rf $$tmp; mkdir -p $$tmp; \
+	echo "fetching $$url"; \
+	curl -fsSL -o $$zip "$$url"; \
+	got=$$($$sha $$zip | cut -d ' ' -f 1); \
+	if [ "$$got" != '$(SVLINT_SHA256)' ]; then \
+	  echo "svlint archive SHA-256 MISMATCH -- refusing to extract:" >&2; \
+	  echo "  asset    : $(SVLINT_ASSET).zip" >&2; \
+	  echo "  expected : $(SVLINT_SHA256)" >&2; \
+	  echo "  actual   : $$got" >&2; \
+	  rm -rf $$tmp; \
+	  exit 1; \
+	fi; \
+	echo "sha256 ok: $$got"; \
+	unzip -Z1 $$zip | awk ' \
+	  /(^|\/)\.\.(\/|$$)/ { print "traversal in member: " $$0 > "/dev/stderr"; bad = 1 } \
+	  /^\// { print "absolute member: " $$0 > "/dev/stderr"; bad = 1 } \
+	  END { exit bad ? 1 : 0 }' \
+	  || { echo "refusing to extract $(SVLINT_ASSET).zip" >&2; rm -rf $$tmp; exit 1; }; \
+	unzip -q $$zip -d $$tmp; \
+	rm -f $$zip; \
+	chmod +x $$tmp/bin/svlint; \
+	test -x $$tmp/bin/svlint; \
+	rm -rf $(SVLINT_DIR); \
+	mv $$tmp $(SVLINT_DIR)
+	@./$(SVLINT_DIR)/bin/svlint --version
 
 # Six small benches. Four landed in `eb18320` and `a4662a2` with no runner
 # (rtl/executor.v, rtl/memory.v, rtl/decoder.v, rtl/regfile.v respectively —
@@ -404,6 +553,9 @@ clean:
 	@# on its own now -- the pin is recorded in tools/sail/.sail-pin and
 	@# compared, so this comment is no longer the only thing making that true.
 	@# `rm -rf tools/sail` still works as the blunt instrument.
+	@# NOT tools/svlint either, and for the same reason: a network fetch that
+	@# `clean` was never asked to rebuild. `make lint-setup` re-fetches
+	@# unconditionally, so `rm -rf tools/svlint` is the blunt instrument there.
 
 # The riscv-formal clone rule and its pin guard live in formal/pin.mk, included
 # above, so the root and formal/ Makefiles cannot drift apart on it.


### PR DESCRIPTION
Closes JEF-657

Adds `make lint` (svlint 0.9.5 over `rtl/`), a tracked `.svlint.toml`, and a `lint` job in CI. **No `rtl/` changes** — `git diff origin/main -- rtl/` is empty.

## Re-measured at `0d23294` (the ticket's numbers were taken at `721930e`)

The ticket's curated set, re-run at HEAD with `rtl/csrs.v` present:

| count | rule |
|---|---|
| 10 | `explicit_case_default` |
| 8 | `implicit_case_default` |
| 4 | `inout_with_tri` |
| 1 | `case_default` |

**23 total — byte-identical to the stale tally.** `rtl/csrs.v` contributes **zero** findings under that set, and the `0d23294` changes to `decoder.v`/`executor.v`/`littlecpu.v`/`structs.v`/`writeback.v` contribute zero. By file: `accessor.v` 16, `littlesoc.v` 4, `executor.v` 2, `decoder.v` 1.

A broader 37-rule safety sweep (rules the ticket did not measure) found 62 findings, all in disabled-with-reason families. `csrs.v`'s only contribution is 18 `localparam_type_twostate` (its CSR-address constants are `logic`, not `bit`) plus 1 `explicit_if_else` — both house-style/2-state-typing calls, not defects. `default_nettype_none` is **already satisfied by all twelve files** in `rtl/`, so it is enabled.

## The case family does not do what its name says — measured, not assumed

The ticket's stated reason for disabling `implicit_case_default` ("no latch is inferred, so its stated reason does not apply") assumes svlint can see the assign-defaults-first idiom. **It cannot.** Two modules differing only in whether `y = 0;` precedes the `case`:

```
== implicit_case_default ==
Fail  t.sv:6:14   y = 1;  hint: Signal driven in `case` statement does not have a default value.
Fail  t.sv:7:14   y = 2;  hint: Signal driven in `case` statement does not have a default value.
Fail  t.sv:14:14  y = 1;  hint: Signal driven in `case` statement does not have a default value.
Fail  t.sv:15:14  y = 2;  hint: Signal driven in `case` statement does not have a default value.
```

Lines 6/7 are the module *with* `y = 0;` before the case. Only an explicit `default:` **arm** satisfies these rules. They are "write a `default:` arm" rules, not latch detectors.

Separately measured: **that class is already covered.** Injecting a defaultless `case` into an `always_comb` in `rtl/fetcher.v` gives

```
ERROR: Latch inferred for signal `\fetcher.\latched [0]' from always_comb process `\fetcher.$proc$rtl/fetcher.v:36$4'.
```

exit 1 from both `write_cxxrtl` (the Makefile's `test/rtl.cc` recipe) and the CI `elaborate` job's `proc; opt_clean; check`. iverilog does not report it; yosys aborting is enough.

## Acceptance criteria

**1. `make lint` exits 0** — yes, both passes. See run below.

**2. Defaultless `case` in `always_comb` → nonzero.** Honest answer: **not with the shipped config**, and per the ticket's own constraint note that is the correct outcome rather than a miss. Both runs, on the same injected mutation in `rtl/fetcher.v`:

```
=== make lint (SHIPPED config) ===
== svlint: rtl/, RVFI off ==
== svlint: rtl/, RVFI on ==
svlint: clean in both passes
EXIT=0

=== same mutation, case_default = true ===
Fail  rtl/accessor.v:147:7  case (1'b1)     hint: Use a `default` expression in `case` statements.
Fail  rtl/fetcher.v:37:5    case (pc[1:0])  hint: Use a `default` expression in `case` statements.
EXIT=1
```

`case_default` **would** catch it, and it is the best of the three: `always_comb`-scoped (it correctly skips the `always_ff` block that `explicit_case_default` also flags) with exactly **one** pre-existing finding — `rtl/accessor.v:147`, whose commented-out default (`// default: not a load or a store this cycle — the zeroed defaults above stand.`) sits precisely where a `default: ;` arm would go. **Turning that comment into an arm is a one-line `rtl/` change that enables the rule at zero ongoing cost.** Filed as a follow-up; not made here. Mutation reverted.

**3. Blocking assignment in `always_ff` → nonzero.** Yes. `regs[waddr] <= wdata` → `= wdata` in `rtl/regfile.v`:

```
== svlint: rtl/, RVFI off ==
Fail  rtl/regfile.v:25:3  always_ff @(posedge clk) begin  hint: Do not use blocking assignments within `always_ff`.
make: *** [lint] Error 1
EXIT=2
```

And under CI conditions (svlint off `PATH`, `GITHUB_ACTIONS=true`), the fallback to the unpacked pinned tree works and the annotation lands:

```
== svlint: rtl/, RVFI off ==
./tools/svlint/bin/svlint -c .svlint.toml -i rtl --github-actions rtl/*.v
Fail: blocking_assignment_in_always_ff
   --> rtl/regfile.v:25:3
::error file=rtl/regfile.v,line=25,col=3::Do not use blocking assignments within `always_ff`.
make: *** [lint] Error 1
EXIT=2
```

Mutation reverted; `git diff origin/main -- rtl/` empty.

**4. CI job.** New `lint` job. Needs neither oss-cad-suite nor the cross compiler, so it is the cheapest job in the workflow.

**5. Every disabled safety rule has a reason.** The config is **exhaustive** — all 4 text rules and all 158 syntax rules are listed with an explicit value. svlint hard-errors on an unknown key, so the list is machine-validated. Each disabled rule with real findings carries its count and its reason; the naming/prefix/style/regex families are grouped with one shared reason each.

**6. `make setup` installs svlint.** macOS: `brew install riscv64-elf-gcc svlint` (brew ships 0.9.5 bottled — same as the pin). Linux: `make setup` prints the path, and `make lint-setup` fetches the pinned release archive.

## Supply chain

`make lint-setup` follows `formal/pin.mk` and `sail-setup` (ADR-0013): pinned version, per-platform SHA-256 verified **before** extraction, zip member audit for traversal/absolute paths, atomic `mv` into place. Digests were computed locally from freshly downloaded assets and cross-checked against the GitHub releases API. Verified working:

- happy path: `sha256 ok: d032be…`, then `svlint v0.9.5 rev:98e84ce9`
- corrupted pin → `svlint archive SHA-256 MISMATCH -- refusing to extract`, exit 2, nothing left on disk
- `make SVLINT_VERSION=9.9.9 lint` → `*** SVLINT_VERSION cannot be set from the command line or the environment`
- bumping the version without re-pinning resolves the digest lookup to empty and `lint-setup` refuses to fetch (the version is spelled out in each digest variable's *name*, deliberately)
- `tools/svlint` is gitignored; no binary is committed

## Two passes, not one

Roughly a fifth of `rtl/` sits behind `ifdef RISCV_FORMAL`. svlint's preprocessor drops it unless the macros are defined, so `make lint` runs the whole thing twice using the same `$(RISCV_FORMAL_MACROS)` list both sim legs use. Both passes clean. Under `-D RISCV_FORMAL` the sweep gains 5 findings (1 `explicit_case_default`, 1 `explicit_if_else`, 3 `package_item_not_in_package`) — all in disabled families, so the enabled set is clean either way.

## Gates run

- `make lint` → exit 0
- `make test` → **51/52, matches `test/EXPECTED_FAIL` exactly**, exit 0
- `make lint-setup` → exit 0
- `.github/workflows/ci.yml` parses; jobs are `elaborate, test, components, lint, monitor-freshness`

## Follow-ups (not done here)

1. **One-line `rtl/accessor.v` change** to add a `default: ;` arm at line 147, then flip `case_default = true`. That is AC 2's detector, at zero ongoing cost.
2. **`rtl/littlesoc.v`**: excluded by path here. Deleting it is probably right and is its own call; deleting it also makes the exclusion unnecessary.
3. **Branch protection**: `lint` is not in the required-checks set. `enforce_admins: true`, so adding it is a human action — deliberately not attempted.
4. **CLAUDE.md** does not mention `make lint`. The ticket scoped this change to three files, so the Commands block and the verification-legs discussion are untouched; worth a follow-up, possibly with an ADR recording the third-parser decision and the measured case-family finding above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)