### PR TITLE
JEF-653: Make the formal ladder assert its own coverage, not just its verdicts

### DIFF
--- a/.github/workflows/formal-nightly.yml
+++ b/.github/workflows/formal-nightly.yml
@@ -68,11 +68,23 @@ jobs:
         continue-on-error: true
         run: make -C formal check
 
-      # The real signal: set-equality against formal/EXPECTED_FAIL, in both
-      # directions, so an unexpected *pass* (e.g. the C.JR fix landing) trips
-      # this as loudly as a new failure (ADR-0022, ADR-0014's contract).
-      # Not `continue-on-error` -- this exit status is the job's.
-      - name: Compare ladder results against formal/EXPECTED_FAIL
+      # The real signal, and it is now TWO set-equalities, both in both
+      # directions (ADR-0022, ADR-0014's contract):
+      #
+      #   formal/EXPECTED_FAIL   which checks are red. An unexpected *pass*
+      #                          (e.g. the C.JR fix landing) trips this as
+      #                          loudly as a new failure.
+      #   formal/EXPECTED_CHECKS which checks EXIST. Without it a lost
+      #                          formal/checks.cfg [depth] line silently
+      #                          shrinks the ladder and the remaining checks
+      #                          still match the baseline exactly -- a green
+      #                          nightly over less coverage than it claims
+      #                          (ADR-0033, gap 1).
+      #
+      # check-baseline.sh defaults its third argument to the EXPECTED_CHECKS
+      # beside it, so the invocation below is unchanged. Not
+      # `continue-on-error` -- this exit status is the job's.
+      - name: Compare ladder results against formal/EXPECTED_{FAIL,CHECKS}
         run: |
           {
             echo "### formal ladder vs formal/EXPECTED_FAIL"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,15 +175,6 @@ What does not work right now:
   practical budget. It is the check that ties RVFI's self-report to the actual register file, so
   without it the other 55 passing checks establish that the core's story about itself is
   spec-consistent, not that the story is true.
-- **A green ladder is narrower than it reads** (ADR-0033). `formal/checks.cfg`'s `[depth]` table is
-  the list of checks that *exist*, not a tuning table: `genchecks` drops any check with no depth
-  line, silently, and `formal/check-baseline.sh` globs directories `sby` creates only for checks
-  that ran — so a never-generated check is missing from the results and from `formal/EXPECTED_FAIL`
-  at once, and set equality reports a clean match. Fourteen upstream checks are dropped today;
-  `checks.cfg` reasons about ten of them, and one of the other four (`ill`) is applicable, would
-  fail today, and is off the ladder. **So `formal/EXPECTED_FAIL` reaching empty — M2's declared
-  signal — is necessary but not sufficient until the check count is asserted.** Read it with the
-  generated count beside it.
 - **The formal nightly cannot go red** (ADR-0022). `.github/workflows/formal-nightly.yml:48` is
   `make -C formal check || true`, and `formal/Makefile`'s `check` has no `-k`, so the sub-make also
   stops scheduling at the first failure. Today's nightly runs a partial ladder and reports it as
@@ -192,6 +183,34 @@ What does not work right now:
   `components_accessor`, and `components_writeback` contain no assertions at all, only reset
   assumptions, so they "pass" meaninglessly. CI deliberately does not run them; ADR-0006 slates
   them for deletion. A green run of one of those is not a result.
+
+**The ladder now asserts its own shape, so a green ladder can no longer shrink quietly**
+(ADR-0033's gap 1). `formal/checks.cfg`'s `[depth]` table is the list of checks that *exist*, not a
+tuning table — `genchecks` returns early on any check with no depth line, silently — and
+`formal/check-baseline.sh` used to glob the run directories `sby` creates only for checks it
+actually started, so a never-generated check was missing from the results and from
+`formal/EXPECTED_FAIL` at once and set equality called that a clean match. Two files close it, both
+set equalities in **both** directions per ADR-0014: `formal/EXPECTED_CHECKS` names every check that
+must be generated, and `checks.cfg`'s `#omit` lines name every check `genchecks` considered and
+skipped, with a reason each. `formal/genchecks-audit.py` derives both sets by tracing `genchecks`'
+own `get_depth_cfg` calls — it does not re-implement the naming, and it cross-checks its trace
+against `genchecks`' own `consistency_checks`/`instruction_checks` sets and against the `.sby` files
+on disk, so a wrong inventory fails rather than being reported. `check-baseline.sh` now enumerates
+`checks/*.sby` rather than directories, so a generated-but-never-scheduled check resolves to
+NO-STATUS and counts non-PASS, and `make -C formal check` ends in that comparison rather than in
+`sby`'s exit code, which `expect pass,fail` makes meaningless. Deleting any one `[depth]` line —
+including a **passing** check's — now fails at generation in a second and again at the post-run
+gate.
+
+Three checks joined the ladder in the same change, taking it from 79 to **82**: `ill_ch0` (red — see
+`formal/EXPECTED_FAIL`), `causal_mem_ch0` and `hang` (both pass). `ill_ch0` is deliberately landed
+**red**: ADR-0033's rule is that a known-red check on the ladder is the system working and a
+known-red check off the ladder is the system lying. Fifteen upstream checks remain declined, each
+with a `#omit` line; the count is derived from the generator, not asserted in prose. **One of the
+fifteen is a trap for a future reader**: adding a bare `csrc` depth line generates three checks
+reading `rvfi_csrc_check.sv`, which does not exist at the pin — the six real models
+(`rvfi_csrc_{any,const,hpm,inc,upcnt,zero}_check.sv`) are reached only through a per-CSR *test list*
+in `[csrs]`.
 
 What does work: `yosys ... write_cxxrtl` elaborates the current RTL cleanly with zero warnings, the
 cxxrtl binary builds and runs, the `.S` suite passes under it except the one M3 test still seeded in
@@ -280,7 +299,8 @@ make waves          # iverilog + VCD (testbench.vvp's baked-in program) -> waves
 make monitor-check  # regenerate test/monitor.v at the pin and diff
 
 make -C formal components_decoder   # component proofs
-make -C formal check                # the riscv-formal ladder (79 checks; see ADR-0023)
+make -C formal check                # the riscv-formal ladder (82 checks; see ADR-0023)
+make -C formal check-baseline       # re-grade a finished ladder: EXPECTED_CHECKS + EXPECTED_FAIL
 
 make sail-setup     # once: fetch the pinned sail-riscv release into tools/sail/
 make cosim-run      # Sail co-simulation on ONE program (PROG=add.S). Opt-in; see ADR-0032
@@ -374,9 +394,11 @@ in both sim legs) and `86e2721` landed the ladder port itself (`wrapper.v` / `ch
 wording is "re-proves everything the serialized core proved", and 15 red checks plus an inconclusive
 `reg` plus a non-converging `equiv.sh` is not that. ADR-0023 lists what closing it takes; the
 `formal/EXPECTED_FAIL` baseline of ADR-0022 reaching empty is the signal — read together with the
-generated check count, per ADR-0033. `rtl/csrs.v` took that baseline from 11 entries to 9 (both
-`csrw_*`) on a 79-check ladder; the remaining 9 are all the trap gap, so the next M3 step closes
-them or the attribution behind them was wrong.
+generated check count, per ADR-0033, which is now `formal/EXPECTED_CHECKS` and is asserted rather
+than recited. `rtl/csrs.v` took that baseline from 11 entries to 9 (both `csrw_*`) on a 79-check
+ladder; landing `ill_ch0` red made it 10 on an 82-check ladder. **All ten are the trap gap** — nine
+misalignment, one illegal-instruction — so the next M3 step closes every one of them or the
+attribution behind them was wrong.
 
 ## Pointers
 

--- a/formal/EXPECTED_CHECKS
+++ b/formal/EXPECTED_CHECKS
@@ -1,0 +1,141 @@
+# The riscv-formal ladder's EXPECTED SHAPE: every check formal/checks.cfg's
+# [depth] table causes genchecks to generate, one per line.
+#
+# WHY THIS FILE EXISTS (ADR-0033, gap 1). formal/EXPECTED_FAIL answers "did
+# any check's verdict move?" It cannot answer "did a check stop existing?",
+# and those are different questions with the same green. genchecks' two call
+# sites both end with `if depth_cfg is None: return`, so deleting or
+# mistyping one [depth] line removes a check silently -- no .sby, no
+# directory, no status file, no warning, exit 0. A never-generated check is
+# then absent from the results AND absent from EXPECTED_FAIL at once, so
+# that file's set-equality reports a clean match on a smaller ladder. The
+# worst single line to lose is `reg`: ADR-0023 calls reg_ch0 the check that
+# ties RVFI's self-report back to the actual register file.
+#
+# TWO mechanisms read this file, and they catch different things:
+#
+#   formal/genchecks-audit.py  set-equalities the GENERATED set against it
+#                              at generation time, so a lost depth line
+#                              fails in a second rather than after a
+#                              three-minute ladder.
+#   formal/check-baseline.sh   set-equalities the *.sby files on disk
+#                              against it after the run, and treats a name
+#                              here with no status file as non-PASS. That is
+#                              what makes "sby never scheduled it" and "its
+#                              directory vanished" both count as failures
+#                              rather than as a quiet, matching baseline.
+#
+# Set equality in BOTH directions, per ADR-0014's contract: an unexpected
+# ADDITION fails this as loudly as a disappearance. That is the case worth
+# having after a pin bump (ADR-0013) -- upstream growing a check nobody here
+# has ruled on should stop the ladder, not join it unexamined.
+#
+# Edit by hand, never regenerate from a run; regenerating launders exactly
+# the regression this file exists to catch. Adding a line is a claim that
+# the same commit adds a [depth] entry and (if it is red) a formal/
+# EXPECTED_FAIL entry with a reason. Removing one is a claim that the
+# corresponding check should no longer exist, which needs a `#omit` line in
+# checks.cfg saying why.
+#
+# Nothing here is a verdict. Every check on this ladder is `mode bmc`, so a
+# PASS means "no counterexample found within the check's configured depth",
+# not that the property holds; and everything runs under
+# RISCV_FORMAL_ALTOPS, so insn_mul/insn_div/insn_rem passing says nothing
+# whatever about the real multiplier or divider (ADR-0010). This file
+# asserts only that the checks EXIST.
+#
+# Seeded from a from-scratch `python3 formal/genchecks-audit.py` against
+# main at 0d23294 plus this change: 82 generated, 15 declined. The 79-check
+# ladder recorded in ADR-0031 and ADR-0034 grew by three -- causal_mem_ch0,
+# hang and ill_ch0 -- see checks.cfg's declined-checks block for why each.
+
+# --- consistency checks (genchecks' check_cons) -------------------------
+causal_ch0
+causal_mem_ch0
+hang
+ill_ch0
+liveness_ch0
+pc_bwd_ch0
+pc_fwd_ch0
+reg_ch0
+unique_ch0
+
+# --- CSR write checks (check_insn, csr_mode) ----------------------------
+# One per name in checks.cfg's [csrs], which is NOT "the CSRs this core
+# implements" -- see the reasoning next to that list.
+csrw_mcycle_ch0
+csrw_minstret_ch0
+csrw_mscratch_ch0
+
+# --- per-instruction checks (check_insn over riscv-formal's isa_rv32imc
+# --- table at the pin) --------------------------------------------------
+insn_add_ch0
+insn_addi_ch0
+insn_and_ch0
+insn_andi_ch0
+insn_auipc_ch0
+insn_beq_ch0
+insn_bge_ch0
+insn_bgeu_ch0
+insn_blt_ch0
+insn_bltu_ch0
+insn_bne_ch0
+insn_c_add_ch0
+insn_c_addi_ch0
+insn_c_addi16sp_ch0
+insn_c_addi4spn_ch0
+insn_c_and_ch0
+insn_c_andi_ch0
+insn_c_beqz_ch0
+insn_c_bnez_ch0
+insn_c_j_ch0
+insn_c_jal_ch0
+insn_c_jalr_ch0
+insn_c_jr_ch0
+insn_c_li_ch0
+insn_c_lui_ch0
+insn_c_lw_ch0
+insn_c_lwsp_ch0
+insn_c_mv_ch0
+insn_c_or_ch0
+insn_c_slli_ch0
+insn_c_srai_ch0
+insn_c_srli_ch0
+insn_c_sub_ch0
+insn_c_sw_ch0
+insn_c_swsp_ch0
+insn_c_xor_ch0
+insn_div_ch0
+insn_divu_ch0
+insn_jal_ch0
+insn_jalr_ch0
+insn_lb_ch0
+insn_lbu_ch0
+insn_lh_ch0
+insn_lhu_ch0
+insn_lui_ch0
+insn_lw_ch0
+insn_mul_ch0
+insn_mulh_ch0
+insn_mulhsu_ch0
+insn_mulhu_ch0
+insn_or_ch0
+insn_ori_ch0
+insn_rem_ch0
+insn_remu_ch0
+insn_sb_ch0
+insn_sh_ch0
+insn_sll_ch0
+insn_slli_ch0
+insn_slt_ch0
+insn_slti_ch0
+insn_sltiu_ch0
+insn_sltu_ch0
+insn_sra_ch0
+insn_srai_ch0
+insn_srl_ch0
+insn_srli_ch0
+insn_sub_ch0
+insn_sw_ch0
+insn_xor_ch0
+insn_xori_ch0

--- a/formal/EXPECTED_FAIL
+++ b/formal/EXPECTED_FAIL
@@ -9,6 +9,17 @@
 # same commit backs up; adding one back is a regression and needs the same
 # justification test/EXPECTED_FAIL's convention requires.
 #
+# THIS FILE ANSWERS ONLY HALF THE QUESTION, and did not used to say so.
+# It reports whether any check's verdict moved. It cannot report whether a
+# check stopped existing — a check with no formal/checks.cfg [depth] line is
+# never generated, so it is absent from the results AND absent from here at
+# once, and set equality on this file alone calls that a clean match on a
+# smaller ladder (ADR-0033, gap 1). Its sibling formal/EXPECTED_CHECKS
+# asserts which checks exist; check-baseline.sh now enforces both, and a
+# name in EXPECTED_CHECKS with no status file counts as non-PASS here.
+# **Read this file's emptiness as the M2 signal only together with that
+# count.**
+#
 # Every check on this ladder is `mode bmc` (formal/checks.cfg's `solver
 # btormc`, which genchecks turns into `btor btormc`) -- a PASS means "no
 # counterexample found within the check's configured depth," a bounded
@@ -69,6 +80,31 @@ insn_c_lw_ch0
 insn_c_lwsp_ch0
 insn_c_sw_ch0
 insn_c_swsp_ch0
+
+# ill_ch0 is the tenth, and it is here because ADR-0033 decided a known-red
+# check belongs ON the ladder rather than off it: "a known-red check on the
+# ladder is the system working; a known-red check off the ladder is the
+# system lying." It had no [depth] line, so it was never generated, never
+# ran, and never appeared here — the exact shape of hole this file plus
+# formal/EXPECTED_CHECKS now close.
+#
+# checks/rvfi_ill_check.sv reads only ordinary RVFI ports this core already
+# drives. It assumes a retire whose `insn` is all zeros — the canonical
+# illegal instruction — and asserts `trap`, plus `rd_addr == 0`,
+# `rd_wdata == 0`, `mem_wmask == 0`. What makes it red is the same single
+# fact as the nine above: `rvfi_trap` is hardwired 0 in rtl/littlecpu.v
+# because trap entry does not exist yet (M3, ADR-0011; rtl/csrs.v landed the
+# CSR file but nothing reads mtvec/mepc/mcause). Verified rather than
+# argued — btormc reports `bad state property 0 reachable at bound k = 15
+# SATISFIABLE`, a real counterexample at the configured depth, not a build
+# or elaboration error.
+#
+# This is the entry that burns down with the trap work, and it burns down
+# for a different reason than its neighbours: the nine above go green when a
+# misaligned access traps, this one goes green when an ILLEGAL INSTRUCTION
+# traps (ADR-0030's cause 2). Two of ADR-0030's five causes are therefore
+# on the ladder rather than one.
+ill_ch0
 
 # The C.JR/C.JALR decode defect (ADR-0021): rtl/decoder.v:114 routes
 # instr_jalr through i_immediate = instr[31:20], which for a 16-bit

--- a/formal/Makefile
+++ b/formal/Makefile
@@ -19,11 +19,38 @@ all: complete check dmemcheck imemcheck components_decoder components_executor
 # `-k`: without it, GNU make stops scheduling new jobs at the first failing
 # check, so a ladder with known failures (formal/EXPECTED_FAIL) never runs
 # past its first parallel wave and the rest report as "no status" rather
-# than PASS or FAIL (ADR-0022). `-k` is what makes "all 78 checks ran" true.
+# than PASS or FAIL (ADR-0022). `-k` is what makes "all 82 checks ran" true.
+#
+# The leading `-` on the sub-make is what lets check-baseline below be the
+# target's verdict, and it is not laundering an error. Every generated .sby
+# carries `expect pass,fail`, so `sby` exits 0 whether a check passed or
+# failed and the sub-make's exit status never carried a verdict in the first
+# place -- what it CAN do is abort before the compare step runs, which would
+# leave the target exiting 0 with nothing having been checked. Anything the
+# sub-make really failed to run shows up as a missing status file, which
+# check-baseline counts as non-PASS.
 check: checks $(RISCV_FORMAL_DIR)
-	$(MAKE) -BC $< -j$(JOBS) -k
+	-$(MAKE) -BC $< -j$(JOBS) -k
+	$(MAKE) check-baseline
 
-checks: genchecks-local.py checks.cfg | $(RISCV_FORMAL_DIR)
+# Set equality against BOTH baselines, in both directions: EXPECTED_CHECKS
+# (which checks exist) and EXPECTED_FAIL (which of them are red). Split out
+# as its own target so a ladder that has already run can be re-graded in a
+# second without re-running it, and so a local `make check` is gated by the
+# same script the nightly grades with rather than by sby's suppressed exit
+# code (ADR-0022, ADR-0033).
+.PHONY: check-baseline
+check-baseline: check-baseline.sh EXPECTED_FAIL EXPECTED_CHECKS
+	./check-baseline.sh checks EXPECTED_FAIL EXPECTED_CHECKS
+
+# genchecks-audit.py runs genchecks-local.py and additionally asserts the
+# ladder's SHAPE before anything runs it: the generated set against
+# EXPECTED_CHECKS, and the set genchecks DECLINED (no [depth] line, silently
+# skipped) against checks.cfg's `#omit` declarations. Both are set
+# equalities in both directions. It fails in about a second, which is the
+# point -- check-baseline catches the same shrunken ladder, but only after
+# the full run (ADR-0033).
+checks: genchecks-audit.py genchecks-local.py checks.cfg EXPECTED_CHECKS | $(RISCV_FORMAL_DIR)
 	python3 $<
 
 # genchecks-local.py is vendored from the pin and may differ from it only by

--- a/formal/check-baseline.sh
+++ b/formal/check-baseline.sh
@@ -1,28 +1,105 @@
 #!/bin/bash
-# Tallies the riscv-formal ladder's per-check status files (`make -C formal
-# check`, formal/checks/*/status) and checks the resulting non-PASS set
-# against formal/EXPECTED_FAIL — same contract as test/run_tests.sh /
-# ADR-0014, applied to the formal ladder per ADR-0022: set equality in both
-# directions, so an unexpected *pass* trips this as loudly as a new failure.
+# The riscv-formal ladder's gate. Asserts TWO things, and both are set
+# equalities in both directions (ADR-0014's contract, applied to the formal
+# ladder per ADR-0022 -- an unexpected *pass*, or an unexpected *check*,
+# fails this as loudly as a regression):
 #
-# A check whose directory has no `status` file at all (make stopped
-# scheduling it, or it's still running) counts as non-PASS too — that is
-# exactly the "ladder didn't actually finish" failure mode ADR-0022 names,
-# and it must not read as a quiet, matching baseline.
+#   1. SHAPE.  The checks genchecks generated (formal/checks/*.sby) are
+#      exactly the ones formal/EXPECTED_CHECKS names.
+#   2. VERDICT. The checks whose status is not PASS are exactly the ones
+#      formal/EXPECTED_FAIL names.
 #
-# Usage: check-baseline.sh <checks-dir> <expected-fail-file>
+# (1) is not decoration. Without it this script could not tell a ladder that
+# shrank from one that passed. formal/checks.cfg's [depth] table is the list
+# of checks that EXIST -- genchecks skips any check with no depth line,
+# silently -- so deleting one line removes a check from the results AND from
+# EXPECTED_FAIL at the same time, and (2) alone reports a clean match on
+# less coverage than it claims. That is ADR-0033's gap 1, and (1) closes it.
+#
+# This script deliberately enumerates the generated `*.sby` FILES, not the
+# run directories. `sby` creates a directory only for a check it actually
+# STARTS, so globbing directories made a generated-but-never-scheduled check
+# invisible: it fell out of the actual set, it was never in the baseline,
+# and set equality called that a match. Reading the .sby files instead means
+# such a check resolves to NO-STATUS and counts as non-PASS, which is what
+# this script's header has promised since it was written -- "make stopped
+# scheduling it, or it's still running" is a failure, not a quiet pass.
+#
+# A check named in EXPECTED_CHECKS with no .sby on disk is likewise
+# NO-STATUS, so a lost [depth] line trips BOTH assertions rather than
+# neither.
+#
+# Nothing here is a verdict about the core. Every check on this ladder is
+# `mode bmc`: PASS means no counterexample was found within that check's
+# configured depth, not that the property holds. And the whole ladder runs
+# under RISCV_FORMAL_ALTOPS, so a passing insn_mul/insn_div says nothing
+# whatever about the real multiplier or divider (ADR-0010).
+#
+# Usage: check-baseline.sh <checks-dir> <expected-fail-file> [expected-checks-file]
 set -u
+
+if [ $# -lt 2 ] || [ $# -gt 3 ]; then
+  echo "usage: $0 <checks-dir> <expected-fail-file> [expected-checks-file]" >&2
+  exit 2
+fi
 
 CHECKS_DIR=$1
 EXPECTED_FAIL=$2
+EXPECTED_CHECKS=${3:-$(dirname "$0")/EXPECTED_CHECKS}
 
-declare -a dirs=("$CHECKS_DIR"/*/)
-total=${#dirs[@]}
+for f in "$EXPECTED_FAIL" "$EXPECTED_CHECKS"; do
+  if [ ! -f "$f" ]; then
+    echo "error: no such file: $f" >&2
+    exit 2
+  fi
+done
+
+# `#` comments and blank lines out, as both baseline files already allow.
+strip() {
+  sed -e 's/#.*//' -e 's/[[:space:]]*$//' -e '/^[[:space:]]*$/d' "$1" | sort
+}
+
+expected_checks=$(strip "$EXPECTED_CHECKS")
+expected_fail=$(strip "$EXPECTED_FAIL")
+
+# The generated set: one line per checks/<name>.sby. `find` rather than a
+# glob, so a missing or empty directory yields nothing instead of the
+# literal unexpanded pattern -- which would otherwise become a one-element
+# set named `*.sby` and produce a confusing diff instead of the explicit
+# error below.
+generated=$(find "$CHECKS_DIR" -maxdepth 1 -name '*.sby' \
+  -exec basename {} .sby \; 2>/dev/null | sort)
+
+if [ -z "$generated" ]; then
+  echo "error: no *.sby files under $CHECKS_DIR -- the ladder was never" >&2
+  echo "       generated. Run 'make -C formal checks' first." >&2
+  exit 2
+fi
+
+failed=0
+
+if [ "$generated" != "$expected_checks" ]; then
+  echo "Generated check set does NOT match $EXPECTED_CHECKS:"
+  diff <(echo "$expected_checks") <(echo "$generated") \
+    --label expected --label generated
+  echo
+  echo "A check that disappeared here lost its formal/checks.cfg [depth] line"
+  echo "(ADR-0033). A check that appeared needs a [depth] line, an"
+  echo "EXPECTED_CHECKS line, and -- if red -- an $EXPECTED_FAIL entry."
+  echo
+  failed=1
+fi
+
+# Status is read over the UNION of what was generated and what was expected,
+# so a name missing from either side still gets a verdict rather than
+# dropping out of the tally entirely.
+all_checks=$(printf '%s\n%s\n' "$generated" "$expected_checks" | sort -u)
+
+total=0
 declare -a actual_fail=()
-
-for d in "${dirs[@]}"; do
-  name=$(basename "$d")
-  status=$(awk '{print $1; exit}' "$d/status" 2>/dev/null)
+for name in $all_checks; do
+  total=$((total + 1))
+  status=$(awk '{print $1; exit}' "$CHECKS_DIR/$name/status" 2>/dev/null)
   if [ -z "$status" ]; then
     status="NO-STATUS"
   fi
@@ -35,15 +112,19 @@ passed=$((total - ${#actual_fail[@]}))
 echo "$total checks: $passed pass, ${#actual_fail[@]} fail"
 
 actual_sorted=$(printf '%s\n' "${actual_fail[@]:-}" | sed '/^$/d' | sort)
-expected_sorted=$(sed -e 's/#.*//' -e '/^[[:space:]]*$/d' "$EXPECTED_FAIL" | sort)
 
-if [ "$actual_sorted" = "$expected_sorted" ]; then
+if [ "$actual_sorted" = "$expected_fail" ]; then
   echo "Failure list matches $EXPECTED_FAIL exactly."
-  exit 0
+else
+  echo
+  echo "Failure list does NOT match $EXPECTED_FAIL:"
+  diff <(echo "$expected_fail") <(echo "$actual_sorted") \
+    --label expected --label actual
+  failed=1
 fi
 
-echo
-echo "Failure list does NOT match $EXPECTED_FAIL:"
-diff <(echo "$expected_sorted") <(echo "$actual_sorted") \
-  --label expected --label actual
-exit 1
+if [ "$failed" -eq 0 ]; then
+  echo "Generated check set matches $EXPECTED_CHECKS exactly ($total checks)."
+fi
+
+exit "$failed"

--- a/formal/checks.cfg
+++ b/formal/checks.cfg
@@ -83,54 +83,121 @@ minstret
 mscratch
 
 # ------------------------------------------------------------------------
-# The ten checks upstream generates that this ladder deliberately omits.
+# THE CHECKS UPSTREAM OFFERS THAT THIS LADDER DECLINES.
 #
-# genchecks calls check_cons for `fault` and for nine `bus_*` checks. None
-# appears below in [depth], so genchecks silently skips all ten. That is a
-# decision, not an oversight, and it is not a depth problem -- it is an
-# interface problem this core does not have the ports to solve:
+# READ THIS BEFORE READING [depth] AS A TUNING TABLE. It is not one. It is
+# the list of checks that EXIST: both of genchecks' call sites end with
+# `if depth_cfg is None: return`, so a check with no line below is not
+# generated at all -- no .sby, no directory, no status file, no warning,
+# exit 0. Deleting a line silently shrinks the ladder, and because a
+# never-generated check is missing from the results AND from
+# formal/EXPECTED_FAIL at once, that file's set-equality would report a
+# clean match on the smaller ladder (ADR-0033, gap 1).
 #
-#   fault                       needs rvfi_mem_fault + rvfi_mem_fault_rmask/
-#                               wmask, and asserts mcause == 1/5/7. The core
-#                               drives none of the three, rvfi_trap is
-#                               hardwired 0, and mcause does not exist (M3).
+# So the declined set is DECLARED, not described. Each `#omit` line below
+# names one check genchecks considered and skipped, with its reason.
+# formal/genchecks-audit.py traces genchecks' own get_depth_cfg calls,
+# collects everything it dropped, and set-equalities that against these
+# lines in both directions -- so the COUNT here is derived from the
+# generator's behaviour rather than asserted in prose, and a check that
+# upstream adds at the next pin bump (ADR-0013) fails generation until
+# someone rules on it. Its sibling assertion is formal/EXPECTED_CHECKS,
+# which does the same for the checks that ARE generated.
 #
-#   bus_imem, bus_imem_fault    all nine need `RISCV_FORMAL_BUS`, i.e. a
-#   bus_dmem, bus_dmem_fault    second RVFI interface: bus_valid, bus_insn,
-#   bus_dmem_io_read(_fault)    bus_data, bus_fault, bus_addr, bus_rmask,
-#   bus_dmem_io_write(_fault)   bus_wmask, bus_rdata, bus_wdata. The core
-#   bus_dmem_io_order           drives zero of them.
+# genchecks' cfg parser drops every line starting with `#`, so these
+# declarations are invisible to it and cannot perturb generation.
 #
-# Three separate reasons they are not simply "future work with a depth line":
+# The reasons, grouped. Nothing here is a depth problem:
 #
-# 1. Every `*_fault` variant models a bus that can refuse a transaction.
-#    This core's bus cannot: imem_data/imem_data2/mem_rdata are free every
-#    cycle with no fault line and no handshake (invariant 1, ADR-0015,
-#    formal/wrapper.v). Worse, a bus fault is by construction detected
-#    *after* decode, and invariant 2 says nothing faults after decode. So
-#    fault, bus_imem_fault, bus_dmem_fault, bus_dmem_io_read_fault and
-#    bus_dmem_io_write_fault are not merely unimplemented -- they check a
-#    trap model this design has ruled out. They need an ADR before they need
-#    a depth.
+# 1. `fault` and every `*_fault` variant model a bus that can refuse a
+#    transaction. This core's bus cannot: imem_data/imem_data2/mem_rdata
+#    are free every cycle with no fault line and no handshake (invariant 1,
+#    ADR-0015, formal/wrapper.v). More decisively, a bus fault is by
+#    construction detected *after* decode, and invariant 2 says nothing
+#    faults after decode. These check a trap model this design has ruled
+#    out; they need an ADR before they need a depth.
 #
-# 2. The three io ones (bus_dmem_io_read, bus_dmem_io_write,
-#    bus_dmem_io_order) additionally need `rvformal_addr_io` -- a
-#    distinguished MMIO region with ordering semantics. ADR-0008's map has a
-#    tohost word, not an IO region the RTL treats differently, and there is
-#    no ordering to check with one outstanding access at a time.
+# 2. All nine bus_* need `RISCV_FORMAL_BUS` -- a second RVFI interface:
+#    bus_valid, bus_insn, bus_data, bus_fault, bus_addr, bus_rmask,
+#    bus_wmask, bus_rdata, bus_wdata. The core drives zero of them. The
+#    three io ones additionally need `rvformal_addr_io`, a distinguished
+#    MMIO region with ordering semantics; ADR-0008's map has a tohost word,
+#    not a region the RTL treats differently, and there is no ordering to
+#    check with one outstanding access at a time. bus_imem and bus_dmem are
+#    the only two whose *property* is meaningful here -- and
+#    formal/imemcheck.sv and formal/dmemcheck.sv already check it against
+#    the real split imem_addr/imem_addr2 interface (ADR-0003), and both
+#    pass. Adopting the bus_* forms would mean plumbing nine RVFI outputs to
+#    re-derive a result already held, and would put an `ifdef RISCV_FORMAL`
+#    value on a path the core reads -- exactly what ADR-0020's
+#    non-perturbation argument depends on nothing doing.
 #
-# 3. bus_imem and bus_dmem are the only two whose *property* is meaningful
-#    here -- and formal/imemcheck.sv and formal/dmemcheck.sv already check
-#    it, against the real split imem_addr/imem_addr2 interface (ADR-0003),
-#    and both pass. Adopting the bus_* forms would mean plumbing nine RVFI
-#    outputs to re-derive a result already held, and would put an `ifdef
-#    RISCV_FORMAL` value on a path the core reads -- exactly the thing
-#    ADR-0020's non-perturbation argument depends on nothing doing.
+# 3. The three csrc_* are declined because THEY CANNOT BUILD, and this is
+#    the one omission that is a trap for a future reader rather than a
+#    judgement call. [csrs] holds bare names, so genchecks calls check_cons
+#    with csr_test=None, which sets check_name = "csrc" and would emit a
+#    .sby reading `rvfi_csrc_check.sv`. NO SUCH FILE EXISTS AT THE PIN: the
+#    re-vendor's six models are rvfi_csrc_{any,const,hpm,inc,upcnt,zero}
+#    _check.sv, all reached only through a per-CSR test list in [csrs]
+#    (`minstret inc`, `mvendorid const`, ...). Adding a bare `csrc` depth
+#    line would therefore generate three checks that fail to elaborate.
+#    The right move is a test list -- see the [csrs] comment above, which
+#    names csrc_inc_minstret as the one to reach for first (ADR-0027) --
+#    and each one needs its own derived depth (ADR-0025) and
+#    formal/EXPECTED_FAIL entry (ADR-0022).
 #
-# Summary: 0 of 10 are applicable as the core stands. bus_imem/bus_dmem are
-# the only two worth revisiting, and only if the bus interface grows a fault
-# or handshake line; the other eight need M3 traps, an MMIO region, or a
-# trap model invariant 2 forbids.
+# 4. `cover` is not lost, it is relocated: formal/cover.sby runs it
+#    standalone with this repo's own five goals (>=2 loads, >=2 stores, >=2
+#    compressed and >=2 uncompressed retires in a single trace) rather than
+#    genchecks' default, which is precisely why it is not wanted on the
+#    generated ladder as well.
+#
+# 5. `causal_io` needs the same `rvformal_addr_io` region as the three bus
+#    io checks, for the same reason: there isn't one.
+#
+# THREE checks that used to sit in this list are now ON the ladder, and
+# their absence was the hole ADR-0033 found.
+#
+#   ill_ch0         reads only ordinary RVFI ports this core already drives,
+#                   and FAILS today -- rvfi_trap is hardwired 0 -- so
+#                   leaving it out kept a known-red property off the ladder
+#                   AND out of formal/EXPECTED_FAIL at the same time. It is
+#                   now generated, red, and baselined, which is the system
+#                   working; the M3 trap work retires it.
+#
+#   causal_mem_ch0  runs entirely off standard RVFI mem signals and needs no
+#                   RISCV_FORMAL_BUS at all, so there was never a reason to
+#                   decline it. PASSes.
+#
+#   hang            was going to be declined here as "subsumed by the
+#                   passing liveness_ch0". Reading the two models says
+#                   otherwise, and the difference is the whole point of this
+#                   block. rvfi_liveness_check.sv opens with
+#                   `assume(rvfi_valid[...])` at its trig cycle: it bounds
+#                   the gap from one retire to the next, and is VACUOUS on a
+#                   core that never retires at all. rvfi_hang_check.sv
+#                   asserts a retire happened by its check cycle with no
+#                   such assumption, which is a strictly different property.
+#                   formal/cover.sby exhibits retires, but a cover witness
+#                   is not a proof of an assertion. So the reason for
+#                   omitting it evaporated on inspection, and the check went
+#                   on the ladder instead. PASSes in ~3s.
+#
+#omit fault_ch0                   needs rvfi_mem_fault{,_rmask,_wmask} and mcause; models a post-decode trap invariant 2 forbids
+#omit bus_imem_ch0                needs RISCV_FORMAL_BUS; property already held by formal/imemcheck.sv
+#omit bus_imem_fault_ch0          needs RISCV_FORMAL_BUS; and a bus that can refuse a transaction
+#omit bus_dmem_ch0                needs RISCV_FORMAL_BUS; property already held by formal/dmemcheck.sv
+#omit bus_dmem_fault_ch0          needs RISCV_FORMAL_BUS; and a bus that can refuse a transaction
+#omit bus_dmem_io_read_ch0        needs RISCV_FORMAL_BUS and rvformal_addr_io; no MMIO region exists
+#omit bus_dmem_io_read_fault_ch0  needs RISCV_FORMAL_BUS, rvformal_addr_io, and a faulting bus
+#omit bus_dmem_io_write_ch0       needs RISCV_FORMAL_BUS and rvformal_addr_io; no MMIO region exists
+#omit bus_dmem_io_write_fault_ch0 needs RISCV_FORMAL_BUS, rvformal_addr_io, and a faulting bus
+#omit bus_dmem_io_order_ch0       needs RISCV_FORMAL_BUS and rvformal_addr_io; one outstanding access, no ordering to check
+#omit causal_io_ch0               needs rvformal_addr_io; no MMIO region exists
+#omit csrc_mcycle_ch0             bare [csrs] name emits rvfi_csrc_check.sv, which does not exist at the pin
+#omit csrc_minstret_ch0           bare [csrs] name emits rvfi_csrc_check.sv, which does not exist at the pin
+#omit csrc_mscratch_ch0           bare [csrs] name emits rvfi_csrc_check.sv, which does not exist at the pin
+#omit cover                       run standalone by formal/cover.sby with this repo's own five goals
 # ------------------------------------------------------------------------
 
 [depth]
@@ -175,6 +242,23 @@ mscratch
 # ALL OF THE ABOVE ASSUMES `RISCV_FORMAL_ALTOPS` (see [defines]). Without it
 # the real divider holds executor_out.valid for 32 cycles, the single-hop
 # floor becomes ~38, and every number here must be re-derived.
+#
+# `ill` and `causal_mem` were added after the rest, and take their depths from
+# the sibling whose shape they share rather than from a fresh derivation:
+#
+#   ill        check_cons(..., depth=0), so one column, and RESET_CYCLES
+#              defaults to 1 -- byte-for-byte the configuration `insn` runs
+#              under. rvfi_ill_check.sv assumes one retiring instruction with
+#              insn == 0 and asserts on that instruction's own retired values
+#              (trap, rd_addr, rd_wdata, mem_wmask), which is the same
+#              instruction-lifetime question `insn` asks. Same shape, same
+#              floor, so the same 15.
+#
+#   causal_mem check_cons(..., start=0, depth=1), the two-column retire-gap
+#              form `causal` uses, and rvfi_causal_mem_check.sv is
+#              rvfi_causal_check.sv's argument over memory bytes instead of
+#              register indices -- it watches the same rvfi_valid/rvfi_order
+#              stream over the same (depth - start) window. Same 10 20.
 insn           15
 reg      15    20
 pc_fwd   10    30
@@ -182,6 +266,9 @@ pc_bwd   10    30
 liveness 1  10 30
 unique   1  10 30
 causal   10    20
+causal_mem 10  20
+hang     1     30
+ill            15
 csrw           30
 
 [script-sources]

--- a/formal/genchecks-audit.py
+++ b/formal/genchecks-audit.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+#
+# Generates the riscv-formal ladder and asserts its SHAPE -- which checks
+# exist -- before anything runs them.
+#
+# Why this exists (ADR-0033, gap 1). `formal/checks.cfg`'s `[depth]` section
+# reads as a tuning table. It is not: it is the list of checks that exist.
+# Both of genchecks' call sites end with
+#
+#     if depth_cfg is None: return
+#
+# so a check with no matching `[depth]` line is not generated at all -- no
+# `.sby`, no directory, no status file, no warning, exit 0. Deleting or
+# mistyping one line therefore removes a check from the ladder silently, and
+# nothing downstream notices: a never-generated check is absent from the
+# results AND absent from `formal/EXPECTED_FAIL` at once, so that file's
+# set-equality reports a clean match with less coverage than it claims.
+#
+# This script closes that by deriving, from the generator's own behaviour,
+# the two sets a reader cares about:
+#
+#   generated  every check genchecks emitted a .sby for
+#   dropped    every check genchecks CONSIDERED and skipped for want of a
+#              [depth] line
+#
+# and asserting both against files the repo commits to -- `EXPECTED_CHECKS`
+# and `checks.cfg`'s `#omit` declarations -- with set equality in BOTH
+# directions, per ADR-0014's contract: an unexpected *addition* trips this as
+# loudly as a disappearance. That matters after a pin bump (ADR-0013), which
+# is exactly when upstream may grow a check nobody here has ruled on.
+#
+# HOW the derivation works, and why it is not a second copy of genchecks'
+# logic. `genchecks-local.py` must stay byte-comparable with the pin except
+# for `basedir` (ADR-0031), so it cannot be instrumented. Instead this script
+# runs it under `sys.settrace` and records every `get_depth_cfg` call: its
+# `patterns` argument and whether it returned None. The LAST pattern in that
+# argument is, at every call site, the fully-qualified check name --
+# `insn_add_ch0`, `csrw_mcycle_ch0`, `causal_ch0`, `hang` -- which is what
+# makes a name recoverable without re-deriving it here.
+#
+# That assumption is not trusted, it is CHECKED: the names this script
+# recovers as generated must equal genchecks' own `consistency_checks |
+# instruction_checks` sets, and those must equal the `.sby` files actually on
+# disk. If a future pin changes how a check name is built, or adds a
+# `filter-checks` drop this script cannot see, the three disagree and this
+# fails rather than quietly reporting a wrong inventory.
+#
+# Run from formal/, exactly like `python3 genchecks-local.py`, which it
+# replaces as the `checks` target's recipe.
+
+import os
+import re
+import runpy
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+GENCHECKS = os.path.join(HERE, "genchecks-local.py")
+CFG = os.path.join(HERE, "checks.cfg")
+EXPECTED_CHECKS = os.path.join(HERE, "EXPECTED_CHECKS")
+CHECKS_DIR = os.path.join(HERE, "checks")
+
+# `#omit <check-name> <one-line reason>` in checks.cfg. genchecks' own cfg
+# parser drops every line starting with `#` before it sees a section, so
+# these are invisible to it and cannot perturb generation.
+OMIT_RE = re.compile(r"^#omit\s+(\S+)\s+(\S.*)$")
+
+
+def read_name_list(path):
+    """One name per line; `#` comments and blank lines ignored, as
+    formal/EXPECTED_FAIL and test/EXPECTED_FAIL already do."""
+    names = []
+    with open(path) as f:
+        for line in f:
+            line = line.split("#", 1)[0].strip()
+            if line:
+                names.append(line)
+    return names
+
+
+def read_omit_decls(path):
+    decls = {}
+    with open(path) as f:
+        for line in f:
+            match = OMIT_RE.match(line.rstrip("\n"))
+            if match:
+                decls[match.group(1)] = match.group(2).strip()
+    return decls
+
+
+def report_set_diff(label, expected, actual, expected_label, actual_label):
+    """Both directions, ADR-0014's contract. Returns True on mismatch."""
+    missing = sorted(expected - actual)
+    extra = sorted(actual - expected)
+    if not missing and not extra:
+        return False
+    print(f"\n{label}: MISMATCH", file=sys.stderr)
+    for name in missing:
+        print(f"  in {expected_label} but not {actual_label}: {name}", file=sys.stderr)
+    for name in extra:
+        print(f"  in {actual_label} but not {expected_label}: {name}", file=sys.stderr)
+    return True
+
+
+# ---------------------------------------------------------------- the trace
+
+records = []
+
+
+def return_tracer(frame, event, arg):
+    if event == "return":
+        records.append((tuple(frame.f_locals["patterns"]), arg))
+    return None
+
+
+def call_tracer(frame, event, arg):
+    if event == "call" and frame.f_code.co_name == "get_depth_cfg":
+        return return_tracer
+    return None
+
+
+def main():
+    # genchecks reads `checks.cfg` and writes `checks/` relative to the
+    # working directory, and takes `corename` from its last path component.
+    # Running it from anywhere else silently produces a ladder somewhere
+    # else, so refuse rather than do that.
+    if os.path.realpath(os.getcwd()) != os.path.realpath(HERE):
+        print(f"error: run from {HERE}, not {os.getcwd()}", file=sys.stderr)
+        return 1
+
+    sys.settrace(call_tracer)
+    try:
+        genchecks = runpy.run_path(GENCHECKS, run_name="__main__")
+    finally:
+        sys.settrace(None)
+
+    if not records:
+        print(
+            "error: traced no get_depth_cfg calls. genchecks-local.py no longer\n"
+            "       has a function by that name, or no longer takes `patterns`.\n"
+            "       Re-read this script's header against the pin before trusting\n"
+            "       any inventory it prints.",
+            file=sys.stderr,
+        )
+        return 1
+
+    considered = {}
+    for patterns, result in records:
+        name = patterns[-1]
+        was_generated = result is not None
+        if considered.get(name, was_generated) != was_generated:
+            print(
+                f"error: {name} was both generated and dropped -- the "
+                "last-pattern-is-the-name assumption no longer holds.",
+                file=sys.stderr,
+            )
+            return 1
+        considered[name] = was_generated
+
+    generated = {n for n, ok in considered.items() if ok}
+    dropped = {n for n, ok in considered.items() if not ok}
+
+    failed = False
+
+    # 1. The derivation validates itself against genchecks' own bookkeeping.
+    #    If these disagree, every count below is wrong and none of the
+    #    set-equalities beneath mean anything.
+    genchecks_own = set(genchecks["consistency_checks"]) | set(
+        genchecks["instruction_checks"]
+    )
+    failed |= report_set_diff(
+        "traced check names vs genchecks' own sets",
+        genchecks_own,
+        generated,
+        "genchecks",
+        "trace",
+    )
+
+    # 2. ...and against what is actually on disk, which is what sby runs.
+    on_disk = {
+        e[: -len(".sby")] for e in os.listdir(CHECKS_DIR) if e.endswith(".sby")
+    }
+    failed |= report_set_diff(
+        "generated check names vs checks/*.sby on disk",
+        generated,
+        on_disk,
+        "genchecks",
+        "disk",
+    )
+
+    # 3. The ladder is the size the repo says it is (ADR-0033's assertion).
+    expected = set(read_name_list(EXPECTED_CHECKS))
+    failed |= report_set_diff(
+        "generated ladder vs formal/EXPECTED_CHECKS",
+        expected,
+        generated,
+        "EXPECTED_CHECKS",
+        "generated",
+    )
+
+    # 4. Every check upstream offered and this ladder declined is declined on
+    #    purpose, in writing, next to [depth]. This is what makes the
+    #    omission count derived rather than prose.
+    omitted = read_omit_decls(CFG)
+    failed |= report_set_diff(
+        "dropped checks vs checks.cfg #omit declarations",
+        set(omitted),
+        dropped,
+        "#omit",
+        "dropped",
+    )
+
+    print(
+        f"Ladder shape: {len(generated)} generated, {len(dropped)} declined "
+        f"for want of a [depth] line."
+    )
+    if failed:
+        print(
+            "\nThe ladder is not the shape this repo committed to. Either the\n"
+            "change was intended -- in which case update formal/EXPECTED_CHECKS\n"
+            "and/or checks.cfg's #omit list in the same commit, and say why --\n"
+            "or a [depth] line was lost, which is the failure ADR-0033 named.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"formal/EXPECTED_CHECKS: {len(expected)} names, exact match. "
+        f"checks.cfg #omit: {len(omitted)} names, exact match."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes JEF-653

Implements ADR-0033's gap 1: `formal/EXPECTED_FAIL` reaching empty — M2's declared signal — was necessary but not sufficient, because nothing asserted that the checks still *existed*.

## The hole

Four mechanisms, none individually wrong:

1. `genchecks-local.py`'s two call sites both end `if depth_cfg is None: return`, so a check with no `[depth]` line is never generated — no `.sby`, no directory, no status file, no warning, exit 0.
2. Nothing asserted how many checks should exist. The number lived in prose (CLAUDE.md and three ADRs).
3. `check-baseline.sh` enumerated the run **directories** `sby` creates only for checks it actually *starts*, so a generated-but-never-scheduled check landed in neither the actual-fail set nor the baseline.
4. Every generated `.sby` carries `expect pass,fail`, so `sby`'s exit code carried no verdict either.

Deleting one `[depth]` line for a currently-**passing** check therefore left the non-PASS set identical to the baseline. Demonstrated against the old script, with `reg_ch0`'s directory removed:

```
81 checks: 71 pass, 10 fail
Failure list matches EXPECTED_FAIL exactly.
old exit: 0
```

`reg_ch0` is the worst one to lose — ADR-0023 calls it the check that ties RVFI's self-report back to the actual register file.

## What landed

- **`formal/EXPECTED_CHECKS`** — every check that must be generated, set-equalled in both directions (ADR-0014's contract), so an unexpected *addition* fails as loudly as a disappearance. That is the case worth having after a pin bump.
- **`formal/genchecks-audit.py`** — derives the generated and declined sets from the generator rather than re-implementing its naming. `genchecks-local.py` must stay byte-comparable with the pin except for `basedir` (ADR-0031), so it cannot be instrumented; the audit runs it under `sys.settrace` and records every `get_depth_cfg` call and whether it returned `None`. The derivation is **cross-checked, not trusted**: the names it recovers must equal genchecks' own `consistency_checks`/`instruction_checks` sets *and* the `.sby` files on disk, so a future pin that changes how a name is built fails rather than reporting a wrong inventory.
- **`checks.cfg`** — one `#omit` line per declined check with a reason each; the audit set-equals them, so the count is derived from the generator rather than asserted in prose.
- **`check-baseline.sh`** — enumerates `checks/*.sby` instead of directories, and reads status over the union of generated and expected names, so a lost `[depth]` line trips *both* assertions rather than neither. Third argument defaults to the sibling `EXPECTED_CHECKS`, so the nightly's existing invocation is unchanged.
- **`formal/Makefile`** — `check` ends in that comparison, and a `check-baseline` target re-grades a finished ladder in a second.

## Three checks joined the ladder: 79 → 82

| check | verdict | why |
|---|---|---|
| `ill_ch0` | **red**, baselined | `rvfi_ill_check.sv` reads only RVFI ports this core already drives. btormc: `bad state property 0 reachable at bound k = 15 SATISFIABLE` — a real counterexample, because `rvfi_trap` is hardwired 0 until trap entry lands (M3, ADR-0011). Per ADR-0033, a known-red check on the ladder is the system working; off it, the system lying. Burns down on ADR-0030's cause **2**, not the misalignment causes the other nine wait for. |
| `causal_mem_ch0` | PASS | runs entirely off standard RVFI mem signals; no `RISCV_FORMAL_BUS` needed, so there was never a reason to decline it. |
| `hang` | PASS | **the ticket's stated reason for omitting it does not hold.** `rvfi_liveness_check.sv` assumes a retire at its trig cycle — it bounds retire-to-retire gaps and is *vacuous* on a core that never retires at all. `rvfi_hang_check.sv` asserts a retire happened with no such assumption. Different property, so the check went on the ladder rather than into the omission list. |

## Two corrections to the ticket's numbers

- The ticket said fourteen checks are dropped. **Eighteen were**, at main. The extra four are `cover` (relocated to `formal/cover.sby`, correctly) and three `csrc_*`. Fifteen remain declined after this change.
- The three `csrc_*` are a trap for a future reader and are now documented as one: `[csrs]` holds bare names, so a bare `csrc` depth line would emit three checks reading `rvfi_csrc_check.sv`, **which does not exist at the pin**. The six real models are `rvfi_csrc_{any,const,hpm,inc,upcnt,zero}_check.sv`, reachable only through a per-CSR *test list*. Adding the depth line would generate checks that fail to elaborate.

## Acceptance criteria, with output

**1. Deleting any one `[depth]` line — including a passing check's (`reg`) — fails the gate.** At generation:

```
$ make -C formal checks
generated ladder vs formal/EXPECTED_CHECKS: MISMATCH
  in EXPECTED_CHECKS but not generated: reg_ch0
dropped checks vs checks.cfg #omit declarations: MISMATCH
  in dropped but not #omit: reg_ch0
make: *** [checks] Error 1
```

and again at the post-run gate:

```
Generated check set does NOT match EXPECTED_CHECKS:
81d80
< reg_ch0
82 checks: 71 pass, 11 fail
Failure list does NOT match EXPECTED_FAIL:
10a11
> reg_ch0
check-baseline exit: 1
```

**2. Deleting one check's directory after the run fails the gate** (`.sby` still present, so this is the never-scheduled case):

```
82 checks: 71 pass, 11 fail
Failure list does NOT match EXPECTED_FAIL:
10a11
> reg_ch0
check-baseline exit: 1
```

**3. The omission count is derived, not asserted.** `checks.cfg` carries 15 `#omit` lines; `genchecks-audit.py` traces what genchecks actually dropped and set-equals it.

**4. `ill_ch0` is generated, runs, and is baselined** with the `rvfi_trap`-hardwired-0 justification in `formal/EXPECTED_FAIL`.

**5. `make -C formal check` exits nonzero on a deviation, with no workflow involved.** Real run with `ill_ch0` removed from the baseline:

```
82 checks: 72 pass, 10 fail
Failure list does NOT match EXPECTED_FAIL:
0a1
> ill_ch0
make[1]: *** [check-baseline] Error 1
make: *** [check] Error 2
make -C formal check exit: 2
```

**6. Full ladder tally, verbatim.** From-scratch `make -C formal check`, 2m48s wall, **exit 0**:

```
Generated 82 checks.
Ladder shape: 82 generated, 15 declined for want of a [depth] line.
formal/EXPECTED_CHECKS: 82 names, exact match. checks.cfg #omit: 15 names, exact match.
82 checks: 72 pass, 10 fail
Failure list matches EXPECTED_FAIL exactly.
Generated check set matches EXPECTED_CHECKS exactly (82 checks).
```

**Change from 79/70/9, explained:** +3 generated (`ill_ch0`, `causal_mem_ch0`, `hang`), +2 pass (`causal_mem_ch0`, `hang`), +1 fail (`ill_ch0`). No previously-existing check's verdict moved.

All 10 non-PASS report sby status `ERROR 16` on this machine rather than `FAIL`: btormc found its counterexample and then failed to shell out to `btorsim`, which is absent locally. Same mechanical caveat ADR-0025 records; the check still failed, only the witness is missing. On CI's OSS CAD Suite they report `FAIL`.

## Negative controls on the new gate

Asking of this code the question the ticket asks of the old code — it must not be able to pass vacuously:

- absent/empty checks dir → `exit 2` with an explicit error, not a silent empty-set match
- missing `EXPECTED_CHECKS` → `exit 2`
- a check generated but *not* in `EXPECTED_CHECKS` → fails, both at generation and at the gate
- a trace that captured nothing, or a broken name derivation → hard error; the generated set must equal genchecks' own sets and the on-disk `.sby` files

## Scope

`formal/` only. **No `rtl/` file is touched** — `ill_ch0` going green is the trap ticket's job. The pin is unchanged (ADR-0013); `make -C formal genchecks-check` still reports `genchecks-local.py` as matching the clone (header + `basedir` only).

Two files outside `formal/` changed, both because they now describe the gate wrongly: CLAUDE.md's "what does not work" bullet for ADR-0033 (the gap is closed) plus the 79→82 counts, and `formal-nightly.yml`'s compare-step name and comment (no functional change — `check-baseline.sh`'s third argument defaults, so the invocation is untouched). `ci.yml` is not touched; CI does not run the ladder.

Every check on this ladder is `mode bmc`, so a PASS means no counterexample was found within that check's configured depth, not that the property holds — and the whole ladder runs under `RISCV_FORMAL_ALTOPS`, so a passing `insn_mul` or `insn_div` says nothing whatever about the real multiplier or divider (ADR-0010). **This change moves M2 no closer. It makes the signal M2 is defined against mean what it says.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
