### PR TITLE
ADR-0036: gate-hardening decisions ratified at integration

### DIFF
--- a/.svlint.toml
+++ b/.svlint.toml
@@ -153,16 +153,23 @@ action_block_with_side_effect = true  # assertion action blocks must not drive s
 # (pending_addr16)` statements in rtl/accessor.v that enumerate every value of
 # their 2-bit and 1-bit selector -- provably exhaustive, flagged anyway.
 #
-# case_default is the one worth revisiting: it is always_comb-scoped (it
-# correctly skips the always_ff block) and has exactly ONE finding on rtl/ --
-# rtl/accessor.v:147, whose commented-out default ("not a load or a store this
-# cycle -- the zeroed defaults above stand") sits precisely where a
+# case_default looked like the one worth revisiting: it is always_comb-scoped
+# (it correctly skips the always_ff block) and has exactly ONE finding on rtl/
+# -- rtl/accessor.v:147, whose commented-out default ("not a load or a store
+# this cycle -- the zeroed defaults above stand") sits precisely where a
 # `default: ;` arm would go. Turning that comment into an arm is a ONE-LINE
-# rtl/ change that would let this rule come on at zero ongoing cost, and it is
-# the rule that would catch a future `case` in `always_comb` with no defaults.
-# That change is deliberately not made here (this file adds a gate; it does not
-# edit what the gate finds) and is filed as a follow-up.
-case_default = false               # 1 finding: rtl/accessor.v:147 wants a `default: ;` arm -- see above
+# rtl/ change that would let the rule come on at zero ongoing cost.
+#
+# That follow-up is DECLINED, not deferred (ADR-0036), and the reason is the
+# measurement at the top of this file: yosys ERRORS on a defaultless
+# `always_comb` case -- `Latch inferred for signal ...`, exit 1 -- so both the
+# elaborate job and the test/rtl.cc recipe already gate that class. The only
+# thing case_default catches that yosys does not is a `case` that is ALREADY
+# SAFE, because it has its defaults assigned first. That is a style
+# requirement, not a defect class, and it is not worth an rtl/ edit to the
+# stage whose legibility CLAUDE.md singles out. Reopening it needs a defect
+# class yosys does not already error on.
+case_default = false               # style, not safety: yosys already errors on the latch -- see above
 explicit_case_default = false      # 10 findings; 4 provably exhaustive, and it fires inside always_ff too
 implicit_case_default = false      # 8 findings; measured NOT to honour a preceding default assignment
 

--- a/docs/adr/0036-three-gate-hardening-decisions-ratified-at-integration.md
+++ b/docs/adr/0036-three-gate-hardening-decisions-ratified-at-integration.md
@@ -1,0 +1,151 @@
+# ADR-0036: Three gate-hardening decisions ratified at integration, and a correction to ADR-0031
+
+**Status:** Accepted · 2026-07-31 · *Recorded at integration. Corrects ADR-0031's `csrc_*`
+framing; scopes the `case` family disabled in `.svlint.toml`; notes a gap in ADR-0022's
+enforcement.*
+
+## Context
+
+Three changes landed together because all three are about the same thing: the gates that decide
+whether work merges. `0355193` added a structural lint gate, `b585b17` hardened the simulation
+gate so an assembler or `objcopy` failure cannot report PASS (ADR-0035), and `961e359` made the
+formal ladder assert its own shape rather than only its verdicts (ADR-0033's gap 1).
+
+Each carried a judgement the ticket that asked for it did not anticipate, and two of them
+contradicted a claim written down elsewhere in this repo. A wrong claim left standing in an ADR
+is worse than one never written, because the next reader has no way to tell it apart from a
+measured one. So the corrections are recorded here rather than only in the reviews.
+
+## Decision
+
+### 1. `hang` belongs on the ladder. `liveness` does not subsume it.
+
+The ticket asked for `hang` to be declined as "subsumed by the passing `liveness`". **That is
+false**, and the two models say so directly at the pin (`c992aa6`).
+
+`checks/rvfi_liveness_check.sv` opens its trigger cycle with
+
+```verilog
+if (trig) begin
+    assume(rvfi_valid[`RISCV_FORMAL_CHANNEL_IDX]);
+```
+
+so the entire property is conditioned on a retire existing at the trigger cycle. It bounds the gap
+from one retire to the *next*, and it is **vacuous on a core that never retires at all**.
+`checks/rvfi_hang_check.sv` carries no such assumption: `okay` starts at 0, is set only by
+`rvfi_valid`, and is asserted at the check cycle. "A retire happened by cycle N" is a strictly
+different — and strictly stronger, on the never-retires case — property than "retires are not more
+than N apart".
+
+`formal/cover.sby` exhibits retires, but a cover witness is not a proof of an assertion. No sound
+omission reason exists, so `hang` is on the ladder. It passes in ~3s.
+
+The general rule this instance confirms: **an omission whose stated reason evaporates on inspection
+is not an omission, it is a missing check.** `formal/checks.cfg`'s `#omit` lines are load-bearing
+precisely because each one must survive being read against the model it declines.
+
+### 2. ADR-0031 is corrected on the `csrc_*` family
+
+ADR-0031 says the counter-CSR checks "are now generatable and are still not on the ladder", and
+that adding one is "a follow-up needing its own derived depth (ADR-0025) and `formal/EXPECTED_FAIL`
+entry (ADR-0022)". **That framing is incomplete in a way that will mislead whoever acts on it.**
+
+`[csrs]` holds bare names. `genchecks` calls `check_cons` with `csr_test=None` for each, which sets
+`check_name = "csrc"`, and the `.sby` template emits `rvfi_@check@_check.sv` — that is,
+`rvfi_csrc_check.sv`. **No such file exists at the pin.** The six real models are
+`rvfi_csrc_{any,const,hpm,inc,upcnt,zero}_check.sv`, and they are reachable *only* through a
+per-CSR **test list** in `[csrs]` (`minstret inc`, `mvendorid const`, …).
+
+So adding a bare `csrc` depth line does not produce three checks that fail; it produces three
+checks that **cannot elaborate**. What ADR-0031 got right is that the six models are present and
+that `csrc_inc_minstret` is the one to reach for first (ADR-0027). What it got wrong is the
+implication that a `[depth]` line is the missing piece. The `[csrs]` test list is.
+
+This is the one omission in `formal/checks.cfg` that is a trap for a future reader rather than a
+judgement call, and it is now declared there with that reason attached, alongside its three
+`#omit` lines.
+
+### 3. The `case` family stays disabled, and the `rtl/accessor.v` follow-up is declined
+
+`.svlint.toml` disables `case_default`, `explicit_case_default` and `implicit_case_default`. The
+ticket's stated reason — that they do not see the assign-defaults-before-`case` idiom — was wrong,
+and the engineer corrected it with a measurement: on a two-module file differing only in whether
+`y = 0;` precedes the `case`, **all three rules fire identically on both**. Only an explicit
+`default:` arm satisfies them. They are "write a `default:` arm" rules, not latch detectors.
+Re-verified here against svlint 0.9.5: four findings per module, same positions.
+
+That correction stands. The decision it was offered in support of also stands, but **for a
+different reason than either the ticket or `.svlint.toml` first gave**, and the reason is the
+second measurement in the same change: yosys does *not* accept a defaultless `always_comb` `case`.
+It errors
+
+```
+ERROR: Latch inferred for signal `\m.\y' from always_comb process
+```
+
+and exits 1 — re-verified here under Yosys 0.67. The `elaborate` job already runs `proc; opt_clean;
+check`, and the `test/rtl.cc` recipe already runs `write_cxxrtl`, so **the latch class is already a
+hard gate in two places.**
+
+Therefore the proposed one-line follow-up — turning `rtl/accessor.v`'s commented-out default into a
+`default: ;` arm so `case_default` could be enabled — **is declined, not deferred.** Enabling the
+rule would buy a style requirement, not a defect class: the only thing it catches that yosys does
+not is a `case` that is already safe. Paying an `rtl/` edit for that, in the stage whose legibility
+CLAUDE.md singles out, is the wrong trade. `.svlint.toml`'s comment on the rule is corrected in the
+same commit as this ADR, because as written it claimed a value the same file's own measurement
+refutes.
+
+The engineer's ticket discipline in *not* making that `rtl/` edit was correct regardless. A lint
+change that edits what the lint finds is not a lint change.
+
+## Consequences
+
+- `hang` is on the ladder and in `formal/EXPECTED_CHECKS`. If it ever goes red, the core stopped
+  retiring; that is a different and louder failure than `liveness` going red.
+- ADR-0031's `csrc_*` paragraph should be read together with this one. Nothing in the RTL or the
+  ladder changes as a result — the family was not on the ladder before and is not now — but the
+  *route* to putting it there is a `[csrs]` test list, not a `[depth]` line.
+- `case_default` is closed as a question rather than left as a standing invitation. Reopening it
+  needs a defect class yosys does not already error on.
+- **`make lint` is a gate that nothing enforces.** The `lint` CI job runs on every PR, but
+  `main`'s branch protection requires only `elaborate`, `test`, `components` and
+  `monitor-freshness`. A red `lint` therefore does not block a merge today. That is a repository
+  settings change, not a code change, and it is left for a human to make deliberately — the same
+  care ADR-0018 took over which checks gate an automerge. Until it is made, `make lint` is
+  advisory in CI and binding only by convention.
+
+## A gap this integration surfaced but did not close
+
+**`formal/EXPECTED_FAIL` records names only, and ADR-0035 has just shown why that is not enough.**
+The simulation gate learned this lesson in `b585b17`: matching on the test name alone left the set
+equality blind to *why* a test failed, so a broken harness and a broken test were both laundered
+into a green gate, and `test/EXPECTED_FAIL` grew a status field. The formal gate has the identical
+shape and did not.
+
+This is not hypothetical. The post-merge verification run of `make -C formal check` on a machine
+**without `btorsim`** produced:
+
+```
+82 checks: 72 pass, 10 fail
+Failure list matches EXPECTED_FAIL exactly.
+Generated check set matches EXPECTED_CHECKS exactly (82 checks).
+```
+
+exit 0 — while **all ten** non-PASS checks reported `ERROR 16 2`, not `FAIL`. `btormc` found the
+counterexamples correctly (`ill_ch0`: `bad state property 0 reachable at bound k = 15
+SATISFIABLE`); `sby` then failed to render the traces, because the step that does so shells out to
+`btorsim`, which was not on `PATH`. `check-baseline.sh` buckets everything that is not `PASS`
+together, so "a real counterexample at the configured depth" and "the trace renderer is missing"
+are the same result to the gate.
+
+The consequence that matters is the inverse case: if `btorsim` ever vanished from the nightly's
+pinned OSS CAD Suite, every red check would flip `FAIL` → `ERROR`, the set equality would still
+match exactly, and the ladder would stay green having stopped distinguishing a proof failure from a
+tooling failure. That is the same shape as ADR-0033's gaps — *a check that can stop checking
+without anything going red* — one level down, in the status field rather than the check list.
+
+It is recorded and **not** closed here, because closing it is a change to the baseline format and
+its script, which is its own ticket and wants the same treatment ADR-0035 gave the simulation side:
+a second field pinning the status, with `ERROR` never a legitimate baselined value. `961e359` is
+strictly an improvement over what preceded it and this gap predates it; nothing above is a reason
+to hold that work.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -40,6 +40,7 @@ and what it costs. Reversing one is fine — write a new ADR that supersedes it.
 | [0033](0033-what-the-green-ladder-does-not-cover.md) | What a green ladder does not cover — three assurance gaps, named | Accepted |
 | [0034](0034-what-the-csr-ladder-checks-cannot-see.md) | What the CSR ladder checks cannot see, and the decisions the CSR file forced | Accepted |
 | [0035](0035-the-baseline-pins-the-failure-mode.md) | `test/EXPECTED_FAIL` pins the failure mode, not just the file name | Accepted |
+| [0036](0036-three-gate-hardening-decisions-ratified-at-integration.md) | Three gate-hardening decisions ratified at integration, and a correction to ADR-0031 | Accepted |
 
 0001–0007 came from the design brief
 ([`docs/ideas/finish-the-rewrite.md`](../ideas/finish-the-rewrite.md)). 0008–0011 came out of
@@ -69,7 +70,13 @@ integrating the CSR file: it records the two decode-side decisions ADR-0005's fi
 corrects ADR-0027 on the counter `h` halves, measures what the `csrw_*` checks cannot see, and fixes
 a `CLAUDE.md` engineering rule that named the wrong file. 0035 amends 0014 and applies 0033's lens
 to the *simulation* gate: `test/run_tests.sh` had three ways to report success without having tested
-anything, so the failure set now records name **and** status and every build step is checked.
+anything, so the failure set now records name **and** status and every build step is checked. 0036 was
+recorded integrating those three gate changes together: it ratifies putting `hang` on the ladder
+(`liveness` does not subsume it — it *assumes* a retire at its trigger cycle and is vacuous on a core
+that never retires), corrects 0031 on how the `csrc_*` family is actually reached, and closes the
+`case_default` question by measuring that yosys already errors on the latch. It also records a
+gap it did not close: `formal/EXPECTED_FAIL` still matches on names only, so a red check that flips
+from `FAIL` to `ERROR` keeps the ladder green — 0035's lesson, unapplied to the formal side.
 
 ## Deferred decisions
 


### PR DESCRIPTION
Recorded while integrating the three gate-hardening changes (#43 `0355193`, #42
`b585b17`, #44 `961e359`). Docs only -- no `rtl/`, no scripts, no CI.

Three judgement calls those changes carried beyond their tickets, each verified
here rather than accepted:

- **`hang` stays on the ladder.** The ticket wanted it declined as "subsumed by
  the passing `liveness`". Read against the models at the pin, that is false:
  `rvfi_liveness_check.sv` opens its trigger cycle with
  `assume(rvfi_valid[...])`, so it bounds retire-to-retire *gaps* and is vacuous
  on a core that never retires. `rvfi_hang_check.sv` asserts a retire happened by
  its check cycle with no such assumption. Ratified.
- **ADR-0031 is corrected on `csrc_*`.** A bare `[csrs]` name makes genchecks set
  `check_name = "csrc"` and emit `rvfi_csrc_check.sv`, which does not exist at the
  pin -- the six real models are reachable only through a per-CSR test list. The
  missing piece is a `[csrs]` entry, not a `[depth]` line, and ADR-0031 implied
  otherwise. Confirmed against `genchecks-local.py:632` and the pin's `checks/`.
- **The `rtl/accessor.v` `default: ;` follow-up is declined, not deferred.** Both
  corrections behind it were re-verified: svlint's case rules fire identically
  whether or not defaults precede the case (4 findings per module on a two-module
  probe), and yosys errors `Latch inferred for signal ...` and exits 1 on a
  defaultless `always_comb` case. Since the elaborate job already gates that
  class, enabling `case_default` would buy a style requirement, not a defect
  class. `.svlint.toml`'s comment claimed a value the same file's own measurement
  refutes; corrected in the same commit.

And two gaps recorded rather than closed:

- **`make lint` is a gate nothing enforces.** `main`'s branch protection requires
  `elaborate`, `test`, `components`, `monitor-freshness`. The new `lint` job is
  not among them, so a red lint does not block a merge. Repository settings, left
  for a human to change deliberately.
- **`formal/EXPECTED_FAIL` matches on names only** -- ADR-0035's lesson, still
  unapplied to the formal side. Demonstrated live rather than argued: the
  post-merge ladder run on a machine without `btorsim` printed

  ```
  82 checks: 72 pass, 10 fail
  Failure list matches EXPECTED_FAIL exactly.
  Generated check set matches EXPECTED_CHECKS exactly (82 checks).
  ```

  exit 0, while all ten non-PASS checks reported `ERROR 16 2` rather than `FAIL`.
  btormc had found every counterexample correctly (`ill_ch0`: `bad state property
  0 reachable at bound k = 15 SATISFIABLE`); only the trace-rendering step failed.
  If `btorsim` ever left the nightly's pinned OSS CAD Suite, every red check would
  flip `FAIL` -> `ERROR` and the gate would stay green. This predates `961e359`
  and is a candidate ticket, not a reason to hold any of the three.