### PR TITLE
JEF-649: run the riscv-formal ladder on the PR gate, not only in the nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -460,19 +460,25 @@ jobs:
       # a silent pass.
       - name: Gate on formal/EXPECTED_FAIL + formal/EXPECTED_CHECKS
         run: |
+          # NO PIPE ON THE GRADED COMMAND, DELIBERATELY. The obvious spelling
+          # of this step is `check-baseline.sh ... | tee -a "$GITHUB_STEP_
+          # SUMMARY"` and it silently cannot fail: without an explicit
+          # `shell:` key a `run:` step is `bash -e {0}`, which sets errexit
+          # but NOT pipefail -- only an explicit `shell: bash` gets
+          # `-eo pipefail` -- so `$?` after that pipeline is tee's status,
+          # which is always 0. Demonstrated: with the pipe in place, a
+          # deliberately wrong formal/EXPECTED_FAIL printed "Failure list
+          # does NOT match" and the job still reported success. Redirect to a
+          # file, capture the status off the unpiped command, then publish.
+          set +e
+          formal/check-baseline.sh formal/checks formal/EXPECTED_FAIL > "$RUNNER_TEMP/baseline-report.txt" 2>&1
+          status=$?
+          set -e
+          cat "$RUNNER_TEMP/baseline-report.txt"
           {
             echo "### formal ladder vs formal/EXPECTED_{FAIL,CHECKS}"
             echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
-          # `-e`/`pipefail` are both on by default for GH Actions bash steps,
-          # so a failing pipeline would abort the script here and skip the
-          # closing code-fence and the caveat below; toggle them off for this
-          # one command and capture its real status via pipefail.
-          set +e
-          formal/check-baseline.sh formal/checks formal/EXPECTED_FAIL | tee -a "$GITHUB_STEP_SUMMARY"
-          status=$?
-          set -e
-          {
+            cat "$RUNNER_TEMP/baseline-report.txt"
             echo '```'
             echo "A match here means the ladder still agrees with its baseline."
             echo "It is not a correctness result: every check is \`mode bmc\` (no"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,3 +305,148 @@ jobs:
             echo "### monitor-freshness"
             echo "wall time: ${elapsed}s"
           } >> "$GITHUB_STEP_SUMMARY"
+
+  # The riscv-formal ladder, on the PR gate.
+  #
+  # Until this job existed the ladder ran only in formal-nightly.yml, so an
+  # edit to formal/EXPECTED_FAIL -- the burn-down file ADR-0022 designed for
+  # exactly that edit -- merged green and was contradicted hours later, by
+  # which time the change was on main and the nightly failure read as
+  # somebody else's problem. The check that a baseline edit is honest now
+  # runs on the change that makes it.
+  #
+  # WHAT IS GATED HERE IS formal/check-baseline.sh's EXIT STATUS, NOT sby's.
+  # Every generated .sby carries `expect pass,fail`, so `sby` exits 0 whether
+  # a check passed or failed -- its exit code has never carried a verdict.
+  # The verdict exists only as the two set equalities check-baseline.sh
+  # performs, both in both directions per ADR-0014: formal/EXPECTED_CHECKS
+  # (which checks genchecks generated) and formal/EXPECTED_FAIL (which of
+  # them are red). Deleting a baseline line without fixing the check fails
+  # here; fixing a check without deleting its line fails here too.
+  #
+  # WHAT A GREEN RUN HERE DOES NOT MEAN. Every check on this ladder is
+  # `mode bmc`: PASS means no counterexample was found within that check's
+  # configured depth, not that the property holds. The whole ladder runs
+  # under RISCV_FORMAL_ALTOPS, so a passing insn_mul/insn_div says nothing
+  # whatever about the real multiplier or divider (ADR-0010). Green here
+  # means "the ladder still matches its baseline" and nothing more. It is not
+  # a proof of correctness, and it is not M2 -- M2's signal is
+  # formal/EXPECTED_FAIL reaching empty, read together with
+  # formal/EXPECTED_CHECKS (ADR-0023, ADR-0033).
+  #
+  # The nightly keeps running the full sweep. It is still the place for what
+  # this gate cannot afford -- `complete`'s depth-50 whole-ISA walk and
+  # equiv.sh (ADR-0020) -- it is just no longer the only place the ladder
+  # runs at all. `complete`, `equiv.sh`, `cover` and the Sail co-sim
+  # (ADR-0032, whose fetch has not had formal/pin.mk's treatment) stay out of
+  # this job deliberately.
+  #
+  # Adding this job to ci.yml does not by itself gate anything: main's
+  # branch-protection required set is elaborate/test/components/
+  # monitor-freshness/lint, and adding `formal` to it is a repository-settings
+  # change for a human to make deliberately (ADR-0036, which says the same of
+  # `lint`). Until then this is advisory.
+  formal:
+    name: formal
+    runs-on: little-cpu-runners
+    # ADR-0025 measures the sweep at 4m05s wall with -j6 at the depths
+    # checks.cfg configures; add the clone, the cache restore and the
+    # generation pass and this lands in single-digit minutes. The ceiling is
+    # loose because there is no per-check wall bound -- ADR-0031 retired
+    # checks.cfg's `timeout=` and ADR-0033 records the replacement as not
+    # implemented -- so one non-converging check starves everything scheduled
+    # after it and `-k` does not help, because the job dies rather than the
+    # check. Raising any depth in checks.cfg re-opens this number.
+    timeout-minutes: 20
+    steps:
+      - name: Record job start
+        run: echo "JOB_START=$(date +%s)" >> "$GITHUB_ENV"
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up OSS CAD Suite
+        uses: ./.github/actions/setup-oss-cad-suite
+        with:
+          tag: ${{ env.OSS_CAD_SUITE_TAG }}
+          file: ${{ env.OSS_CAD_SUITE_FILE }}
+          sha256: ${{ env.OSS_CAD_SUITE_SHA256 }}
+
+      # Not a formality. check-baseline.sh compares check NAMES, not
+      # statuses: any status that is not PASS lands a check in the actual-
+      # fail set, so ERROR and FAIL are indistinguishable to it. sby's btor
+      # engine solves with btormc and then replays the witness with btorsim,
+      # and btorsim is reached ONLY on a check that found a counterexample --
+      # so on a box without it every red check reports ERROR instead of FAIL,
+      # the name set still matches formal/EXPECTED_FAIL exactly, and this job
+      # goes green on a broken toolchain. (Confirmed: btorsim is absent from
+      # a stock macOS brew install of yosys+sby, where exactly that happens.)
+      # Assert it up front rather than inferring it from a green run.
+      - name: Confirm the BMC toolchain is complete
+        run: |
+          set -euo pipefail
+          missing=0
+          for tool in yosys sby btormc btorsim; do
+            if path=$(command -v "$tool"); then
+              echo "$tool: $path"
+            else
+              echo "::error::$tool is not on PATH in the pinned OSS CAD Suite"
+              missing=1
+            fi
+          done
+          if [ "$missing" -ne 0 ]; then
+            echo "::error::formal/check-baseline.sh cannot tell ERROR from FAIL," \
+                 "so an incomplete toolchain would make this gate green on a" \
+                 "ladder that never really ran. Refusing to report a verdict."
+            exit 1
+          fi
+
+      # Generates the ladder (formal/genchecks-audit.py, which asserts its
+      # SHAPE against EXPECTED_CHECKS in about a second before anything runs)
+      # and then runs all 82 checks with `-k`. `continue-on-error` because
+      # this step's exit status is not the signal and never was -- `make
+      # check` ends in check-baseline itself, and the step below re-runs that
+      # comparison as the gate so the verdict is unambiguously the
+      # comparison's and its output lands in the step summary. Re-grading a
+      # finished ladder costs a second (formal/Makefile's check-baseline
+      # target exists to be re-runnable); running it here does not re-run a
+      # single check.
+      - name: Generate and run the ladder (make -C formal check)
+        continue-on-error: true
+        run: make -C formal check
+
+      # THE GATE. Not continue-on-error: this exit status is the job's.
+      # A ladder that failed to generate at all resolves to exit 2 here
+      # ("no *.sby files"), so the step above being swallowed cannot produce
+      # a silent pass.
+      - name: Gate on formal/EXPECTED_FAIL + formal/EXPECTED_CHECKS
+        run: |
+          {
+            echo "### formal ladder vs formal/EXPECTED_{FAIL,CHECKS}"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          # `-e`/`pipefail` are both on by default for GH Actions bash steps,
+          # so a failing pipeline would abort the script here and skip the
+          # closing code-fence and the caveat below; toggle them off for this
+          # one command and capture its real status via pipefail.
+          set +e
+          formal/check-baseline.sh formal/checks formal/EXPECTED_FAIL | tee -a "$GITHUB_STEP_SUMMARY"
+          status=$?
+          set -e
+          {
+            echo '```'
+            echo "A match here means the ladder still agrees with its baseline."
+            echo "It is not a correctness result: every check is \`mode bmc\` (no"
+            echo "counterexample within a bounded depth, not a proof), and the"
+            echo "ladder runs under \`RISCV_FORMAL_ALTOPS\`, so the mul/div checks"
+            echo "do not exercise the real multiplier or divider (ADR-0010)."
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit "$status"
+
+      - name: Report job wall time
+        if: always()
+        run: |
+          elapsed=$(( $(date +%s) - JOB_START ))
+          {
+            echo "### formal"
+            echo "wall time: ${elapsed}s"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -348,7 +348,29 @@ jobs:
   # `lint`). Until then this is advisory.
   formal:
     name: formal
-    runs-on: little-cpu-runners
+    # Stays GitHub-hosted, and unlike `test` and `lint` above the reason is
+    # memory rather than packaging. Measured, because two runs of this job
+    # died on little-cpu-runners with "The self-hosted runner lost
+    # communication with the server ... starves it for CPU/Memory" before
+    # they could even upload a log:
+    #
+    #   in-cluster pod   cpu.max 300000 100000 (a 3-CPU quota), memory.max
+    #                    1610612736 (1.5 GiB), of which memory.current was
+    #                    already 876480000 (836 MiB) at job start
+    #   one ladder check peak RSS 918781952 (876 MiB) for insn_add_ch0
+    #
+    # So a single check does not fit in what the pod has left, at any
+    # parallelism -- `-j1` would not have saved it. Note also that `nproc`
+    # reports 12 in that pod, because it reads the CPU affinity mask and a
+    # CFS quota does not narrow it; that is why formal/Makefile's `nproc`
+    # default is wrong in a container and JOBS is pinned below. None of the
+    # other little-cpu-runners jobs surfaced any of this because none of them
+    # runs a wide parallel make of memory-hungry solvers.
+    #
+    # Moving this back in-cluster needs the runner pod's memory limit raised
+    # (cluster repo: charts/actions/runners/values.yaml) to at least
+    # JOBS x 1 GiB plus the ~1 GiB the runner and toolchain already hold.
+    runs-on: ubuntu-latest
     # ADR-0025 measures the sweep at 4m05s wall with -j6 at the depths
     # checks.cfg configures; add the clone, the cache restore and the
     # generation pass and this lands in single-digit minutes. The ceiling is
@@ -411,19 +433,17 @@ jobs:
       # target exists to be re-runnable); running it here does not re-run a
       # single check.
       #
-      # JOBS IS CAPPED, AND THAT IS NOT TUNING. formal/Makefile defaults it
-      # to `nproc`, which is right on a workstation and wrong in a container:
-      # nproc reads the CPU affinity mask, which a CFS quota (a Kubernetes
-      # `limits.cpu`) does not narrow, so inside the in-cluster runner it
-      # reports the NODE's core count and `make -j` that wide oversubscribes
-      # the pod. The first run of this job did exactly that and the runner
-      # died 12 minutes in with "The self-hosted runner lost communication
-      # with the server ... starves it for CPU/Memory" -- which is a job
-      # failure, not a ladder verdict, and is the one way this gate can go
-      # red while saying nothing about the core. The diagnostics below print
-      # what the pod actually has; re-tune against those numbers, not by
-      # guessing. `JOBS=` on the command line overrides the Makefile's `:=`
-      # default and still passes its own numeric sanity guard.
+      # JOBS IS PINNED, AND IT IS A MEMORY BUDGET, NOT A SPEED KNOB. One
+      # check peaks around 876 MiB resident (measured, insn_add_ch0), so the
+      # ladder's peak footprint is roughly JOBS GiB and 4 is what fits a
+      # 16 GiB GitHub-hosted runner with room to spare. formal/Makefile
+      # defaults JOBS to `nproc`, which is right on a workstation and wrong
+      # anywhere the core count is not the binding constraint -- see the
+      # runs-on comment above for how that killed two runs outright. `JOBS=`
+      # on the command line overrides the Makefile's `:=` default and still
+      # passes its own numeric sanity guard, so a local `make -C formal
+      # check` is unaffected. The diagnostics print what the host actually
+      # has: re-tune against those numbers, not by guessing.
       - name: Generate and run the ladder (make -C formal check)
         continue-on-error: true
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -410,9 +410,29 @@ jobs:
       # finished ladder costs a second (formal/Makefile's check-baseline
       # target exists to be re-runnable); running it here does not re-run a
       # single check.
+      #
+      # JOBS IS CAPPED, AND THAT IS NOT TUNING. formal/Makefile defaults it
+      # to `nproc`, which is right on a workstation and wrong in a container:
+      # nproc reads the CPU affinity mask, which a CFS quota (a Kubernetes
+      # `limits.cpu`) does not narrow, so inside the in-cluster runner it
+      # reports the NODE's core count and `make -j` that wide oversubscribes
+      # the pod. The first run of this job did exactly that and the runner
+      # died 12 minutes in with "The self-hosted runner lost communication
+      # with the server ... starves it for CPU/Memory" -- which is a job
+      # failure, not a ladder verdict, and is the one way this gate can go
+      # red while saying nothing about the core. The diagnostics below print
+      # what the pod actually has; re-tune against those numbers, not by
+      # guessing. `JOBS=` on the command line overrides the Makefile's `:=`
+      # default and still passes its own numeric sanity guard.
       - name: Generate and run the ladder (make -C formal check)
         continue-on-error: true
-        run: make -C formal check
+        run: |
+          set -uo pipefail
+          echo "nproc:            $(nproc)"
+          echo "cgroup cpu.max:   $(cat /sys/fs/cgroup/cpu.max 2>/dev/null || echo unavailable)"
+          echo "cgroup memory.max:$(cat /sys/fs/cgroup/memory.max 2>/dev/null || echo unavailable)"
+          free -h 2>/dev/null || true
+          make -C formal check JOBS=4
 
       # THE GATE. Not continue-on-error: this exit status is the job's.
       # A ladder that failed to generate at all resolves to exit 2 here

--- a/.github/workflows/formal-nightly.yml
+++ b/.github/workflows/formal-nightly.yml
@@ -1,13 +1,33 @@
 name: Formal Nightly
 
-# ADR-0006 estimates ~75 insn_* checks at depth 15-30 as nightly-scale
-# (1-3h wall with -j), not something the PR gate (ci.yml) can afford to run
-# on every push. This workflow is that nightly ladder: the full
-# genchecks-local.py sweep (insn_*/reg/pc_fwd/pc_bwd/liveness/unique/
-# causal/csrw), the hand-authored imemcheck/dmemcheck/cover tasks, the
-# depth-50 whole-ISA `complete` walk, and equiv.sh (ADR-0020). None of this
-# gates merges: there is no required-status-check entry for this workflow,
-# unlike ci.yml's elaborate/test/components/monitor-freshness.
+# The nightly ladder: the full genchecks-local.py sweep (insn_*/reg/pc_fwd/
+# pc_bwd/liveness/unique/causal/csrw), the hand-authored imemcheck/dmemcheck/
+# cover tasks, the depth-50 whole-ISA `complete` walk, and equiv.sh
+# (ADR-0020). None of this gates merges: there is no required-status-check
+# entry for this workflow, unlike ci.yml's elaborate/test/components/
+# monitor-freshness/lint.
+#
+# This is no longer the only place the genchecks sweep runs, and the reason
+# it used to be has expired. This header used to open by citing ADR-0006's
+# estimate of ~75 checks at depth 15-30 as "1-3h wall with -j, not something
+# the PR gate (ci.yml) can afford to run on every push". That estimate
+# predates ADR-0024's engine switch: ADR-0025 measures the sweep at 4m05s
+# wall with -j6 at the depths checks.cfg actually configures. A cost claim
+# nothing re-measures is how a workflow keeps a boundary it no longer needs,
+# so it is recorded here as superseded rather than quietly deleted.
+#
+# ci.yml's `formal` job therefore runs the same `make -C formal check` on
+# every pull request and gates on the same formal/check-baseline.sh
+# comparison -- because an edit to formal/EXPECTED_FAIL that this workflow
+# contradicts the next morning is a baseline edit that merged unverified.
+# Keep the two ladder invocations identical: both call the same Makefile
+# target against the same two baseline files, on purpose, so the nightly
+# cannot start grading a different ladder than the gate. What stays here is
+# what the gate genuinely cannot afford -- `complete` and equiv.sh below --
+# plus the budget for anything whose runtime is unbounded. ADR-0025's
+# addendum is the live one to watch: CSR serialization pushed the two-hop
+# figure to ~15, so `insn 15` now sits on its floor with no margin, and a
+# depth bump re-opens the PR gate's budget question along with it.
 #
 # ADR-0022: the ladder step reports against the explicit baseline in
 # formal/EXPECTED_FAIL (set equality in both directions, formal/

--- a/.github/workflows/formal-nightly.yml
+++ b/.github/workflows/formal-nightly.yml
@@ -104,21 +104,39 @@ jobs:
       # check-baseline.sh defaults its third argument to the EXPECTED_CHECKS
       # beside it, so the invocation below is unchanged. Not
       # `continue-on-error` -- this exit status is the job's.
+      #
+      # NO PIPE ON THE GRADED COMMAND, DELIBERATELY, and this step did have
+      # one until now, which meant it could not fail. The comment it replaces
+      # asserted that "`-e`/`pipefail` are both on by default for GH Actions
+      # bash steps". Half right, and the wrong half: without an explicit
+      # `shell:` key a `run:` step is `bash -e {0}` -- errexit only. Only an
+      # explicit `shell: bash` gets `-eo pipefail`. So `$?` after
+      # `check-baseline.sh | tee ...` was tee's status, which is always 0,
+      # and this step reported success no matter what the comparison found.
+      # Demonstrated on a scratch branch against ci.yml's copy of the same
+      # step: a deliberately wrong formal/EXPECTED_FAIL printed "Failure list
+      # does NOT match" and the job still went green.
+      #
+      # That is worth stating plainly, because it means the guarantee
+      # ADR-0022 records -- "that comparison step's exit status is the job's
+      # real signal" -- has never actually held. Replacing `|| true` with
+      # this step moved the defect rather than fixing it: the nightly still
+      # could not go red. Redirect to a file, capture the status off the
+      # unpiped command, then publish.
       - name: Compare ladder results against formal/EXPECTED_{FAIL,CHECKS}
         run: |
+          set +e
+          formal/check-baseline.sh formal/checks formal/EXPECTED_FAIL \
+            > "$RUNNER_TEMP/baseline-report.txt" 2>&1
+          status=$?
+          set -e
+          cat "$RUNNER_TEMP/baseline-report.txt"
           {
             echo "### formal ladder vs formal/EXPECTED_FAIL"
             echo '```'
+            cat "$RUNNER_TEMP/baseline-report.txt"
+            echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
-          # `-e`/`pipefail` are both on by default for GH Actions bash steps,
-          # so a failing pipeline would otherwise abort the script here and
-          # skip the closing code-fence line below; toggle them off just for
-          # this one command and capture its real exit status via pipefail.
-          set +e
-          formal/check-baseline.sh formal/checks formal/EXPECTED_FAIL | tee -a "$GITHUB_STEP_SUMMARY"
-          status=$?
-          set -e
-          echo '```' >> "$GITHUB_STEP_SUMMARY"
           exit "$status"
 
       - name: Summarize checks


### PR DESCRIPTION
Closes JEF-649

## Problem

`formal/EXPECTED_FAIL` is a burn-down file (ADR-0022): the change that pays off a red check deletes its line in the same commit. Nothing checked that on the pull request. The ladder ran only in `formal-nightly.yml`, so a baseline edit merged green and was contradicted hours later — by which time the change was on main and the nightly failure read as somebody else's problem.

This is live right now: a concurrent change drives all ten baseline entries to empty. That is exactly the change this gate exists to check.

## What this does

Adds a `formal` job to `.github/workflows/ci.yml`. It reuses the existing SHA-pinned `./.github/actions/setup-oss-cad-suite`, runs `make -C formal check`, and **gates on `formal/check-baseline.sh`'s exit status, not sby's** — every generated `.sby` carries `expect pass,fail`, so sby exits 0 whether a check passed or failed. Confirmed in the run below: all ten red checks report `DONE (FAIL, rc=0)`.

Nothing in `rtl/` or `test/` is touched (`git diff main --stat` is two workflow files). The `ci.yml` change is a single appended hunk with zero deletions, so it merges cleanly alongside the concurrent `ci.yml` edit.

## Three findings this turned up, none of which were the ticket

### 1. The nightly's gate step could never fail. A pipe was eating its exit status.

The first version of this job graded a deliberately-wrong `formal/EXPECTED_FAIL`, printed `Failure list does NOT match formal/EXPECTED_FAIL` with the correct diff — **and reported success.**

The step ran `check-baseline.sh ... | tee -a "$GITHUB_STEP_SUMMARY"` and read `$?`. Without an explicit `shell:` key a `run:` step is `bash -e {0}` — errexit, and **no pipefail**. Only an explicit `shell: bash` gets `-eo pipefail`. So `$?` was tee's status, which is always 0.

I copied that step from `formal-nightly.yml`, including its comment asserting the opposite ("`-e`/`pipefail` are both on by default for GH Actions bash steps"). The nightly has the identical pipe. **So the guarantee ADR-0022 records — "that comparison step's exit status is the job's real signal" — has never actually held.** Replacing the old `|| true` with a comparison step moved the defect rather than fixing it: the nightly still could not go red, for a different reason than before. CLAUDE.md's "the formal nightly cannot go red" turns out to have stayed true through the change that was meant to fix it.

Both copies are fixed: redirect to a file under `RUNNER_TEMP`, take the status off the unpiped command, then publish to log and step summary. No pipe stands between the graded command and `$?`.

### 2. `nproc` lies inside a CPU-limited container

`formal/Makefile` defaults `JOBS` to `nproc`. In the in-cluster runner pod `nproc` reports **12** while `cpu.max` is `300000 100000` — a **3-CPU quota**. `nproc` reads the CPU affinity mask, and a CFS quota does not narrow that mask. So `make -j$(nproc)` oversubscribes the pod 4x. `JOBS` is now pinned to 4 on the command line, which overrides the Makefile's `:=` default and still passes its own numeric sanity guard, so a local `make -C formal check` is unaffected.

Capping `-j` alone did **not** fix the job, which is what led to finding 3.

### 3. One ladder check does not fit the self-hosted pod — it is memory, not time

Two runs died with `The self-hosted runner lost communication with the server ... starves it for CPU/Memory`, before they could upload a log. Measured with a throwaway probe job:

| | |
|---|---|
| pod `memory.max` | 1610612736 (1.5 GiB) |
| pod `memory.current` at job start | 876480000 (836 MiB) |
| peak RSS of **one** check, `insn_add_ch0` | 918781952 (**876 MiB**) |

A single check does not fit in what the pod has left. **`-j1` would not have saved it** — there is no parallelism setting that makes this work in-cluster. The fix is a bigger memory limit on the runner pod (cluster repo `charts/actions/runners/values.yaml`, needs roughly `JOBS x 1 GiB` plus the ~1 GiB the runner and toolchain already hold), which is not this repo's file.

So `formal` runs on `ubuntu-latest` (4 vCPU / 16 GiB), with the measurements written into the job. That makes three of six `ci.yml` jobs GitHub-hosted, each for a stated and different reason: `test` needs root apt installs, `lint` needs `unzip`, this needs memory. Both numbers are in the workflow so the next person re-tunes against measurements rather than re-deriving them from a dead runner.

## btorsim is present, and is asserted rather than assumed

`check-baseline.sh` compares check **names**, not statuses. On a box without `btorsim` every red check reports `ERROR 16` instead of `FAIL`, the name set still matches the baseline exactly, and the job goes green on a toolchain that never produced a verdict.

That is not hypothetical — I reproduced it on my own machine, where a full ladder run exits 0 with `Failure list matches EXPECTED_FAIL exactly` while all ten reds are `ERROR 16`, because a stock macOS `brew` yosys+sby ships no `btorsim`.

In the pinned OSS CAD Suite it **is** present, and the ten reds report `FAIL`. The job now asserts all four tools up front rather than inferring it from a green run:

```
yosys: /home/runner/work/little-cpu/little-cpu/oss-cad-suite/bin/yosys
sby: /home/runner/work/little-cpu/little-cpu/oss-cad-suite/bin/sby
btormc: /home/runner/work/little-cpu/little-cpu/oss-cad-suite/bin/btormc
btorsim: /home/runner/work/little-cpu/little-cpu/oss-cad-suite/bin/btorsim
```

The full status-field fix (so `ERROR` and `FAIL` are distinguishable to the baseline) is a separate ticket; this job's guard is the stopgap that keeps the gate honest until then.

## What green here does not mean

Every check on the ladder is `mode bmc` — PASS means no counterexample within a configured depth, not that the property holds — and the whole ladder runs under `RISCV_FORMAL_ALTOPS`, so the mul/div checks say nothing about the real multiplier or divider (ADR-0010). The job name, the step summary and the workflow comments all say "the ladder matches its baseline" and stop there. **This is not M2** (ADR-0023).

On ADR-0022's "no status check from this workflow may be added to branch protection while the expected-failure set is non-empty": that clause scopes to the nightly workflow, whose ladder step reports raw verdicts. This gates on the two set equalities instead, which are well-defined over a non-empty baseline — ADR-0033's "a known-red check on the ladder is the system working" is the same reasoning. A non-empty `EXPECTED_FAIL` is not a reason to withhold this gate; it is the reason to have it.

The nightly keeps `complete` and `equiv.sh`. Its header used to open by citing ADR-0006's estimate of the sweep as "1-3h wall with -j, not something the PR gate can afford to run on every push" — that predates ADR-0024's engine switch, and ADR-0025 measures it at 4m05s. The header now records the estimate as superseded rather than quietly deleting it.

## Human follow-up — not attempted here

`formal` needs adding to main's branch-protection required set (`elaborate, test, components, monitor-freshness, lint`). That is a repository-settings change under `enforce_admins: true` and is deliberately left for a human, the same standing `lint` has today (ADR-0036). **Until that happens this job is advisory.**

Separately: `CLAUDE.md:178-181` still describes the nightly as having `|| true` and no `-k`, both fixed before this change. Finding 1 above means its conclusion ("the formal nightly cannot go red") was accidentally still correct until this PR. Left alone here — outside this ticket's `.github/` + `formal/` scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
