### PR TITLE
DEMO (do not merge) JEF-649 criterion 1: delete a formal/EXPECTED_FAIL line without fixing the check

### DIFF
--- a/formal/EXPECTED_FAIL
+++ b/formal/EXPECTED_FAIL
@@ -104,7 +104,6 @@ insn_c_swsp_ch0
 # misaligned access traps, this one goes green when an ILLEGAL INSTRUCTION
 # traps (ADR-0030's cause 2). Two of ADR-0030's five causes are therefore
 # on the ladder rather than one.
-ill_ch0
 
 # The C.JR/C.JALR decode defect (ADR-0021): rtl/decoder.v:114 routes
 # instr_jalr through i_immediate = instr[31:20], which for a 16-bit


### PR DESCRIPTION
Scratch demonstration for JEF-649 acceptance criterion 1. **Do not merge — this will be closed.**

Deletes `ill_ch0` from `formal/EXPECTED_FAIL`. `ill_ch0` is red on the ladder and nothing here fixes it, so the new `formal` job must go red on this line alone. Based on the JEF-649 branch so the diff is the mutation only.