### PR TITLE
DEMO (do not merge) JEF-649 criterion 2: baseline claims a passing check is red

### DIFF
--- a/formal/EXPECTED_FAIL
+++ b/formal/EXPECTED_FAIL
@@ -105,6 +105,7 @@ insn_c_swsp_ch0
 # traps (ADR-0030's cause 2). Two of ADR-0030's five causes are therefore
 # on the ladder rather than one.
 ill_ch0
+insn_add_ch0
 
 # The C.JR/C.JALR decode defect (ADR-0021): rtl/decoder.v:114 routes
 # instr_jalr through i_immediate = instr[31:20], which for a 16-bit


### PR DESCRIPTION
Scratch demonstration for JEF-649 acceptance criterion 2 — the other direction of the set equality. **Do not merge — this will be closed.**

Adds `insn_add_ch0` to `formal/EXPECTED_FAIL`. That check passes on the ladder, so the baseline now claims a red check that is green: exactly the shape of "a change fixed a check and forgot to delete its baseline line", reached without touching `rtl/` (JEF-649 is scoped to `.github/` and `formal/`). `check-baseline.sh` produces the identical diff either way. Based on the JEF-649 branch so the diff is the mutation only.