### PR TITLE
JEF-648: detect every trap in decode; enter and return from machine mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,8 +33,9 @@ stage to stage riding the existing valid-bit protocol; `rtl/accessor.v` adds the
 addr/rmask/wmask/rdata/wdata capture (the one stage that actually knows those values, including the
 one-cycle load-response latch); `rtl/writeback.v` drives `rvfi_valid`/`rvfi_order`/etc. from the
 retiring `accessor_output`, exactly where invariant 3 below says retire happens. `trap`/`halt`/
-`intr`/`mode`/`ixl`/the CSR fields are hardwired constants in `rtl/littlecpu.v` (no traps or CSRs
-exist yet — M3). `test/monitor.v` stays pristine and tracked; a gitignored, build-time-derived
+`intr`/`mode`/`ixl`/the CSR fields were hardwired constants in `rtl/littlecpu.v` at that commit,
+because no traps and no CSRs existed yet; only `halt`/`intr`/`mode`/`ixl` still are (the CSR fields
+came alive with `rtl/csrs.v`, `rvfi_trap` with trap entry — both below). `test/monitor.v` stays pristine and tracked; a gitignored, build-time-derived
 `test/monitor.sim.v` (`test/sanitize_monitor.py`) carries the build-time repairs it needs —
 originally two, stripping the `$time`-in-`$display` yosys can't elaborate and ADR-0019's DIV/REM
 signedness fix, now three with the `!spec_trap` gate below — and **both** legs read it, so they
@@ -112,10 +113,11 @@ unenforced drift there is exactly what produced the five-year-stale fork ADR-003
 the clone, so any residual diff is drift by construction and is printed. It runs in CI in the
 `monitor-freshness` job, which has already paid for the from-scratch clone at the pin.
 
-`test/EXPECTED_FAIL` is **no longer empty**: `csr.S`, `minstret.S` and `trap.S` were seeded there
+`test/EXPECTED_FAIL` was seeded with three M3 tests — `csr.S`, `minstret.S` and `trap.S` — written
 ahead of the RTL that pays them off, which is the direction ADR-0014's burn-down contract was
-designed for. Two of the three are paid off (below); `trap.S` remains, so `make test` is
-**51 pass / 1 expected-fail** and still exits 0 only on set equality. That equality is now over
+designed for. All three are paid off now (the third by the trap change below), so it is **empty
+again** and `make test` is **52 pass / 0 expected-fail**, exiting 0 only on set equality. That
+equality is over
 **name-and-status pairs** (ADR-0035) — the baselined entry is `trap.S      MONITOR-ERROR 101`, so a
 baselined test that starts failing some *other* way (a broken assembly, a `TIMEOUT`, an unstartable
 runner) is a red gate rather than a match. The same change made every build step's exit status
@@ -123,7 +125,8 @@ checked and `mktemp` fatal: an unchecked `objcopy` that emitted an **empty** RAM
 `tohost` read zero and every data-independent test still report `PASS`.
 `test/run_tests.sh` also grew a `MONITOR-ERROR` label for runner exit 4, which used to fall into
 `RUNNER-ERROR` and read as "the sim would not start" when it actually means the per-retire oracle
-disagreed with the core mid-run. **Nothing here checks M3 semantics against an oracle**:
+disagreed with the core mid-run, and a `TRAP-TO-ZERO` label for exit 5 (ADR-0029, below).
+**Nothing here checks M3 semantics against an oracle**:
 riscv-formal ships no spec model for `csrr*`/`ecall`/`ebreak`/`mret` at the pinned SHA, so
 `spec_valid` is 0 for every one of them and the monitor's whole semantic block is skipped. The
 trap and CSR tests assert on values their own handler recorded. Error 133 ("expected intr after
@@ -212,12 +215,64 @@ reading `rvfi_csrc_check.sv`, which does not exist at the pin — the six real m
 (`rvfi_csrc_{any,const,hpm,inc,upcnt,zero}_check.sv`) are reached only through a per-CSR *test list*
 in `[csrs]`.
 
+**M3's keystone: every trap is now detected AND committed in decode, and the formal baseline is
+empty.** `rtl/decoder.v` computes misalignment from the same `$signed(immediate) +
+$signed(reg_rs1)` it already had, decides illegal-instruction (including ADR-0005's two illegal-CSR
+rules), and commits `ecall`/`ebreak`/illegal/load-misaligned/store-misaligned in the *same*
+non-stalled `else` arm that issues an instruction — which is what buys, for free, no trap on a
+stalled cycle, no trap from a bubble, no double commit, and a `reg_rs1` the scoreboard has already
+made hazard-clear. **A trap is a branch**: `pc <= mtvec` is the same override `jal` and the
+branches use, so there is still no flush anywhere (invariant 1). `rtl/csrs.v` gains a second write
+port (`trap_entry`/`trap_cause`/`trap_epc`/`mret_entry`) and hands `mtvec`/`mepc` back to decode;
+`mret` gets its own decode, restores MIE from MPIE, and serializes on the existing drain
+predicate; `wfi`, `fence` and `fence.i` become the NOPs ADR-0005 always said they were, which was
+optional right up until "unrecognised" started meaning "illegal instruction". `rtl/accessor.v`'s
+`mem_misaligned` and `rtl/littlecpu.v`'s `mem_misaligned_trap` are **gone** — ADR-0011's deferred
+debt, discharged — and the top-level `trap` port is redefined per ADR-0028 as a one-cycle "trap
+entry committed" pulse that something finally consumes. `rvfi_trap` is driven from the retiring
+instruction's shadow instead of being hardwired 0. **`formal/EXPECTED_FAIL` reaches EMPTY: 82
+checks, 82 pass** — the nine misalignment entries and `ill_ch0` all closed at once, exactly as the
+attribution predicted, and `insn_lb`/`insn_lbu`/`insn_sb` (the byte accesses, which cannot be
+misaligned) never moved. `test/EXPECTED_FAIL` reaches empty too, at 52/52. **This does not by
+itself mean M2** — see the milestone table.
+
+ADR-0034's sunset condition **fired**: `decoder_output`'s `csr_addr`/`is_csr_imm` were kept as
+scaffolding on the explicit condition that they be struck in the trap change if neither acquired a
+downstream consumer, and neither did. They are gone. ADR-0029's harness half landed with the RTL
+that makes it reachable: `test/testbench.v` raises a `(* keep *) trap_to_zero` flag when a trap
+redirects to address 0, `test/cxxrtl.cc` turns that into exit code 5 and `test/run_tests.sh` labels
+it `TRAP-TO-ZERO`, so a test that faults before installing `mtvec` gets a named failure instead of
+a timeout. And `test/sail/memory-map.json` sets `memory.misaligned.exceptions.load_store` to
+`{"Some": "AlignmentException"}` — the **global** key, which is what actually governs; the
+per-region `misaligned_exceptions` attribute is checked after address translation and with no MMU
+is never consulted. Without it the reference model completes misaligned accesses and reports a
+false divergence on every one; verified both ways (`trap.S` agrees 214/214 with the key, diverges
+at architectural change #6 without it).
+
+**The iverilog leg was dead, and this change is what noticed.** `rtl/decoder.v`'s hazard
+scoreboard called a `function automatic live_producer(r)` from two continuous assigns. iverilog
+builds such an assign's sensitivity list from the *call's arguments*, so a function body that also
+reads module-level signals (`out`, `executor_out`, `accessor_pending_*`) never re-evaluated when
+those changed — **under**-sensitivity, the one direction CLAUDE.md's `sorry:` exception says is a
+real bug, and iverilog emits no diagnostic for it. Measured: `hazard_rs1` latched high at the first
+RAW hazard of every program and never fell, so `make waves`' own baked-in loop executed two
+instructions and then span (0 memory writes in 200 cycles, on `main`, before this change), and no
+`.S` program could reach `tohost`. yosys evaluates the function correctly, so cxxrtl and the whole
+formal ladder were unaffected — which is precisely why it went unnoticed: the leg the verification
+table calls the microscope was reporting nothing, and nothing it reported was wrong. The two
+assigns are now written out. All 52 `.S` programs run to `PASS` under `vvp` with the per-retire
+monitor live, the first time that has ever been true. **There is still no tracked runner for it**:
+`test/testbench.v` has a baked-in program and no image loader, so the 52/52 above was measured with
+a scratch harness. `make waves` is the tracked iverilog exercise and it now executes real
+instructions rather than deadlocking.
+
 What does work: `yosys ... write_cxxrtl` elaborates the current RTL cleanly with zero warnings, the
-cxxrtl binary builds and runs, the `.S` suite passes under it except the one M3 test still seeded in
-`test/EXPECTED_FAIL`, `make test-units` passes (six benches: `exec_tb`, `mem_tb`, `decoder_tb`,
+cxxrtl binary builds and runs, the whole `.S` suite passes under it with `test/EXPECTED_FAIL`
+empty, `make test-units` passes (six benches: `exec_tb`, `mem_tb`, `decoder_tb`,
 `regfile_tb` — which covers the write-through bypass and x0 semantics — `csr_tb`, which covers
-`rtl/csrs.v`'s read mux, its `implemented` address set and its WARL masks, and `monitor_tb`, which
-checks the oracle itself rather than the core), and the decoder and executor component proofs pass
+`rtl/csrs.v`'s read mux, its `implemented` address set, its WARL masks and its trap-entry/`mret`
+port, and `monitor_tb`, which checks the oracle itself rather than the core), and the decoder and
+executor component proofs pass
 by k-induction (see ADR-0017 for what the decoder proof does and does not establish). `make waves`
 now runs the iverilog leg (`testbench.vvp`) instead of the cxxrtl runner, matching the verification
 table below,
@@ -384,7 +439,7 @@ the oracle (ADR-0019).
 | M0 | Foundation | this file, riscv-formal SHA-pinned, dead references gone |
 | M1 | Finish the pipeline | all RV32IM `.S` tests pass under cxxrtl — **reached, `a4662a2`** |
 | M2 | **Parity checkpoint** | the pipelined core re-proves everything the serialized core proved |
-| M3 | Past the old core | CSRs + machine-mode traps — CSRs done (`rtl/csrs.v`); traps are next |
+| M3 | Past the old core | CSRs + machine-mode traps — **both landed** (`rtl/csrs.v`; trap commit in `rtl/decoder.v`) |
 | M4 | Full ladder + CI | nightly formal green; tag a release (PR gate `c66527d`; nightly `86e2721`, report-only until ADR-0022) |
 
 M1 is reached. **M2 is the milestone that erases the verified→unverified regression** — treat it
@@ -396,14 +451,34 @@ wording is "re-proves everything the serialized core proved", and 15 red checks 
 `formal/EXPECTED_FAIL` baseline of ADR-0022 reaching empty is the signal — read together with the
 generated check count, per ADR-0033, which is now `formal/EXPECTED_CHECKS` and is asserted rather
 than recited. `rtl/csrs.v` took that baseline from 11 entries to 9 (both `csrw_*`) on a 79-check
-ladder; landing `ill_ch0` red made it 10 on an 82-check ladder. **All ten are the trap gap** — nine
-misalignment, one illegal-instruction — so the next M3 step closes every one of them or the
-attribution behind them was wrong.
+ladder; landing `ill_ch0` red made it 10 on an 82-check ladder; **the trap change took it to zero
+on that same 82-check ladder.** All ten were the trap gap — nine misalignment, one
+illegal-instruction — and all ten closed together, which is the attribution behind them holding.
+
+**That signal has now fired, and M2 is still not reached.** Read what the signal is and is not,
+because the temptation to read it as the milestone is exactly what ADR-0023 and ADR-0033 were
+written against:
+
+- every check on the ladder is `mode bmc`, so 82 PASS means "no counterexample within each check's
+  configured depth", not that any property holds;
+- the whole ladder runs under `RISCV_FORMAL_ALTOPS` (ADR-0010), so `insn_mul`/`insn_div`/`insn_rem`
+  passing says nothing whatever about the real multiplier or divider;
+- `formal/equiv.sh` still does not converge (ADR-0020), so ADR-0006's guarantee that RVFI
+  instrumentation does not perturb core behaviour remains **argued, not proven** — and the argument
+  now has one more `ifdef RISCV_FORMAL` field to cover (`rvfi_shadow.trap`);
+- `formal/complete` still fails, for `ecall`/`ebreak`/`mret`/CSR retires that riscv-formal has no
+  spec model for at the pin. It is on no gate and ADR-0022/ADR-0023/ADR-0034 already record it;
+- the nightly still cannot go red (ADR-0022's `|| true`);
+- and riscv-formal ships **no spec model at all** for `ecall`/`ebreak`/`mret`/`csrr*`, so the
+  behaviour this milestone step actually added is checked by `test/asm/trap.S`, `test/csr_tb.v`,
+  `test/decoder_tb.v` and `rtl/decoder.v`'s own component proof — against assertions this repo
+  wrote, not against an oracle. An empty baseline is a **necessary** condition for M2, and the
+  remaining work is the list above, not another red check.
 
 ## Pointers
 
 - Design brief: [`docs/ideas/finish-the-rewrite.md`](docs/ideas/finish-the-rewrite.md)
-- Decisions: [`docs/adr/`](docs/adr/) — thirty-three accepted ADRs, plus a deferred list
+- Decisions: [`docs/adr/`](docs/adr/) — thirty-six accepted ADRs, plus a deferred list
 - Reference text from the old core: `git show 1709433^:rtl/riscv.v` (RVFI retire block),
   `git show e67875c^:rtl/alu.v` (arithmetic)
 - Work is tracked in Linear, project **Little CPU** (team JEF). Named here so you know where the

--- a/formal/EXPECTED_FAIL
+++ b/formal/EXPECTED_FAIL
@@ -67,72 +67,39 @@
 # correctly WARL-masked mtvec/mepc/mstatus/mcause on that list would FAIL on
 # a CORRECT core. Those are checked in test/csr_tb.v instead.
 
-# `rvfi_trap` is hardwired 0 until misalignment traps land (M3, ADR-0011).
-# Every byte-granularity access (lb/lbu/sb) passes -- this is exactly the
-# set of accesses whose address can be misaligned, which is what makes this
-# attribution checkable rather than asserted (ADR-0022, ADR-0023).
-insn_lh_ch0
-insn_lhu_ch0
-insn_lw_ch0
-insn_sh_ch0
-insn_sw_ch0
-insn_c_lw_ch0
-insn_c_lwsp_ch0
-insn_c_sw_ch0
-insn_c_swsp_ch0
-
-# ill_ch0 is the tenth, and it is here because ADR-0033 decided a known-red
-# check belongs ON the ladder rather than off it: "a known-red check on the
-# ladder is the system working; a known-red check off the ladder is the
-# system lying." It had no [depth] line, so it was never generated, never
-# ran, and never appeared here — the exact shape of hole this file plus
-# formal/EXPECTED_CHECKS now close.
+# THE BASELINE IS EMPTY, and reaching that is what this change was for. All
+# ten entries that stood here came out together, because all ten were the same
+# missing feature: trap entry did not exist, so `rvfi_trap` was hardwired 0 in
+# rtl/littlecpu.v.
 #
-# checks/rvfi_ill_check.sv reads only ordinary RVFI ports this core already
-# drives. It assumes a retire whose `insn` is all zeros — the canonical
-# illegal instruction — and asserts `trap`, plus `rd_addr == 0`,
-# `rd_wdata == 0`, `mem_wmask == 0`. What makes it red is the same single
-# fact as the nine above: `rvfi_trap` is hardwired 0 in rtl/littlecpu.v
-# because trap entry does not exist yet (M3, ADR-0011; rtl/csrs.v landed the
-# CSR file but nothing reads mtvec/mepc/mcause). Verified rather than
-# argued — btormc reports `bad state property 0 reachable at bound k = 15
-# SATISFIABLE`, a real counterexample at the configured depth, not a build
-# or elaboration error.
+# Nine of them were misaligned accesses -- insn_lh, insn_lhu, insn_lw, insn_sh,
+# insn_sw and the four compressed word forms insn_c_lw, insn_c_lwsp, insn_c_sw,
+# insn_c_swsp. Each `insn_*` check ends in `assert(spec_trap == trap)` outside
+# the `!spec_trap` gate, and under RISCV_FORMAL_ALIGNED_MEM each of those
+# models sets `spec_trap` on a misaligned effective address. Every
+# byte-granularity access (insn_lb, insn_lbu, insn_sb) already passed, which is
+# exactly the set whose address CANNOT be misaligned -- that is what made the
+# attribution checkable rather than asserted, and it held: the same change that
+# turned the nine green left the three alone.
 #
-# This is the entry that burns down with the trap work, and it burns down
-# for a different reason than its neighbours: the nine above go green when a
-# misaligned access traps, this one goes green when an ILLEGAL INSTRUCTION
-# traps (ADR-0030's cause 2). Two of ADR-0030's five causes are therefore
-# on the ladder rather than one.
-ill_ch0
-
-# The C.JR/C.JALR decode defect (ADR-0021): rtl/decoder.v:114 routes
-# instr_jalr through i_immediate = instr[31:20], which for a 16-bit
-# instruction is whatever sits next in memory. A fix is in flight in a
-# parallel change; when it lands these two go green and this baseline must
-# shrink in the same commit, which is the set-equality check working as
-# designed, not a surprise.
-
-# The ALTOPS divide operand-latching defect (ADR-0023): rtl/executor.v's
-# `ifdef RISCV_FORMAL_ALTOPS` divide branch reads `in.rs1`/`in.rs2` a cycle
-# after issue instead of the already-latched mul_div_x/mul_div_y. Scoped to
-# RISCV_FORMAL_ALTOPS, so the synthesized divider is unaffected -- ADR-0010
-# already says the real arithmetic has no formal coverage in any form. A fix
-# is in flight in a parallel change; same expectation as the C.JR pair above.
-
-# reg_ch0 was here (ADR-0023: the check that ties RVFI's self-report back to
-# the actual register file) as a single depth-21 BMC query that did not
-# converge under smtbmc yices in a practical budget (>20 minutes,
-# independently reproduced twice). It PASSes under btor btormc in ~8-12s at
-# the same depth -- verified by a full from-scratch 78-check sweep under each
-# engine, not by argument (see this file's header). Removed, not because the
-# property changed, but because the tool that had failed to answer it was
-# replaced by one that could.
+# The tenth, ill_ch0, went green for a DIFFERENT reason, which is why ADR-0033
+# put it on the ladder rather than leaving it off. checks/rvfi_ill_check.sv
+# assumes a retire whose `insn` is all zeros and asserts `trap`, `rd_addr == 0`,
+# `rd_wdata == 0` and `mem_wmask == 0`. That is the formal statement of the
+# ILLEGAL-INSTRUCTION trap (ADR-0030's cause 2) plus ADR-0028's convention for
+# what a trapping retire may have done -- not of misalignment. Two of
+# ADR-0030's five causes are therefore on the ladder; the other three
+# (breakpoint, environment call, and the load/store causes' handler-visible
+# `mcause`) are checked in test/asm/trap.S, because riscv-formal ships no spec
+# model for ecall/ebreak/mret at the pin.
 #
-# Then re-confirmed after formal/genchecks-local.py was re-vendored from the
-# pin. That change reached the ladder in exactly two ways -- every generated
-# .sby now says `read -sv` where it said `read_verilog -sv` (upstream's
-# frontend-agnostic spelling; identical without Verific), and reg_ch0 lost the
-# per-check `timeout 1800` line, which upstream genchecks has no way to emit
-# and which btormc made moot. Same 78 checks, same names, same verdicts: 67
-# pass, the 11 below.
+# READ THIS EMPTINESS WITH ADR-0023 AND ADR-0033 BESIDE IT. Every check on this
+# ladder is `mode bmc`, so a PASS is "no counterexample within the configured
+# depth", not a proof; everything runs under RISCV_FORMAL_ALTOPS, so a green
+# insn_mul/insn_div says nothing about the real multiplier or divider
+# (ADR-0010); and this file's emptiness is a NECESSARY, not sufficient, M2
+# signal -- read it together with formal/EXPECTED_CHECKS, which is what asserts
+# the ladder did not merely shrink. `formal/equiv.sh` still does not converge
+# (ADR-0020), so ADR-0006's non-perturbation guarantee remains argued rather
+# than proven, and that argument now covers one more `ifdef RISCV_FORMAL`
+# field: rvfi_shadow.trap, written in decode and read only by rtl/writeback.v.

--- a/formal/pcloop.sv
+++ b/formal/pcloop.sv
@@ -47,7 +47,15 @@ module pcloop (
     // any CSR address is implemented and hand back any read value.
     input logic accessor_out_valid,
     input logic [31:0] csr_rdata,
-    input logic csr_implemented
+    input logic csr_implemented,
+    // ADR-0028's trap-entry pair, free for the same reason: rtl/csrs.v is not
+    // instantiated here, so the solver may present any mtvec and any mepc.
+    // That is the stronger environment for this task -- the PC-increment
+    // assertions below exclude trap and mret cycles as jumps (see
+    // f_jump_branch), so an arbitrary redirect target cannot make them pass;
+    // it can only make them harder to satisfy on the cycles they do cover.
+    input logic [31:0] mtvec,
+    input logic [31:0] mepc
 );
   logic [31:0] pc;
   logic [31:0] imem_addr, imem_addr2;
@@ -59,6 +67,10 @@ module pcloop (
   logic [11:0] csr_addr;
   logic        csr_ren, csr_wen, instret;
   logic [31:0] csr_wdata;
+  // Likewise driven by the decoder and read by nothing here: rtl/csrs.v is the
+  // consumer in the real pipeline, and this task is about the PC loop.
+  logic        trap_entry, mret_entry;
+  logic [31:0] trap_cause, trap_epc;
 
   fetcher fetcher (
     .clk(clk),
@@ -85,6 +97,8 @@ module pcloop (
     .accessor_out_valid(accessor_out_valid),
     .csr_rdata(csr_rdata),
     .csr_implemented(csr_implemented),
+    .mtvec(mtvec),
+    .mepc(mepc),
     .pc(pc),
     .rs1(rs1),
     .rs2(rs2),
@@ -93,6 +107,10 @@ module pcloop (
     .csr_wen(csr_wen),
     .csr_wdata(csr_wdata),
     .instret(instret),
+    .trap_entry(trap_entry),
+    .trap_cause(trap_cause),
+    .trap_epc(trap_epc),
+    .mret_entry(mret_entry),
     .out(decoder_out)
   );
 
@@ -180,18 +198,37 @@ module pcloop (
        (executor_out.valid && executor_out.rd == rs2) ||
        (accessor_pending_valid && accessor_pending_rd == rs2));
   // ADR-0026's fourth stall reason, transcribed the same way: a Zicsr access
-  // (SYSTEM opcode with a non-zero funct3[1:0], the six csrr* encodings) is
-  // held in decode until the pipe drains. Over-approximated like the rest --
-  // the real term also requires the pipe to be busy, and this deliberately
-  // does not look at that -- so it only ever excuses more cycles, never
-  // fewer. ecall/ebreak stay covered by the increment assertion below,
-  // because funct3 is 0 for both and they never serialize.
-  logic f_csr_access;
-  assign f_csr_access = f_uncompressed && f_instr[6:2] == 5'b11100 &&
-                        f_instr[13:12] != 2'b00;
+  // is held in decode until the pipe drains, and `mret` joins it there
+  // (CLAUDE.md invariant 5). Over-approximated like the rest -- the real term
+  // also requires the pipe to be busy, and this deliberately does not look at
+  // that -- so it only ever excuses more cycles, never fewer.
+  //
+  // Widened to the WHOLE SYSTEM opcode rather than the six csrr* funct3s,
+  // because `mret` has funct3 == 0 and the narrower test missed it: a
+  // serializing `mret` held the pc on a cycle this signal called quiet and the
+  // increment assertion below failed. `ecall`/`ebreak` come along for the ride
+  // and are covered by f_redirect anyway, since they now trap.
+  logic f_system;
+  assign f_system = f_uncompressed && f_instr[6:2] == 5'b11100;
 
   assign f_may_stall = divider_stall || accessor_stall || f_live_rs1 || f_live_rs2 ||
-      f_csr_access;
+      f_system;
+
+  // Trap entry and `mret` also write a non-sequential pc (ADR-0028: a trap is
+  // a branch), so the sequential-advance assertion must not cover those
+  // cycles either. Unlike everything above, these are NOT re-derived from
+  // `f_instr`: "would the decoder consider this word illegal" is decode, and
+  // restating it here would be the duplication this file refuses. They are
+  // read off the decoder's own OUTPUT PORTS instead -- pcloop-scope nets, not
+  // the phantom hierarchical references the note above warns about.
+  //
+  // Excusing a cycle on the DUT's own say-so would be a hole if nothing else
+  // covered it, so nothing else is left uncovered: the two assertions at the
+  // bottom of this block pin where the pc actually went on exactly these
+  // cycles. A decoder that claimed a spurious trap to escape the increment
+  // assertion would then have to land on mtvec to satisfy those.
+  logic f_redirect;
+  assign f_redirect = trap_entry || mret_entry;
 
   // Registered history, sampled at the same posedge that updates pc. That
   // same-edge sample is the phase relationship rtl/decoder.v:442 dictates:
@@ -205,15 +242,20 @@ module pcloop (
   // ports are always driven), and the one garbage sample possible -- the
   // pre-reset initial state at cycle 0 -- lands under prev_reset = 1, which
   // every assertion below excludes.
-  logic [31:0] past_pc;
+  logic [31:0] past_pc, prev_mtvec, prev_mepc;
   logic prev_reset, prev_may_stall, prev_hard_stall, prev_jump_branch, prev_uncompressed;
+  logic prev_trap_entry, prev_mret_entry;
   always_ff @(posedge clk) begin
     past_pc           <= pc;
     prev_reset        <= reset;
     prev_may_stall    <= f_may_stall;
     prev_hard_stall   <= divider_stall || accessor_stall;
-    prev_jump_branch  <= f_jump_branch;
+    prev_jump_branch  <= f_jump_branch || f_redirect;
     prev_uncompressed <= f_uncompressed;
+    prev_trap_entry   <= trap_entry;
+    prev_mret_entry   <= mret_entry;
+    prev_mtvec        <= mtvec;
+    prev_mepc         <= mepc;
   end
 
   // The echo, asserted rather than assumed. This one line is what turns the
@@ -244,6 +286,16 @@ module pcloop (
   // task's assertion, as above.
   always_ff @(posedge clk)
     if (clocked && prev_hard_stall && !prev_reset) assert(pc == past_pc);
+
+  // The redirect cycles the increment assertion above steps around, covered
+  // here instead of merely excused. A trap goes to mtvec and an mret goes to
+  // mepc -- through the real closed loop, so the decoder's `pc` output and the
+  // address the fetcher will present next cycle are the same thing (the echo
+  // assertion above is what ties them together).
+  always_ff @(posedge clk)
+    if (clocked && !prev_reset && prev_trap_entry) assert(pc == prev_mtvec);
+  always_ff @(posedge clk)
+    if (clocked && !prev_reset && prev_mret_entry) assert(pc == prev_mepc);
  `endif
 endmodule
 

--- a/rtl/accessor.v
+++ b/rtl/accessor.v
@@ -11,8 +11,13 @@ module accessor(
     output logic [3:0]  mem_wstrb,
     output logic [31:0] mem_wdata,
     input  logic [31:0] mem_rdata,
-    // fault signals
-    output logic mem_misaligned,
+    // No fault signal, and this stage has none to give: every trap is detected
+    // and committed in decode (CLAUDE.md invariant 2). Misalignment used to be
+    // detected HERE, which was post-decode and contradicted that invariant;
+    // ADR-0011 scoped the move to M3 and it has happened, in rtl/decoder.v,
+    // where the effective address is already computed. A trapping load or
+    // store never reaches this stage with any `is_l*`/`is_s*` flag set, so it
+    // issues no bus request at all.
     // ADR-0009-style stall broadcast (ADR-0009): the memory (test/testbench.v,
     // rtl/memory.v) registers mem_rdata one cycle after the address is
     // presented — a real, unavoidable round trip, not a choice — so a load
@@ -100,14 +105,6 @@ module accessor(
   rvfi_shadow  pending_rvfi;
   logic [31:0] pending_rvfi_mem_addr;
  `endif
-  // Misaligned-access detection per RISC-V spec: word accesses require 4-byte alignment,
-  // halfword accesses require 2-byte alignment; byte accesses are always aligned.
-  // Gated by in_valid (ADR-0011): a bubble must never raise a spurious
-  // trap. Detection itself stays here — moving it to decode is M3 (ADR-0011).
-  assign mem_misaligned = in_valid &&
-    (((in_is_lw || in_is_sw) && in_mem_addr[1:0] != 2'b00) ||
-     ((in_is_lh || in_is_lhu || in_is_sh) && in_mem_addr[0] != 1'b0));
-
   logic [31:0] write_request;
 
   // Hoisted out of the always_comb below for the same reason as decoder.v's

--- a/rtl/csrs.v
+++ b/rtl/csrs.v
@@ -21,17 +21,18 @@
 //                misa = 0x4000_1104 (RV32IMC), mvendorid/marchid/mimpid/
 //                mhartid = 0
 //
-// Nothing reads mtvec, mepc or mcause yet. That is deliberate: trap entry is
-// the next M3 step and is deliberately partitioned out of this one
-// (ADR-0011). The registers exist and behave now so that step is wiring, not
-// wiring plus a CSR file.
+// Trap entry and `mret` are the second write port, and the only architectural
+// CSR update no CSR *instruction* performs. They arrive from the decoder on
+// the edge the trapping instruction (or the `mret`) issues, because that is
+// where every trap is detected and committed (CLAUDE.md invariant 2,
+// ADR-0005). `mtvec_value`/`mepc_value` go back out to the decoder, which owns
+// the PC (invariant 1) and therefore has to be the thing that redirects it.
 //
-// A write to a CSR this module does not implement, and an illegal access to
-// one it does, do NOT raise a trap here. `implemented` is fed back into the
-// decoder's existing `instr_valid` term, so an unimplemented CSR reads as an
-// unrecognised instruction -- which is what an unimplemented CSR did before
-// this file existed. Turning that into a real illegal-instruction trap
-// belongs with trap entry.
+// A trap does NOT raise a trap here: this module never decides that an access
+// is illegal. `implemented` feeds the decoder's `instr_valid` term and the
+// read-only test is on the ADDRESS (addr[11:10] == 2'b11), so both illegal-CSR
+// rules are decided in rtl/decoder.v alongside every other trap cause -- one
+// priority encoder, one commit point, one ADR (ADR-0030) covering all five.
 module csrs(
   input  logic clk,
   input  logic reset,
@@ -55,7 +56,23 @@ module csrs(
 
   // ADR-0027: minstret counts non-trapping *issues*. High for exactly the
   // cycles the decoder issues one.
-  input  logic        instret
+  input  logic        instret,
+
+  // ---- trap entry and mret (ADR-0005 / ADR-0028) -------------------------
+  // `trap_entry` is high for exactly the cycle the decoder commits a trap;
+  // `mret_entry` for exactly the cycle it commits an `mret`. They cannot
+  // coincide with each other (a trapping instruction does not also execute)
+  // nor with `wen` (the decoder gates `csr_wen` on a NON-trapping commit, and
+  // `mret` is not a CSR access), so the three write paths below need no
+  // priority between them -- but the code says so explicitly rather than
+  // relying on last-assignment-wins.
+  input  logic        trap_entry,
+  input  logic [31:0] trap_cause,
+  input  logic [31:0] trap_epc,
+  input  logic        mret_entry,
+  // Read back by rtl/decoder.v, combinationally, to redirect the PC.
+  output logic [31:0] mtvec_value,
+  output logic [31:0] mepc_value
  `ifdef RISCV_FORMAL
   ,
   // ADR-0006 shadow payloads, for exactly the CSRs formal/checks.cfg's
@@ -114,6 +131,16 @@ module csrs(
   logic [31:0] mstatus_value;
   // MPP = 2'b11 at [12:11]; MPIE at [7]; MIE at [3]; everything else 0.
   assign mstatus_value = {19'b0, 2'b11, 3'b0, mstatus_mpie, 3'b0, mstatus_mie, 3'b0};
+
+  // The two registers the decoder redirects the PC through. Straight
+  // continuous assigns of the register outputs, i.e. the values as of the
+  // START of the issuing cycle. That is the right phase and not an accident:
+  // decode issues at most one instruction per cycle, so a trapping
+  // instruction and a `csrw mtvec` are never the same edge, and the trap must
+  // vector through the mtvec that was architecturally in place when it
+  // issued.
+  assign mtvec_value = mtvec;
+  assign mepc_value  = mepc;
 
   // ---- read mux ---------------------------------------------------------
   always_comb begin
@@ -175,6 +202,17 @@ module csrs(
   logic warl_mie, warl_mpie;
   assign warl_mie  = warl[3];
   assign warl_mpie = warl[7];
+
+  // Trap entry writes mepc through the SAME WARL mask an explicit `csrw mepc`
+  // goes through. `trap_epc` is an instruction address, so bit 0 is already
+  // clear and the mask changes nothing today -- it is here so that the mask is
+  // stated in one place rather than two, and so a reader can see that bit 1 is
+  // deliberately preserved: C makes 2-byte targets legal (ADR-0005), and a
+  // mask that cleared bit 1 too would resume two bytes early after any fault
+  // at `pc % 4 == 2`. test/asm/trap.S faults a compressed instruction at
+  // exactly that alignment for this reason.
+  logic [31:0] trap_epc_warl;
+  assign trap_epc_warl = {trap_epc[31:1], 1'b0};
 
   // ---- the counters -----------------------------------------------------
   // Both advance first and are then overwritten by an explicit write to the
@@ -239,6 +277,28 @@ module csrs(
           // no-op here by construction rather than by omission.
           default: ;
         endcase
+      end
+      // ---- trap entry / mret (ADR-0005) ----------------------------------
+      // The privileged-spec sequence, written out: a trap saves the faulting
+      // PC and the cause, pushes MIE into MPIE and disables interrupts; `mret`
+      // pops it back and leaves MPIE set. There are no interrupts on this core
+      // (mie/mip are read-only zero), so MIE/MPIE are architectural state a
+      // program can observe through mstatus rather than something that gates
+      // anything -- which is exactly why they have to be right: nothing else
+      // would notice if they were not.
+      //
+      // `else if` rather than two independent `if`s: mutually exclusive by
+      // construction (see the port comments), and stating the exclusion here
+      // means a future cause that broke it fails loudly at the priority
+      // encoder in rtl/decoder.v rather than silently double-writing mstatus.
+      if (trap_entry) begin
+        mepc         <= trap_epc_warl;
+        mcause       <= trap_cause;
+        mstatus_mpie <= mstatus_mie;
+        mstatus_mie  <= 1'b0;
+      end else if (mret_entry) begin
+        mstatus_mie  <= mstatus_mpie;
+        mstatus_mpie <= 1'b1;
       end
     end
   end

--- a/rtl/decoder.v
+++ b/rtl/decoder.v
@@ -59,6 +59,21 @@ module decoder (
   input  logic        csr_implemented,
   // ADR-0027: minstret counts non-trapping issues, and issue happens here.
   output logic        instret,
+  // ---- trap entry (CLAUDE.md invariant 2 / ADR-0005 / ADR-0030) ----------
+  // Every trap this core takes is detected AND committed here, in decode, on
+  // the edge the trapping instruction issues. `trap_entry` is high for exactly
+  // that cycle; rtl/csrs.v commits mepc/mcause/mstatus off it and rtl/
+  // littlecpu.v exports it as the top-level `trap` pulse (ADR-0028).
+  // `mtvec`/`mepc` come back the other way because decode owns the PC
+  // (invariant 1) -- a trap is a branch, and it is taken by the same
+  // mechanism every other branch here uses. There is no flush and there is
+  // nothing to flush: nothing downstream of this stage can fault.
+  output logic        trap_entry,
+  output logic [31:0] trap_cause,
+  output logic [31:0] trap_epc,
+  output logic        mret_entry,
+  input  logic [31:0] mtvec,
+  input  logic [31:0] mepc,
  `ifdef RISCV_FORMAL
   // ADR-0006: the CSR file's shadow payload for the access being presented
   // this cycle, latched below into the issuing instruction's shadow.
@@ -337,12 +352,37 @@ module decoder (
                      instr_csrrs ? (csr_rdata | csr_arg) :
                                    (csr_rdata & ~csr_arg);
 
-  logic instr_error;
+  // The SYSTEM instructions with funct3 == 0, distinguished from each other by
+  // funct12 alone -- which is why each one has to be spelled out exactly.
+  // Before trap entry existed, `mret` and `wfi` fell through to
+  // "unrecognised", which was harmless because unrecognised meant "execution
+  // flags suppressed, no trap". It stops being harmless the moment
+  // unrecognised means illegal-instruction.
+  logic instr_error, instr_mret, instr_wfi;
   assign instr_error = opcode == 5'b11100 && uncompressed && funct3 == 0 && rs1 == 0 && rd == 0;
   assign instr_ecall = instr_error && instr[31:20] == 12'h0;
-  // funct12 must be exactly 1 (ebreak's SYSTEM encoding); any other nonzero funct12
-  // (e.g. mret = 0x302, wfi = 0x105) is a different SYSTEM instruction, not ebreak.
   assign instr_ebreak = instr_error && instr[31:20] == 12'h1;
+  // ADR-0005: `mret` restores MIE <- MPIE, sets MPIE, and jumps to mepc.
+  // Committed in the publish block below, alongside trap entry, and serialized
+  // on the same drain predicate CSR instructions use (CLAUDE.md invariant 5).
+  assign instr_mret = instr_error && instr[31:20] == 12'h302;
+  // `wfi` executes as a NOP, which is spec-legal. With `mie`/`mip` read-only
+  // zero there is no interrupt that could ever resume it, so "wait" and
+  // "continue" are the same instruction on this core.
+  assign instr_wfi = instr_error && instr[31:20] == 12'h105;
+
+  // MISC-MEM: `fence` and `fence.i` are NOPs (ADR-0005). One hart, no caches,
+  // and a Harvard ROM no store can reach (ADR-0008), so there is nothing for
+  // either to order or to invalidate. Same story as `wfi` above: merely
+  // unrecognised until trap entry landed, at which point a legal `fence` would
+  // have faulted. Only funct3 is tested -- `fence`'s fm/pred/succ fields and
+  // `fence.i`'s reserved immediate are legal-value fields with nothing to act
+  // on here.
+  logic instr_miscmem, instr_fence, instr_fencei;
+  assign instr_miscmem = opcode == 5'b00011 && uncompressed;
+  assign instr_fence  = instr_miscmem && funct3 == 3'b000;
+  assign instr_fencei = instr_miscmem && funct3 == 3'b001;
+
   logic instr_valid;
 
   assign instr_valid = instr_auipc || instr_jal || instr_jalr || instr_beq || instr_bne || instr_blt
@@ -350,7 +390,89 @@ module decoder (
     instr_and || instr_mul || instr_mulh || instr_mulhu || instr_mulhsu || instr_div || instr_divu
     || instr_rem || instr_remu || instr_sll || instr_slt || instr_sltu || instr_srl || instr_sra ||
     instr_lui || instr_lb || instr_lbu || instr_lh || instr_lhu || instr_lw || instr_sb || instr_sh
-    || instr_sw || instr_ecall || instr_ebreak || (instr_csr_access && csr_implemented);
+    || instr_sw || instr_ecall || instr_ebreak || instr_mret || instr_wfi || instr_fence ||
+    instr_fencei || (instr_csr_access && csr_implemented);
+
+  // ---- trap detection (CLAUDE.md invariant 2, ADR-0005, ADR-0030) ---------
+  //
+  // The effective address, computed once and used twice: here, to decide
+  // whether the access is misaligned, and in the publish block below as
+  // `out.mem_addr`. Misalignment was detected in rtl/accessor.v until this
+  // change -- post-decode, contradicting invariant 2. ADR-0011 scoped the move
+  // to M3 and this is it. That the address is already available here for free
+  // is the whole reason invariant 2 is affordable.
+  logic [31:0] mem_addr_calc;
+  assign mem_addr_calc = $signed(immediate) + $signed(reg_rs1);
+
+  // Word accesses need 4-byte alignment, halfword accesses 2-byte; byte
+  // accesses are always aligned. That is why `lb`/`lbu`/`sb` appear nowhere
+  // here -- and why every one of the nine misalignment checks that used to sit
+  // in formal/EXPECTED_FAIL was a word or halfword access while every
+  // byte-granularity one already passed.
+  logic load_misaligned, store_misaligned;
+  assign load_misaligned  = (instr_lw && mem_addr_calc[1:0] != 2'b00) ||
+                            ((instr_lh || instr_lhu) && mem_addr_calc[0] != 1'b0);
+  assign store_misaligned = (instr_sw && mem_addr_calc[1:0] != 2'b00) ||
+                            (instr_sh && mem_addr_calc[0] != 1'b0);
+
+  // ADR-0005's two illegal-CSR rules. Both are tests on the ENCODING plus the
+  // CSR file's own address decode, never on a value:
+  //
+  //   * an access to a CSR rtl/csrs.v does not implement, which reaches this
+  //     through `instr_valid` above exactly as it did before traps existed;
+  //   * a WRITE to a read-only CSR, which the privileged spec encodes in the
+  //     address itself (addr[11:10] == 2'b11). `csr_write_op` already has
+  //     Zicsr's suppression rules applied, so `csrr misa` -- a CSRRS with
+  //     rs1 == x0, write suppressed -- stays legal while `csrw misa` does not.
+  //     That rule was architecturally unobservable until this change, which is
+  //     recorded next to formal/checks.cfg's `[csrs]` list.
+  logic csr_readonly_write, instr_illegal;
+  assign csr_readonly_write = instr_csr_access && csr_write_op && csr_addr[11:10] == 2'b11;
+  assign instr_illegal = !instr_valid || csr_readonly_write;
+
+  // Cause codes (ADR-0005). Instruction-address-misaligned (0) is unreachable
+  // -- C makes 2-byte targets legal (ADR-0002) -- and is deliberately absent.
+  localparam logic [31:0] CAUSE_ILLEGAL_INSTRUCTION = 32'd2;
+  localparam logic [31:0] CAUSE_BREAKPOINT          = 32'd3;
+  localparam logic [31:0] CAUSE_LOAD_MISALIGNED     = 32'd4;
+  localparam logic [31:0] CAUSE_STORE_MISALIGNED    = 32'd6;
+  localparam logic [31:0] CAUSE_ECALL_M             = 32'd11;
+
+  logic trap_pending;
+  assign trap_pending = instr_illegal || instr_ebreak || instr_ecall ||
+                        load_misaligned || store_misaligned;
+
+  // ADR-0030's priority order: illegal (2) -> breakpoint (3) -> environment
+  // call (11) -> load misaligned (4) -> store misaligned (6). An instruction
+  // that is not legal cannot meaningfully be said to have a misaligned
+  // operand: the address computation is only defined for an instruction the
+  // decoder recognises.
+  //
+  // Deliberately NOT `(* parallel_case *)`, and that is the point of ADR-0030.
+  // The five cases cannot co-occur today -- an illegal instruction has every
+  // execution flag suppressed and so has no memory operand; `ecall` and
+  // `ebreak` differ in funct12 and are SYSTEM rather than LOAD/STORE; a load
+  // and a store are different opcodes -- which makes this priority encoder
+  // vacuous. Claiming one-hot to synthesis would turn that disjointness from
+  // something the `ifdef FORMAL` block below ASSERTS into something the RTL
+  // silently assumes, so a later cause that broke it would be a lie to
+  // synthesis rather than a failed proof.
+  always_comb begin
+    case (1'b1)
+      instr_illegal:    trap_cause = CAUSE_ILLEGAL_INSTRUCTION;
+      instr_ebreak:     trap_cause = CAUSE_BREAKPOINT;
+      instr_ecall:      trap_cause = CAUSE_ECALL_M;
+      load_misaligned:  trap_cause = CAUSE_LOAD_MISALIGNED;
+      store_misaligned: trap_cause = CAUSE_STORE_MISALIGNED;
+      default:          trap_cause = 32'b0;
+    endcase
+  end
+
+  // mepc is the address of the FAULTING instruction, not of the next one --
+  // that is what lets a handler fix up and resume, and it is asserted directly
+  // in test/asm/trap.S rather than inferred from the fact that the test
+  // resumed.
+  assign trap_epc = fetcher_pc;
 
   always_comb begin
     (* parallel_case, full_case *)
@@ -421,12 +543,35 @@ module decoder (
   assign uses_rs2 = (instr_math && !instr_math_immediate) || instr_sb || instr_sh || instr_sw ||
     instr_beq || instr_bne || instr_blt || instr_bltu || instr_bge || instr_bgeu;
 
-  // Shared by hazard_rs1/hazard_rs2 below: is register `r` the destination
-  // of a live (not-yet-retired) producer at any of the three checked points?
-  function automatic logic live_producer(input logic [4:0] r);
-    live_producer = (out.valid && out.rd == r) || (executor_out.valid && executor_out.rd == r) ||
-      (accessor_pending_valid && accessor_pending_rd == r);
-  endfunction
+  // Is this operand's register the destination of a live (not-yet-retired)
+  // producer at any of the three checked points? Spelled out twice rather than
+  // shared through a `function automatic live_producer(r)` called from the two
+  // continuous assigns below, and THAT IS A CORRECTNESS REQUIREMENT, not a
+  // style preference:
+  //
+  //   iverilog builds a continuous assign's sensitivity list from the function
+  //   CALL's arguments. A function whose body additionally reads module-level
+  //   signals -- `out`, `executor_out`, `accessor_pending_*` -- therefore never
+  //   re-evaluates when any of those change, only when `r` does. That is
+  //   UNDER-sensitivity, which is the one direction CLAUDE.md's documented
+  //   `sorry:` exception says is a real bug rather than harmless noise, and it
+  //   is silent: iverilog issues no diagnostic for it at all.
+  //
+  // Measured, not theorised. With the function form, the iverilog leg froze at
+  // the FIRST RAW hazard of every program -- `hazard_rs1` latched high and
+  // never fell -- so `make waves`' own baked-in program executed two
+  // instructions and then span, and no `.S` program could reach `tohost`. The
+  // cxxrtl and formal legs were unaffected (yosys evaluates the function
+  // correctly), which is exactly why it went unnoticed: the leg CLAUDE.md's
+  // verification table calls the microscope was reporting nothing, and nothing
+  // it reported was wrong.
+  logic live_rs1, live_rs2;
+  assign live_rs1 = (out.valid && out.rd == rs1) ||
+    (executor_out.valid && executor_out.rd == rs1) ||
+    (accessor_pending_valid && accessor_pending_rd == rs1);
+  assign live_rs2 = (out.valid && out.rd == rs2) ||
+    (executor_out.valid && executor_out.rd == rs2) ||
+    (accessor_pending_valid && accessor_pending_rd == rs2);
 
   // CLAUDE.md invariant 5 / ADR-0005: a CSR instruction is held in decode
   // until execute, access and writeback have drained. ADR-0026: this is a
@@ -447,14 +592,20 @@ module decoder (
   // through the ordinary `is_add` pass-through, where the scoreboard above
   // already covers RAW. Delete this stall and no hazard appears -- what
   // appears is a `csrr minstret` inflated by whatever is in flight behind it.
+  //
+  // `mret` joins the CSR instructions on this stall for the reason CLAUDE.md
+  // invariant 5 names them together: it reads mepc and writes mstatus in
+  // decode, the same one-cycle-wide architectural update a CSR instruction
+  // makes, and holding it until the pipe drains keeps that update from being
+  // interleaved with instructions that issued before it.
   logic pipe_drained, csr_serialize;
   assign pipe_drained = !out.valid && !executor_out.valid && !accessor_out_valid &&
     !accessor_pending_valid;
-  assign csr_serialize = instr_csr_access && !pipe_drained;
+  assign csr_serialize = (instr_csr_access || instr_mret) && !pipe_drained;
 
   logic hazard_rs1, hazard_rs2, hazard, stall;
-  assign hazard_rs1 = uses_rs1 && rs1 != 0 && live_producer(rs1);
-  assign hazard_rs2 = uses_rs2 && rs2 != 0 && live_producer(rs2);
+  assign hazard_rs1 = uses_rs1 && rs1 != 0 && live_rs1;
+  assign hazard_rs2 = uses_rs2 && rs2 != 0 && live_rs2;
   assign hazard = hazard_rs1 || hazard_rs2 || csr_serialize;
 
  `ifdef RISCV_FORMAL
@@ -516,15 +667,29 @@ module decoder (
   // is precisely the bug this signal exists to avoid.
   logic issuing;
   assign issuing = !reset && !stall;
-  assign csr_ren = issuing && instr_valid && csr_read_op;
-  assign csr_wen = issuing && instr_valid && csr_write_op;
-  // ADR-0027: increment at issue, for NON-TRAPPING issues only. No trap is
-  // taken yet -- trap entry is the next M3 step (ADR-0011) -- so today the
-  // only issue that does not retire architecturally is an unrecognised
-  // instruction, which `instr_valid` already names. That is not an
-  // approximation of the rule standing in for it: it is exactly the set that
-  // starts trapping when trap entry lands, so this line does not move then.
-  assign instret = issuing && instr_valid;
+
+  // The one cycle an instruction actually takes architectural effect: it
+  // issued AND it did not trap. Everything that commits state outside the
+  // pipeline registers hangs off this.
+  logic committing;
+  assign committing = issuing && !trap_pending;
+  assign csr_ren = committing && csr_read_op;
+  assign csr_wen = committing && csr_write_op;
+  // ADR-0027: increment at issue, for NON-TRAPPING issues only. A trapping
+  // instruction issues, and retires in RVFI with `rvfi_trap = 1`, but it did
+  // not retire architecturally, so it must not be counted. `!trap_pending`
+  // implies `instr_valid` (an unrecognised instruction is now cause 2), so
+  // this is strictly the rule ADR-0027 states, not an approximation of it.
+  assign instret = committing;
+
+  // ADR-0028: the trap-entry pulse. rtl/csrs.v commits mepc/mcause/mstatus off
+  // it and rtl/littlecpu.v exports it as the top-level `trap` port. High for
+  // exactly one cycle per trap because `issuing` is, and no trap can be
+  // committed twice: the publish block's `else` arm below runs on exactly the
+  // same condition, so the redirect and the CSR update are the same edge.
+  assign trap_entry = issuing && trap_pending;
+  // `mret` is not a trap, so it commits on the ordinary non-trapping path.
+  assign mret_entry = committing && instr_mret;
 
   // publish the decoded results
   always_ff @(posedge clk) begin
@@ -559,10 +724,27 @@ module decoder (
       pc <= pc;
       out <= '0;
     end else begin
+      // THIS ARM IS THE ONE CYCLE AN INSTRUCTION ISSUES, and every trap is
+      // committed in it, at the bottom -- deliberately, because that single
+      // placement gives four things for free that would otherwise each need
+      // their own guard, and each of which a later edit can break silently:
+      //
+      //   * no trap on a stalled cycle -- this arm does not run then;
+      //   * no trap from a bubble -- a bubble is the arm above, not this one;
+      //   * no double commit -- an instruction reaches this arm exactly once;
+      //   * `reg_rs1` is hazard-clear, so the misalignment test below is
+      //     computed from the ARCHITECTURAL value of rs1 rather than a stale
+      //     one. That holds because `uses_rs1` is true for every load and
+      //     every store (it excludes only lui/jal/auipc and the zimm CSR
+      //     forms), so the ADR-0004 scoreboard has already stalled this
+      //     instruction on any live producer of rs1 before it can get here.
+      //     Narrow `uses_rs1` to exclude a memory op and misalignment
+      //     detection silently starts reading the wrong register.
+      //
       // branches handled below
       pc <= fetcher_pc + pc_inc;
       out.valid <= 1'b1;
-      out.mem_addr <= $signed(immediate) + $signed(reg_rs1);
+      out.mem_addr <= mem_addr_calc;
       // forwards
       out.rs1 <= instr_lui ? immediate : reg_rs1;
       out.rs2 <= instr_math ? math_arg : reg_rs2;
@@ -582,6 +764,9 @@ module decoder (
       // for free -- no separate ternary needed.
       out.rvfi.insn <= instr;
       out.rvfi.pc_rdata <= fetcher_pc;
+      // ADR-0028. Decode is the only stage that knows this, because decode is
+      // the only stage that can fault (CLAUDE.md invariant 2).
+      out.rvfi.trap <= trap_pending;
       out.rvfi.rs1_addr <= rvfi_rs1_valid ? rs1 : 5'b0;
       out.rvfi.rs2_addr <= rvfi_rs2_valid ? rs2 : 5'b0;
       out.rvfi.rs1_rdata <= rvfi_rs1_valid ? reg_rs1 : 32'b0;
@@ -625,8 +810,6 @@ module decoder (
       out.is_sw <= instr_sw;
       out.is_ecall <= instr_ecall;
       out.is_ebreak <= instr_ebreak;
-      out.csr_addr <= csr_addr;
-      out.is_csr_imm <= is_csr_imm;
       out.is_valid_instr <= instr_valid;
       // calculate branch
       (* parallel_case *)
@@ -701,9 +884,49 @@ module decoder (
           out.rd <= 0;
         end
       endcase
-      // Suppress all execution flags for unrecognized instructions (covers illegal opcodes,
-      // reserved encodings, and unimplemented CSR — prevents silent pipeline corruption)
-      if (!instr_valid) begin
+
+      // ---- mret: a branch, taken exactly like every other branch here -----
+      // The mstatus half (MIE <- MPIE, MPIE <- 1) is committed by rtl/csrs.v
+      // off `mret_entry` on this same edge. Nothing else about `mret` reaches
+      // the pipeline: rd is x0 in its encoding, so `out.rd` is already 0 and
+      // no execution flag is set for it.
+      if (instr_mret) begin
+        pc <= mepc;
+       `ifdef RISCV_FORMAL
+        out.rvfi.pc_wdata <= mepc;
+       `endif
+      end
+
+      // ---- trap entry (ADR-0028 / ADR-0030) -------------------------------
+      // A TRAP IS A BRANCH. `pc <= mtvec` here is the same override the jump
+      // and branch arms above use, on the same edge, through the same
+      // register -- which is why no flush exists and none is needed
+      // (CLAUDE.md invariant 1): the trapping instruction is the newest one in
+      // the machine, and everything behind it is already correct.
+      //
+      // Last in the block on purpose. Non-blocking assignments take the last
+      // write, so this beats the `pc` and `out.*` values the arms above set,
+      // and the suppression below beats every flag they set -- no arm has to
+      // know about traps and no ordering rule has to be remembered.
+      //
+      // The instruction still RETIRES (`out.valid` is 1, set at the top of
+      // this arm): ADR-0028's convention is that a trapping instruction
+      // retires having architecturally done nothing except redirect. Clearing
+      // every execution flag is what makes `rvfi_mem_rmask`/`wmask` zero --
+      // rtl/accessor.v builds them from the real bus, and with no flag set it
+      // issues no request at all, so a trapping store never reaches memory.
+      // That is the property `dmemcheck` catches (its environment shadow comes
+      // from the real `mem_wstrb`/`mem_wdata` while `rvfi_dmem_check`'s comes
+      // from `rvfi_mem_*`, so a suppressed-but-executed store desynchronises
+      // them), and `rvfi_insn_check` explicitly does not.
+      //
+      // Forcing `out.rd` to 0 does the same job for the register file: it
+      // gates rtl/writeback.v's `wen` and makes `rvfi_rd_addr`/`rd_wdata` zero.
+      if (trap_pending) begin
+        pc <= mtvec;
+       `ifdef RISCV_FORMAL
+        out.rvfi.pc_wdata <= mtvec;
+       `endif
         out.is_add <= 0; out.is_sub <= 0; out.is_xor <= 0; out.is_or <= 0; out.is_and <= 0;
         out.is_mul <= 0; out.is_mulh <= 0; out.is_mulhu <= 0; out.is_mulhsu <= 0;
         out.is_div <= 0; out.is_divu <= 0; out.is_rem <= 0; out.is_remu <= 0;
@@ -752,9 +975,16 @@ module decoder (
   // chained across another register adds an extra cycle of history the
   // solver can fill with a pre-reset garbage value that this component
   // proof, standing alone, has no way to rule out.
+  //
+  // `trap_pending` and `instr_mret` join the jumps and branches here because
+  // they are jumps: both override `pc` in the publish block above, so a cycle
+  // whose predecessor took one did not advance sequentially. That is the same
+  // exclusion the six branches get, for the same reason, and forgetting it is
+  // how "a trap is a branch" stops being true in the proof while staying true
+  // in the RTL.
   logic branch_jump;
   always_ff @(posedge clk) if (reset) branch_jump <= 1'b0;
-    else branch_jump <= instr_jal || instr_jalr || instr_beq || instr_bne || instr_blt || instr_bltu || instr_bge || instr_bgeu;
+    else branch_jump <= instr_jal || instr_jalr || instr_beq || instr_bne || instr_blt || instr_bltu || instr_bge || instr_bgeu || trap_pending || instr_mret;
   logic [31:0] past_pc;
   logic prev_reset, prev_stall, prev_uncompressed;
   always_ff @(posedge clk) begin
@@ -795,9 +1025,79 @@ module decoder (
     // the assertion below fail on every legal `csrr`. Listed separately, not
     // folded into one term, so a decode change that made two of them true at
     // once would still be caught -- they are distinguished only by funct3.
-    instr_ebreak, instr_csrrw, instr_csrrs, instr_csrrc});
+    instr_ebreak, instr_csrrw, instr_csrrs, instr_csrrc,
+    // The four M3 additions. `mret` and `wfi` are SYSTEM/funct3==0 forms told
+    // apart from ecall/ebreak (and from each other) by funct12 alone; `fence`
+    // and `fence.i` are MISC-MEM and differ only in funct3. All four are now
+    // in `instr_valid`, so omitting them here would fail this assertion on
+    // every legal one of them -- which is exactly what makes the omission
+    // catchable rather than silent.
+    instr_mret, instr_wfi, instr_fence, instr_fencei});
 
   // we should only get one type of instruction
   always_comb if (instr_valid) assert(one_of);
+
+  // ---- ADR-0030: the trap causes, and why the priority encoder is vacuous --
+  //
+  // The disjointness argument written out as an assertion, which is what keeps
+  // the ADR honest as the core grows: an illegal instruction has no memory
+  // operand (`instr_valid` is what admits a load or a store in the first
+  // place, and `csr_readonly_write` is a SYSTEM encoding), `ecall`/`ebreak`
+  // differ in funct12 and are neither LOAD nor STORE, and a load and a store
+  // are different opcodes in both the 32-bit and the compressed forms. Add a
+  // sixth cause that overlaps an existing one and this fails rather than the
+  // behaviour quietly becoming whatever the encoder happened to produce.
+  always_comb assert($onehot0({instr_illegal, instr_ebreak, instr_ecall,
+                               load_misaligned, store_misaligned}));
+
+  // ...and the committed cause is the one ADR-0030's order names. Written per
+  // cause rather than as a restatement of the case statement, so a reordering
+  // of the arms is caught rather than mirrored.
+  always_comb if (instr_illegal)    assert(trap_cause == CAUSE_ILLEGAL_INSTRUCTION);
+  always_comb if (instr_ebreak)     assert(trap_cause == CAUSE_BREAKPOINT);
+  always_comb if (instr_ecall)      assert(trap_cause == CAUSE_ECALL_M);
+  always_comb if (load_misaligned)  assert(trap_cause == CAUSE_LOAD_MISALIGNED);
+  always_comb if (store_misaligned) assert(trap_cause == CAUSE_STORE_MISALIGNED);
+  always_comb if (!trap_pending)    assert(trap_cause == 32'b0);
+
+  // ---- ADR-0028: what a trapping retire is allowed to have done ------------
+  // `mtvec`/`mepc` are free inputs in this standalone task (rtl/csrs.v is not
+  // instantiated), so these are registered copies rather than reads of the
+  // live input -- the same technique the pc-increment history above uses, and
+  // for the same reason.
+  logic        prev_trap_entry, prev_mret_entry;
+  logic [31:0] prev_mtvec, prev_mepc;
+  always_ff @(posedge clk) begin
+    prev_trap_entry <= trap_entry;
+    prev_mret_entry <= mret_entry;
+    prev_mtvec      <= mtvec;
+    prev_mepc       <= mepc;
+  end
+
+  // The redirect actually happened, and it went to mtvec -- which is the one
+  // thing ADR-0028 records that NO check on the riscv-formal ladder can see:
+  // `rvfi_insn_check` drops every value assertion under `spec_trap`, and
+  // pc_fwd/pc_bwd are satisfied by any target so long as it is honestly
+  // reported. This is the check that says it must be `mtvec`.
+  always_comb if (clocked && !prev_reset && prev_trap_entry) assert(pc == prev_mtvec);
+  always_comb if (clocked && !prev_reset && prev_mret_entry) assert(pc == prev_mepc);
+
+  // A trapping instruction writes no register and issues no memory access. The
+  // executor and accessor read these flags off `out`, so clearing them here is
+  // the whole mechanism -- there is no downstream kill signal and CLAUDE.md
+  // invariant 1 forbids adding one.
+  always_comb if (clocked && !prev_reset && prev_trap_entry) begin
+    assert(out.rd == 5'b0);
+    assert(!out.is_lb && !out.is_lbu && !out.is_lh && !out.is_lhu && !out.is_lw);
+    assert(!out.is_sb && !out.is_sh && !out.is_sw);
+  end
+
+  // ADR-0027: a trapping issue does not increment minstret, and does not
+  // commit a CSR write either. Both fall out of `committing`, asserted here so
+  // that a future edit that re-gated one of them on `instr_valid` (the
+  // pre-M3 spelling, which is weaker) fails.
+  always_comb if (trap_pending) assert(!instret && !csr_wen && !csr_ren);
+  // A trap and an mret are different instructions; nothing may commit both.
+  always_comb assert(!(trap_entry && mret_entry));
  `endif
 endmodule

--- a/rtl/littlecpu.v
+++ b/rtl/littlecpu.v
@@ -72,13 +72,23 @@ module littlecpu(
   // it. accessor_out is declared further down, next to its instantiation, so
   // this carries its valid bit up to the decoder's port list.
   logic accessor_out_valid;
-  // trap is asserted when the decoded instruction is unrecognized (illegal-instruction)
-  // or when the accessor detects a misaligned memory access.  Gated by !reset so that
-  // the pipeline flush state does not produce spurious traps, and by decoder_out.valid
-  // so a hazard/divide bubble (which zeroes is_valid_instr along with everything else)
-  // never looks like an illegal instruction (ADR-0009).
-  logic mem_misaligned_trap;
-  assign trap = !reset && ((decoder_out.valid && !decoder_out.is_valid_instr) || mem_misaligned_trap);
+  // ADR-0028: `trap` is redefined, not deleted -- it is now a one-cycle "trap
+  // entry committed this cycle" pulse, driven straight from the decode stage
+  // that commits it (CLAUDE.md invariant 2). It used to be a combinational OR
+  // of "the decoded instruction was unrecognised" with the accessor's
+  // POST-DECODE misalignment signal, and nothing consumed it. Both halves of
+  // that are gone: the accessor no longer detects misalignment (ADR-0011's
+  // debt, discharged in rtl/decoder.v), and an unrecognised instruction is now
+  // a real illegal-instruction trap rather than a silently suppressed one.
+  //
+  // It is kept rather than removed because deleting it would change the port
+  // list in formal/wrapper.v, formal/dmemcheck.sv, formal/imemcheck.sv,
+  // formal/cover.sv, formal/complete.sv and test/testbench.v for no functional
+  // gain -- and because ADR-0029's harness check (a trap taken with mtvec == 0
+  // is a silent restart at `_start`, since test/asm/sections.lds links .text
+  // at 0) needs exactly this signal.
+  logic decoder_trap_entry;
+  assign trap = decoder_trap_entry;
   logic  [31:0] pc;
   fetcher_output fetcher_out;
   fetcher fetcher(
@@ -118,6 +128,12 @@ module littlecpu(
   logic [31:0] csr_wdata, csr_rdata;
   logic        csr_implemented;
   logic        csr_instret;
+  // ADR-0005 / ADR-0028: the trap-entry side of the same decode/CSR pair. The
+  // decoder detects and commits; the CSR file records mepc/mcause/mstatus and
+  // hands back the two registers the decoder redirects the PC through.
+  logic        csr_trap_entry, csr_mret_entry;
+  logic [31:0] csr_trap_cause, csr_trap_epc;
+  logic [31:0] csr_mtvec, csr_mepc;
  `ifdef RISCV_FORMAL
   rvfi_csr64 csr_rvfi_mcycle, csr_rvfi_minstret;
   rvfi_csr32 csr_rvfi_mscratch;
@@ -138,6 +154,8 @@ module littlecpu(
     .accessor_out_valid(accessor_out_valid),
     .csr_rdata(csr_rdata),
     .csr_implemented(csr_implemented),
+    .mtvec(csr_mtvec),
+    .mepc(csr_mepc),
    `ifdef RISCV_FORMAL
     .csr_rvfi_mcycle(csr_rvfi_mcycle),
     .csr_rvfi_minstret(csr_rvfi_minstret),
@@ -152,6 +170,10 @@ module littlecpu(
     .csr_wen(csr_wen),
     .csr_wdata(csr_wdata),
     .instret(csr_instret),
+    .trap_entry(decoder_trap_entry),
+    .trap_cause(csr_trap_cause),
+    .trap_epc(csr_trap_epc),
+    .mret_entry(csr_mret_entry),
     .out(decoder_out)
   );
 
@@ -164,9 +186,15 @@ module littlecpu(
     .wen(csr_wen),
     .wdata(csr_wdata),
     .instret(csr_instret),
+    .trap_entry(decoder_trap_entry),
+    .trap_cause(csr_trap_cause),
+    .trap_epc(csr_trap_epc),
+    .mret_entry(csr_mret_entry),
     // outputs
     .rdata(csr_rdata),
-    .implemented(csr_implemented)
+    .implemented(csr_implemented),
+    .mtvec_value(csr_mtvec),
+    .mepc_value(csr_mepc)
    `ifdef RISCV_FORMAL
     ,
     .rvfi_mcycle(csr_rvfi_mcycle),
@@ -198,8 +226,6 @@ module littlecpu(
     .mem_wstrb(mem_wstrb),
     .mem_wdata(mem_wdata),
     .mem_rdata(mem_rdata),
-    // fault signals
-    .mem_misaligned(mem_misaligned_trap),
     .stalled(accessor_stalled),
     .pending_valid(accessor_pending_valid),
     .pending_rd(accessor_pending_rd),
@@ -219,6 +245,7 @@ module littlecpu(
    `ifdef RISCV_FORMAL
     ,
     .rvfi_valid(rvfi_valid),
+    .rvfi_trap(rvfi_trap),
     .rvfi_order(rvfi_order),
     .rvfi_insn(rvfi_insn),
     .rvfi_rs1_addr(rvfi_rs1_addr),
@@ -250,13 +277,13 @@ module littlecpu(
   );
 
  `ifdef RISCV_FORMAL
-  // The CSR fields are per-retire data now (rtl/csrs.v, threaded through the
-  // shadow to rtl/writeback.v). These five are not, and stay constants:
-  // rvfi_trap has nothing upstream computing it until trap entry lands (the
-  // next M3 step, ADR-0011), and M-mode only / XLEN=32 / no interrupts
-  // (CLAUDE.md: mie and mip are read-only zero) makes mode/ixl/intr
-  // properties of the design rather than of an instruction.
-  assign rvfi_trap = 1'b0;
+  // The CSR fields are per-retire data (rtl/csrs.v, threaded through the shadow
+  // to rtl/writeback.v), and so is `rvfi_trap` now -- rtl/decoder.v computes it
+  // where every trap is committed (CLAUDE.md invariant 2) and rtl/writeback.v
+  // drives it at retire. These four are not per-retire data and stay constants:
+  // M-mode only / XLEN=32 / no interrupts (mie and mip are read-only zero) and
+  // no halt makes mode/ixl/intr/halt properties of the design rather than of an
+  // instruction.
   assign rvfi_halt = 1'b0;
   assign rvfi_intr = 1'b0;
   assign rvfi_mode = 2'd3;

--- a/rtl/structs.v
+++ b/rtl/structs.v
@@ -51,6 +51,13 @@ typedef struct packed {
   logic [4:0]  rs2_addr;
   logic [31:0] rs1_rdata;
   logic [31:0] rs2_rdata;
+  // ADR-0028: `rvfi_trap` for this instruction. Decode is the one stage that
+  // knows it -- every trap is detected and committed there (CLAUDE.md
+  // invariant 2) -- so it rides down with the rest of the shadow rather than
+  // being recomputed at retire. A trapping instruction still retires
+  // (`valid` reaching writeback, invariant 3); it just retires having
+  // architecturally done nothing except redirect the PC.
+  logic        trap;
   // Exactly the CSRs formal/checks.cfg's `[csrs]` list names, captured in
   // decode -- the one stage that knows them, since ADR-0005 reads and
   // commits every CSR access there -- and forwarded on the same valid-bit
@@ -101,23 +108,21 @@ typedef struct packed {
   logic        is_sw;
   logic        is_ecall;
   logic        is_ebreak;
-  // ADR-0005's decode-side record of a Zicsr access: which CSR, and whether
-  // the operand was a zimm rather than rs1. No stage after decode reads
-  // either -- a CSR access is read, computed and committed entirely in
-  // decode (rtl/csrs.v is the decoder's sibling, not a pipeline stage), and
-  // the *result* reaches rd through `is_add` like lui/jal/auipc already do.
-  // They are carried anyway, per ADR-0005, because they are the only place
-  // downstream a reader (or a waveform) can tell a CSR access apart from the
-  // add it is disguised as.
+  // What is deliberately NOT here, and must not come back:
   //
-  // What is deliberately NOT here: `is_csrrw`/`is_csrrs`/`is_csrrc`, which
-  // this struct used to carry with rtl/executor.v:198 an empty statement for
-  // them. They cannot coexist with the `is_add` pass-through: the executor's
-  // op select is one `(* parallel_case *) case (1'b1)`, and setting both
-  // `is_add` and a CSR flag would make two arms match at once -- a lie to
-  // synthesis, not merely redundant.
-  logic [11:0] csr_addr;
-  logic        is_csr_imm;
+  //   `is_csrrw`/`is_csrrs`/`is_csrrc`, which this struct used to carry with
+  //   rtl/executor.v an empty statement for them. They cannot coexist with
+  //   ADR-0005's `is_add` pass-through: the executor's op select is one
+  //   `(* parallel_case *) case (1'b1)`, and setting both `is_add` and a CSR
+  //   flag would make two arms match at once -- a lie to synthesis, not
+  //   merely redundant.
+  //
+  //   `csr_addr`/`is_csr_imm`, which ADR-0034 kept as scaffolding with an
+  //   explicit sunset condition: strike them in the trap-entry change if
+  //   neither has acquired a downstream consumer by then. Neither did --
+  //   trap detection, CSR read/write and trap commit all happen in decode --
+  //   so they are gone. Thirteen bits of struct that nothing reads is the
+  //   incidental machinery this project's stated goal warns against.
 } decoder_output;
 
 typedef struct packed {

--- a/rtl/writeback.v
+++ b/rtl/writeback.v
@@ -12,13 +12,13 @@ module writeback(
   output logic [31:0] wdata
   // ADR-0006 / CLAUDE.md invariant 3: "retire is `valid` reaching
   // writeback, which gates wen and drives rvfi_valid" — this is that spot.
-  // `rvfi_trap` stays hardwired 0 in littlecpu.v: nothing upstream computes
-  // it yet (trap entry is the next M3 step, ADR-0011). The CSR fields no
-  // longer are — rtl/csrs.v builds them and they ride the shadow down here
-  // like every other per-retire value.
+  // `rvfi_trap` is no longer hardwired either: rtl/decoder.v computes it where
+  // every trap is detected and committed (invariant 2) and it rides the shadow
+  // down here like the CSR fields and everything else per-retire.
  `ifdef RISCV_FORMAL
   ,
   output logic        rvfi_valid,
+  output logic        rvfi_trap,
   output logic [63:0] rvfi_order,
   output logic [31:0] rvfi_insn,
   output logic [ 4:0] rvfi_rs1_addr,
@@ -71,6 +71,40 @@ module writeback(
   // registered accessor_output, stable for exactly the one cycle it
   // retires, so there is nothing to re-register here except the running
   // order counter below.
+  // ADR-0028's convention for a TRAPPING retire, restated here because this is
+  // the drive site and a reader has no other way to learn that the oracle is
+  // silent about it. riscv-formal's checks/rvfi_insn_check.sv puts rd_addr,
+  // rd_wdata, pc_wdata and every mem_* assertion inside `if (!spec_trap)` and
+  // keeps only `assert(spec_trap == trap)` outside, so the ladder cannot tell
+  // a core that traps correctly from one that traps AND corrupts rd, writes
+  // memory, and redirects somewhere arbitrary. What this core commits to:
+  //
+  //   rvfi_valid  1   -- a trapping instruction DOES retire
+  //   rvfi_trap   1
+  //   rvfi_rd_addr / rvfi_rd_wdata            0
+  //   rvfi_mem_rmask / rvfi_mem_wmask         0
+  //   rvfi_pc_wdata                           mtvec
+  //
+  // None of it is enforced here: it is enforced upstream, in rtl/decoder.v,
+  // by suppressing `out.rd` and every execution flag on a trapping issue, so
+  // the values below are zero because nothing produced anything -- not because
+  // this block masks them. Three ladder checks catch it INDIRECTLY if that
+  // breaks (`dmemcheck` for a store that still strobes the bus, `reg` for an
+  // rd that still lands, `pc_fwd`/`pc_bwd` for a redirect that is misreported
+  // or not taken); none of them names traps in its title, and the connection
+  // is not discoverable from CI output. The one thing nothing on the ladder
+  // can see -- that the target is `mtvec` -- is asserted in rtl/decoder.v's
+  // component proof.
+  // A continuous assign rather than a line in the always_comb below, and that
+  // is the documented pattern rather than a style choice (ADR-0034): every
+  // struct-field read inside an `always_comb` is a constant part-select
+  // iverilog cannot build a precise sensitivity entry for, so it emits
+  // `sorry: constant selects in always_* processes are not fully supported`
+  // and falls back to whole-struct sensitivity. Safe, but a diagnostic, and
+  // CLAUDE.md caps the count at exactly 20. Adding this one line in there made
+  // it 21.
+  assign rvfi_trap = in.rvfi.trap;
+
   always_comb begin
     rvfi_valid = !reset && in.valid;
     rvfi_insn = in.rvfi.insn;

--- a/test/EXPECTED_FAIL
+++ b/test/EXPECTED_FAIL
@@ -12,9 +12,9 @@
 #
 # The status is the exact label test/run_tests.sh prints in its table:
 # ASSEMBLE-ERROR, ASSEMBLE-WARNING, OBJCOPY-ERROR <region>,
-# OBJCOPY-EMPTY <region>, FAIL <n>, TIMEOUT, MONITOR-ERROR <n>, or
-# RUNNER-ERROR <n>. Whitespace between the fields is free; a line with only a
-# name is rejected rather than half-matched.
+# OBJCOPY-EMPTY <region>, FAIL <n>, TIMEOUT, MONITOR-ERROR <n>, TRAP-TO-ZERO,
+# or RUNNER-ERROR <n>. Whitespace between the fields is free; a line with only
+# a name is rejected rather than half-matched.
 #
 # The status is here because matching on the name alone made the gate blind to
 # *why* a test failed. A baselined entry stayed matched if its assembly broke
@@ -37,30 +37,33 @@
 # file stays empty. See ADR-0019 before ever adding a line back for a
 # monitor-side problem.
 #
-# The line below is the M3 debt, added deliberately and ahead of the RTL that
-# pays it off — this is the direction the burn-down contract was designed for.
-# It names behaviour ADR-0028 / ADR-0030 specify and no `rtl/` file implements
-# yet: there is no trap commit. It is NOT a monitor-side problem (ADR-0019's
-# case) and NOT a regression; it is a test written before its feature, so that
-# the M3 RTL change that pays it off has a checkable simulation acceptance
-# criterion instead of an argument.
+# THE FILE IS EMPTY AGAIN, and the entry that came out is the one it was
+# seeded with ahead of its RTL.
 #
-# `csr.S` and `minstret.S` were here alongside it and came out together with
-# the CSR file (`rtl/csrs.v`), which is exactly how this burn-down is meant to
-# go: one line, in the commit that makes that test pass.
+#   trap.S      MONITOR-ERROR 101 -- every implemented trap cause (ADR-0005 /
+#               ADR-0030) taken deliberately, plus ADR-0028's convention that a
+#               trapping instruction writes no register and no memory, plus
+#               ADR-0027's rule that a trapping instruction does not increment
+#               `minstret`. It reported MONITOR-ERROR 101 ("mismatch in trap")
+#               rather than FAIL because with no trap logic the core COMPLETED
+#               the misaligned load and the per-retire monitor caught the
+#               disagreement before `tohost` was ever written. Pinning that
+#               exact number is what the status field is for: had trap.S
+#               started failing some other way in the meantime, the gate would
+#               have gone red instead of matching.
 #
-#   trap.S      — every implemented trap cause (ADR-0005 / ADR-0030) taken
-#                 deliberately, plus ADR-0028's convention that a trapping
-#                 instruction writes no register and no memory, plus
-#                 ADR-0027's rule that a trapping instruction does not
-#                 increment `minstret` (which moved here from minstret.S,
-#                 because it needs a trap to be takeable at all). Reports
-#                 MONITOR-ERROR rather than FAIL today: with no trap logic the
-#                 core completes the misaligned load, and the per-retire
-#                 monitor catches the disagreement before `tohost` is ever
-#                 written. Error 101 is "mismatch in trap" — the check
-#                 ADR-0033 gap 2 keeps live under `spec_trap`. Pinning that
-#                 number here is the point of the status field: if trap.S
-#                 starts failing some other way, it is a new failure, not this
-#                 one.
-trap.S      MONITOR-ERROR 101
+# It came out with the RTL that pays it off -- misalignment, illegal
+# instruction, ebreak, ecall and the two illegal-CSR rules all detected and
+# committed in decode (CLAUDE.md invariant 2), which is ADR-0011's deferred
+# debt discharged. The same change grew trap.S by two cases (a write to a
+# read-only CSR, and a COMPRESSED faulting instruction so `mepc` is exercised
+# 2-aligned) and grew this script's status vocabulary by TRAP-TO-ZERO, which
+# is ADR-0029's harness check: `mtvec` resets to 0 and sections.lds links
+# `.text` there, so a trap taken before a handler is installed used to look
+# like a timeout rather than like a fault.
+#
+# `csr.S` and `minstret.S` were here alongside it and came out with
+# `rtl/csrs.v`. Three lines, three commits, one per feature -- which is exactly
+# how ADR-0014's burn-down contract was meant to go. The file staying empty is
+# now a plain all-pass gate again; ADR-0014's set equality still runs in both
+# directions, so an unexpected *pass* is caught too.

--- a/test/asm/trap.S
+++ b/test/asm/trap.S
@@ -125,8 +125,72 @@ test_4:
 
   TEST_CASE( 12, a4, 2, la a3, trap_cause; lw a4, 0(a3); )
 
-  # Six traps taken, six handler entries.
-  TEST_CASE( 13, a4, 6, la a3, trap_count; lw a4, 0(a3); )
+  #-------------------------------------------------------------
+  # ...and the other illegal-CSR rule: a WRITE to a CSR that is read-only by
+  # address (mvendorid is 0xF11, so addr[11:10] == 2'b11). The read side of the
+  # same CSR is legal and csr.S asserts that it is, so this is specifically the
+  # write that must fault. Until trap entry existed the rule was
+  # architecturally unobservable -- which is why formal/checks.cfg records that
+  # csrw_mscratch_ch0 cannot see the sibling suppression rule either.
+  #-------------------------------------------------------------
+
+  la    a3, trap_cause
+  sw    x0, 0(a3)
+
+  .option push
+  .option norvc
+  csrw  mvendorid, t0
+  .option pop
+
+  TEST_CASE( 13, a4, 2, la a3, trap_cause; lw a4, 0(a3); )
+
+  #-------------------------------------------------------------
+  # A COMPRESSED faulting instruction, so `mepc` is exercised at pc % 4 == 2 --
+  # the one case the WARL mask on mepc must not break. That mask clears bit 0
+  # only, because C makes 2-byte targets legal (ADR-0005); a mask that cleared
+  # bit 1 as well would resume two bytes early here and nowhere else in this
+  # file, since every other trapping instruction above is `.option norvc` and
+  # therefore 4-byte aligned.
+  #
+  # Two pieces of layout are load-bearing, both consequences of the handler
+  # resuming at mepc+4 unconditionally (it cannot read the faulting instruction
+  # to learn its length: Harvard buses, ADR-0008, and riscv_test.h constraint
+  # 1). The `.align 2` plus a 2-byte `c.nop` puts the faulting instruction at
+  # pc % 4 == 2; the `c.nop` behind it is 2 bytes of padding so mepc+4 lands on
+  # an instruction boundary rather than inside one. Test 16 asserts the
+  # alignment actually came out that way, so this cannot quietly degrade into a
+  # 4-aligned case that proves nothing.
+  #-------------------------------------------------------------
+
+  la    a0, tdat
+  addi  a0, a0, 1
+  li    a1, 0x5a5
+
+  .option push
+  .option rvc
+  .align 2
+  c.nop
+mis_clw:
+  c.lw  a1, 0(a0)
+  c.nop
+  .option pop
+
+  TEST_CASE( 14, a4, 4, la a3, trap_cause; lw a4, 0(a3); )
+
+test_15:
+  la    a3, trap_epc
+  lw    a4, 0(a3)
+  la    x29, mis_clw
+  li    TESTNUM, 15
+  bne   a4, x29, fail
+
+  TEST_CASE( 16, a4, 2, la a3, mis_clw; andi a4, a3, 3; )
+
+  # A trapping compressed load writes no register either (ADR-0028).
+  TEST_CASE( 17, a1, 0x5a5, nop; )
+
+  # Eight traps taken, eight handler entries.
+  TEST_CASE( 18, a4, 8, la a3, trap_count; lw a4, 0(a3); )
 
   #-------------------------------------------------------------
   # ADR-0027's second counter rule: a trapping instruction issues, and retires
@@ -140,7 +204,7 @@ test_4:
   # handler resumes at mepc+4.
   #-------------------------------------------------------------
 
-test_14:
+test_19:
   la    a3, tdat
   addi  a3, a3, 1
 
@@ -162,12 +226,12 @@ test_14:
   sub   a5, a6, a5
   srli  a5, a5, 2
   addi  x29, a5, 1
-  li    TESTNUM, 14
+  li    TESTNUM, 19
   bne   a2, x29, fail
 
-  # The trap really was taken — otherwise test 14 would be asserting about a
+  # The trap really was taken — otherwise test 19 would be asserting about a
   # sequence that never entered the handler at all.
-  TEST_CASE( 15, a4, 7, la a3, trap_count; lw a4, 0(a3); )
+  TEST_CASE( 20, a4, 9, la a3, trap_count; lw a4, 0(a3); )
 
   TEST_PASSFAIL
 

--- a/test/csr_tb.v
+++ b/test/csr_tb.v
@@ -32,6 +32,11 @@ module csr_tb;
   logic [31:0] rdata;
   logic        implemented;
   logic        instret;
+  // ADR-0028's second write port. rtl/decoder.v drives these for exactly the
+  // cycle it commits a trap (or an mret); this bench drives them directly.
+  logic        trap_entry, mret_entry;
+  logic [31:0] trap_cause, trap_epc;
+  logic [31:0] mtvec_value, mepc_value;
  `ifdef RISCV_FORMAL
   rvfi_csr64 rvfi_mcycle, rvfi_minstret;
   rvfi_csr32 rvfi_mscratch;
@@ -46,7 +51,13 @@ module csr_tb;
     .wdata(wdata),
     .rdata(rdata),
     .implemented(implemented),
-    .instret(instret)
+    .instret(instret),
+    .trap_entry(trap_entry),
+    .trap_cause(trap_cause),
+    .trap_epc(trap_epc),
+    .mret_entry(mret_entry),
+    .mtvec_value(mtvec_value),
+    .mepc_value(mepc_value)
    `ifdef RISCV_FORMAL
     ,
     .rvfi_mcycle(rvfi_mcycle),
@@ -107,6 +118,27 @@ module csr_tb;
     end
   endtask
 
+  // Commit one trap entry on the next edge, the way rtl/decoder.v does.
+  task automatic take_trap(input logic [31:0] cause, input logic [31:0] epc);
+    begin
+      trap_cause = cause;
+      trap_epc = epc;
+      trap_entry = 1'b1;
+      @(posedge clk);
+      #1;
+      trap_entry = 1'b0;
+    end
+  endtask
+
+  task automatic take_mret;
+    begin
+      mret_entry = 1'b1;
+      @(posedge clk);
+      #1;
+      mret_entry = 1'b0;
+    end
+  endtask
+
   logic [31:0] before_lo, before_hi;
 
   initial begin
@@ -115,6 +147,10 @@ module csr_tb;
     wen = 1'b0;
     wdata = 32'b0;
     instret = 1'b0;
+    trap_entry = 1'b0;
+    mret_entry = 1'b0;
+    trap_cause = 32'b0;
+    trap_epc = 32'b0;
     reset = 1'b1;
     repeat (2) @(posedge clk);
     #1;
@@ -189,8 +225,13 @@ module csr_tb;
     poke(12'h300, 32'h0000_0008);
     check_read("mstatus MIE alone", 12'h300, 32'h0000_1808);
 
-    // Read-only CSRs ignore writes rather than trapping here (the trap for
-    // an illegal access lands with trap entry -- ADR-0005, ADR-0011).
+    // Read-only CSRs ignore writes rather than trapping HERE. This module
+    // never decides an access is illegal: the read-only test is on the
+    // address (addr[11:10] == 2'b11) and it lives in rtl/decoder.v alongside
+    // every other trap cause (ADR-0005, ADR-0030). So these writes reaching
+    // this module at all is a case the real core no longer produces -- kept
+    // because the WARL fallback that swallows them is what makes the RVFI
+    // report tell the truth about what landed.
     poke(12'h301, 32'hffff_ffff);
     check_read("misa ignores a write", 12'h301, 32'h4000_1104);
     poke(12'h304, 32'hffff_ffff);
@@ -245,11 +286,52 @@ module csr_tb;
     check_read("an explicit mcycle write beats the increment", 12'hB00, 32'h0000_0000);
     check_read("...and does not disturb mcycleh", 12'hB80, before_hi);
 
+    // ---- trap entry and mret (ADR-0005 / ADR-0028) -----------------------
+    // The privileged-spec sequence, driven directly. Nothing on the
+    // riscv-formal ladder can see any of it: rvfi_insn_check drops every value
+    // assertion under `spec_trap`, and mtvec/mepc/mcause/mstatus are
+    // deliberately off formal/checks.cfg's [csrs] list because
+    // rvfi_csrw_check.sv has no WARL model. This bench and test/asm/trap.S are
+    // the whole coverage.
+    poke(12'h305, 32'h0000_0100);   // mtvec = 0x100
+    poke(12'h300, 32'h0000_0008);   // mstatus.MIE = 1, MPIE = 0
+    check_hex("mtvec_value echoes mtvec for the decoder", mtvec_value, 32'h0000_0100);
+
+    take_trap(32'd4, 32'h0000_0080);
+    check_read("a trap records the cause", 12'h342, 32'd4);
+    check_read("...and the faulting pc in mepc", 12'h341, 32'h0000_0080);
+    check_read("...pushes MIE into MPIE and clears MIE", 12'h300, 32'h0000_1880);
+    check_hex("mepc_value echoes mepc for the decoder", mepc_value, 32'h0000_0080);
+
+    // mret pops it back: MIE <- MPIE, MPIE <- 1. mepc is NOT touched by mret;
+    // the handler's own `csrw mepc` is what moves it (test/asm/riscv_test.h).
+    take_mret();
+    check_read("mret restores MIE from MPIE and sets MPIE", 12'h300, 32'h0000_1888);
+    check_read("...and leaves mepc alone", 12'h341, 32'h0000_0080);
+    check_read("...and leaves mcause alone", 12'h342, 32'd4);
+
+    // A trap taken with MIE already clear leaves MPIE clear too -- the value
+    // pushed is MIE, not a constant.
+    poke(12'h300, 32'h0000_0000);
+    take_trap(32'd2, 32'h0000_0200);
+    check_read("a trap with MIE clear pushes a clear MPIE", 12'h300, 32'h0000_1800);
+    check_read("...and records the new cause", 12'h342, 32'd2);
+
+    // mepc's WARL mask applies to trap entry too, and it masks bit 0 ONLY:
+    // a compressed instruction faulting at pc % 4 == 2 must record an mepc
+    // with bit 1 SET, or the handler resumes two bytes early (ADR-0005).
+    // test/asm/trap.S faults a real `c.lw` at that alignment for the same
+    // reason; this is the same rule stated against the register itself.
+    take_trap(32'd4, 32'h0000_0146);
+    check_read("mepc preserves bit 1 on a 2-aligned faulting pc", 12'h341, 32'h0000_0146);
+    take_trap(32'd4, 32'h0000_0147);
+    check_read("...and still masks bit 0", 12'h341, 32'h0000_0146);
+
     if (errors != 0) begin
       $display("FAILED: %0d mismatches", errors);
       $fatal(1);
     end else begin
-      $display("PASSED: CSR file (read mux, implemented set, WARL, suppression, counters)");
+      $display("PASSED: CSR file (read mux, implemented set, WARL, suppression, counters, trap entry)");
       $finish;
     end
   end

--- a/test/cxxrtl.cc
+++ b/test/cxxrtl.cc
@@ -8,7 +8,10 @@
 // timeout, 3 = usage/setup error (bad args, missing file, image too big for
 // the simulated memories), 4 = RVFI monitor error (a per-retire mismatch,
 // ADR-0006 — distinct from 1 because tohost never got a say: the failure is
-// in the pipeline's own bookkeeping, not the test program's assertions).
+// in the pipeline's own bookkeeping, not the test program's assertions),
+// 5 = trap taken with mtvec == 0 (ADR-0029 — the program has silently
+// restarted at `_start`; distinct from 2 because the timeout that would
+// otherwise result says nothing about the fault that caused it).
 #include <cxxrtl/cxxrtl_vcd.h>
 #include "rtl.cc"
 
@@ -178,6 +181,25 @@ int main(int argc, char **argv) {
     return 3;
   }
 
+  // ADR-0029: `mtvec` resets to 0 and sections.lds links `.text` there, so a
+  // trap taken before a handler is installed restarts the program at `_start`
+  // — a livelock that reads as a timeout with no hint of the fault behind it.
+  // test/testbench.v raises this the cycle after any trap that redirects to
+  // address 0; see the comment there for why that needs no hierarchical
+  // reference into the CSR file. Looked up the same way as the monitor's
+  // errcode above, and missing is a setup error rather than something to
+  // skip: a silently absent check is exactly what this exists to prevent.
+  const cxxrtl::debug_item *trap_to_zero = nullptr;
+  try {
+    trap_to_zero = &all_debug_items.at("trap_to_zero").at(0);
+  } catch (const std::out_of_range &) {
+    std::fprintf(stderr,
+                  "error: ADR-0029's trap-to-zero check ('trap_to_zero') not "
+                  "found in the simulated design -- did test/testbench.v lose "
+                  "the (* keep *) on it?\n");
+    return 3;
+  }
+
   std::unique_ptr<cxxrtl::vcd_writer> vcd;
   std::ofstream vcd_out;
   if (!args.vcd_path.empty()) {
@@ -211,6 +233,15 @@ int main(int argc, char **argv) {
     if (errcode != 0) {
       std::fprintf(stderr, "RVFI monitor error %u at cycle %ld\n", errcode, cycle);
       return 4;
+    }
+
+    if ((trap_to_zero->curr[0] & 1) != 0) {
+      std::fprintf(stderr,
+                    "trap taken with mtvec == 0 at cycle %ld -- the handler was "
+                    "never installed and the program has restarted at _start "
+                    "(ADR-0029)\n",
+                    cycle);
+      return 5;
     }
 
     uint32_t tohost = ram_data[tohost_index];

--- a/test/decoder_tb.v
+++ b/test/decoder_tb.v
@@ -35,6 +35,14 @@ module decoder_tb;
   logic [11:0] csr_addr;
   logic csr_ren, csr_wen, instret;
   logic [31:0] csr_wdata;
+  // ADR-0028's trap-entry pair. rtl/csrs.v is a sibling of the decoder, not
+  // part of it, so these are stubbed the same way the read port above is:
+  // mtvec/mepc are driven to recognisable constants and the trap-commit
+  // outputs are observed.
+  logic [31:0] mtvec = 32'h0000_0100;
+  logic [31:0] mepc  = 32'h0000_0244;
+  logic trap_entry, mret_entry;
+  logic [31:0] trap_cause, trap_epc;
 
   decoder dut (
     .clk(clk),
@@ -50,6 +58,8 @@ module decoder_tb;
     .accessor_out_valid(accessor_out_valid),
     .csr_rdata(csr_rdata),
     .csr_implemented(csr_implemented),
+    .mtvec(mtvec),
+    .mepc(mepc),
     .pc(pc),
     .rs1(rs1),
     .rs2(rs2),
@@ -58,6 +68,10 @@ module decoder_tb;
     .csr_wen(csr_wen),
     .csr_wdata(csr_wdata),
     .instret(instret),
+    .trap_entry(trap_entry),
+    .trap_cause(trap_cause),
+    .trap_epc(trap_epc),
+    .mret_entry(mret_entry),
     .out(out)
   );
 
@@ -103,23 +117,27 @@ module decoder_tb;
     #1;
     check_hex("xori out.rs2 (registered math_arg)", out.rs2, 32'hffffffff);
 
-    // ebreak: 0x00100073 (funct12 == 1) must set is_ebreak.
+    // ebreak is funct12 == 1 EXACTLY; mret (0x302) and wfi (0x105) are
+    // different SYSTEM instructions sharing funct3 == 0 with it, and folding
+    // them into ebreak was the original defect here.
+    //
+    // Read off the decode flag rather than off `out.is_ebreak`, because since
+    // trap entry landed `ebreak` traps (cause 3) and ADR-0028 suppresses every
+    // execution flag on a trapping issue -- so the registered flag is now 0
+    // for all three and the vector would pass vacuously.
     in.instr = 32'h00100073;
-    @(posedge clk);
     #1;
-    check_bit("ebreak sets is_ebreak", out.is_ebreak, 1'b1);
-
-    // mret: 0x30200073 (funct12 == 0x302) must NOT set is_ebreak.
+    check_bit("ebreak sets instr_ebreak", dut.instr_ebreak, 1'b1);
     in.instr = 32'h30200073;
-    @(posedge clk);
     #1;
-    check_bit("mret does not set is_ebreak", out.is_ebreak, 1'b0);
-
-    // wfi: 0x10500073 (funct12 == 0x105) must NOT set is_ebreak.
+    check_bit("mret does not set instr_ebreak", dut.instr_ebreak, 1'b0);
+    check_bit("...it sets instr_mret", dut.instr_mret, 1'b1);
     in.instr = 32'h10500073;
+    #1;
+    check_bit("wfi does not set instr_ebreak", dut.instr_ebreak, 1'b0);
+    check_bit("...it sets instr_wfi", dut.instr_wfi, 1'b1);
     @(posedge clk);
     #1;
-    check_bit("wfi does not set is_ebreak", out.is_ebreak, 1'b0);
 
     // ---- Zicsr (ADR-0005) ------------------------------------------------
     // The three immediate forms used to be folded straight into the register
@@ -197,17 +215,174 @@ module decoder_tb;
     check_bit("csrrw with rd == x0 suppresses the read", dut.csr_read_op, 1'b0);
     check_bit("...and still writes", dut.csr_write_op, 1'b1);
 
-    // An unimplemented CSR stays an unrecognised instruction (ADR-0005): the
-    // trap for it lands with trap entry, not here.
+    // An unimplemented CSR is not a recognised instruction, and that is now
+    // how it becomes an illegal-instruction TRAP (ADR-0005) rather than a
+    // silently suppressed no-op.
     csr_implemented = 1'b0;
     #1;
     check_bit("an unimplemented CSR is not a valid instruction", dut.instr_valid, 1'b0);
+    check_bit("...so it is illegal", dut.instr_illegal, 1'b1);
+    check_hex("...with cause 2", trap_cause, 32'd2);
+    csr_implemented = 1'b1;
+
+    // ---- M3 traps (CLAUDE.md invariant 2 / ADR-0005 / ADR-0030) ----------
+    // Every cause, taken directly against the decoder. The `.S` suite takes
+    // the same five through a real handler; this is where the CAUSE ENCODER
+    // itself is pinned, including the cases the suite cannot reach because
+    // they never co-occur with anything observable.
+
+    // The four M3 additions to instr_valid. Until trap entry landed these were
+    // merely unrecognised, which was harmless only while unrecognised meant
+    // "no trap" -- a legal `fence` would fault the moment that changed
+    // (ADR-0034 recorded this as the change that must fix it).
+    in.instr = 32'h0ff0000f;   // fence iorw, iorw
+    #1;
+    check_bit("fence is a valid instruction", dut.instr_valid, 1'b1);
+    check_bit("...and does not trap", dut.trap_pending, 1'b0);
+    in.instr = 32'h0000100f;   // fence.i
+    #1;
+    check_bit("fence.i is a valid instruction", dut.instr_valid, 1'b1);
+    check_bit("...and does not trap", dut.trap_pending, 1'b0);
+    in.instr = 32'h10500073;   // wfi
+    #1;
+    check_bit("wfi is a valid instruction", dut.instr_valid, 1'b1);
+    check_bit("...and does not trap", dut.trap_pending, 1'b0);
+    in.instr = 32'h30200073;   // mret
+    #1;
+    check_bit("mret is a valid instruction", dut.instr_valid, 1'b1);
+    check_bit("...and does not trap", dut.trap_pending, 1'b0);
+    check_bit("...and is not an ecall", dut.instr_ecall, 1'b0);
+
+    // Cause 2, the canonical illegal instruction: the all-zero word.
+    in.instr = 32'h00000000;
+    #1;
+    check_bit("the all-zero word is illegal", dut.instr_illegal, 1'b1);
+    check_hex("...cause 2", trap_cause, 32'd2);
+    check_bit("...and traps", dut.trap_pending, 1'b1);
+
+    // Cause 3 and cause 11: ebreak and ecall.
+    in.instr = 32'h00100073;
+    #1;
+    check_hex("ebreak is cause 3", trap_cause, 32'd3);
+    in.instr = 32'h00000073;
+    #1;
+    check_hex("ecall is cause 11", trap_cause, 32'd11);
+
+    // Cause 4: a misaligned load. `lw a1, 4(a0)` (0x00452583) with a0 holding
+    // an odd address -- the effective address is what is tested, not the
+    // register and not the immediate.
+    in.instr = 32'h00452583;
+    reg_rs1 = 32'h0001_0001;
+    #1;
+    check_hex("misaligned lw is cause 4", trap_cause, 32'd4);
+    check_bit("...and traps", dut.trap_pending, 1'b1);
+    reg_rs1 = 32'h0001_0000;
+    #1;
+    check_bit("an aligned lw does not trap", dut.trap_pending, 1'b0);
+    // 2-byte alignment is not enough for a word access.
+    reg_rs1 = 32'h0001_0002;
+    #1;
+    check_bit("a 2-aligned lw still traps", dut.trap_pending, 1'b1);
+
+    // Cause 6: a misaligned store. `sh a1, 0(a0)` (0x00b51023) needs only
+    // 2-byte alignment, so an odd address traps and an even one does not.
+    in.instr = 32'h00b51023;
+    reg_rs1 = 32'h0001_0001;
+    #1;
+    check_hex("misaligned sh is cause 6", trap_cause, 32'd6);
+    reg_rs1 = 32'h0001_0002;
+    #1;
+    check_bit("a 2-aligned sh does not trap", dut.trap_pending, 1'b0);
+
+    // Byte accesses are aligned by construction and can never raise either
+    // cause -- which is what made the riscv-formal attribution checkable:
+    // insn_lb/insn_lbu/insn_sb passed while the nine word/halfword checks
+    // failed. `sb a1, 0(a0)` (0x00b50023) at the most awkward address there is.
+    in.instr = 32'h00b50023;
+    reg_rs1 = 32'h0001_0003;
+    #1;
+    check_bit("a byte store never traps", dut.trap_pending, 1'b0);
+    // `lb a1, 0(a0)` (0x00050583)
+    in.instr = 32'h00050583;
+    #1;
+    check_bit("a byte load never traps", dut.trap_pending, 1'b0);
+    reg_rs1 = 32'b0;
+
+    // Cause 2 again, the other illegal-CSR rule: a WRITE to a CSR that is
+    // read-only by address. mvendorid is 0xF11, so addr[11:10] == 2'b11.
+    // `csrw mvendorid, a0` == csrrw x0, mvendorid, a0 (0xf1151073).
+    in.instr = 32'hf1151073;
+    #1;
+    check_bit("an implemented read-only CSR is still a valid encoding",
+              dut.instr_valid, 1'b1);
+    check_bit("...but writing it is illegal", dut.csr_readonly_write, 1'b1);
+    check_hex("...cause 2", trap_cause, 32'd2);
+    // ...while READING the same CSR is legal, because CSRRS with rs1 == x0
+    // suppresses the write. `csrr a0, mvendorid` (0xf1102573).
+    in.instr = 32'hf1102573;
+    #1;
+    check_bit("reading a read-only CSR is not a write", dut.csr_readonly_write, 1'b0);
+    check_bit("...and does not trap", dut.trap_pending, 1'b0);
+
+    // ADR-0027: a trapping issue commits nothing outside the pipeline
+    // registers -- no minstret increment and no CSR access. Checked on the
+    // illegal CSR write above, which is both a trap AND a CSR instruction, so
+    // a gate that only looked at `instr_valid` (the pre-M3 spelling) would
+    // still let its write through.
+    //
+    // A CSR instruction serializes whether or not it is legal, so this needs a
+    // drained pipe to issue at all -- and the checks below would otherwise be
+    // satisfied by the stall rather than by the trap, which is exactly the
+    // vacuous pass worth avoiding here.
+    in.instr = 32'hf1151073;
+    @(posedge clk);
+    #1;
+    check_bit("...it issues once the pipe drains", dut.issuing, 1'b1);
+    check_bit("a trapping issue does not count in minstret", instret, 1'b0);
+    check_bit("...and commits no CSR write", csr_wen, 1'b0);
+    check_bit("...and no CSR read", csr_ren, 1'b0);
+    check_bit("...but it does commit a trap", trap_entry, 1'b1);
+
+    // ADR-0028: the trapping instruction retires having architecturally done
+    // nothing -- pc goes to mtvec, rd is x0, and no memory flag survives, so
+    // rtl/accessor.v issues no bus request and rvfi_mem_* come out zero.
+    // Checked after the edge, on the published decoder_output.
+    in.instr = 32'h00452583;   // the misaligned lw again
+    reg_rs1 = 32'h0001_0001;
+    in.pc = 32'h0000_0080;
+    #1;
+    check_hex("trap_epc is the FAULTING pc, not the next one", trap_epc, 32'h0000_0080);
+    @(posedge clk);
+    #1;
+    check_hex("a trap redirects pc to mtvec", pc, 32'h0000_0100);
+    check_bit("...the trapping instruction still retires", out.valid, 1'b1);
+    check_hex("...writing no register", {27'b0, out.rd}, 32'b0);
+    check_bit("...and issuing no load", out.is_lw, 1'b0);
+    reg_rs1 = 32'b0;
+
+    // mret is a branch to mepc, taken by the same mechanism. It serializes
+    // (CLAUDE.md invariant 5), so it needs a drained pipe to issue: the
+    // previous vector is still in decoder_out, which bubbles this cycle and
+    // drains it.
+    in.instr = 32'h30200073;
+    #1;
+    check_bit("mret serializes while the pipe is busy", dut.csr_serialize, 1'b1);
+    check_bit("...so it does not commit yet", mret_entry, 1'b0);
+    @(posedge clk);
+    #1;
+    check_bit("...the serializing cycle bubbles decoder_out", out.valid, 1'b0);
+    check_bit("...which drains the pipe", dut.pipe_drained, 1'b1);
+    check_bit("...so it commits now", mret_entry, 1'b1);
+    check_bit("...and is not a trap", trap_entry, 1'b0);
+    @(posedge clk);
+    #1;
+    check_hex("mret redirects pc to mepc", pc, 32'h0000_0244);
 
     if (errors != 0) begin
       $display("FAILED: %0d mismatches", errors);
       $fatal(1);
     end else begin
-      $display("PASSED: decode vectors (xori immediate, ebreak/mret/wfi, Zicsr)");
+      $display("PASSED: decode vectors (xori immediate, ebreak/mret/wfi, Zicsr, M3 traps)");
       $finish;
     end
   end

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -146,11 +146,14 @@ for src in "$ASM_DIR"/*.S; do
     sim_status=$?
     set -e
     # The runner's exit ladder (test/cxxrtl.cc): 0 pass, 1 tohost fail, 2 cycle
-    # limit, 3 usage/setup, 4 RVFI monitor error. 4 gets its own label because
-    # it means something entirely different from the others — the per-retire
-    # oracle disagreed with the core mid-run (ADR-0019), which is a wrong-result
-    # report, not a broken harness. Lumping it into RUNNER-ERROR made it
-    # indistinguishable from "the sim could not be started at all".
+    # limit, 3 usage/setup, 4 RVFI monitor error, 5 trap-to-zero. 4 and 5 get
+    # their own labels because each means something entirely different from
+    # "the test failed": 4 is the per-retire oracle disagreeing with the core
+    # mid-run (ADR-0019), a wrong-result report rather than a broken harness,
+    # and 5 is a trap taken before a handler was installed (ADR-0029), which
+    # would otherwise surface as a TIMEOUT naming neither the fault nor its
+    # cause. Lumping either into RUNNER-ERROR made it indistinguishable from
+    # "the sim could not be started at all".
     case $sim_status in
       0) status="PASS" ;;
       1) num=$(awk '/^FAIL/{print $2; exit}' "$tmp/$base.run.log")
@@ -158,6 +161,7 @@ for src in "$ASM_DIR"/*.S; do
       2) status="TIMEOUT" ;;
       4) code=$(awk '/RVFI monitor error/{print $4; exit}' "$tmp/$base.run.log")
          status="MONITOR-ERROR${code:+ $code}" ;;
+      5) status="TRAP-TO-ZERO" ;;
       *) status="RUNNER-ERROR $sim_status" ;;
     esac
   fi

--- a/test/sail/memory-map.json
+++ b/test/sail/memory-map.json
@@ -25,6 +25,35 @@
 // HTIF" note there).
 {
   "memory": {
+    // MISALIGNED ACCESSES MUST TRAP, and this is the key that decides it --
+    // NOT the per-region `misaligned_exceptions` attribute below, which is
+    // restated in both regions and has NO EFFECT here. The model's own default
+    // config documents the difference: this global key is "checked before
+    // address translation" while the region attribute is "checked after", and
+    // with no MMU the region attribute is never consulted. Measured, not
+    // inferred: changing the region attribute in both regions leaves a
+    // misaligned `lw` completing; setting this one redirects to mtvec.
+    //
+    // Our config did not set this key at all, so it inherited Sail's default
+    // of `{"None": null}` -- the reference model COMPLETED misaligned accesses.
+    // That agreed with the core until ADR-0030's causes 4 and 6 landed, and
+    // would have produced a false divergence on every misaligned access from
+    // that moment on (ADR-0033 flagged it as part of the trap work rather than
+    // as a co-simulation detail). `AlignmentException` is the value matching
+    // ADR-0005's causes: load address misaligned = 4, store address
+    // misaligned = 6. `AccessFault` would be causes 5 and 7 and is a different
+    // implementation choice this core did not make.
+    //
+    // A config override is where you can talk the oracle into agreeing with
+    // you: Sail is authoritative about RISC-V semantics but not about which
+    // implementation-defined choice this core makes -- we tell it. Every knob
+    // here should trace to a decision that predates the divergence it
+    // resolves. This one traces to ADR-0005, written before any of this ran.
+    "misaligned": {
+      "exceptions": {
+        "load_store": { "Some": "AlignmentException" }
+      }
+    },
     "regions": [
       {
         // test/asm/sections.lds: rom at 0x0 (16K) + ram at 0x10000 (4K),

--- a/test/testbench.v
+++ b/test/testbench.v
@@ -195,6 +195,45 @@ module testbench(
     end
   end
 
+  // ADR-0029: `mtvec` resets to 0 and test/asm/sections.lds links `.text`
+  // there, so a trap taken before a test installs its handler redirects to
+  // `_start` and the program silently RESTARTS. That failure mode looks like a
+  // livelock or a timeout, produces no error, and puts the actual cause -- a
+  // fault several instructions earlier -- nowhere near the symptom.
+  //
+  // This is a HARNESS assertion, not an RTL one: a real program is entitled to
+  // put a handler at 0, and it would need revisiting if sections.lds ever
+  // moved `.text`. It also needs no hierarchical reference into the CSR file.
+  // `trap` is ADR-0028's one-cycle "trap entry committed" pulse, and decode
+  // registers `pc <= mtvec` on that same edge, so the fetch address one cycle
+  // later IS mtvec (rtl/fetcher.v drives imem_addr straight off pc).
+  //
+  // `(* keep *)` because test/cxxrtl.cc reads `trap_to_zero` by debug-item
+  // name to turn this into a distinct process exit code; without it yosys is
+  // free to optimise away a register nothing in the design reads.
+  //
+  // Plain `always @(posedge clk)`, not `always_ff`, for the same reason every
+  // other diagnostic block in this file is: iverilog warns that a system task
+  // cannot be synthesised inside an `always_ff` process, and CLAUDE.md says
+  // warnings are errors. Nothing in this bench is synthesised.
+  logic trap_taken_d;
+  (* keep *) logic trap_to_zero;
+  initial begin
+    trap_taken_d = 1'b0;
+    trap_to_zero = 1'b0;
+  end
+  always @(posedge clk) begin
+    trap_taken_d <= !reset && trap;
+    if (trap_taken_d && imem_addr == 32'b0) begin
+      trap_to_zero <= 1'b1;
+      $display("TRAP TO ZERO: a trap was taken while mtvec == 0 (ADR-0029).");
+      $display("No handler was installed, so the program has restarted at _start.");
+     `ifdef ICARUS
+      $fatal(1);
+     `endif
+    end
+  end
+
   // ADR-0009: for every store, mem_wstrb is high for
   // exactly one cycle. Direct regression for the divide-replay defect, where
   // the accessor kept re-issuing the same store every cycle the executor sat


### PR DESCRIPTION
Closes JEF-648

M3's keystone: every trap this core implements is now **detected and committed in decode**
(CLAUDE.md invariant 2), and `formal/EXPECTED_FAIL` **reaches empty**.

## What changed

* **`rtl/decoder.v`** computes misalignment from the same `$signed(immediate) + $signed(reg_rs1)`
  it already had, decides illegal-instruction (including ADR-0005's two illegal-CSR rules), and
  commits all five causes in the **same non-stalled `else` arm that issues an instruction**. That
  placement is load-bearing and is commented as such: it gives no trap on a stalled cycle, no trap
  from a bubble, no double commit, and a `reg_rs1` the ADR-0004 scoreboard has already made
  hazard-clear (`uses_rs1` is true for every load and store — narrow it and misalignment detection
  silently starts reading a stale register).
* **A trap is a branch.** `pc <= mtvec` is the same override `jal` and the six branches use, on the
  same edge, through the same register. **No flush was added and none is needed** — invariant 1
  intact. ADR-0030's priority encoder is deliberately *not* `parallel_case`, because it is vacuous
  today; the decoder component proof asserts the `$onehot0` disjointness that makes it vacuous.
* **`rtl/csrs.v`** gains a second write port (`trap_entry`/`trap_cause`/`trap_epc`/`mret_entry`)
  and returns `mtvec`/`mepc` to decode. `mepc` goes through the same WARL mask an explicit
  `csrw mepc` does — bit 0 only, because C makes 2-byte targets legal.
* **`mret` gets its own decode** (it was classified illegal — correct before, wrong after) and
  serializes on the existing drain predicate. **`wfi`/`fence`/`fence.i` become NOPs** — not
  cleanup: they were merely *unrecognised*, and unrecognised now means illegal-instruction, so a
  legal `fence` would have faulted (ADR-0034 flagged this as the change that must fix it).
* **ADR-0011's debt discharged**: `rtl/accessor.v` has no `mem_misaligned`, `rtl/littlecpu.v` has
  no `mem_misaligned_trap`. `trap` is redefined per ADR-0028 as a one-cycle "trap entry committed"
  pulse that something finally consumes.
* **ADR-0034's sunset condition FIRED.** `decoder_output`'s `csr_addr`/`is_csr_imm` acquired no
  consumer in this ticket (trap detection, CSR access and trap commit all happen in decode), so
  both are struck.
* **ADR-0029's harness half** landed with the RTL that makes it reachable: `trap_to_zero` →
  cxxrtl exit 5 → `TRAP-TO-ZERO` in `run_tests.sh`, plus `$fatal` under iverilog.

## Acceptance criteria

### 1. `formal/EXPECTED_FAIL` empty — 82 checks, 82 pass, 0 fail

From-scratch `rm -rf formal/checks && make -C formal check`:

```
82 checks: 82 pass, 0 fail
Failure list matches EXPECTED_FAIL exactly.
Generated check set matches EXPECTED_CHECKS exactly (82 checks).
```

Full per-check tally, verbatim:

```
causal_ch0               PASS   insn_c_addi4spn_ch0      PASS   insn_c_xor_ch0           PASS   insn_sll_ch0             PASS
causal_mem_ch0           PASS   insn_c_and_ch0           PASS   insn_div_ch0             PASS   insn_slli_ch0            PASS
csrw_mcycle_ch0          PASS   insn_c_andi_ch0          PASS   insn_divu_ch0            PASS   insn_slt_ch0             PASS
csrw_minstret_ch0        PASS   insn_c_beqz_ch0          PASS   insn_jal_ch0             PASS   insn_slti_ch0            PASS
csrw_mscratch_ch0        PASS   insn_c_bnez_ch0          PASS   insn_jalr_ch0            PASS   insn_sltiu_ch0           PASS
hang                     PASS   insn_c_j_ch0             PASS   insn_lb_ch0              PASS   insn_sltu_ch0            PASS
ill_ch0                  PASS   insn_c_jal_ch0           PASS   insn_lbu_ch0             PASS   insn_sra_ch0             PASS
insn_add_ch0             PASS   insn_c_jalr_ch0          PASS   insn_lh_ch0              PASS   insn_srai_ch0            PASS
insn_addi_ch0            PASS   insn_c_jr_ch0            PASS   insn_lhu_ch0             PASS   insn_srl_ch0             PASS
insn_and_ch0             PASS   insn_c_li_ch0            PASS   insn_lui_ch0             PASS   insn_srli_ch0            PASS
insn_andi_ch0            PASS   insn_c_lui_ch0           PASS   insn_lw_ch0              PASS   insn_sub_ch0             PASS
insn_auipc_ch0           PASS   insn_c_lw_ch0            PASS   insn_mul_ch0             PASS   insn_sw_ch0              PASS
insn_beq_ch0             PASS   insn_c_lwsp_ch0          PASS   insn_mulh_ch0            PASS   insn_xor_ch0             PASS
insn_bge_ch0             PASS   insn_c_mv_ch0            PASS   insn_mulhsu_ch0          PASS   insn_xori_ch0            PASS
insn_bgeu_ch0            PASS   insn_c_or_ch0            PASS   insn_mulhu_ch0           PASS   liveness_ch0             PASS
insn_blt_ch0             PASS   insn_c_slli_ch0          PASS   insn_or_ch0              PASS   pc_bwd_ch0               PASS
insn_bltu_ch0            PASS   insn_c_srai_ch0          PASS   insn_ori_ch0             PASS   pc_fwd_ch0               PASS
insn_bne_ch0             PASS   insn_c_srli_ch0          PASS   insn_rem_ch0             PASS   reg_ch0                  PASS
insn_c_add_ch0           PASS   insn_c_sub_ch0           PASS   insn_remu_ch0            PASS   unique_ch0               PASS
insn_c_addi_ch0          PASS   insn_c_sw_ch0            PASS   insn_sb_ch0              PASS
insn_c_addi16sp_ch0      PASS   insn_c_swsp_ch0          PASS   insn_sh_ch0              PASS
```

All ten baseline entries removed. Nine were misalignment (`insn_lh/lhu/lw/sh/sw` +
`insn_c_lw/c_lwsp/c_sw/c_swsp`); the tenth, `ill_ch0`, went green for a *different* reason —
`rvfi_ill_check.sv` is the formal statement of the illegal-instruction trap plus ADR-0028's
convention. **`insn_lb`, `insn_lbu`, `insn_sb` — the byte accesses whose address cannot be
misaligned — never moved**, which is the attribution behind those entries holding rather than
being asserted.

### 2. `dmemcheck` stays PASS

```
SBY [dmemcheck] DONE (PASS, rc=0)
```

Per ADR-0028 this is the guard that a trapping store never reaches the bus: `formal/dmemcheck.sv`
builds its environment shadow from the **real** `mem_wstrb`/`mem_wdata` while `rvfi_dmem_check`
builds its shadow purely from `rvfi_mem_*`, so a store that is architecturally suppressed but
still strobes the bus desynchronises the two and a later load fails at the RVFI level. This is
work `rvfi_insn_check` declines to do — it drops every `mem_*` assertion under `spec_trap`.

**Measured caveat, reported rather than assumed** (ADR-0023): I could not make `dmemcheck` go red
with either mutation I tried at its configured depth. Dropping `is_sb/is_sh/is_sw` from the trap
suppression (a trapping store that executes *and* is reported) leaves both shadows agreeing, so
no desync exists — that one is caught by criterion 6 instead (`trap.S FAIL 8`). Forcing
`out.rvfi_mem_wmask <= 4'b0` in `rtl/accessor.v` while the bus still strobes — ADR-0028's literal
scenario — also returned `DONE (PASS, rc=0)` (18 min run). So the *reasoning* stands but the
*catch* is unconfirmed at this depth; worth an ADR-0028 amendment.

### 3. `reg_ch0` stays PASS

`reg_ch0 PASS` (see tally). Guards that a trapping instruction does not write `rd`, because
`rvfi_rs1_rdata`/`rs2_rdata` are captured from the *real* regfile in decode, so a corrupted `rd`
surfaces as a later instruction disagreeing with the shadow model.

### 4. `pc_fwd_ch0` / `pc_bwd_ch0` stay PASS

`pc_fwd_ch0 PASS`, `pc_bwd_ch0 PASS` (see tally). They assert `pc_wdata(N) == pc_rdata(N+1)` with
no trap special case, so the redirect is both honestly reported and actually taken. They are
satisfied by *any* target — that the target is `mtvec` is asserted in `rtl/decoder.v`'s own
component proof, which is the one place it can be.

### 5. `test/asm/trap.S` in both sim legs

cxxrtl (`make test`): `trap.S PASS`, part of `52/52 passed`.

iverilog: `IVERILOG-RESULT: PASS`, with `test/monitor.sim.v` instantiated and no error code. The
whole suite runs under `vvp` now: **52 pass, 0 fail** (see the iverilog-leg note below).

`trap.S` takes all five causes plus both illegal-CSR rules and asserts `mcause` is
4 / 6 / 11 / 3 / 2 / 2 / 2 / 4 and that `mepc` equals the faulting PC, `mret`ing back each time.
Two cases are new:

* a **write to a read-only CSR** (`csrw mvendorid, t0`, addr[11:10] == 2'b11) → cause 2, the rule
  `formal/checks.cfg` records as architecturally unobservable until trap entry existed;
* a **compressed faulting instruction** — `c.lw` placed at `pc % 4 == 2` via `.align 2` + `c.nop`,
  with a `c.nop` behind it so the handler's unconditional `mepc+4` resume lands on an instruction
  boundary. Test 16 asserts `mis_clw & 3 == 2`, so the case cannot quietly degrade into a
  4-aligned one that proves nothing about the WARL `mepc[0]` mask.

Verified layout: `mis_clw` at `0x146`, `c.lw` 2 bytes, `c.nop` at `0x148`, resume at `0x14a`.

### 6. Misaligned store leaves the target RAM word unchanged

`trap.S` TEST_CASE 8 reads `tdat` back after a misaligned `sw` and requires `0x0ff0`. Proven live
by mutation — dropping `out.is_sb/is_sh/is_sw <= 0` from the trap suppression:

```
trap.S           FAIL 8
51/52 passed
```

Reverted; `trap.S PASS`, `52/52`. This is checked on real memory and is independent of (2).

### 7. Monitor error 101, and the mutation that fires it

Clean: `trap.S PASS` under cxxrtl (error 101 would surface as `MONITOR-ERROR 101`), and
`IVERILOG-RESULT: PASS` with no monitor banner under iverilog.

**The mutation: report `rvfi_trap` one retire late.** In `rtl/writeback.v`, replace
`assign rvfi_trap = in.rvfi.trap;` with

```systemverilog
logic rvfi_trap_late;
always_ff @(posedge clk) if (!reset && in.valid) rvfi_trap_late <= in.rvfi.trap;
assign rvfi_trap = rvfi_trap_late;
```

cxxrtl leg:

```
trap.S           MONITOR-ERROR 101
51/52 passed
Failure list does NOT match test/EXPECTED_FAIL:
> trap.S MONITOR-ERROR 101
```

Error 101 is "mismatch in trap" — the one comparison
`checks/rvfi_insn_check.sv` keeps live under `spec_trap` and that
`test/sanitize_monitor.py`'s rule 3 must therefore leave outside its gate. `monitor_tb` vector 7
covers the gate-disabled case; this is the live-core case. Reverted.

*(The iverilog leg reported PASS on this mutated build. The `.S` programs there terminate via
`tohost` and the mutated monitor's banner did not gate that run; the cxxrtl leg turns errcode into
exit status and is the one that catches it. Reported as measured.)*

### 8. ADR-0011's debt discharged

`rtl/accessor.v` has no `mem_misaligned` output and no detection logic; `rtl/littlecpu.v` has no
`mem_misaligned_trap`. Both diffs are in the change.

### 9. `make test` / `test-units` / `lint` / elaboration

```
52/52 passed
Failure list matches test/EXPECTED_FAIL exactly (name and status).
```

`test/EXPECTED_FAIL` is **empty** (`trap.S MONITOR-ERROR 101` removed — the third and last of the
three M3 tests seeded ahead of their RTL). `make test-units` green, six benches including the
extended `decoder_tb` (all five causes, both illegal-CSR rules, `fence`/`fence.i`/`wfi`/`mret`
legality, trap-vs-mret redirect, `minstret`/CSR suppression on a trapping issue) and `csr_tb`
(trap entry, MIE→MPIE→MIE round trip, `mepc` WARL on a 2-aligned faulting PC).

`make lint`: `svlint: clean in both passes`. yosys strict elaboration (CI's exact script): **0
promoted warnings**. iverilog: **0 warnings**, and the `sorry:` count is **20 before and 20
after** — held there by driving `rvfi_trap` as a continuous assign rather than adding a line to
`rtl/writeback.v`'s `always_comb` (ADR-0034's documented pattern; the `always_comb` spelling
measured 21). `make monitor-check` and `make -C formal genchecks-check` both clean.

### 10. Sail co-simulation

`test/sail/memory-map.json` now sets the **global** `memory.misaligned.exceptions.load_store` to
`{"Some": "AlignmentException"}`, confirmed against `--print-config-schema` (enum is
`AccessFault` | `AlignmentException` | `None`). `AlignmentException` is the value matching
ADR-0005's causes 4 and 6; `AccessFault` would be 5 and 7, a choice this core did not make.

```
make cosim-run PROG=trap.S
sail changes       : 214  (spin-loop reached: True, last pc=0x00000218)
core changes       : 214   (tohost: PASS 729)
AGREE trap.S: 214 architectural register-file changes, identical in order and value.
```

Proven load-bearing — with the key reverted to the inherited `{"None": null}`:

```
sail changes       : 15
core changes       : 214
DISAGREE trap.S
DIVERGENCE at architectural change #6
  sail instruction #8  pc=0x0000001c  lw x11, 0x0(x10)    mis_lw+0
  sail : x11=0xf000000f
  core : x5=0x0001021c
```

Suite-wide: 50/52 AGREE. The two that do not — `csr.S` and `minstret.S` — **already disagreed
before this change** (verified by stashing): Sail reports `misa = 0x4034112f` against this core's
`0x40001104`, an ISA-configuration mismatch in the Sail config, unrelated to traps. Co-simulation
is opt-in and on no gate (ADR-0032); left as-is rather than tuning the oracle inside this ticket.

## The iverilog leg was dead, and this change found it

`rtl/decoder.v`'s hazard scoreboard called `function automatic live_producer(r)` from two
continuous assigns. **iverilog builds such an assign's sensitivity list from the call's
*arguments***, so a function body that also reads module-level signals (`out`, `executor_out`,
`accessor_pending_*`) never re-evaluated when those changed. That is *under*-sensitivity — the one
direction CLAUDE.md's `sorry:` exception says is a real bug — and iverilog emits no diagnostic for
it at all.

Measured on **`main`, before this change**: `hazard_rs1` latched high at the first RAW hazard of
every program and never fell, so `make waves`' own baked-in loop executed two instructions and
then span — **0 memory writes in 200 cycles**, one `ifetch` line total. No `.S` program could
reach `tohost`. yosys evaluates the function correctly, so cxxrtl and the entire formal ladder
were unaffected, which is exactly why it went unnoticed: the leg the verification table calls the
microscope was reporting nothing, and nothing it reported was wrong.

The two assigns are now written out (same expression, same behaviour under yosys — ladder still
82/82, all component proofs still pass). `make waves` executes real instructions, and all 52 `.S`
programs run to `PASS` under `vvp` with the per-retire monitor live.

**Caveat, and a suggested follow-up:** `test/testbench.v` has a baked-in program and no image
loader, so the 52/52 iverilog figure was measured with a scratch harness (`$readmemh` of the
objcopy images + a `tohost` watcher), not something a reviewer can re-run from the repo. A tracked
iverilog runner for `test/asm/*.S` is worth its own ticket now that the leg works.

## Read this before quoting the empty baseline

**An empty `formal/EXPECTED_FAIL` is necessary for M2, not sufficient, and M2 is not reached.**
Every check is `mode bmc` — PASS means "no counterexample within the configured depth". Everything
runs under `RISCV_FORMAL_ALTOPS` (ADR-0010), so green `insn_mul`/`insn_div`/`insn_rem` say nothing
about the real multiplier or divider. `formal/equiv.sh` still does not converge (ADR-0020), so
ADR-0006's non-perturbation guarantee is still argued rather than proven — and now covers one more
`ifdef RISCV_FORMAL` field, `rvfi_shadow.trap`, which is write-only with respect to the core.
`formal/complete` still fails (pre-existing, ADR-0034; on no gate). The nightly still cannot go
red (ADR-0022). And riscv-formal ships **no spec model at all** for `ecall`/`ebreak`/`mret`/
`csrr*` at the pin, so the behaviour this ticket adds is checked against assertions this repo
wrote — `trap.S`, `csr_tb`, `decoder_tb`, and the decoder component proof — not against an oracle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
