### PR TITLE
ADR-0037: an empty formal baseline is not M2, and two ADR corrections

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,10 +178,13 @@ What does not work right now:
   practical budget. It is the check that ties RVFI's self-report to the actual register file, so
   without it the other 55 passing checks establish that the core's story about itself is
   spec-consistent, not that the story is true.
-- **The formal nightly cannot go red** (ADR-0022). `.github/workflows/formal-nightly.yml:48` is
-  `make -C formal check || true`, and `formal/Makefile`'s `check` has no `-k`, so the sub-make also
-  stops scheduling at the first failure. Today's nightly runs a partial ladder and reports it as
-  success. It needs `-k` and a `formal/EXPECTED_FAIL` baseline before its green means anything.
+- ~~**The formal nightly cannot go red**~~ — **fixed, and it was never the `|| true`** (ADR-0037).
+  This bullet described `formal-nightly.yml` as `make -C formal check || true` with no `-k`; both
+  were fixed earlier, and the bullet outlived them. The real defect survived both fixes: the graded
+  `check-baseline.sh` call was piped into `tee`, and a `run:` block without an explicit `shell:` key
+  is `bash -e {0}` — errexit but **not** pipefail — so the step's exit status was `tee`'s and was
+  always 0. **ADR-0022's central guarantee had never held.** `1961234` fixed both copies of the step
+  (nightly and the new PR-gate `formal` job) and demonstrated both failure directions on real runs.
 - **Three of the five component-proof tasks are vacuous.** `components_fetcher`,
   `components_accessor`, and `components_writeback` contain no assertions at all, only reset
   assumptions, so they "pass" meaninglessly. CI deliberately does not run them; ADR-0006 slates
@@ -266,7 +269,11 @@ monitor live, the first time that has ever been true. **There is still no tracke
 a scratch harness. `make waves` is the tracked iverilog exercise and it now executes real
 instructions rather than deadlocking.
 
-What does work: `yosys ... write_cxxrtl` elaborates the current RTL cleanly with zero warnings, the
+What does work: `yosys ... write_cxxrtl` elaborates the current RTL cleanly — **one** warning,
+`Deep recursion in AST simplifier`, which is a recursion-depth notice rather than a correctness
+signal and is the single entry on the `elaborate` gate's allowlist; everything else yosys prefixes
+`Warning:` is promoted to an error there (`.github/workflows/ci.yml`, which cross-references this
+note). It is not zero, and this line said zero until ADR-0037. The
 cxxrtl binary builds and runs, the whole `.S` suite passes under it with `test/EXPECTED_FAIL`
 empty, `make test-units` passes (six benches: `exec_tb`, `mem_tb`, `decoder_tb`,
 `regfile_tb` — which covers the write-through bypass and x0 semantics — `csr_tb`, which covers
@@ -373,6 +380,19 @@ no multilib or newlib is needed. Formal needs a pinned YosysHQ OSS CAD Suite.
 | **iverilog** | microscope | waveforms, `$display`, second elaboration frontend |
 | **riscv-formal** | oracle | exhaustive per-instruction semantics, pipeline corners |
 
+**The iverilog leg was inert for the whole of M1 — `a4662a2` to `6309b3e` — and this table did not
+know** (ADR-0037). `rtl/decoder.v`'s hazard scoreboard called a `function automatic
+live_producer(r)` from two continuous assigns, and iverilog derives such an assign's sensitivity
+list from the **call's arguments**, so a body that also read `out`/`executor_out`/
+`accessor_pending_*` never re-evaluated when those changed. Under-sensitivity — the one direction
+the `sorry:` exception below says is a real bug — and iverilog emits no diagnostic for it at all.
+Measured on `main` before the fix: `hazard_rs1` latched high at the first RAW hazard and never
+fell, the PC advanced `0x0`→`0x4` and froze, and `make waves` did **0 memory writes in 200 cycles**
+(201 reads, all to address 0). After the fix the same program does 22 writes. yosys evaluates the
+function correctly, so cxxrtl and the whole ladder were unaffected — which is exactly why nothing
+caught it. **A leg that cannot fail is not a leg**: treat a green iverilog run as evidence only if
+you can point at something it would have failed on.
+
 **riscv-formal runs with `RISCV_FORMAL_ALTOPS`, so it never checks the real multiplier or divider.**
 That arithmetic is covered only by the `.S` suite and the executor component proof. Do not assume a
 green formal ladder means the ALU is correct.
@@ -397,7 +417,8 @@ the oracle (ADR-0019).
   **One documented exception**, and only this one: iverilog emits `sorry: constant selects in
   always_* processes are not fully supported` for every struct-field read inside an
   **`always_comb`** block — 20 of them, all from `rtl/writeback.v`, against
-  `in[311:0]` (`accessor_output`). It cannot build a precise sensitivity entry for a constant
+  `in[952:0]` (`accessor_output`, with the `RISCV_FORMAL*` macros on — 953 bits; it was 952 before
+  `6309b3e` added `rvfi_shadow.trap`, and the count held at 20 across that change). It cannot build a precise sensitivity entry for a constant
   part-select, so it falls back to whole-struct sensitivity.
   **That fallback is provably safe**: over-sensitivity re-evaluates redundantly and can never
   yield a stale value; only *under*-sensitivity is a correctness bug. Everywhere the select was
@@ -411,8 +432,13 @@ the oracle (ADR-0019).
   **The diagnostic is specific to `always_comb`**, where the sensitivity list is *inferred*.
   `rtl/executor.v` emits **zero** of these despite its `case (1'b1)` over 39 `in.is_*` flags,
   because that body sits in `always_ff @(posedge clk)`, whose sensitivity is written out.
-  Compile any module alone to attribute them (`iverilog -g2012 -s <mod> rtl/structs.v
-  rtl/<mod>.v`). **Do not add new ones outside `rtl/writeback.v`**, and prefer a continuous
+  Attribute them by struct width rather than by the diagnostic, which carries **no filename at
+  all** (it prints `:0:`): `$bits` gives `decoder_output` 943, `executor_output` 921,
+  `accessor_output` **953**, and only the last matches `in[952:0]`. ADR-0034 printed
+  `iverilog -g2012 -s <mod> rtl/structs.v rtl/<mod>.v` for this; **that command does not run** —
+  it needs `-I./rtl/`, and even then reports 0 for every module, because the reads in question are
+  inside `ifdef RISCV_FORMAL` and it passes no macros (ADR-0037). Use `make testbench.vvp`.
+  **Do not add new ones outside `rtl/writeback.v`**, and prefer a continuous
   assign for any new struct-field read in an `always_comb` — that is what holds the count at 20
   (ADR-0034; this bullet named `rtl/executor.v` until then, which was measurably wrong).
 - **Every non-trivial change adds or updates tests and runs the full suite** before being declared
@@ -438,7 +464,7 @@ the oracle (ADR-0019).
 |---|---|---|
 | M0 | Foundation | this file, riscv-formal SHA-pinned, dead references gone |
 | M1 | Finish the pipeline | all RV32IM `.S` tests pass under cxxrtl — **reached, `a4662a2`** |
-| M2 | **Parity checkpoint** | the pipelined core re-proves everything the serialized core proved |
+| M2 | **Parity checkpoint** | **all six** conditions below hold. An empty `formal/EXPECTED_FAIL` is *one* of them and on its own means nothing — it was reached at `6309b3e` and M2 was not (ADR-0037) |
 | M3 | Past the old core | CSRs + machine-mode traps — **both landed** (`rtl/csrs.v`; trap commit in `rtl/decoder.v`) |
 | M4 | Full ladder + CI | nightly formal green; tag a release (PR gate `c66527d`; nightly `86e2721`, report-only until ADR-0022) |
 
@@ -447,38 +473,54 @@ as the real finish line, not M1. `b2dafcc` cleared M2's blocker (RVFI is driven,
 in both sim legs) and `86e2721` landed the ladder port itself (`wrapper.v` / `checks.cfg` /
 `imemcheck` / `dmemcheck` / `cover` / `equiv.sh`, ADR-0006) — but **M2 is not reached.** M2's own
 wording is "re-proves everything the serialized core proved", and 15 red checks plus an inconclusive
-`reg` plus a non-converging `equiv.sh` is not that. ADR-0023 lists what closing it takes; the
-`formal/EXPECTED_FAIL` baseline of ADR-0022 reaching empty is the signal — read together with the
-generated check count, per ADR-0033, which is now `formal/EXPECTED_CHECKS` and is asserted rather
-than recited. `rtl/csrs.v` took that baseline from 11 entries to 9 (both `csrw_*`) on a 79-check
+`reg` plus a non-converging `equiv.sh` is not that. ADR-0023 lists what closing it takes. An empty
+`formal/EXPECTED_FAIL`, read together with `formal/EXPECTED_CHECKS` per ADR-0033, is a **necessary
+condition and not a sufficient one** — this file called it "the signal" until ADR-0037, which is
+the language of sufficiency for something that was only ever necessary, and a change nobody
+believes completes the milestone duly satisfied it.
+
+`rtl/csrs.v` took that baseline from 11 entries to 9 (both `csrw_*`) on a 79-check
 ladder; landing `ill_ch0` red made it 10 on an 82-check ladder; **the trap change took it to zero
 on that same 82-check ladder.** All ten were the trap gap — nine misalignment, one
 illegal-instruction — and all ten closed together, which is the attribution behind them holding.
 
-**That signal has now fired, and M2 is still not reached.** Read what the signal is and is not,
-because the temptation to read it as the milestone is exactly what ADR-0023 and ADR-0033 were
-written against:
+**The baseline is empty and M2 is still not reached** (ADR-0037). **M2 requires all six of the
+following.** Closing it means deleting terms from this list — a burn-down with the same shape as
+`formal/EXPECTED_FAIL` itself. Term 1 is the only one met:
 
-- every check on the ladder is `mode bmc`, so 82 PASS means "no counterexample within each check's
-  configured depth", not that any property holds;
-- the whole ladder runs under `RISCV_FORMAL_ALTOPS` (ADR-0010), so `insn_mul`/`insn_div`/`insn_rem`
-  passing says nothing whatever about the real multiplier or divider;
-- `formal/equiv.sh` still does not converge (ADR-0020), so ADR-0006's guarantee that RVFI
-  instrumentation does not perturb core behaviour remains **argued, not proven** — and the argument
-  now has one more `ifdef RISCV_FORMAL` field to cover (`rvfi_shadow.trap`);
-- `formal/complete` still fails, for `ecall`/`ebreak`/`mret`/CSR retires that riscv-formal has no
-  spec model for at the pin. It is on no gate and ADR-0022/ADR-0023/ADR-0034 already record it;
-- the nightly still cannot go red (ADR-0022's `|| true`);
-- and riscv-formal ships **no spec model at all** for `ecall`/`ebreak`/`mret`/`csrr*`, so the
-  behaviour this milestone step actually added is checked by `test/asm/trap.S`, `test/csr_tb.v`,
-  `test/decoder_tb.v` and `rtl/decoder.v`'s own component proof — against assertions this repo
-  wrote, not against an oracle. An empty baseline is a **necessary** condition for M2, and the
-  remaining work is the list above, not another red check.
+1. **`formal/EXPECTED_FAIL` empty and `formal/EXPECTED_CHECKS` matching — MET at `6309b3e`**: 82
+   generated, 82 pass, both set equalities in both directions.
+2. **The mul/div checks run without `RISCV_FORMAL_ALTOPS`**, or ADR-0010's gap is closed by a named
+   oracle that does. Today `insn_mul`/`insn_div`/`insn_rem` passing says nothing whatever about the
+   real multiplier or divider.
+3. **`reg_ch0` returns a verdict** rather than exhausting its budget (ADR-0023). It is the one
+   check tying RVFI's self-report back to `rtl/regfile.v`; ADR-0032 measured exactly that hole by
+   injecting an architectural write the entire ladder missed.
+4. **`formal/equiv.sh` converges** (ADR-0020), or ADR-0006's guarantee that RVFI instrumentation
+   does not perturb the core is proven another way. The argument now has one more `ifdef
+   RISCV_FORMAL` field to cover (`rvfi_shadow.trap`).
+5. **`formal/complete` passes**, or every check it declines has a recorded reason. It fails today
+   on `ecall`/`ebreak`/`mret`/CSR retires, on no gate.
+6. **The nightly can go red, and is green.** It can go red as of `1961234` — but not for the reason
+   this file used to give. The `|| true` and the missing `-k` were fixed earlier; what remained is
+   that the graded comparison was piped into `tee`, and a `run:` block without an explicit `shell:`
+   key is `bash -e {0}` — errexit but **not** pipefail — so its exit status was `tee`'s, always 0.
+   **ADR-0022's "that comparison step's exit status is the job's real signal" had therefore never
+   held**, and stayed accidentally true only because the ladder kept matching its baseline
+   (ADR-0037). General rule: never put the graded command in a pipeline in a `run:` block.
+
+**Two caveats qualify what any green ladder here means, and neither is closable by burning
+down a list.** Every check is `mode bmc` — PASS means "no counterexample within this check's
+configured depth", not that the property holds, and there is no `mode prove` anywhere on the
+ladder. And riscv-formal ships **no spec model at all** for `ecall`/`ebreak`/`mret`/`csrr*` at the
+pin, so the behaviour M3 actually added is checked by `test/asm/trap.S`, `test/csr_tb.v`,
+`test/decoder_tb.v` and `rtl/decoder.v`'s own component proof — against assertions this repo wrote,
+not against an oracle. An empty baseline is loudest exactly where the ladder is quietest.
 
 ## Pointers
 
 - Design brief: [`docs/ideas/finish-the-rewrite.md`](docs/ideas/finish-the-rewrite.md)
-- Decisions: [`docs/adr/`](docs/adr/) — thirty-six accepted ADRs, plus a deferred list
+- Decisions: [`docs/adr/`](docs/adr/) — thirty-seven accepted ADRs, plus a deferred list
 - Reference text from the old core: `git show 1709433^:rtl/riscv.v` (RVFI retire block),
   `git show e67875c^:rtl/alu.v` (arithmetic)
 - Work is tracked in Linear, project **Little CPU** (team JEF). Named here so you know where the

--- a/docs/adr/0022-the-formal-nightly-reports-against-an-explicit-baseline.md
+++ b/docs/adr/0022-the-formal-nightly-reports-against-an-explicit-baseline.md
@@ -1,6 +1,11 @@
 # ADR-0022: The formal nightly reports against an explicit baseline, not `|| true`
 
 **Status:** Accepted · 2026-07-29 · *Supplements ADR-0006, ADR-0013, ADR-0014 · Follow-up required*
+· **Corrected by [ADR-0037](0037-an-empty-baseline-is-not-m2.md): the guarantee below — that the
+comparison step's exit status is the job's real signal — did NOT hold as written. The step piped
+the graded command into `tee`, and a `run:` block without an explicit `shell:` key is `bash -e {0}`,
+errexit but not pipefail, so `$?` was `tee`'s status and was always 0. Fixed in both workflows;
+the conclusion below stayed accidentally true only because the ladder kept matching its baseline.**
 
 ## Context
 

--- a/docs/adr/0028-the-rvfi-convention-for-a-trapping-retire.md
+++ b/docs/adr/0028-the-rvfi-convention-for-a-trapping-retire.md
@@ -1,6 +1,11 @@
 # ADR-0028: The RVFI convention for a trapping retire
 
 **Status:** Accepted · 2026-07-31 · *Supplements ADR-0006*
+· **Corrected by [ADR-0037](0037-an-empty-baseline-is-not-m2.md): the `dmemcheck` bullet below is
+STRUCK. The two shadows it relies on are not independent — `rtl/accessor.v` builds `rvfi_mem_wmask`/
+`rvfi_mem_wdata` from the same bus signals `dmemcheck` samples — so they cannot desynchronise the way
+described. Two mutations, including this bullet's literal scenario, left `dmemcheck` PASS. Two of the
+three indirect guards remain, and one of those (`reg`) is inconclusive.**
 
 ## Context
 
@@ -41,7 +46,8 @@ The instruction retires. It just retires having architecturally done nothing exc
 This is the load-bearing part of the ADR, because none of it is obvious and CI would not notice if
 a future change broke the reasoning:
 
-- **`dmemcheck` catches a trapping store that still reaches the bus.** `formal/dmemcheck.sv:61-68`
+- ~~**`dmemcheck` catches a trapping store that still reaches the bus.**~~ **STRUCK — see ADR-0037.**
+  The claim as written was: `formal/dmemcheck.sv:61-68`
   builds its environment shadow from the **real** `mem_wstrb`/`mem_wdata`, while `rvfi_dmem_check`
   builds its shadow purely from `rvfi_mem_*`. A store that is architecturally suppressed but still
   strobes the bus desynchronises the two, and a later load fails at the RVFI level.
@@ -60,8 +66,8 @@ a future change broke the reasoning:
 - The convention above is a repo commitment, not a spec requirement discovered by tooling. It must
   be restated in `rtl/writeback.v` at the drive site, because a reader of that code has no other way
   to learn that the ladder is silent here.
-- Any future change to trap reporting must be checked against the three indirect guards above by
-  hand — they are not named in any check's title and the connection is not discoverable from CI
+- Any future change to trap reporting must be checked against the **two** surviving indirect guards
+  above by hand (the `dmemcheck` one is struck — ADR-0037 — and `reg` is inconclusive, ADR-0023) — they are not named in any check's title and the connection is not discoverable from CI
   output.
 - The top-level `trap` port on `rtl/littlecpu.v` is **redefined, not deleted**: it becomes a
   one-cycle "trap entry committed this cycle" pulse. Deleting it would change the port list in

--- a/docs/adr/0034-what-the-csr-ladder-checks-cannot-see.md
+++ b/docs/adr/0034-what-the-csr-ladder-checks-cannot-see.md
@@ -110,6 +110,15 @@ iverilog -g2012 -s executor  rtl/structs.v rtl/executor.v    ->  0
 iverilog -g2012 -s writeback rtl/structs.v rtl/writeback.v   -> 20
 ```
 
+**Both commands above are wrong as printed — corrected by ADR-0037.** They fail preprocessing
+(`Include file structs.v not found`; they need `-I./rtl/`), and once that is fixed they report 0
+for *every* module, because the `always_comb` reads in question are inside `ifdef RISCV_FORMAL`.
+The macro set is required too. The width `in[311:0]` below is the macro-less figure and matches no
+real build: in `make testbench.vvp`, which is what produces the 20, it was `in[951:0]` when this
+ADR was written and is `in[952:0]` now. The attribution itself is confirmed by `$bits`, which on
+merged main gives `decoder_output` 943, `executor_output` 921, `accessor_output` **953** — and
+`accessor_output` is `rtl/writeback.v`'s port type, the only one of the three that matches.
+
 The reason is principled rather than a toolchain accident: the diagnostic is about an **inferred**
 sensitivity list, so it is specific to `always_comb`. `rtl/executor.v`'s `case (1'b1)` over 39
 flags sits inside `always_ff @(posedge clk)`, whose sensitivity is written out and needs no

--- a/docs/adr/0037-an-empty-baseline-is-not-m2.md
+++ b/docs/adr/0037-an-empty-baseline-is-not-m2.md
@@ -1,0 +1,222 @@
+# ADR-0037: An empty formal baseline is not M2, and the milestone criterion said it was
+
+**Status:** Accepted · 2026-08-01 · *Recorded at integration. Amends the M2 row of `CLAUDE.md`'s
+milestone ladder; corrects ADR-0028's `dmemcheck` claim; corrects ADR-0022's account of its own
+enforcement; corrects ADR-0034's reproduction command. Ratifies a branch-protection
+recommendation that a human must apply.*
+
+## Context
+
+`6309b3e` took `formal/EXPECTED_FAIL` to empty: 82 checks generated, 82 pass, both set equalities
+matching in both directions. `CLAUDE.md`'s milestone ladder said, in as many words, that this was
+M2's signal:
+
+> the `formal/EXPECTED_FAIL` baseline of ADR-0022 reaching empty is the signal
+
+The engineer who landed it declined to claim M2 and listed why. That is the right call, and the
+fact that it had to be a *judgement call* is the defect this ADR is about. **A milestone criterion
+that can be satisfied by a change nobody believes completes the milestone is not a criterion. It is
+a coincidence with a checkbox next to it.**
+
+This is the same failure mode ADR-0033 named for the ladder itself — a gate that reports green
+without having checked what it claims to check — applied one level up, to the milestone table
+rather than to a check. The table is where a reader goes to find out whether the project is done.
+
+## Decision
+
+### 1. M2 is NOT reached at `6309b3e`.
+
+Six things are true of the ladder that just went green, and each is independently sufficient to
+deny the milestone. M2's own wording is "the pipelined core re-proves everything the serialized
+core proved", and the serialized core's result was not bounded, not ALTOPS, and not
+self-refereed.
+
+1. **Every check is `mode bmc`.** PASS means "no counterexample within this check's configured
+   depth", not that the property holds. There is no `mode prove` anywhere on the ladder.
+2. **The whole ladder runs under `RISCV_FORMAL_ALTOPS`** (ADR-0010), so `insn_mul`, `insn_div`,
+   `insn_rem` and their siblings say nothing whatever about the real multiplier or divider.
+3. **`reg_ch0` is inconclusive** (ADR-0023) — a single depth-21 BMC query that does not return in
+   a practical budget. It is the *one* check that ties RVFI's self-report back to `rtl/regfile.v`.
+   Without it the other 81 establish that the core's story about itself is spec-consistent, not
+   that the story is true. ADR-0032 measured exactly this hole: an injected extra architectural
+   write was missed by the entire ladder when gated to fire past the BMC bound.
+4. **`formal/equiv.sh` does not converge** (ADR-0020), so ADR-0006's guarantee that RVFI
+   instrumentation does not perturb the core is still argued, not proven — and `6309b3e` added one
+   more `ifdef RISCV_FORMAL` field for that argument to cover (`rvfi_shadow.trap`).
+5. **`formal/complete` still fails**, on no gate.
+6. **riscv-formal ships no spec model for `ecall`/`ebreak`/`mret`/`csrr*` at the pin.** So the
+   behaviour `6309b3e` actually added — the whole of M3's trap semantics — is checked against
+   assertions *this repo wrote*, in `test/asm/trap.S`, `test/csr_tb.v`, `test/decoder_tb.v` and
+   `rtl/decoder.v`'s component proof. That is worth having and it is not an oracle. An empty
+   baseline is loudest precisely where the ladder is quietest.
+
+### 2. The M2 criterion is rewritten as a conjunction, and the empty baseline is demoted to one term of it.
+
+`CLAUDE.md`'s M2 row now requires **all six** of the following, and says explicitly that the first
+one alone means nothing:
+
+1. `formal/EXPECTED_FAIL` empty **and** `formal/EXPECTED_CHECKS` matching — *met at `6309b3e`*;
+2. the mul/div checks run without `RISCV_FORMAL_ALTOPS`, or ADR-0010's gap is closed by a named
+   oracle that does;
+3. `reg_ch0` returns a verdict rather than exhausting its budget;
+4. `formal/equiv.sh` converges, or ADR-0006's non-perturbation guarantee is proven another way;
+5. `formal/complete` passes, or every check it declines has a recorded reason;
+6. the nightly can go red (see §4) and is green.
+
+**Necessary-but-not-sufficient conditions must be written as such.** The old wording called item 1
+"the signal", which is the language of sufficiency for something that was only ever necessary.
+ADR-0033 had already recorded the distinction in prose; the table did not carry it, and the table
+is what gets read.
+
+### 3. ADR-0028's `dmemcheck` claim does not hold. Struck.
+
+ADR-0028 lists three ladder checks that indirectly guard the trapping-retire convention. The first
+is wrong:
+
+> **`dmemcheck` catches a trapping store that still reaches the bus.** `formal/dmemcheck.sv:61-68`
+> builds its environment shadow from the **real** `mem_wstrb`/`mem_wdata`, while `rvfi_dmem_check`
+> builds its shadow purely from `rvfi_mem_*`. A store that is architecturally suppressed but still
+> strobes the bus desynchronises the two.
+
+**The two shadows cannot desynchronise that way, because they are not independent.**
+`rtl/accessor.v` builds the RVFI write shadow *from the same bus signals* `dmemcheck` samples:
+
+```verilog
+out.rvfi_mem_wmask <= is_store ? mem_wstrb    : 4'b0;
+out.rvfi_mem_wdata <= is_store ? write_request : 32'b0;
+```
+
+A store that reaches the bus is therefore reported faithfully in `rvfi_mem_*` too, and the two
+shadows agree. Two mutations were run against the real ladder: dropping the store-flag suppression
+(both shadows agree, no desync exists) and forcing `rvfi_mem_wmask <= 0` while the bus strobes —
+ADR-0028's literal scenario. Both left `dmemcheck` **PASS** at 18 minutes.
+
+The other two guards in that list (`reg` for a trapping `rd`, `pc_fwd`/`pc_bwd` for a dishonest
+redirect) stand, with the standing caveat that `reg` is item 3 of §1 above and is inconclusive.
+
+This matters beyond bookkeeping: ADR-0028's consequences section instructs the reader to check
+future trap-reporting changes against those three guards by hand. One of the three does not exist.
+A guard that is named but absent is worse than no guard, because it stops the next reader from
+looking — `docs/THREAT_MODEL.md` calls this class out by name as a **prose-only guard** and rates
+it a real finding. `rtl/writeback.v`'s comment at the drive site repeats the claim and is corrected
+with it.
+
+### 4. ADR-0022's central guarantee has never held. It holds now.
+
+ADR-0022 records that replacing `make -C formal check || true` with an explicit baseline
+comparison made "that comparison step's exit status the job's real signal". It did not. The
+replacement step was:
+
+```sh
+formal/check-baseline.sh formal/checks formal/EXPECTED_FAIL | tee -a "$GITHUB_STEP_SUMMARY"
+status=$?
+```
+
+A `run:` step without an explicit `shell:` key is `bash -e {0}` — **errexit but not pipefail**;
+only an explicit `shell: bash` gets `-eo pipefail`. So `$?` was `tee`'s status, which is always 0,
+and the nightly's gate could not go red no matter what the comparison found. Demonstrated on CI: a
+deliberately wrong `formal/EXPECTED_FAIL` printed "Failure list does NOT match" and the job
+reported success.
+
+The `|| true` fix moved the defect rather than removing it. Both copies of the step (`ci.yml`,
+`formal-nightly.yml`) now redirect to a file, take the status off the unpiped command, and exit on
+it; both failure directions were demonstrated on real runs. **ADR-0022's conclusion stayed
+accidentally true for its whole life** — the ladder happened to match its baseline every night —
+which is precisely why nothing noticed.
+
+The general rule, worth more than the instance: **`set -e` in a GitHub Actions `run:` block does
+not imply `pipefail`. Never put the graded command in a pipeline.**
+
+### 5. The `formal` job should join the required set. A human must do it.
+
+ADR-0022's "no branch-protection entry" clause was scoped to the **nightly**, whose content is
+unbounded — `complete`'s depth-50 walk and `equiv.sh`, neither of which has a wall-clock bound
+since ADR-0031 retired `checks.cfg`'s `timeout=`. That reasoning does not transfer to the new PR
+job, which runs neither.
+
+Ratified: `formal` **should** be added to `main`'s required status checks. It is measured at
+3m11s against a 20-minute job timeout, it is deterministic, and it closes a real hole — until it
+existed, `formal/EXPECTED_FAIL` was a PR-modifiable baseline that only the nightly compared, so a
+PR could widen the baseline and be contradicted the next morning with the change already on main.
+
+Two costs, recorded rather than discovered later:
+
+- it ties merges to **GitHub-hosted** capacity, deliberately, while `lint` and `test` have moved
+  in-cluster. One ladder check peaks at 876 MiB RSS against a pod with roughly 700 MiB free, so a
+  single check does not fit at any parallelism — `-j1` would not have saved it;
+- there is still **no per-check wall bound**, so one non-converging check starves everything
+  scheduled after it and `-k` does not help, because the job dies rather than the check. The
+  20-minute job timeout is the only backstop, and raising any depth in `checks.cfg` re-opens it.
+
+**This ADR does not change branch protection and no agent should.** It is a repository-settings
+change for a human to make deliberately, exactly as ADR-0036 says of `lint`.
+
+### 6. The iverilog leg was inert for the whole of M1, and the verification table did not know.
+
+`rtl/decoder.v`'s hazard scoreboard called a `function automatic live_producer(r)` from two
+continuous assigns. iverilog derives such an assign's sensitivity list from the **call's
+arguments**, so a body that also reads module-level signals (`out`, `executor_out`,
+`accessor_pending_*`) never re-evaluated when those changed. Under-sensitivity — the one direction
+`CLAUDE.md`'s documented `sorry:` exception says is a real bug rather than harmless noise — and
+iverilog emits no diagnostic for it whatsoever.
+
+Reproduced on `main` before the fix: `hazard_rs1` went 0→1 at the first RAW hazard of the baked-in
+program and **never fell again**; the PC advanced `0x0` → `0x4` and froze; `make waves` performed
+**0 memory writes in 200 cycles** and issued 201 reads all to address `0x00000000`. After the fix,
+the same program performs 22 writes with the PC advancing normally.
+
+The window is exact and it is the whole of M1: `live_producer` was introduced by `a4662a2` — the
+commit that *declared* M1 — and removed by `6309b3e`. yosys evaluates the function correctly, so
+cxxrtl and the entire formal ladder were unaffected, which is why nothing caught it: **the leg the
+verification table calls "the microscope" was reporting nothing, and nothing it reported was
+wrong.**
+
+M1's own criterion is "all RV32IM `.S` tests pass under cxxrtl", so M1 stands. What does not stand
+is the three-leg claim in the verification table for that period, and `CLAUDE.md` now says so with
+the dates. A leg that cannot fail is not a leg.
+
+### 7. ADR-0034's attribution is right; its reproduction command does not run.
+
+ADR-0034 corrected `CLAUDE.md`'s claim that the 20 `sorry:` notes come from `rtl/executor.v`, and
+the correction is **confirmed**: the diagnostic is specific to `always_comb`, where sensitivity is
+inferred, and `rtl/executor.v`'s `case (1'b1)` sits in an `always_ff`. Measured on merged main, all
+20 notes are against `in[952:0]`, and `$bits` resolves the three candidate structs unambiguously —
+`decoder_output` 943, `executor_output` 921, **`accessor_output` 953**, which is `rtl/writeback.v`'s
+port type and the only one that matches. The count is exactly 20 both before and after `6309b3e`;
+the width moves `in[951:0]`→`in[952:0]` for the single bit `rvfi_shadow.trap` adds. (Before the
+change the same three were 955 / 920 / 952 — `decoder_output` loses 12 net, having shed
+`csr_addr`+`is_csr_imm` and gained `trap`.)
+
+Two things in that record are wrong and are fixed here:
+
+- the command ADR-0034 prints, `iverilog -g2012 -s <mod> rtl/structs.v rtl/<mod>.v`, **fails
+  preprocessing** — `Include file structs.v not found`. It needs `-I./rtl/`, and it needs the
+  `RISCV_FORMAL*` macro set, without which every module reports 0 because the `always_comb` reads
+  in question are inside `ifdef RISCV_FORMAL`;
+- the width `in[311:0]` is the macro-less figure and does not match any real build. The build that
+  produces the 20 is `make testbench.vvp`, where it is `in[951:0]`.
+
+An attribution rule whose stated reproduction returns 0 is a prose-only guard of the same family
+as §3.
+
+### 8. Elaboration is not warning-free, and the note it pointed at did not exist.
+
+`CLAUDE.md` said `yosys ... write_cxxrtl` "elaborates the current RTL cleanly with zero warnings".
+It emits **one**: `Warning: Deep recursion in AST simplifier`. That warning is deliberately and
+correctly allowlisted by the `elaborate` gate, which promotes every *other* `Warning:` to an error
+— but the gate's own comment justifies the exception with "see `CLAUDE.md`'s technical notes", and
+`CLAUDE.md` had no such note. A cross-reference to text that does not exist is the same defect
+class as §3 and §7: a reader who goes looking cannot confirm the claim, so the exception reads as
+undocumented. The note now exists and the count is stated as one.
+
+## Consequences
+
+- `CLAUDE.md`'s M2 row is a six-term conjunction. Closing M2 now requires deleting terms from a
+  list, which is a burn-down with the same shape as `formal/EXPECTED_FAIL` itself.
+- The empty baseline stays a real result and should not be talked down. It is item 1 of six, it
+  was earned, and the attribution behind it held exactly — nine misalignment checks plus
+  `ill_ch0` closed together while the three byte-granularity checks never moved.
+- ADR-0028 loses one of its three indirect guards. Trap-reporting changes now have two, one of
+  which is inconclusive. That argues for the `rtl/decoder.v` component proof carrying more of the
+  weight, which is where `6309b3e` already put the `pc == mtvec` assertion the ladder cannot make.
+- Nothing here changes `rtl/`. The RTL merged in this integration is unmodified.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -26,21 +26,22 @@ and what it costs. Reversing one is fine — write a new ADR that supersedes it.
 | [0019](0019-the-monitor-sanitizer-is-the-place-to-fix-generated-monitor-defects.md) | The monitor sanitizer is where generated-monitor defects get fixed | Accepted |
 | [0020](0020-the-rvfi-non-perturbation-guarantee-is-argued-not-proven.md) | The RVFI non-perturbation guarantee is argued, not proven | Accepted |
 | [0021](0021-the-formal-ladder-runs-the-compressed-checks.md) | The formal ladder runs the compressed checks, and it found a real bug | Accepted |
-| [0022](0022-the-formal-nightly-reports-against-an-explicit-baseline.md) | The formal nightly reports against an explicit baseline, not `\|\| true` | Accepted |
+| [0022](0022-the-formal-nightly-reports-against-an-explicit-baseline.md) | The formal nightly reports against an explicit baseline, not `\|\| true` | Accepted · corrected by 0037 |
 | [0023](0023-the-first-ladder-run-does-not-reach-m2.md) | The first ladder run does not reach M2 — three named holes | Accepted |
 | [0024](0024-the-ladders-default-bmc-engine-is-btormc.md) | The ladder's default BMC engine is `btor btormc`, not `smtbmc yices` | Accepted |
 | [0025](0025-formal-ladder-depths-are-derived-not-inherited.md) | The ladder's depths are derived from the pipeline, not inherited | Accepted |
 | [0026](0026-stalls-are-four-reasons-over-two-mechanisms.md) | Stalls are four reasons over two mechanisms | Accepted |
 | [0027](0027-minstret-counts-non-trapping-issues.md) | `minstret` counts non-trapping issues; serialization buys exactness | Accepted |
-| [0028](0028-the-rvfi-convention-for-a-trapping-retire.md) | The RVFI convention for a trapping retire | Accepted |
+| [0028](0028-the-rvfi-convention-for-a-trapping-retire.md) | The RVFI convention for a trapping retire | Accepted · corrected by 0037 |
 | [0029](0029-mtvec-resets-to-zero-and-a-pre-handler-trap-is-loud.md) | `mtvec` resets to zero, and a pre-handler trap is made loud | Accepted |
 | [0030](0030-trap-cause-priority-and-why-the-causes-are-disjoint.md) | Trap cause priority, and why the causes are disjoint | Accepted |
 | [0031](0031-the-vendored-genchecks-copy-tracks-the-pin.md) | The vendored `genchecks` copy tracks the pin, and only `basedir` differs | Accepted |
 | [0032](0032-sail-co-simulation-is-worth-building-and-stays-opt-in.md) | Sail co-simulation is worth building, and stays opt-in | Accepted |
 | [0033](0033-what-the-green-ladder-does-not-cover.md) | What a green ladder does not cover — three assurance gaps, named | Accepted |
-| [0034](0034-what-the-csr-ladder-checks-cannot-see.md) | What the CSR ladder checks cannot see, and the decisions the CSR file forced | Accepted |
+| [0034](0034-what-the-csr-ladder-checks-cannot-see.md) | What the CSR ladder checks cannot see, and the decisions the CSR file forced | Accepted · corrected by 0037 |
 | [0035](0035-the-baseline-pins-the-failure-mode.md) | `test/EXPECTED_FAIL` pins the failure mode, not just the file name | Accepted |
 | [0036](0036-three-gate-hardening-decisions-ratified-at-integration.md) | Three gate-hardening decisions ratified at integration, and a correction to ADR-0031 | Accepted |
+| [0037](0037-an-empty-baseline-is-not-m2.md) | An empty formal baseline is not M2, and the milestone criterion said it was | Accepted |
 
 0001–0007 came from the design brief
 ([`docs/ideas/finish-the-rewrite.md`](../ideas/finish-the-rewrite.md)). 0008–0011 came out of

--- a/rtl/writeback.v
+++ b/rtl/writeback.v
@@ -88,11 +88,17 @@ module writeback(
   // None of it is enforced here: it is enforced upstream, in rtl/decoder.v,
   // by suppressing `out.rd` and every execution flag on a trapping issue, so
   // the values below are zero because nothing produced anything -- not because
-  // this block masks them. Three ladder checks catch it INDIRECTLY if that
-  // breaks (`dmemcheck` for a store that still strobes the bus, `reg` for an
-  // rd that still lands, `pc_fwd`/`pc_bwd` for a redirect that is misreported
-  // or not taken); none of them names traps in its title, and the connection
-  // is not discoverable from CI output. The one thing nothing on the ladder
+  // this block masks them. TWO ladder checks catch it INDIRECTLY if that
+  // breaks -- `reg` for an rd that still lands, and `pc_fwd`/`pc_bwd` for a
+  // redirect that is misreported or not taken. Neither names traps in its
+  // title, the connection is not discoverable from CI output, and `reg` is
+  // itself inconclusive (ADR-0023), so this is thinner cover than it looks.
+  // ADR-0028 named a third, `dmemcheck`, for a store that still strobes the
+  // bus; ADR-0037 STRUCK it. The shadow it compares is not independent of the
+  // bus -- rtl/accessor.v builds rvfi_mem_wmask/wdata from the same
+  // mem_wstrb/write_request dmemcheck samples -- so a suppressed-but-executed
+  // store is reported faithfully by both and nothing desynchronises.
+  // Confirmed by mutation: dmemcheck stayed PASS. The one thing nothing on the ladder
   // can see -- that the target is `mtvec` -- is asserted in rtl/decoder.v's
   // component proof.
   // A continuous assign rather than a line in the always_comb below, and that


### PR DESCRIPTION
Recorded at integration, after merging the PR-gate ladder job and the trap-entry
change. No logic changes: one comment-only edit to `rtl/writeback.v`, the rest
is `docs/` and `CLAUDE.md`.

## The ruling: M2 is not reached

`formal/EXPECTED_FAIL` is empty (82 checks, 82 pass) and `CLAUDE.md`'s milestone
table said that was M2's signal. **A milestone criterion that can be satisfied by
a change nobody believes completes the milestone is not a criterion.** The M2 row
becomes a six-term conjunction with the empty baseline demoted to term 1 of six —
the only one met — plus two standing caveats no burn-down can close (`mode bmc`
everywhere; no spec model for `ecall`/`ebreak`/`mret`/`csrr*` at the pin, so M3's
behaviour is checked against assertions this repo wrote, not an oracle).

## Two recorded claims that do not reproduce

**ADR-0028's `dmemcheck` guard is struck.** It relies on two shadows being
independent. They are not — `rtl/accessor.v` builds `rvfi_mem_wmask`/`wdata` from
the same `mem_wstrb`/`write_request` that `dmemcheck` samples, so a
suppressed-but-executed store is reported faithfully by both. Two mutations,
including the ADR's literal scenario, left it PASS. Trap reporting now has two
indirect guards, one of which (`reg`) is inconclusive.

**ADR-0022's central guarantee never held.** The graded comparison was piped into
`tee`, and a `run:` block without an explicit `shell:` key is `bash -e {0}` —
errexit but not pipefail — so `$?` was `tee`'s, always 0. Fixed already; the
conclusion stayed accidentally true only because the ladder kept matching its
baseline.

**ADR-0034's attribution is confirmed, its reproduction command is not.** The
`sorry:` diagnostic carries no filename at all (prints `:0:`); attribution is by
struct width, and `$bits` gives `decoder_output` 943, `executor_output` 921,
`accessor_output` 953 — only the last matches `in[952:0]`, which is
`rtl/writeback.v`'s port type. The printed command fails preprocessing and,
once fixed, reports 0 for every module without the `RISCV_FORMAL` macros.

## Also recorded

The iverilog leg was inert for the whole of M1 (`a4662a2`→`6309b3e`), so the
verification table's three-leg claim was overstated for that window. And
elaboration emits one allowlisted warning rather than zero, where the gate's
justifying cross-reference pointed at a `CLAUDE.md` note that did not exist.

## Ratified, needs a human

`formal` should join `main`'s required status checks — ADR-0022's
no-branch-protection clause was scoped to the *unbounded* nightly, not to a
bounded 3m11s PR job. **This PR does not change branch protection.**