### PR TITLE
JEF-662: add `make fit`, the one logic-cell measurement, and delete the three targets that measured an empty design

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
-riscv.json
-riscv.asc
-timing
-pll.v
+# `make fit` (ADR-0038): the netlist it places, nextpnr's log -- which IS the
+# measurement, so keep it around to read -- and the yosys log, kept out of the
+# terminal so no yosys cell count is ever mistaken for an area number.
+fit.json
+fit.log
+fit.synth.log
 formal/riscv-formal
 formal/riscv-formal.tmp
 formal/complete

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -359,6 +359,9 @@ make setup          # install the RISC-V toolchain (brew on macOS)
 make test           # assemble test/asm/*.S, run under cxxrtl, pass/fail table
 make waves          # iverilog + VCD (testbench.vvp's baked-in program) -> waves.vcd
 make monitor-check  # regenerate test/monitor.v at the pin and diff
+make fit            # the ONE area number: nextpnr logic cells on up5k/sg48 (ADR-0038).
+                    # Placement always fails (231 SB_IO vs 39) and that is expected --
+                    # the utilisation table printed before placement is the measurement.
 
 make -C formal components_decoder   # component proofs
 make -C formal check                # the riscv-formal ladder (82 checks; see ADR-0023)

--- a/Makefile
+++ b/Makefile
@@ -511,38 +511,84 @@ test-units: test/monitor.sim.v
 test: sim test-units
 	@./test/run_tests.sh ./sim test/asm test/EXPECTED_FAIL
 
-pll.v: timing
-	icepll -m -f $@ -i 12 -o $(shell cat $^)
-
-# rtl/imemory.v unconditionally $readmemh's this at elaboration time; it's
-# gitignored and nothing generates it yet (real ROM contents are M1 work, once
-# there's a test-binary-to-hex pipeline). An empty file is enough for
-# synth_ice40 to elaborate — $readmemh on an empty file just leaves the ROM
-# unmodified. Order-only prerequisite so it's not fed to read_verilog.
+# ---------------------------------------------------------------------------
+# `make fit` -- the repo's one and only area measurement (ADR-0038).
 #
-# This deliberately turns a hard yosys error into a successful build, so it has
-# to say out loud that the resulting bitstream has an empty ROM and traps on its
-# first instruction. Never silently.
-rtl/rom.mem:
-	touch $@
-	@echo '*** WARNING: created an EMPTY $@ placeholder. Anything synthesised'
-	@echo '*** from it has an uninitialised ROM and will trap on instruction 0.'
-	@echo '*** Real ROM contents are M1 work (test-binary-to-hex).'
+# Area is measured in *nextpnr logic cells*, never in yosys cell counts, and
+# nothing on this path prints a yosys number. A logic cell holds one LUT4 AND
+# one flip-flop, but a DFF whose D input is not the output of its co-located
+# LUT consumes a whole cell on its own -- over a thousand of this design's
+# cells are exactly that, and an `SB_LUT4` count is structurally blind to it.
+# Two planning estimates were wrong in opposite directions because they counted
+# LUT4s: one said 102% where the truth was 126%, the other undercounted a
+# saving by more than half. Hence the synthesis log below goes to a file.
+#
+# The top is `littlecpu` with its memories external, not `littlesoc`: the SoC's
+# memories are placeholders whose real implementation will be SPRAM and will
+# not consume logic cells. This replaces the `riscv.json`/`riscv.asc`/`timing`
+# targets that stood here, which synthesised `littlesoc` -- whose only outputs
+# are the flash pins, so yosys deleted the entire core and place-and-route
+# reported *4 LCs, 0%*. They measured an empty design and looked like a metric.
+#
+# WHY THIS TARGET TOLERATES A FAILED PLACEMENT, ON PURPOSE:
+# `littlecpu` with memories external presents 231 `SB_IO` against sg48's 39,
+# so nextpnr ALWAYS errors out -- after printing the utilisation table. Even a
+# configuration using 76% of the part fails, and it fails on an `imem_data2`
+# pad, not on logic cells. A top with realistic IO means a real pinout, which
+# means the SoC memory system, which is out of scope here. So a `make fit` that
+# required successful placement would never run at all, which is worse than
+# having no metric because it would look like one (ADR-0038 decision 1a). The
+# measurement is the utilisation nextpnr prints *before* it attempts placement.
+#
+# `icetime` IS DELIBERATELY OUT OF SCOPE, for the same reason: it needs an
+# `.asc`, which needs a completed placement, which needs that real pinout. Fmax
+# stays *declared* at 12 MHz and unmeasured (ADR-0038 decision 2); raising it
+# means breaking invariant 1 or invariant 6 and needs its own ADR. That is also
+# why the `pll.v`/`icepll` rule that fed off `timing` is gone.
+#
+# The contract is therefore inverted from a normal build, and the check below
+# is the whole point of the target:
+#
+#   nextpnr ran, printed a table, then failed to place -> EXPECTED, exit 0
+#   nextpnr absent, crashed, or printed no table       -> exit NONZERO
+#
+# A missing binary or a truncated JSON must not yield a green run with no
+# number in it. nextpnr's exit status cannot tell those apart -- it is nonzero
+# either way -- so the presence of the utilisation table is what decides.
+#
+# The whole table is printed, not just the logic-cell line: `SB_GB` is already
+# at 8/8, so a global-buffer overflow is a placement failure that no logic-cell
+# ratchet would ever predict.
+# ---------------------------------------------------------------------------
+FIT_SRCS := rtl/structs.v rtl/accessor.v rtl/csrs.v rtl/decoder.v rtl/executor.v \
+            rtl/fetcher.v rtl/regfile.v rtl/writeback.v rtl/littlecpu.v
 
-riscv.json: rtl/structs.v rtl/accessor.v rtl/csrs.v rtl/decoder.v rtl/executor.v rtl/fetcher.v rtl/regfile.v rtl/writeback.v rtl/littlecpu.v rtl/littlesoc.v rtl/imemory.v rtl/memory.v | rtl/rom.mem
-	yosys -p 'read_verilog -sv $^; synth_ice40 -dsp -top littlesoc -json $@'
+fit.json: $(FIT_SRCS)
+	@echo 'yosys: synthesising littlecpu for ice40 (log: fit.synth.log)'
+	@yosys -p 'read_verilog -sv $^; synth_ice40 -dsp -top littlecpu -json $@' \
+	  > fit.synth.log 2>&1 || { tail -40 fit.synth.log; exit 1; }
 
-riscv.asc: riscv.json riscv.pcf
-	nextpnr-ice40 --up5k --json riscv.json --pcf riscv.pcf --asc riscv.asc --pcf-allow-unconstrained --opt-timing
-
-timing: riscv.asc
-	icetime -d up5k $^ | egrep -oi '\(\d+' | egrep -o '\d+' > $@
+.PHONY: fit
+fit: fit.json
+	@nextpnr-ice40 --up5k --package sg48 --json $< --pcf-allow-unconstrained \
+	  > fit.log 2>&1 || true
+	@grep -q 'ICESTORM_LC:' fit.log || { \
+	  echo '*** make fit: nextpnr printed no utilisation table, so NO measurement'; \
+	  echo '*** was taken. That is a failure, not a 0% fit. Tail of fit.log:'; \
+	  tail -20 fit.log; \
+	  exit 1; \
+	}
+	@sed -n '/^Info: Device utilisation:/,/^$$/s/^Info: //p' fit.log
+	@awk '/ICESTORM_LC:/ { split($$3, u, "/"); printf "\nLOGIC CELLS: %s of %s (%s)  --  up5k / sg48 / littlecpu, memories external\n", u[1], $$4, $$5 }' fit.log
+	@if grep -q '^ERROR: Unable to place' fit.log; then \
+	  echo 'Placement failed, which is the expected state (ADR-0038 decision 1a);'; \
+	  echo 'the utilisation above is the measurement. Full log: fit.log'; \
+	else \
+	  echo 'Placement did not report the usual error -- read fit.log before quoting this.'; \
+	fi
 
 clean:
-	rm -f riscv.json
-	rm -f riscv.asc
-	rm -f timing
-	rm -f pll.v
+	rm -f fit.json fit.log fit.synth.log
 	rm -f waves.vcd
 	rm -rf sim sim.dSYM
 	rm -rf cosim cosim.dSYM


### PR DESCRIPTION
Closes JEF-662

## What

Adds `make fit` — the repo's one area number — and removes `riscv.json` / `riscv.asc` / `timing` / `pll.v`, which measured an empty design.

Those four synthesised `littlesoc`, whose only outputs are the flash pins. Nothing the CPU computes reaches a port, so yosys deleted the entire core and place-and-route reported **4 LCs, 0%**. That is a live trap in the repo today: a number that reads as a fit and is not one, and it is why the first-ever place-and-route was run on `littlecpu` standalone by hand.

`make fit` synthesises `littlecpu` with memories external (ADR-0038 — the SoC memories are placeholders whose real implementation is SPRAM and will not consume logic cells), runs `nextpnr-ice40 --up5k --package sg48 --pcf-allow-unconstrained`, and prints the whole utilisation table plus the logic-cell total and percentage.

## Baseline

```
Device utilisation:
	         ICESTORM_LC:    6971/   5280   132%
	        ICESTORM_RAM:       0/     30     0%
	               SB_IO:     231/     39   592%
	               SB_GB:       8/      8   100%
	        ICESTORM_PLL:       0/      1     0%
	         SB_WARMBOOT:       0/      1     0%
	        ICESTORM_DSP:       4/      8    50%
	      ICESTORM_HFOSC:       0/      1     0%
	      ICESTORM_LFOSC:       0/      1     0%
	              SB_I2C:       0/      2     0%
	              SB_SPI:       0/      2     0%
	              IO_I3C:       0/      2     0%
	         SB_LEDDA_IP:       0/      1     0%
	         SB_RGBA_DRV:       0/      1     0%
	      ICESTORM_SPRAM:       0/      4     0%

LOGIC CELLS: 6971 of 5280 (132%)  --  up5k / sg48 / littlecpu, memories external
Placement failed, which is the expected state (ADR-0038 decision 1a);
the utilisation above is the measurement. Full log: fit.log
```
`make fit` exit status: **0**.

Trap entry (`6309b3e`) cost **+312 LCs** against the pre-trap-entry 6659.

## Three deliberate choices, each with a comment in the Makefile saying why

- **The placement error is tolerated.** `littlecpu` with memories external presents 231 `SB_IO` against sg48's 39, so nextpnr always errors *after* printing the table — even a 76%-of-part configuration fails, on an `imem_data2` pad, not on logic cells. A `make fit` that required successful placement would never run at all, which is worse than no metric because it would look like one (ADR-0038 decision 1a).
- **`icetime` is out of scope**, for the same reason: it needs an `.asc`, which needs a completed placement, which needs a real pinout, which is the SoC memory work. Fmax stays *declared* at 12 MHz and unmeasured (ADR-0038 decision 2). That is why the `icepll` rule is deleted rather than re-pointed.
- **No yosys cell count reaches the terminal.** The synthesis log goes to `fit.synth.log`. Yosys reports `SB_LUT4`; nextpnr reports logic cells, and a DFF that fails to pair with a LUT consumes a whole cell and is invisible to the former. Both wrong estimates ADR-0038 exists to prevent were yosys counts.

## The inverted contract — demonstrated, not asserted

The target does not read nextpnr's exit status, which is nonzero either way. It requires the utilisation table:

| situation | result |
|---|---|
| nextpnr ran, printed a table, then failed to place | **exit 0** |
| nextpnr absent, crashed, or printed no table | **exit nonzero** |

**Truncated JSON** (`head -c 2000 fit.json`):
```
*** make fit: nextpnr printed no utilisation table, so NO measurement
*** was taken. That is a failure, not a 0% fit. Tail of fit.log:
ERROR: Failed to parse JSON file 'fit.json': unexpected end of input in string.
0 warnings, 1 error
make: *** [fit] Error 1
```

**Binary absent** (`env -i PATH=/usr/bin:/bin make fit`):
```
*** make fit: nextpnr printed no utilisation table, so NO measurement
*** was taken. That is a failure, not a 0% fit. Tail of fit.log:
/bin/sh: nextpnr-ice40: command not found
make: *** [fit] Error 1
```

**Synthesis failure** (`make fit FIT_SRCS=rtl/regfile.v`) also exits nonzero and leaves no `fit.json`, via `.DELETE_ON_ERROR`:
```
ERROR: Module `littlecpu' not found!
make: *** [fit.json] Error 1
```

The whole table is printed rather than just the LC line because `SB_GB` is already at **8/8** — a global-buffer overflow is a placement failure that no logic-cell ratchet would predict.

## Scope

- **No `rtl/` changes.** `make test` is **52/52**, `test/EXPECTED_FAIL` empty.
- Also deleted as dead with those targets: the `rtl/rom.mem` placeholder rule (an order-only prerequisite of `riscv.json` and of nothing else) and the zero-byte `riscv.pcf`. `rtl/littlesoc.v`, `rtl/imemory.v` and `rtl/memory.v` are untouched.
- `fit.json` / `fit.log` / `fit.synth.log` are gitignored.
- Report-only this sprint; the ratchet is a later ticket.
- Depends on #54 for ADR-0038, which the Makefile comments and `CLAUDE.md` cite. Merge order: #54 first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)