### PR TITLE
JEF-663: run Sail co-simulation across the whole .S suite, against a baseline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -297,6 +297,29 @@ exactly) while the co-sim reported it in 0.6s with instruction number, PC and bo
 class is *architectural state no retiring instruction names, corrupted past the BMC bound*. The
 mutation was reverted; `rtl/` is untouched by that change.
 
+**Co-simulation now runs the whole suite against a baseline** (ADR-0039). `make cosim-suite` is
+`test/run_cosim.sh` in the shape of `test/run_tests.sh`, graded by ADR-0014's set equality in both
+directions against `test/COSIM_EXPECTED_FAIL` in ADR-0035's name-and-status format: **52 programs,
+50 agree, 10s wall.** The two baselined entries are read-only-CSR *value* divergences no change to
+this core could close — `csr.S` on `misa` (Sail derives it from its extension set; matching it needs
+seven extensions disabled and a cascade of dependent keys, measured and recorded rather than chased)
+and `minstret.S` on `mcycle` (an ISA model has no pipeline, so it cannot count cycles). `trap.S`
+agrees 214/214. **The mutation was re-run against the integrated leg rather than inherited**: the
+same post-cycle-40 `regs[31] <= wdata` is missed by `make test` at 52/52 and caught by
+`make cosim-suite` in 49 of 52 programs (the three that still agree are the three too short to reach
+cycle 40), and `csr.S`'s baselined status moves from `DISAGREE AT 17` to `DISAGREE AT 11` — the
+second baseline field doing its job.
+
+The same change made `tohost` an 8-byte-aligned `.dword` in `test/asm/riscv_test.h`, which is what
+the HTIF protocol its encoding is borrowed from always specified (ADR-0039 amends ADR-0008). It was
+a 32-bit `.word` at the base of RAM, so `.data` began four bytes inside the doubleword IO window any
+HTIF consumer claims at the symbol; Sail answered every `lw` from `RAM_BASE+4` with zero. **This is
+shared test infrastructure both existing sim legs read** — every program's `.data` moves four bytes
+and every program executes one extra store — and `make test` (52/52) and `make test-units` were
+re-run green in the same change. The verdict macros write the upper word first and the verdict last,
+so the reference model terminates on the same store the cxxrtl runners stop on; the `objcopy
+--strip-symbol=tohost` workaround and the spin-loop convergence heuristic are both gone.
+
 **`86e2721` ports the riscv-formal ladder to `littlecpu`** — the first time any riscv-formal
 check has run against the pipelined core since the 2021 teardown. `formal/wrapper.v` speaks the
 real bus (no handshake: `imem_data`/`mem_rdata` are free every cycle, per invariant 1 and
@@ -366,6 +389,7 @@ make -C formal check-baseline       # re-grade a finished ladder: EXPECTED_CHECK
 
 make sail-setup     # once: fetch the pinned sail-riscv release into tools/sail/
 make cosim-run      # Sail co-simulation on ONE program (PROG=add.S). Opt-in; see ADR-0032
+make cosim-suite    # the whole .S suite under co-sim, graded against COSIM_EXPECTED_FAIL
 ```
 
 Toolchain: macOS `brew install riscv64-elf-gcc`; Linux `apt install gcc-riscv64-unknown-elf`.
@@ -397,13 +421,16 @@ you can point at something it would have failed on.
 That arithmetic is covered only by the `.S` suite and the executor component proof. Do not assume a
 green formal ladder means the ALU is correct.
 
-**There is a fourth thing you can run, and it is deliberately not a leg** (ADR-0032). `make
-cosim-run` diffs the core's *real* `regs` array — read through cxxrtl `debug_items` by
-`test/cosim.cc`, which touches no `rvfi_*` signal at all — against the Sail RISC-V model. All 49
-programs agree (24s for the suite, against 7.3s for `make test`). It is **not** on `make test`'s
-path and **not** a CI gate, on purpose: `make test` must keep working on a machine with no Sail
-installed. Do not wire it in without reading ADR-0032's consequences first — the `tohost`/HTIF
-overlap it works around is real and the fix belongs in shared test infrastructure.
+**There is a fourth thing you can run, and it is deliberately not a leg** (ADR-0032, ADR-0039).
+`make cosim-suite` diffs the core's *real* `regs` array — read through cxxrtl `debug_items` by
+`test/cosim.cc`, which touches no `rvfi_*` signal at all — against the Sail RISC-V model, over the
+whole suite, graded against `test/COSIM_EXPECTED_FAIL`: **50 of 52 agree, 10s**, against 7.3s for
+`make test`. `make cosim-run PROG=x.S` does one program. It is **not** on `make test`'s path and
+**not** in CI's required set, on purpose: `make test` must keep working on a machine with no Sail
+installed (demonstrated by moving `tools/sail` aside), and **adding it to branch protection is what
+ADR-0032 forbids**. The way a change gates on it is by carrying its pre/post output in the pull
+request. `test/cosim.cc` reading no `rvfi_*` signal is the property that makes this leg worth
+having; do not "align" it against `rvfi_valid`.
 
 `test/monitor.v` rides along in both sim legs (`b2dafcc`), so every run is self-checking per-retire —
 a test that corrupts state transiently but converges to the right final registers fails loudly, not
@@ -524,7 +551,7 @@ not against an oracle. An empty baseline is loudest exactly where the ladder is 
   the core does **not** currently place on the up5k (6659/5280 logic cells, 126%). Read ADR-0038
   before quoting any area number: yosys cell counts are blind to unpaired flip-flops and have
   produced two wrong estimates already.
-- Decisions: [`docs/adr/`](docs/adr/) — thirty-seven accepted ADRs, plus a deferred list
+- Decisions: [`docs/adr/`](docs/adr/) — thirty-nine accepted ADRs, plus a deferred list
 - Reference text from the old core: `git show 1709433^:rtl/riscv.v` (RVFI retire block),
   `git show e67875c^:rtl/alu.v` (arithmetic)
 - Work is tracked in Linear, project **Little CPU** (team JEF). Named here so you know where the
@@ -533,4 +560,5 @@ not against an oracle. An empty baseline is loudest exactly where the ladder is 
 **Deferred behind future ADRs** — forwarding network, radix-4 divider, negedge-BRAM regfile, FPGA
 timing closure, interrupts. Each trades away simplicity the current design depends on; none are
 safe to build while the core is unverified. (Sail co-sim came off this list in ADR-0032: the
-harness exists, opt-in; wiring it into `make test` or CI has not been decided.)
+harness exists and ADR-0039 runs it over the whole suite behind `make cosim-suite`, still opt-in;
+wiring it into `make test` or CI's required set is decided *against* and needs a new ADR to change.)

--- a/Makefile
+++ b/Makefile
@@ -44,16 +44,17 @@ sim: test/cxxrtl.cc test/rtl.cc
 	  -isystem $$(yosys-config --datdir)/include/backends/cxxrtl/runtime $< -o $@
 
 # ---------------------------------------------------------------------------
-# Sail co-simulation (docs/adr/0032) -- a SPIKE, deliberately opt-in.
+# Sail co-simulation (docs/adr/0032, docs/adr/0039) -- deliberately opt-in.
 #
-# Nothing below is reachable from `make test`, `make test-units` or CI. The
-# whole point of keeping it off the default path is that `make test` must
-# still work on a machine with no Sail installed, and a time-boxed experiment
-# must not quietly become a merge gate. Run it by hand:
+# Nothing below is reachable from `make test`, `make test-units` or CI's
+# required set. The whole point of keeping it off the default path is that
+# `make test` must still work on a machine with no Sail installed, and an
+# experiment must not quietly become a merge gate. Run it by hand:
 #
 #     make sail-setup     # once: fetch, verify and unpack the pinned release
 #     make cosim          # build the architectural-state tracer
 #     make cosim-run      # run it on one program (PROG=add.S by default)
+#     make cosim-suite    # run the whole suite, graded against the baseline
 # ---------------------------------------------------------------------------
 
 # The sail-riscv release this spike was run against, pinned the way
@@ -75,10 +76,10 @@ sim: test/cxxrtl.cc test/rtl.cc
 #
 # ADR-0033 gap 4 recorded the unverified fetch as accepted-because-opt-in, with
 # "give it pin.mk's treatment" as the precondition for ever putting co-sim on
-# `make test` or CI. That precondition is met here. It is the only one: the
-# rest of ADR-0032's integration list (the `tohost` doubleword, a
-# COSIM_EXPECTED_FAIL baseline, a nightly job) is untouched, and co-simulation
-# stays off every default path.
+# `make test` or CI. That precondition is met here. ADR-0039 then landed the
+# `tohost` doubleword and the `test/COSIM_EXPECTED_FAIL` baseline behind
+# `make cosim-suite`, and co-simulation still stays off every default path:
+# `make test`, `make test-units` and CI's required set do not reach any of it.
 ifneq ($(filter command line environment,$(origin SAIL_RISCV_VERSION)),)
 $(error SAIL_RISCV_VERSION cannot be set from the command line or the \
   environment: it pins bytes this repo executes. Change it in the Makefile, \
@@ -140,7 +141,7 @@ SAIL_PIN   := $(SAIL_RISCV_VERSION) $(SAIL_ASSET) $(SAIL_SHA256)
 # Scoped to the goals that actually run the binary. A stale tools/sail must not
 # break `make test`: co-simulation is opt-in (ADR-0032) and a guard on it that
 # could fail the suite would have made it a gate by the back door.
-ifneq ($(filter cosim-run,$(MAKECMDGOALS)),)
+ifneq ($(filter cosim-run cosim-suite,$(MAKECMDGOALS)),)
 ifneq ($(wildcard $(SAIL_SIM_BIN)),)
 SAIL_PIN_ON_DISK := $(shell sed -n 1p $(SAIL_STAMP) 2>/dev/null)
 ifneq ($(SAIL_PIN_ON_DISK),$(SAIL_PIN))
@@ -238,6 +239,19 @@ PROG ?= add.S
 .PHONY: cosim-run
 cosim-run: cosim
 	./test/cosim.py $(PROG)
+
+# The whole suite under co-simulation, graded by set equality in BOTH
+# directions against test/COSIM_EXPECTED_FAIL -- the same contract `make test`
+# applies to test/EXPECTED_FAIL (ADR-0014, ADR-0035). See docs/adr/0039.
+#
+# Deliberately NOT a prerequisite of `test`, `test-units` or anything CI
+# requires (ADR-0032). It needs a Sail install that `make test` must keep
+# working without, and the moment it became required it would stop being the
+# opt-in experiment it was accepted as. The regfile-to-block-RAM change gates
+# on it by pasting its output into the PR, not by branch protection.
+.PHONY: cosim-suite
+cosim-suite: cosim
+	./test/run_cosim.sh ./cosim test/asm test/COSIM_EXPECTED_FAIL
 
 # test/monitor.sim.v is a build-time-only, gitignored derivative of the
 # tracked test/monitor.v (ADR-0019). test/monitor.v itself stays

--- a/docs/adr/0039-co-simulation-runs-the-whole-suite-against-a-baseline.md
+++ b/docs/adr/0039-co-simulation-runs-the-whole-suite-against-a-baseline.md
@@ -1,0 +1,168 @@
+# ADR-0039: Co-simulation runs the whole suite against a baseline, and `tohost` becomes a doubleword
+
+**Status:** Accepted · 2026-07-31 · *Completes items (1) and (2) of ADR-0032's integration list.
+Amends ADR-0008 on the width of `tohost`. Applies ADR-0014's set-equality contract and ADR-0035's
+name-and-status format to a second gate.*
+
+## Context
+
+ADR-0032 built the co-simulation harness as a time-boxed spike and left suite-wide integration as
+future work. Two things have changed since, and both make finishing it worth doing now.
+
+**It is the only oracle in this repo that reads the real register array.** `test/monitor.v` and every
+`insn_*` check on the riscv-formal ladder evaluate a spec model on `rvfi_insn` / `rvfi_rs1_rdata` /
+`rvfi_rs2_rdata` and compare the result against `rvfi_rd_wdata` — the core's own account of itself.
+`reg_ch0` is the single check that ties that account back to `rtl/regfile.v`, and it is one `mode
+bmc` query at depth 21 (ADR-0024, ADR-0025), which ADR-0023 records as inconclusive. ADR-0032's
+mutation experiment measured the hole exactly: an extra architectural write outside the retiring
+instruction's `rd`, gated to fire after cycle 40, was missed by the whole `.S` suite with the
+per-retire monitor live **and** by the entire 78-check ladder, and caught by co-simulation in 0.6s.
+
+**The regfile is about to move to block RAM**, and that change cannot be gated on anything weaker.
+`make cosim-run` takes one program at a time and has no baseline, so today it cannot be a gate at
+all.
+
+There is a second, independent reason, measured while planning this: deleting the rs2 write-through
+bypass — a direct violation of CLAUDE.md invariant 6 — **passes `reg_ch0`**, while the `.S` suite
+catches it instantly (52 × `MONITOR-ERROR`). The formal ladder is not the oracle for that property.
+The simulation legs are, and this is one of them.
+
+## Decision
+
+**A per-program suite runner, graded by set equality in both directions against a baseline — and
+`tohost` widened to the doubleword the protocol it borrows always specified.**
+
+### 1. `tohost` is an 8-byte-aligned `.dword`, and the verdict macros write both halves
+
+`test/asm/riscv_test.h`'s `RVTEST_DATA_BEGIN` emitted `tohost` as a 32-bit `.word`. ADR-0008 places
+it at the base of RAM with `.data` immediately after, so every load/store test's `TEST_DATA` began
+four bytes *inside* the doubleword IO window any HTIF consumer claims at the symbol. Sail answered
+every `lw` from `RAM_BASE+4` with zero and eight programs "diverged" for a reason that was entirely
+this repo's fault. The spike worked around it by stripping the symbol from a throwaway ELF copy.
+
+Both workarounds are now gone. `tohost` is `.align 3` + `.dword 0`; the IO window covers only
+`tohost` itself; `test/cosim.py` hands the reference model **the same ELF the other two legs run**,
+unmodified.
+
+`RVTEST_PASS` and `RVTEST_FAIL` write the upper word (always zero) first and the verdict last.
+Sail's HTIF fires on a half-write once it has seen the other half, so this order makes the verdict
+store the single event that terminates the reference model — the same store `test/cxxrtl.cc` and
+`test/cosim.cc` already stop on when RAM's low word goes non-zero. Both sides end on the same
+instruction. Neither store writes a register, so the sequence of architectural register-file states
+is unchanged by the pair.
+
+**`--inst-limit` therefore goes back to being a runaway bound.** The spike used it as a convergence
+*criterion*, inferring "the reference reached a verdict" from its last eight traced PCs being a
+self-loop. Now `SUCCESS` / `FAILURE: <n>` on Sail's own output is the criterion, and a run that hits
+the limit without one is `INCONCLUSIVE` and is not compared. There is deliberately no fallback to
+Sail's process exit status: it is 0 both for `SUCCESS` and for hitting `--inst-limit`, so reading it
+would silently turn "never reached a verdict" into "the program passed".
+
+The verdicts themselves are compared as well, so a run in which the two ran the program to different
+outcomes is a divergence even in the case — unreachable if the register comparison is working — that
+the register traces matched.
+
+### 2. `test/run_cosim.sh` + `test/COSIM_EXPECTED_FAIL`, driven by `make cosim-suite`
+
+Shaped after `test/run_tests.sh`, and for the same reason: the failure mode that matters in a gate is
+a **false green**. The properties that exist only for that are the baseline being read and
+format-checked before the suite runs, the program list being checked for emptiness (a glob matching
+nothing would otherwise print `0/0 agreed` and match an empty baseline), and the per-program status
+coming from `test/cosim.py`'s own `COSIM-STATUS` line cross-checked against its exit code — a run
+that produced no status line is `COSIM-ERROR`, not a verdict about the core.
+
+The baseline is name-and-status per ADR-0035, and the statuses pin **how** the two disagreed:
+`DISAGREE AT <n>` (the index of the first differing architectural change), `DISAGREE LENGTH`,
+`DISAGREE VERDICT`, `INCONCLUSIVE SAIL-LIMIT`, `INCONCLUSIVE CORE-TIMEOUT`. A baselined program that
+starts diverging at a different point is diverging for a new reason and goes red.
+
+### 3. It stays opt-in — that part of ADR-0032 is not amended
+
+`make test`, `make test-units` and CI's required set reach none of it, and `make test` keeps working
+on a machine with no Sail installed. **Adding this to branch protection's required set is what
+ADR-0032 forbids**, and this ADR does not do it. The regfile change gates on co-simulation by
+carrying its pre/post output in the pull request, reviewed by a human — which is why criterion 5
+below is not decoration.
+
+## Rationale — measured, not argued
+
+**The suite is green and the baseline has two entries.** 52 programs, 50 agree, 10s wall (against
+7.3s for `make test`; the spike measured 24s, and the difference is HTIF termination replacing a
+run to the instruction limit).
+
+Both baselined entries are read-only CSR **value** divergences that no change to this core could
+close:
+
+- **`csr.S` — `DISAGREE AT 17`, `csrr a0, misa`.** Sail reports `0x4034112f` against this core's
+  `0x40001104` (ADR-0002). `misa` is not a configuration knob in the Sail model; it is derived from
+  the extension set. Bringing the two into agreement was attempted and measured: it needs A, B, D,
+  F, S, U and V disabled, and each disable pulls in a further cascade the model's own validator
+  demands — `Ssccptr`, `Svade`, `Svadu`, `Svvptc`, then the `Zve*`/`Zvfh*` family, then
+  `memory.physaddr_bits` and two `base.mstatus.*_legal_states` keys. That is a large,
+  version-fragile config edit to make one CSR read match, on a schema ADR-0032 already flags as
+  something a version bump moves. Recorded rather than chased.
+- **`minstret.S` — `DISAGREE AT 7`, `csrr a0, mcycle`.** `mcycle` counts cycles and the reference
+  model has no pipeline, so it counts something else by construction (6 against this core's 30 at
+  the same point). The rate is implementation-defined; the test asserts only monotonicity and a
+  bound, which is why it passes on both sides. No configuration makes a cycle-accurate reference
+  model out of an ISA model.
+
+**`trap.S` agrees, 214/214.** ADR-0030's causes against the reference model's own trap semantics,
+with `test/sail/memory-map.json`'s global `memory.misaligned.exceptions.load_store` set to
+`{"Some": "AlignmentException"}` to match ADR-0005's causes 4 and 6. No divergence in this suite is
+attributable to the memory-map configuration.
+
+**A gate that compares nothing is worse than no gate**, so the mutation was re-run against the
+integrated leg rather than inherited from ADR-0032. One extra architectural write (`regs[31] <=
+wdata` alongside `regs[waddr]`, gated to fire only after cycle 40 — ADR-0032's mutation B, reverted
+before commit):
+
+| Leg | Result under the mutation |
+|---|---|
+| `make test` — 52 `.S` under cxxrtl, per-retire RVFI monitor live in both sim legs | **52/52 PASS — misses it** |
+| `make cosim-suite` | **3/52 agreed — catches it in 49 programs**, and the gate exits 1 |
+
+The three that still agree (`jal.S`, `simple.S`, `straddle.S`) are the three too short to reach
+cycle 40, which is the mutation's own gate rather than a hole in the leg. `add.S` reproduces
+ADR-0032's measurement exactly:
+
+```
+DIVERGENCE at architectural change #18
+  sail instruction #27  pc=0x0000004a  add x14, x1, x2
+  sail : x14=0x80000000
+  core : x14=0x80000000 x31=0x80000000   (cycle 44, decode pc=0x00000054)
+```
+
+Note also that `csr.S`'s status moved from `DISAGREE AT 17` to `DISAGREE AT 11` under the mutation.
+That is the second field of the baseline doing its job: a baselined program that starts diverging
+earlier does not launder a new defect into a match.
+
+## Consequences
+
+- **`test/asm/riscv_test.h` is shared infrastructure and this changed it.** Every program's `.data`
+  moves four bytes and every program executes one extra store. `make test` (52/52) and
+  `make test-units` (six benches) were re-run green in the same change. `test/cxxrtl.cc`,
+  `test/cosim.cc` and `test/testbench.v` are untouched: `tohost` is still the first word at
+  `RAM_BASE`, and the upper word stays zero, so reading the low word alone remains a faithful read
+  of the riscv-tests encoding on a little-endian machine.
+- **This leg inherits the `.S` suite's coverage exactly**, as ADR-0032 already said. It says nothing
+  about instructions or operand patterns those 52 programs never reach — including the real
+  multiplier and divider on untested operands (ADR-0010). It makes the programs already being run
+  check vastly more per run; it is not a proof and does not become one.
+- **Nothing runs it by default, so nothing notices if nobody runs it.** That is the accepted cost of
+  staying off CI's required set, and it is why the regfile change carries pasted output rather than
+  a green check. A nightly job — ADR-0032's integration item (3), with the formal nightly as
+  precedent — is still unbuilt, and ADR-0037's warning applies to it in advance: never put the
+  graded command in a pipeline in a `run:` block.
+- **`test/cosim.py`'s exit codes changed**: 0 agree, 1 disagree, **2 inconclusive**, 3 setup error.
+  Inconclusive used to share 3 with a broken setup, which is exactly the conflation ADR-0035 spent
+  a whole decision separating. `make cosim-run` is otherwise unchanged.
+- **`test/cosim.cc` still reads no `rvfi_*` signal**, and must not start. ADR-0032's consequence
+  stands unamended: the moment it samples one to align its trace it stops being independent of the
+  oracle it exists to cross-check, and the mutation table above stops holding. Nothing in this
+  change goes near it — `test/cosim.cc:183`'s `"uut regfile regs"` bind and `:191`'s `depth == 32`
+  assertion are deliberately left as they are for the regfile change to repoint.
+- **ADR-0032's integration list is now items (3) and (4).** The nightly, and extending the
+  comparison to memory (`--dump-memory` on one side, the RAM array already in hand on the other),
+  which would cover stores — checked today only by `dmemcheck`, bounded, and by whatever the test
+  program asserts.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -43,6 +43,7 @@ and what it costs. Reversing one is fine — write a new ADR that supersedes it.
 | [0036](0036-three-gate-hardening-decisions-ratified-at-integration.md) | Three gate-hardening decisions ratified at integration, and a correction to ADR-0031 | Accepted |
 | [0037](0037-an-empty-baseline-is-not-m2.md) | An empty formal baseline is not M2, and the milestone criterion said it was | Accepted |
 | [0038](0038-area-is-measured-in-logic-cells-and-two-levers-are-rejected.md) | Area is measured in logic cells, Fmax is declared at 12 MHz, and two area levers are rejected | Accepted |
+| [0039](0039-co-simulation-runs-the-whole-suite-against-a-baseline.md) | Co-simulation runs the whole suite against a baseline, and `tohost` becomes a doubleword | Accepted |
 
 0001–0007 came from the design brief
 ([`docs/ideas/finish-the-rewrite.md`](../ideas/finish-the-rewrite.md)). 0008–0011 came out of
@@ -78,7 +79,11 @@ recorded integrating those three gate changes together: it ratifies putting `han
 that never retires), corrects 0031 on how the `csrc_*` family is actually reached, and closes the
 `case_default` question by measuring that yosys already errors on the latch. It also records a
 gap it did not close: `formal/EXPECTED_FAIL` still matches on names only, so a red check that flips
-from `FAIL` to `ERROR` keeps the ladder green — 0035's lesson, unapplied to the formal side.
+from `FAIL` to `ERROR` keeps the ladder green — 0035's lesson, unapplied to the formal side. 0039
+finishes the first half of 0032's integration list: the whole `.S` suite now runs under
+co-simulation behind `make cosim-suite`, graded by 0014's set equality in 0035's name-and-status
+format, and `tohost` becomes the doubleword the HTIF protocol it borrows always specified — an
+amendment to 0008, and the one change here that touches what both existing sim legs read.
 
 ## Deferred decisions
 
@@ -104,5 +109,6 @@ trades away simplicity the current design depends on.
 - ~~**Spike or Sail co-simulation**~~ — **resolved by [ADR-0032](0032-sail-co-simulation-is-worth-building-and-stays-opt-in.md).**
   The old test ("revisit only if formal and simulation ever disagree") could only fire on a bug both
   legs can see; a spike measured what neither can. The harness exists and is deliberately opt-in —
-  `make cosim-run`, never `make test`, never CI. Integrating it across the whole suite is
-  still future work, scoped in that ADR's consequences.
+  `make cosim-run` / `make cosim-suite`, never `make test`, never CI's required set.
+  [ADR-0039](0039-co-simulation-runs-the-whole-suite-against-a-baseline.md) integrated it across the
+  whole suite against a baseline; a nightly job and memory comparison remain future work.

--- a/test/COSIM_EXPECTED_FAIL
+++ b/test/COSIM_EXPECTED_FAIL
@@ -1,0 +1,63 @@
+# The co-simulation baseline (ADR-0039), in ADR-0035's format and under
+# ADR-0014's contract. `make cosim-suite` exits 0 only when the set of programs
+# that do NOT agree with the Sail RISC-V model matches this file exactly, in
+# both directions — so an unexpected *agreement* is caught too.
+#
+# FORMAT — two fields, not one:
+#
+#     <test>.S  <STATUS>
+#
+# The status is the exact label test/run_cosim.sh prints in its table:
+#
+#   DISAGREE AT <n>      the two register traces differ at architectural
+#                        change n (the FIRST one that differs)
+#   DISAGREE LENGTH      the traces agree as far as the shorter one goes, but
+#                        one side made more architectural changes than the other
+#   DISAGREE VERDICT     identical register traces, different pass/fail verdicts
+#   INCONCLUSIVE SAIL-LIMIT | INCONCLUSIVE CORE-TIMEOUT
+#                        one side ran out of budget; nothing was compared
+#   COSIM-ERROR <...>    the harness failed. Nothing should ever be baselined
+#                        under this — it describes a broken setup, not a known
+#                        property — but the format admits it, and a line under
+#                        it is a review flag.
+#
+# Whitespace between the fields is free; a line with only a name is rejected
+# rather than half-matched.
+#
+# Pinning the divergence POINT is the whole reason the second field is here. A
+# baselined program that starts diverging somewhere else is diverging for a new
+# reason, and that is a red gate, not a match. Changing a status is the same
+# kind of claim as removing the line and needs the same justification in the PR
+# that does it. This file is never regenerated wholesale from a run.
+#
+# Both entries below are read-only-CSR value divergences, not core defects, and
+# neither is reachable by fixing this core:
+#
+#   csr.S       DISAGREE AT 17 -- `csrr a0, misa`. Sail reports 0x4034112f
+#               against this core's 0x40001104 (ADR-0002's RV32IMC_Zicsr).
+#               misa is not a knob in the Sail configuration; it is derived
+#               from the extension set, and bringing the two into agreement
+#               means disabling A, B, D, F, S, U and V in
+#               test/sail/memory-map.json — measured, and each disable pulls in
+#               a further cascade of dependent-extension and paging keys the
+#               model's own validator demands (Ssccptr, Svade, Svadu, Svvptc,
+#               then the Zve*/Zvfh* family, then physaddr_bits and two
+#               mstatus.*_legal_states). That is a large, version-fragile
+#               config edit to make one CSR read match, on a model whose
+#               config schema ADR-0032 already flags as something a version
+#               bump moves. Not worth it; recorded here instead.
+#
+#   minstret.S  DISAGREE AT 7 -- `csrr a0, mcycle`. mcycle counts CYCLES, and
+#               the reference model has no pipeline, so it counts something
+#               else by construction (6 against this core's 30 at the same
+#               point). The rate of mcycle is implementation-defined; the test
+#               itself asserts only monotonicity and a bound, which is why it
+#               passes on both sides. There is nothing here for either side to
+#               fix, and no configuration that would make a cycle-accurate
+#               reference model out of an ISA model.
+#
+# Everything else in the suite AGREES, including trap.S (ADR-0030's causes,
+# with test/sail/memory-map.json's global misaligned-exception key set to match
+# ADR-0005) and rvc.S/straddle.S (ADR-0003's compressed fetch window).
+csr.S           DISAGREE AT 17
+minstret.S      DISAGREE AT 7

--- a/test/asm/riscv_test.h
+++ b/test/asm/riscv_test.h
@@ -4,9 +4,11 @@
 // modes and no PMP, so none of that setup belongs here. RVTEST_CODE_BEGIN just
 // establishes `_start` and zeroes the test-number register;
 // RVTEST_PASS/RVTEST_FAIL write the riscv-tests `tohost` encoding (ADR-0008) to
-// a fixed word in RAM and spin. The cxxrtl runner (test/cxxrtl.cc) and the
-// iverilog bench watch that address for the magic write instead of relying on
-// ecall/mtvec.
+// a fixed doubleword at the base of RAM and spin. The cxxrtl runner
+// (test/cxxrtl.cc) and the iverilog bench watch that address for the magic
+// write instead of relying on ecall/mtvec; the Sail model (ADR-0032) speaks
+// the same HTIF protocol and terminates on it. See RVTEST_DATA_BEGIN for why
+// the doubleword width is not cosmetic.
 //
 // The trap-handler macros at the bottom are strictly opt-in and
 // RVTEST_CODE_BEGIN is deliberately untouched by them: the suite's other tests
@@ -70,9 +72,24 @@ _start:                                                                      \
 #define RVTEST_CODE_END                                                      \
 1:      j       1b
 
+// Both verdict macros write the doubleword's UPPER word first and the verdict
+// itself last, and the order is deliberate (ADR-0039). This core has no 64-bit
+// store, so the doubleword `tohost` is written as two `sw`s; Sail's HTIF fires
+// on each half-write once the other half has been seen, so writing the upper
+// (always-zero) word first makes the verdict store the single event that
+// terminates the reference model -- the same store test/cxxrtl.cc and
+// test/cosim.cc already stop on when RAM_BASE's low word goes non-zero. Both
+// sides then end on the same instruction. Writing them the other way round
+// works too, but leaves the reference model running one store longer than the
+// core, for no gain.
+//
+// Neither store writes a register, so the sequence of architectural
+// register-file states -- which is what ADR-0032's co-simulation compares --
+// is unchanged by this pair.
 #define RVTEST_PASS                                                          \
         li      TESTNUM, 1;                                                 \
         la      t0, tohost;                                                 \
+        sw      x0, 4(t0);                                                  \
         sw      TESTNUM, 0(t0);                                             \
 1:      j       1b
 
@@ -80,15 +97,39 @@ _start:                                                                      \
         sll     TESTNUM, TESTNUM, 1;                                        \
         or      TESTNUM, TESTNUM, 1;                                        \
         la      t0, tohost;                                                 \
+        sw      x0, 4(t0);                                                  \
         sw      TESTNUM, 0(t0);                                             \
 1:      j       1b
 
+// `tohost` is a full DOUBLEWORD, 8-byte aligned, and both of those are
+// load-bearing rather than cosmetic (ADR-0039, amending ADR-0008).
+//
+// The riscv-tests HTIF protocol this encoding is borrowed from defines
+// `tohost` as a 64-bit location, and every consumer that speaks HTIF -- the
+// Sail RISC-V model among them -- claims the whole doubleword at the symbol
+// as an IO window the moment it sees the symbol in the ELF. It was a 32-bit
+// `.word` here, so `.data` (every load/store test's TEST_DATA, ADR-0008 puts
+// it immediately after) began four bytes INSIDE that window: the reference
+// model answered every `lw` from RAM_BASE+4 with zero. Eight programs
+// "diverged" for a reason that was entirely this file's fault.
+//
+// Padding it is what makes the co-simulation leg (ADR-0032) able to hand Sail
+// the same ELF the other two legs run, unmodified, and to terminate on the
+// verdict rather than on an instruction budget.
+//
+// Nothing else moves. `tohost` is still the first thing in the RAM region and
+// still the low word at RAM_BASE, so test/cxxrtl.cc's `ram_data[0]`,
+// test/cosim.cc's, and test/testbench.v's RAM decode are all unchanged; the
+// `.data` that follows simply starts four bytes later. RVTEST_PASS/FAIL still
+// write it with a 32-bit `sw` -- this core has no 64-bit store -- and the
+// upper word stays zero, which is what makes the low word alone a faithful
+// read of the riscv-tests encoding on a little-endian machine.
 #define RVTEST_DATA_BEGIN                                                    \
         .pushsection .tohost,"aw",@progbits;                                \
-        .align  2;                                                          \
+        .align  3;                                                          \
         .global tohost;                                                     \
 tohost:                                                                      \
-        .word   0;                                                          \
+        .dword  0;                                                          \
         .popsection;                                                        \
         .data;                                                              \
         .align  2;

--- a/test/cosim.py
+++ b/test/cosim.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 """Lockstep co-simulation of this core against the Sail RISC-V model.
 
-A spike, not a fourth verification leg: `make test` neither builds nor runs
-this, and CI does not gate on it. See docs/adr/0032 for what it is for and
-what it costs.
+One program per invocation; test/run_cosim.sh runs the suite and grades it
+against test/COSIM_EXPECTED_FAIL. Opt-in, and it stays that way: `make test`
+neither builds nor runs any of this and CI does not gate on it. See
+docs/adr/0032 for what it is for and what it costs, and docs/adr/0039 for
+what suite-wide integration changed.
 
 WHAT IS ACTUALLY COMPARED
 -------------------------
@@ -24,32 +26,32 @@ counts as an event without special-casing.  Writes to x0 are dropped on the
 Sail side for the same reason -- rtl/regfile.v guards them and the ISA makes
 them unobservable.
 
-HTIF HAS TO BE DISABLED, AND THAT IS A REAL FINDING
----------------------------------------------------
-Sail auto-detects HTIF from the ELF's `tohost` symbol and then claims the
-whole DOUBLEWORD at that address as an IO window.  ADR-0008 puts `tohost` at
-the base of the RAM region and test/asm/riscv_test.h emits it as a 32-bit
-`.word`, so `.data` -- every load/store test's TEST_DATA -- starts four bytes
-later, INSIDE that window.  Left alone, Sail answers every `lw` from 0x10004
-with zero (`--trace-mem` shows `htif[0x000010004] -> 0x0` ahead of the read)
-and eight of this suite's programs "diverge" for a reason that is entirely
-the harness's fault.
+HTIF IS SPOKEN, NOT WORKED AROUND
+--------------------------------
+Sail auto-detects HTIF from the ELF's `tohost` symbol and claims the whole
+DOUBLEWORD at that address as an IO window.  `tohost` used to be a 32-bit
+`.word` at the base of RAM, so `.data` -- every load/store test's TEST_DATA,
+which ADR-0008 places immediately after -- began four bytes INSIDE that
+window: Sail answered every `lw` from 0x10004 with zero and eight programs
+"diverged" for a reason that was entirely this repo's fault.  The spike
+(ADR-0032) worked around it by stripping the symbol from a throwaway ELF copy
+and then bounding the reference run with `--inst-limit`, checking it had
+reached the pass/fail spin loop by looking for a self-loop at one PC.
 
-It also does not help on the other side: HTIF acts on a 64-bit doubleword
-write, and RVTEST_PASS stores with `sw`, so the run does not terminate on the
-verdict either (`--trace-htif` logs the write and keeps going).
+Both workarounds are gone.  test/asm/riscv_test.h now emits `tohost` as an
+8-byte-aligned `.dword` (ADR-0039), which is what the HTIF protocol always
+specified, so the IO window covers only `tohost` itself and Sail reads test
+data out of real memory.  The verdict macros write the doubleword's upper
+word first and the verdict last, so the reference model TERMINATES on the
+same store the cxxrtl runners stop on, and `--inst-limit` goes back to being
+what it should always have been: a runaway bound, not a convergence
+criterion.  A run that hits it without an HTIF verdict is INCONCLUSIVE and
+says so, rather than being compared and reported as a finding.
 
-So the ELF handed to Sail gets its `tohost` symbol stripped -- a harness-side
-`objcopy` on a throwaway copy, changing nothing about what either existing
-sim leg builds or how ADR-0008's protocol works.  The reference run is then
-bounded with `--inst-limit` and confirmed to have reached the pass/fail spin
-loop by checking that its last instructions are a self-loop at one PC.
-
-The alternative -- padding `tohost` to a full doubleword in riscv_test.h so
-it stops overlapping test data, which is what upstream riscv-tests does -- is
-the better long-term fix and would buy a clean HTIF exit as well.  It is a
-change to shared test infrastructure that both existing legs read, so it
-belongs in the integration ticket, not in a spike.
+Both sides' verdicts are compared as well as their register traces, so a run
+where the reference model passes the program and the core fails it (or the
+reverse) is a divergence even in the impossible case that the register
+sequences matched.
 """
 
 import argparse
@@ -193,7 +195,11 @@ def find_sail(explicit):
 
 def assemble(cc, src, outdir):
     """Assemble one test/asm/*.S exactly as test/run_tests.sh does, and emit
-    the ELF (for Sail) plus the two objcopy images (for the cxxrtl runner)."""
+    the ELF (for Sail) plus the two objcopy images (for the cxxrtl runner).
+
+    The reference model gets the SAME ELF, unmodified -- no stripped symbol,
+    no throwaway copy (ADR-0039). If the two legs ever stop building from
+    identical bytes, this is the function that would have to say so."""
     base = os.path.splitext(os.path.basename(src))[0]
     elf = os.path.join(outdir, base + ".elf")
     rom = os.path.join(outdir, base + ".rom.hex")
@@ -214,18 +220,34 @@ def assemble(cc, src, outdir):
             [objcopy, "-O", "verilog", "--verilog-data-width=4", *args, elf, out],
             check=True, capture_output=True,
         )
-    # A throwaway copy with `tohost` removed from the symbol table, so Sail
-    # does not auto-detect HTIF and shadow the test data that ADR-0008's
-    # memory map places immediately after it. See the module docstring.
-    sail_elf = os.path.join(outdir, base + ".sail.elf")
-    subprocess.run([objcopy, "--strip-symbol=tohost", elf, sail_elf],
-                   check=True, capture_output=True)
-    return sail_elf, rom, ram
+    return elf, rom, ram
+
+
+def sail_verdict(output):
+    """The reference model's HTIF verdict, in the vocabulary test/cosim.cc
+    prints for the core, or None if the run did not reach one.
+
+    Sail terminates on the doubleword `tohost` write (ADR-0039) and announces
+    it: `SUCCESS` for the riscv-tests pass encoding, `FAILURE: <n>` for
+    `(testnum << 1) | 1`, where n is the test number. There is deliberately no
+    fallback to the process exit status -- it is 0 both for SUCCESS and for
+    hitting `--inst-limit`, so reading it would turn "the reference model never
+    reached the program's verdict" into "the program passed".
+    """
+    for line in output.splitlines():
+        line = line.strip()
+        if line == "SUCCESS":
+            return "PASS"
+        m = re.match(r"^FAILURE:\s+(\d+)", line)
+        if m:
+            return f"FAIL {m.group(1)}"
+    return None
 
 
 def run_sail(sail, elf, inst_limit, outdir):
     """Run the reference model and return its list of distinct register-file
-    states, each tagged with the instruction that produced it."""
+    states, each tagged with the instruction that produced it, plus the HTIF
+    verdict it terminated on (None if it never reached one)."""
     trace = os.path.join(outdir, "sail.trace")
     proc = subprocess.run(
         [sail, "--rv32", "--config-override", MEMORY_MAP,
@@ -238,7 +260,7 @@ def run_sail(sail, elf, inst_limit, outdir):
 
     regs = [0] * 32
     records = []       # (change_index, sail_idx, pc, disasm, {reg: val})
-    tail_pcs = []
+    saw_insn = False
     current = None     # (idx, pc, disasm)
     pending = {}
 
@@ -260,9 +282,7 @@ def run_sail(sail, elf, inst_limit, outdir):
                 flush()
                 current = (int(m.group("idx")), int(m.group("pc"), 16),
                            m.group("disasm"))
-                tail_pcs.append(current[1])
-                if len(tail_pcs) > 8:
-                    tail_pcs.pop(0)
+                saw_insn = True
                 continue
             m = GPR_RE.match(line)
             if m and current is not None:
@@ -271,14 +291,9 @@ def run_sail(sail, elf, inst_limit, outdir):
                     pending[reg] = int(m.group("val"), 16)
     flush()
 
-    if not tail_pcs:
+    if not saw_insn:
         raise Fatal(f"sail traced no instructions:\n{proc.stdout}{proc.stderr}")
-    # riscv_test.h's RVTEST_PASS/RVTEST_FAIL both end in `1: j 1b`, so a run
-    # that reached a verdict is parked on one PC. If it is not, --inst-limit
-    # cut the reference short and any length mismatch below would be an
-    # artefact of this harness rather than a finding.
-    converged = len(set(tail_pcs)) == 1 and len(tail_pcs) == 8
-    return records, converged, tail_pcs[-1]
+    return records, sail_verdict(proc.stdout + proc.stderr)
 
 
 def run_dut(binary, rom, ram, cycles):
@@ -315,9 +330,14 @@ def fmt(writes):
 
 
 def compare(sail_records, dut_records):
-    """Return (ok, list_of_report_lines). Reports the FIRST divergence with
+    """Return (status, list_of_report_lines). Reports the FIRST divergence with
     instruction number, PC and both values, per the spike's acceptance
-    criteria."""
+    criteria.
+
+    `status` is "AGREE" or one of the DISAGREE labels test/run_cosim.sh
+    baselines against test/COSIM_EXPECTED_FAIL. The labels distinguish HOW the
+    two disagreed, so a baselined program that starts diverging somewhere else
+    is a red gate rather than a match (ADR-0035)."""
     out = []
     for i in range(min(len(sail_records), len(dut_records))):
         _, sidx, spc, sdis, swrites = sail_records[i]
@@ -328,7 +348,7 @@ def compare(sail_records, dut_records):
             out.append(f"  sail : {fmt(swrites)}")
             out.append(f"  core : {fmt(dwrites)}   (cycle {cycle}, "
                        f"decode pc=0x{dpc:08x})")
-            return False, out
+            return f"DISAGREE AT {i}", out
     if len(sail_records) != len(dut_records):
         n = min(len(sail_records), len(dut_records))
         out.append(
@@ -345,8 +365,34 @@ def compare(sail_records, dut_records):
         else:
             out.append(f"  first unmatched ({label}): cycle {extra[1]} "
                        f"-> {fmt(extra[2])} (decode pc=0x{extra[3]:08x})")
-        return False, out
-    return True, out
+        return "DISAGREE LENGTH", out
+    return "AGREE", out
+
+
+def core_verdict(raw):
+    """test/cosim.cc's terminator line reduced to sail_verdict()'s vocabulary.
+
+    `PASS <cycle>` -> "PASS", `FAIL <n> <cycle>` -> "FAIL <n>", `TIMEOUT` ->
+    None. The cycle number is dropped on purpose: it is the one part of the
+    verdict the reference model has no opinion about."""
+    fields = raw.split()
+    if not fields or fields[0] == "TIMEOUT":
+        return None
+    if fields[0] == "FAIL" and len(fields) >= 2:
+        return f"FAIL {fields[1]}"
+    return fields[0]
+
+
+# The one line test/run_cosim.sh reads. Everything else this script prints is
+# for a human; this is the machine-readable verdict, and it is emitted for
+# every outcome that got as far as running both sides. Its absence means the
+# run did not get that far, which the suite runner reports as its own label
+# rather than as a verdict about the core.
+STATUS_PREFIX = "COSIM-STATUS"
+
+
+def emit(status):
+    print(f"{STATUS_PREFIX} {status}")
 
 
 def main():
@@ -360,6 +406,9 @@ def main():
     ap.add_argument("--inst-limit", type=int, default=20000,
                     help="sail instruction budget")
     ap.add_argument("--quiet", action="store_true")
+    ap.add_argument("--check-setup", action="store_true",
+                    help="probe the toolchain, the pinned sail binary and the "
+                         "cosim runner, then exit; runs no program")
     args = ap.parse_args()
 
     try:
@@ -367,6 +416,15 @@ def main():
         sail, sail_provenance = find_sail(args.sail)
         if not os.path.isfile(args.cosim_binary):
             raise Fatal(f"{args.cosim_binary} not built. Run 'make cosim'.")
+        # test/run_cosim.sh calls this once before the suite, so a missing
+        # toolchain or an unverified sail binary says so once, up front,
+        # instead of as 52 identical per-program errors.
+        if args.check_setup:
+            print(f"cross compiler     : {cc}")
+            print(f"sail               : {sail}")
+            print(f"sail provenance    : {sail_provenance}")
+            print(f"cosim runner       : {args.cosim_binary}")
+            return 0
         src = args.program
         if not os.path.isabs(src):
             src = os.path.join(ASM_DIR, os.path.basename(src))
@@ -375,41 +433,59 @@ def main():
 
         with tempfile.TemporaryDirectory(prefix="littlecpu-cosim.") as outdir:
             elf, rom, ram = assemble(cc, src, outdir)
-            sail_records, converged, last_pc = run_sail(
+            sail_records, sail_end = run_sail(
                 sail, elf, args.inst_limit, outdir)
-            dut_records, verdict = run_dut(
+            dut_records, dut_end_raw = run_dut(
                 args.cosim_binary, rom, ram, args.cycles)
     except Fatal as e:
         print(f"error: {e}", file=sys.stderr)
         return 3
 
     name = os.path.basename(src)
+    dut_end = core_verdict(dut_end_raw)
     if not args.quiet:
         print(f"program            : {name}")
         print(f"sail               : {sail}")
         print(f"sail provenance    : {sail_provenance}")
         print(f"sail changes       : {len(sail_records)}  "
-              f"(spin-loop reached: {converged}, last pc=0x{last_pc:08x})")
-        print(f"core changes       : {len(dut_records)}   (tohost: {verdict})")
+              f"(htif verdict: {sail_end})")
+        print(f"core changes       : {len(dut_records)}   "
+              f"(tohost: {dut_end_raw})")
 
-    if not converged:
+    # Neither budget is a finding. A run that ran out of one was never
+    # compared against a complete reference, so reporting it as agreement or
+    # as a divergence would both be lies about what was measured.
+    if sail_end is None:
         print(f"INCONCLUSIVE {name}: sail hit --inst-limit "
-              f"{args.inst_limit} without reaching the pass/fail spin loop; "
-              f"raise it.", file=sys.stderr)
-        return 3
-    if verdict.startswith("TIMEOUT"):
+              f"{args.inst_limit} without an HTIF verdict; raise it.",
+              file=sys.stderr)
+        emit("INCONCLUSIVE SAIL-LIMIT")
+        return 2
+    if dut_end is None:
         print(f"INCONCLUSIVE {name}: the core hit its {args.cycles}-cycle "
               f"budget without a tohost verdict.", file=sys.stderr)
-        return 3
+        emit("INCONCLUSIVE CORE-TIMEOUT")
+        return 2
 
-    ok, report = compare(sail_records, dut_records)
-    if ok:
+    status, report = compare(sail_records, dut_records)
+    if status == "AGREE" and sail_end != dut_end:
+        # Unreachable by construction if the register comparison is doing its
+        # job -- the verdict is a store of a value the program computed into a
+        # register first -- which is exactly why it is worth asserting: if it
+        # ever fires, the register comparison stopped comparing.
+        status = "DISAGREE VERDICT"
+        report = [f"DIVERGENCE in verdict: sail ran the program to {sail_end}, "
+                  f"the core to {dut_end}, with identical register traces"]
+
+    if status == "AGREE":
         print(f"AGREE {name}: {len(sail_records)} architectural register-file "
-              f"changes, identical in order and value.")
+              f"changes, identical in order and value; both ran to {sail_end}.")
+        emit(status)
         return 0
     print(f"DISAGREE {name}")
     for line in report:
         print(line)
+    emit(status)
     return 1
 
 

--- a/test/run_cosim.sh
+++ b/test/run_cosim.sh
@@ -1,0 +1,158 @@
+#!/bin/bash
+# Runs every test/asm/*.S under Sail co-simulation (test/cosim.py, ADR-0032)
+# and checks the resulting table against test/COSIM_EXPECTED_FAIL — the same
+# set-equality contract, in both directions, on name-and-status pairs, that
+# test/run_tests.sh applies to test/EXPECTED_FAIL (ADR-0014, ADR-0035).
+# Invoked by `make cosim-suite`. See docs/adr/0039.
+#
+# Usage: run_cosim.sh <cosim-binary> <asm-dir> <expected-fail-file>
+#
+# This is NOT on `make test`'s path and NOT in CI's required set, deliberately
+# (ADR-0032): it needs a Sail install that `make test` must keep working
+# without. What it is instead is the gate the block-RAM regfile change has to
+# pass, because it is the only oracle in this repo that reads the real
+# register array rather than the core's RVFI self-report.
+#
+# That makes a FALSE GREEN the failure mode that matters, exactly as in
+# run_tests.sh, and the properties below exist only for it:
+#
+#   * the baseline is read and format-checked BEFORE the suite runs, so a
+#     mistyped path fails in a second rather than after a full run having
+#     compared nothing;
+#   * the program list is checked for emptiness. A glob that matches nothing
+#     would otherwise print "0/0 passed" and match an empty baseline exactly;
+#   * the per-program status comes from cosim.py's own COSIM-STATUS line, not
+#     from its exit code alone, and a run that produced no such line is
+#     labelled COSIM-ERROR rather than being scored as a verdict about the
+#     core. "The harness broke" and "the core diverged" must not be the same
+#     table entry;
+#   * the failure set records NAME AND STATUS. A baselined program that
+#     starts diverging at a different point, in a different way, or that stops
+#     running at all, is a red gate rather than a match.
+#
+# `set -e` is on; every place a nonzero status is expected handles it at its
+# own call site.
+set -euo pipefail
+
+if [ "$#" -ne 3 ]; then
+  echo "usage: run_cosim.sh <cosim-binary> <asm-dir> <expected-fail-file>" >&2
+  exit 1
+fi
+
+COSIM_BIN=$1
+ASM_DIR=$2
+EXPECTED_FAIL=$3
+HERE=$(cd "$(dirname "$0")" && pwd)
+COSIM_PY="$HERE/cosim.py"
+
+if [ ! -f "$EXPECTED_FAIL" ] || [ ! -r "$EXPECTED_FAIL" ]; then
+  echo "error: baseline '$EXPECTED_FAIL' does not exist or is not readable." >&2
+  echo "The gate compares the divergence set against it; without it there is no gate." >&2
+  exit 1
+fi
+
+if [ ! -x "$COSIM_PY" ]; then
+  echo "error: $COSIM_PY is missing or not executable." >&2
+  exit 1
+fi
+
+# Whitespace-normalised name-and-status pairs. `NF` gates the rebuild rather
+# than following it: awk forces NF to 1 when $1 is assigned, so `{$1=$1} NF`
+# would resurrect blank and comment-only lines as empty entries.
+expected_sorted=$(sed -e 's/#.*//' "$EXPECTED_FAIL" | awk 'NF { $1=$1; print }' | sort)
+
+# A one-field line is a name with no status. Accepting it would make the entry
+# unmatchable in a way that reads like a regression, so name the format — and
+# do it HERE, before the suite runs, rather than after ten seconds of work that
+# was never going to be gradeable.
+malformed=$(printf '%s\n' "$expected_sorted" | awk 'NF == 1 {print}')
+if [ -n "$malformed" ]; then
+  echo "error: $EXPECTED_FAIL has entries with no status (the format is" >&2
+  echo "'<test>.S <STATUS>', e.g. 'csr.S DISAGREE AT 17'):" >&2
+  printf '  %s\n' "$malformed" >&2
+  exit 1
+fi
+
+# One setup probe for the whole suite: the cross compiler, the pinned and
+# digest-checked sail binary, and the cxxrtl co-sim runner. Without Sail this
+# is where the run stops, with the message naming `make sail-setup` — which is
+# the whole point of the leg being opt-in.
+if ! "$COSIM_PY" --check-setup --cosim-binary "$COSIM_BIN"; then
+  echo "error: co-simulation setup is incomplete; nothing was run." >&2
+  exit 1
+fi
+echo
+
+shopt -s nullglob
+programs=("$ASM_DIR"/*.S)
+shopt -u nullglob
+if [ "${#programs[@]}" -eq 0 ]; then
+  echo "error: no .S programs found in '$ASM_DIR'." >&2
+  echo "An empty suite would match an empty baseline and report success." >&2
+  exit 1
+fi
+
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/littlecpu-cosim.XXXXXX") || {
+  echo "error: could not create a temporary directory under ${TMPDIR:-/tmp}." >&2
+  exit 1
+}
+if [ -z "$tmp" ] || [ ! -d "$tmp" ]; then
+  echo "error: mktemp -d produced no usable directory under ${TMPDIR:-/tmp}." >&2
+  exit 1
+fi
+trap 'rm -rf "$tmp"' EXIT
+
+declare -a failures=()
+declare -a table=()
+agreed=0
+
+for src in "${programs[@]}"; do
+  name=$(basename "$src")
+  base=${name%.S}
+  log="$tmp/$base.log"
+
+  # Error-exit is lifted for exactly this call — cosim.py's nonzero exits are
+  # verdicts, not accidents — and restored immediately.
+  set +e
+  "$COSIM_PY" --quiet --cosim-binary "$COSIM_BIN" "$name" > "$log" 2>&1
+  rc=$?
+  set -e
+
+  # The status line is the contract; the exit code is the cross-check. They
+  # disagreeing means cosim.py changed under this script, which is a broken
+  # harness and must not read as a verdict about the core.
+  status=$(awk '/^COSIM-STATUS /{ $1=""; sub(/^ /,""); print; exit }' "$log")
+  if [ -z "$status" ]; then
+    status="COSIM-ERROR $rc"
+  elif { [ "$rc" -eq 0 ] && [ "$status" != "AGREE" ]; } ||
+       { [ "$rc" -ne 0 ] && [ "$status" = "AGREE" ]; }; then
+    status="COSIM-ERROR status/exit mismatch $rc"
+  fi
+
+  if [ "$status" = "AGREE" ]; then
+    agreed=$((agreed + 1))
+  else
+    failures+=("$name $status")
+    echo "--- $name ---" >&2
+    cat "$log" >&2
+  fi
+  table+=("$(printf '%-16s %s' "$name" "$status")")
+done
+
+printf '%s\n' "${table[@]}"
+echo
+echo "$agreed/${#table[@]} agreed"
+
+# Normalised the same way $expected_sorted was, up at the top of the script.
+actual_sorted=$(printf '%s\n' "${failures[@]:-}" | awk 'NF { $1=$1; print }' | sort)
+
+if [ "$actual_sorted" = "$expected_sorted" ]; then
+  echo "Divergence list matches $EXPECTED_FAIL exactly (name and status)."
+  exit 0
+fi
+
+echo
+echo "Divergence list does NOT match $EXPECTED_FAIL:" >&2
+diff <(echo "$expected_sorted") <(echo "$actual_sorted") \
+  --label expected --label actual >&2 || true
+exit 1

--- a/test/sail/memory-map.json
+++ b/test/sail/memory-map.json
@@ -16,13 +16,16 @@
 // Nothing needs it, because the PC is taken from the ELF entry point rather
 // than from a reset vector in that window.
 //
-// The model detects HTIF from the ELF's `tohost` symbol and reports
-// "HTIF located at 0x10000", but does not terminate on this suite's write:
-// test/asm/riscv_test.h's `tohost` is a 32-bit `.word` and the write is an
-// `sw`, which is not the 64-bit doubleword HTIF acts on. That is fine here --
-// test/cosim.py bounds the reference run with `--inst-limit` and truncates
-// both traces at their last architectural change instead (see the "why not
-// HTIF" note there).
+// The model detects HTIF from the ELF's `tohost` symbol, reports "HTIF
+// located at 0x10000", and TERMINATES on this suite's verdict write --
+// `SUCCESS`, or `FAILURE: <testnum>`. That is new (ADR-0039): `tohost` used
+// to be a 32-bit `.word`, so the doubleword IO window HTIF claims at the
+// symbol swallowed the first word of `.data` and no write ever completed the
+// doubleword. test/asm/riscv_test.h now emits an 8-byte-aligned `.dword` and
+// writes both halves, so this window covers only `tohost` itself and the
+// reference model stops on the same store the cxxrtl runners stop on.
+// `--inst-limit` is back to being a runaway bound rather than the
+// convergence criterion.
 {
   "memory": {
     // MISALIGNED ACCESSES MUST TRAP, and this is the key that decides it --


### PR DESCRIPTION
Closes JEF-663

Finishes items (1) and (2) of ADR-0032's integration list. **Test infrastructure only — `git diff origin/main -- rtl/` is empty.** Recorded as [ADR-0039](docs/adr/0039-co-simulation-runs-the-whole-suite-against-a-baseline.md).

## Why

Co-simulation is the only oracle here that reads the **real register array** rather than the core's RVFI self-report. `reg_ch0` is the one formal check that ties the report back to `rtl/regfile.v`, it is a single depth-21 BMC query, and ADR-0023 records it as inconclusive. The regfile-to-block-RAM change cannot be gated on anything weaker, and `make cosim-run` — one program, no baseline — could not be that gate.

## What landed

**1. `tohost` becomes an 8-byte-aligned `.dword`** (amends ADR-0008). It was a 32-bit `.word` at the base of RAM, so `.data` began four bytes *inside* the doubleword IO window any HTIF consumer claims at the symbol; Sail answered every `lw` from `RAM_BASE+4` with zero. `RVTEST_PASS`/`RVTEST_FAIL` now write the upper word first and the verdict last, so the reference model terminates on the same store the cxxrtl runners stop on. Both spike workarounds are gone: `objcopy --strip-symbol=tohost`, and the `--inst-limit` spin-loop convergence heuristic. `--inst-limit` is a runaway bound again; a run that hits it is `INCONCLUSIVE` and is **not** compared. Verdicts are compared too.

This is shared infrastructure both sim legs read — every program's `.data` moves 4 bytes and every program executes one extra store — so `make test` (52/52) and `make test-units` (six benches) were re-run green in the same change.

**2. `test/run_cosim.sh` + `test/COSIM_EXPECTED_FAIL` behind `make cosim-suite`**, shaped after `test/run_tests.sh`, graded by ADR-0014's set equality **in both directions** on ADR-0035's name-and-status pairs. Statuses pin *how* the two disagreed: `DISAGREE AT <n>` / `LENGTH` / `VERDICT`, `INCONCLUSIVE SAIL-LIMIT` / `CORE-TIMEOUT`, `COSIM-ERROR`.

```
50/52 agreed
Divergence list matches test/COSIM_EXPECTED_FAIL exactly (name and status).
```

10s wall (7.3s for `make test`; the spike measured 24s — HTIF termination replaces running to the instruction limit). `trap.S` agrees 214/214. No divergence is attributable to the Sail memory-map configuration.

**Two baselined entries, both read-only-CSR *value* divergences no change to this core could close** (reasons in the baseline file):

| | status | why |
|---|---|---|
| `csr.S` | `DISAGREE AT 17` | `csrr misa`: Sail `0x4034112f` vs `0x40001104`. Not a config knob — derived from the extension set. Matching it was attempted and measured: needs A/B/D/F/S/U/V off, which cascades into `Ssccptr`/`Svade`/`Svadu`/`Svvptc`, then the `Zve*`/`Zvfh*` family, then `physaddr_bits` and two `mstatus.*_legal_states`. Recorded rather than chased. |
| `minstret.S` | `DISAGREE AT 7` | `csrr mcycle`: an ISA model has no pipeline, so it cannot count cycles (6 vs 30). The test asserts only monotonicity and a bound, which is why it passes on both sides. |

## Criterion 5 — the mutation is caught, not assumed

One extra architectural write, `regs[31] <= wdata` alongside `regs[waddr]`, gated to fire only after cycle 40 (ADR-0032's mutation B). **Reverted before commit; `rtl/` carries none of it.**

| Leg | Result |
|---|---|
| `make test` — 52 `.S`, per-retire RVFI monitor live | **52/52 PASS — misses it** |
| `make cosim-suite` | **3/52 agreed — catches it in 49 programs**, gate exits 1 |

The three that still agree (`jal.S`, `simple.S`, `straddle.S`) are the three too short to reach cycle 40. `add.S` reproduces ADR-0032's measurement exactly:

```
DIVERGENCE at architectural change #18
  sail instruction #27  pc=0x0000004a  add x14, x1, x2
  sail : x14=0x80000000
  core : x14=0x80000000 x31=0x80000000   (cycle 44, decode pc=0x00000054)
COSIM-STATUS DISAGREE AT 18
```

`csr.S`'s status also moved `DISAGREE AT 17` → `DISAGREE AT 11` under the mutation — the second baseline field doing its job.

## Criterion 6 — still opt-in

`make test`, `make test-units` and CI's required set reach none of it. Demonstrated with `tools/sail` moved aside:

```
tools/sail present? no
52/52 passed
Failure list matches test/EXPECTED_FAIL exactly (name and status).
...
error: sail_riscv_sim not found. Run 'make sail-setup' to install the pinned release into tools/sail/, ...
error: co-simulation setup is incomplete; nothing was run.
make: *** [cosim-suite] Error 1
```

**Adding co-sim to branch protection's required set is what ADR-0032 forbids. This does not do it, and branch protection is unmodified.** The regfile PR gates on it by pasting pre/post output.

## The gate was shown to fail, in four directions

Missing baseline → exit 1. One-field baseline entry → exit 1 (and now checked *before* the suite runs). Empty program glob → exit 1 ("an empty suite would match an empty baseline"). Baseline expecting a divergence that did not happen → exit 1. `test/cosim.py`'s `COSIM-STATUS` line is cross-checked against its exit code, so "the harness broke" and "the core diverged" cannot become the same table entry.

## Scope notes

- Rebased onto `main` after #54 and #55 merged; the ADR was renumbered 0038 → **0039** because #54 took 0038 for the area/fit decision. All gates re-run green after the rebase.

- `test/cosim.cc` reads **no `rvfi_*` signal** (the three mentions are comments). `:183`'s `"uut regfile regs"` bind and `:191`'s `depth == 32` are deliberately untouched for the regfile ticket to repoint.
- `test/cosim.py`'s exit codes gained a distinct **2 = inconclusive**, which used to share 3 with a broken setup.
- The Makefile edit is confined to the `cosim-suite` target plus one token on the existing stale-`tools/sail` guard (`cosim-run` → `cosim-run cosim-suite`), to keep it mergeable alongside the concurrent `fit` work.
- Not built here, and flagged in ADR-0039's consequences: the nightly job and memory comparison — ADR-0032's integration items (3) and (4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

