### PR TITLE
JEF-664: spike — the formal ladder refuses a negedge regfile rather than mis-modelling one, and `make check` was re-grading the previous run

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,6 +218,38 @@ reading `rvfi_csrc_check.sv`, which does not exist at the pin — the six real m
 (`rvfi_csrc_{any,const,hpm,inc,upcnt,zero}_check.sv`) are reached only through a per-CSR *test list*
 in `[csrs]`.
 
+**`make -C formal check` could not re-run the ladder, and had been re-grading the previous run**
+(ADR-0040). `formal/Makefile`'s `checks` was a plain file target naming a **directory**, and a
+directory's mtime bumps whenever an entry is created inside it — `sby` creates `checks/<name>/` for
+every check it runs, so after one ladder run `checks/` was newer than `checks.cfg`,
+`genchecks-local.py` and `EXPECTED_CHECKS` at once and make called it up to date forever. Editing
+`checks.cfg` between two runs did not regenerate. Compounding it, `genchecks-local.py:72` is
+`sbycmd = "sby"` with no `-f` and the makefile it emits hardcodes that string, so every
+re-invocation aborted inside sby and left the prior `status` file in place; `make -BC checks` forces
+the **rule**, not sby. Measured at `317b86c`: run 1 took 310.4s and wrote 82 status files, run 2 took
+22.0s, printed "Directory already exists" for all 82, wrote **none**, and still reported "82 checks:
+82 pass, 0 fail" — a verdict it had not computed, about RTL that may have changed underneath it.
+`checks` is now `.PHONY` and deletes the run directories before regenerating (~1s), and `-B` is off
+the sub-make. **`make -C formal check` is now always a fresh run**; `make -C formal check-baseline`
+is still how you re-grade a finished one without re-running it.
+
+**The ladder will not silently mis-model a negedge regfile — it refuses to run at all** (ADR-0040).
+This matters because ADR-0038 now *recommends* a negedge-BRAM regfile on area grounds. A raw
+`yosys ... prep -flatten -nordff; write_btor` does discard clock polarity silently (`clk` becomes an
+unused input; the read register and the storage array advance on the same step) — but the ladder
+never takes that path. sby runs its own `prep` model step after the `.sby`'s `[script]`, and
+`formalff -clk2ff` there fails closed: *"CLK clock ... also used with opposite polarity, run
+clk2fflogic instead"*, `DONE (ERROR, rc=16)`, which `check-baseline.sh` counts as red. **The silent
+loss is scoped to bespoke yosys scripts that end in `write_btor`/`write_smt2` without going through
+sby** — `formal/equiv.sh` is one, and any standalone regfile proof written that way would be another.
+`clk2fflogic` is **rejected** as the remedy: at genchecks' own depths it makes `reg_ch0` PASS on a
+regfile with the rs2 write-through bypass deleted, which the stock ladder catches in 13.9s, because
+`clk2fflogic` makes a clock cycle two BMC steps while genchecks ties `skip`/`depth`/
+`RISCV_FORMAL_CHECK_CYCLE` to one `[depth]` column — and no `checks.cfg` expression can decouple
+them. **Deleting the rs2 write-through bypass is this repo's liveness probe for `reg_ch0`**: one
+line, a direct invariant-6 violation, counterexample on bad state property 1 at k=20. Reach for it
+before believing any `reg_ch0` result taken under a changed configuration.
+
 **M3's keystone: every trap is now detected AND committed in decode, and the formal baseline is
 empty.** `rtl/decoder.v` computes misalignment from the same `$signed(immediate) +
 $signed(reg_rs1)` it already had, decides illegal-instruction (including ADR-0005's two illegal-CSR
@@ -361,7 +393,8 @@ make waves          # iverilog + VCD (testbench.vvp's baked-in program) -> waves
 make monitor-check  # regenerate test/monitor.v at the pin and diff
 
 make -C formal components_decoder   # component proofs
-make -C formal check                # the riscv-formal ladder (82 checks; see ADR-0023)
+make -C formal check                # the riscv-formal ladder (82 checks; see ADR-0023). ALWAYS a
+                                    # fresh run -- it deletes checks/ first (ADR-0040)
 make -C formal check-baseline       # re-grade a finished ladder: EXPECTED_CHECKS + EXPECTED_FAIL
 
 make sail-setup     # once: fetch the pinned sail-riscv release into tools/sail/
@@ -524,7 +557,7 @@ not against an oracle. An empty baseline is loudest exactly where the ladder is 
   the core does **not** currently place on the up5k (6659/5280 logic cells, 126%). Read ADR-0038
   before quoting any area number: yosys cell counts are blind to unpaired flip-flops and have
   produced two wrong estimates already.
-- Decisions: [`docs/adr/`](docs/adr/) — thirty-seven accepted ADRs, plus a deferred list
+- Decisions: [`docs/adr/`](docs/adr/) — thirty-nine accepted ADRs, plus a deferred list
 - Reference text from the old core: `git show 1709433^:rtl/riscv.v` (RVFI retire block),
   `git show e67875c^:rtl/alu.v` (arithmetic)
 - Work is tracked in Linear, project **Little CPU** (team JEF). Named here so you know where the

--- a/docs/adr/0040-the-ladder-refuses-a-negedge-regfile-and-make-check-was-re-grading.md
+++ b/docs/adr/0040-the-ladder-refuses-a-negedge-regfile-and-make-check-was-re-grading.md
@@ -1,0 +1,238 @@
+# ADR-0040: The ladder refuses a negedge regfile rather than mis-modelling one, and `make check` had been re-grading the previous run
+
+**Status:** Accepted · 2026-07-31 · *Supplements ADR-0022, ADR-0024, ADR-0025, ADR-0031, ADR-0033;
+records data for a future regfile ADR without pre-deciding it*
+
+## Context
+
+A design brief proposed a negedge-read regfile as the escape hatch if ADR-0004's flip-flop regfile
+blocks timing closure on the up5k (it is on `docs/adr/README.md`'s deferred list under that name).
+The brief assumed such a regfile would force `clk2fflogic` on the riscv-formal ladder and risk a slow
+or inconclusive `reg_ch0`.
+
+A follow-up investigation reported something worse. Driving yosys directly —
+`prep -flatten -nordff` then `write_btor`, which is what the generated `.sby` files' `[script]`
+section ends with — a negedge `$dff` is accepted **with no warning**, and in the emitted btor2 `clk`
+is declared an input and never used while the read register and the storage array advance on the
+same step. The half-cycle relationship is silently discarded. If that survived into the ladder, the
+ladder would go green in the same wall time against a circuit that is not the RTL:
+`docs/THREAT_MODEL.md` category 1, false assurance, and strictly worse than the inconclusive result
+the brief worried about.
+
+This ADR is the measured answer. It changes no RTL, and it does **not** decide whether to build a
+negedge regfile — that decision is still deferred, and this is the data it should be made with.
+
+Everything below was measured on one 10-core machine at `f98f92f`, `-j10`, `btor btormc`
+(ADR-0024), under `RISCV_FORMAL_ALTOPS` (ADR-0010). The negedge and posedge-read regfiles are
+scratch experiments — the spike's instrument, not its deliverable — and are not in the tree.
+
+## Finding 1: the polarity loss is real, and the ladder never takes that path
+
+The reported btor2 shape reproduces exactly. Against the negedge regfile **alone**:
+
+```
+$ yosys -p "read_verilog -sv regfile_negedge.v; prep -flatten -nordff -top regfile; write_btor iso.btor"
+$ grep -n "clk" iso.btor
+3:2 input 1 clk ; regfile_negedge.v:10.23-10.26
+```
+
+Node 2 appears nowhere else in the file as an operand — its only other occurrence is
+`43 sort bitvec 2`, a width argument. `clk` is declared and never used, and `next` for the read
+register and `next` for the storage array sit on the same step. Confirmed.
+
+**But sby does not hand the `[script]` section's output straight to `write_btor`.** It runs its own
+`prep` model step first (`sby_core.py`'s `make_model`), and with `multiclock` off — the default, and
+not settable from `checks.cfg`, see Finding 3 — that step is:
+
+```
+async2sync
+chformal -assume -early
+opt_clean
+formalff -setundef -clk2ff -ff2anyinit -hierarchy
+```
+
+`formalff -clk2ff` is the guard, and on the full `rvfi_testbench` it **fails closed**:
+
+```
+prep: ERROR: CLK clock on $flatten\wrapper.\dut.\regfile.$procdff$2308 ($dff) from module
+             rvfi_testbench also used with opposite polarity, run clk2fflogic instead.
+prep: finished (returncode=1)
+DONE (ERROR, rc=16)
+```
+
+`reg_ch0` dies in 1.0s with no status of `PASS`, and `formal/check-baseline.sh` counts anything that
+is not `PASS` as a failure. **A negedge regfile is a hard stop on the generated ladder, with the
+remedy named in the message. It is not a silent green.** The reported green was measured on the
+regfile in isolation; the extrapolation to the full testbench does not hold, and the difference is
+one yosys pass that sby inserts and a bespoke script does not.
+
+That last clause is the part worth carrying forward. **The hazard is real wherever this repo drives
+yosys itself rather than through sby.** `formal/equiv.sh` does exactly that, and any standalone
+regfile equivalence proof written as a yosys script would too. In those places a negedge `$dff` will
+be modelled as a posedge one, silently, and nothing will say so.
+
+## Finding 2: `clk2fflogic` is what produces the false green
+
+The remedy the error message names makes the ladder pass — vacuously.
+
+Adding `clk2fflogic` through `checks.cfg`'s `[script-link]` hook (the seam
+`genchecks-local.py:449,724` provides, and the only one available given ADR-0031 forbids patching
+that vendored copy) and leaving `[depth]` alone, `reg_ch0` **passes on a regfile that is provably
+wrong**. Two independent broken designs, both green:
+
+- the negedge model changed to `posedge` on the read — one character, and it makes every read a full
+  cycle stale, the exact defect ADR-0004 was written to fix. Without `clk2fflogic` this is a
+  counterexample at k=20 in 3.3s. With it: **PASS in 4.3s**.
+- `rtl/regfile.v` with the rs2 write-through bypass deleted — a one-line, direct violation of
+  invariant 6. Without `clk2fflogic`, a counterexample at k=20 in 13.9s. With it: **PASS in 5.4s**.
+
+Doubling `reg`'s depth line to `reg 30 40` does not rescue it: the broken posedge-read regfile still
+**PASSES**, now in 67.2s. That is the shape of a check that has stopped asking the question, not one
+that is looking harder.
+
+## Finding 3: the vacuity is structural, and `checks.cfg` cannot express the fix
+
+`clk2fflogic` makes one clock cycle **two** BMC steps. riscv-formal's depths are in clock cycles;
+sby's `depth`/`skip` are in BMC steps. genchecks ties them together rigidly — both `check_insn` and
+`check_cons` derive, from the single `[depth]` column, all three of:
+
+```
+skip  = <column>          depth = <column> + 1          `define RISCV_FORMAL_CHECK_CYCLE <column>
+```
+
+Every generated `.sby` on this ladder has `skip == CHECK_CYCLE` and `depth == CHECK_CYCLE + 1`.
+Under `clk2fflogic` the check cycle lands at BMC step `2·CHECK_CYCLE + 1`, so the assertion is never
+reached inside the horizon and every check is vacuous. Measured directly: holding
+`CHECK_CYCLE 20` and widening **only** sby's horizon by hand to `depth 43 / skip 40`, the broken
+posedge-read regfile produces its counterexample at exactly **k = 41**, and the deleted-rs2-bypass
+probe produces one at **k = 41** on bad-state property 1 (the rs2 assertion — the right one).
+
+So the horizon has to be decoupled from the check cycle by a factor of two. **`checks.cfg` has no
+way to say that.** Raising the `[depth]` column raises both numbers together, which is why
+`reg 30 40` above stayed green. Getting it right means either forking `genchecks-local.py` — which
+ADR-0031 forbids and `make -C formal genchecks-check` enforces — or post-processing all 82 generated
+`.sby` files with a script that reads each `CHECK_CYCLE` and rewrites each `depth`/`skip`. That
+script would be a new, unenforced, load-bearing piece of the oracle, and a `.sby` it silently missed
+would be a check that passes without checking. That is the same class of defect as Finding 4.
+
+The cost, on top of that: with the horizon corrected, the deleted-bypass probe takes **186s** where
+the stock ladder settles the same question in 13.9s — 13× for the same verdict on the same check.
+The full ladder under `clk2fflogic` with every depth rescaled had completed **1 of 82** checks after
+10 minutes at `-j10`, against **310s for all 82** on the stock ladder.
+
+## Finding 4: `make -C formal check` could not re-run the ladder
+
+Independent of the above, and the reason a spike whose entire output is before/after comparisons had
+to fix it first. Two defects compounding, both confirmed by measurement:
+
+1. `checks` was a plain file target, and it is a **directory**. A directory's mtime bumps whenever
+   an entry is created inside it, and `sby` creates `checks/<name>/` for every check it runs. After
+   one ladder run, `checks/` is newer than `checks.cfg`, `genchecks-local.py` and `EXPECTED_CHECKS`
+   all at once, so make reports it up to date forever. **Editing `checks.cfg` between two runs did
+   not regenerate the ladder.**
+2. `genchecks-local.py:72` is `sbycmd = "sby"` with no `-f`, and the makefile it emits hardcodes that
+   string. sby refuses to overwrite an existing workdir, so every re-invocation aborted and left the
+   prior `status` file untouched. `make -BC checks`, which `check` used to pass, forces the **rule**,
+   not sby — it made the aborts louder without making anything re-run.
+
+Measured at `317b86c`, two `make -C formal check` invocations from the same tree:
+
+| | wall | status files written | reported |
+|---|---|---|---|
+| run 1 (fresh `checks/`) | 310.4s | 82 | 82 checks: 82 pass, 0 fail |
+| run 2 (immediately after) | 22.0s | **0** | 82 checks: 82 pass, 0 fail |
+
+Run 2 printed `ERROR: Directory '<name>' already exists` for all 82 and every status file's mtime
+was byte-identical to run 1's. **It reported a verdict it had not computed** — about RTL that, in
+the general case, has changed underneath it since. `docs/THREAT_MODEL.md` category 1, and the
+highest-value class of finding that document names.
+
+## Decision
+
+**1. `clk2fflogic` is not adopted, and the ladder keeps a posedge regfile.** Go/no-go on the two
+options the spike was asked to choose between:
+
+- **(a) `clk2fflogic` + re-derived depths — NO.** It is not reachable from `checks.cfg` (Finding 3),
+  the only route to it is a genchecks fork ADR-0031 forbids or a new unenforced `.sby` rewriter, and
+  its default-configured behaviour is a silent false green on designs the stock ladder catches in
+  seconds. Adopting it would *introduce* the failure mode this spike was chartered to rule out.
+- **(b) the fallback — YES, if a negedge regfile is ever built.** A standalone regfile equivalence
+  proof, with the ladder wrapper continuing to see a posedge model.
+
+**2. If (b) is built, the substitution lives at one named seam in `formal/wrapper.v` and nowhere
+else.** Not an `ifdef` inside `rtl/regfile.v`, and not a swapped `read_verilog` line in
+`checks.cfg`'s `[script-sources]` — the second is invisible from the RTL and is drift by
+construction, arriving through the formal harness instead of through an `ifdef`, which is precisely
+what the brief rejects. The seam is: `formal/wrapper.v` instantiates the posedge regfile explicitly,
+by name, with a comment stating that the ladder is proving the core against a posedge model and
+naming the equivalence proof that discharges the difference. A reader of `wrapper.v` must be able to
+see that a substitution happened without reading `checks.cfg`.
+
+**3. The equivalence proof must state its read-timing assumption explicitly, per ADR-0017.** An
+`assume` is a promise made to the solver on the reader's behalf, and the promise here is the load-
+bearing one: that `rs1`/`rs2` are stable from before the falling edge to the rising edge that
+samples the result. Nothing in the ladder checks that — it is a timing-closure property, not a
+functional one — so it must be named where it is made, together with what does check it. And per
+Finding 1, that proof must not be written as a bespoke yosys script that ends in `write_btor`,
+because that is the one context in which the polarity it exists to reason about disappears without
+a diagnostic.
+
+**4. `formal/Makefile`'s `checks` target becomes `.PHONY` and deletes `checks/` before
+regenerating.** `-B` comes off the `check` sub-make in the same change: with no status file on
+disk every rule fires on its own, and keeping a flag that forces rules rather than reruns is what
+made this look handled for as long as it did. `genchecks-local.py` is not patched to add `-f`
+(ADR-0031). Regeneration costs about a second. Re-grading a finished ladder without re-running it is
+still available and is what `make -C formal check-baseline` is for (ADR-0022).
+
+## What this spike establishes about `reg_ch0`
+
+The spike needed a mutation `reg_ch0` demonstrably catches, because without one every timing number
+above is uninterpretable — a fast green and a vacuous green look identical. The investigation that
+prompted this ticket reported that deleting the rs2 write-through bypass **passes** `reg_ch0` on the
+shipping design, which would have meant `reg_ch0` does not cover invariant 6.
+
+**That does not reproduce.** Measured against `rtl/regfile.v` at `f98f92f`, stock ladder
+configuration:
+
+| mutation to `rtl/regfile.v` | `reg_ch0` | wall |
+|---|---|---|
+| *(none — shipping design)* | PASS | 25.6s |
+| rs2 write-through bypass deleted | counterexample, **bad state property 1**, k=20 | 13.9s |
+| rs1 write-through bypass deleted | counterexample, bad state property 0, k=20 | 6.3s |
+| both bypasses deleted | counterexample, bad state property 0, k=20 | 6.2s |
+| `regs[waddr] <= wdata + 1` | counterexample, bad state property 0, k=20 | 5.1s |
+| `waddr != 0` write suppression removed | PASS | 48.4s |
+
+`reg_ch0` **does** cover invariant 6, in both directions, and it distinguishes them: deleting the
+rs2 bypass trips bad state property **1**, which is `rvfi_reg_check.sv`'s rs2 assertion specifically,
+not a generic failure. **Deleting the rs2 write-through bypass is therefore this repo's liveness
+probe for `reg_ch0`** — one line, a direct invariant-6 violation, and it flips the check in about
+14 seconds. Reach for it before believing any `reg_ch0` result obtained under a changed
+configuration. Under `clk2fflogic` at genchecks' own depths it goes silent, which is how Finding 2
+was established rather than assumed.
+
+The one mutation that passes is not a coverage hole. Removing the `waddr != 5'd0` guard lets writes
+land in `regs[0]`, but the read mux returns 0 for `rs1`/`rs2 == 0` unconditionally, so the written
+value is unreachable by construction and there is no architectural difference for any check to find.
+It is recorded here so the next reader does not spend the same hour on it.
+
+## Consequences
+
+- **`make -C formal check` now always re-runs.** A partial ladder can no longer be resumed; every
+  invocation is a fresh run. That is the right trade for a gate, and `check-baseline` covers the
+  re-grade case. Wall cost of the regeneration is about a second on a ~5-minute run.
+- **Two full-ladder wall times on the same machine and the same tree: 310.4s and 532.1s.** Run-to-run
+  spread on this hardware is a factor of 1.7, so no ladder-level timing comparison in this repo
+  should be read as meaningful below about 2×. The single-check numbers above were taken serially
+  and are much tighter.
+- **A standing warning for bespoke yosys scripts.** `formal/equiv.sh` — and anything else that drives
+  yosys directly and ends in `write_btor` or `write_smt2` rather than going through sby's `prep`
+  model step — does not get `formalff -clk2ff`'s polarity guard. Today the RTL is entirely posedge so
+  nothing is lost; the moment that stops being true, those scripts model a different circuit and say
+  nothing about it.
+- **ADR-0025's depth derivation is unaffected**, because `clk2fflogic` is not adopted. Had it been,
+  every number in that derivation would have needed doubling *and* decoupling from
+  `RISCV_FORMAL_CHECK_CYCLE`, and the second half is not expressible in `checks.cfg`.
+- **The negedge-BRAM regfile stays on the deferred list.** This ADR deliberately does not decide it.
+  What it removes is one argument against it — the ladder will not silently mis-model it — and adds
+  a concrete cost and shape for the decision when it is made.

--- a/docs/adr/0040-the-ladder-refuses-a-negedge-regfile-and-make-check-was-re-grading.md
+++ b/docs/adr/0040-the-ladder-refuses-a-negedge-regfile-and-make-check-was-re-grading.md
@@ -1,7 +1,7 @@
 # ADR-0040: The ladder refuses a negedge regfile rather than mis-modelling one, and `make check` had been re-grading the previous run
 
-**Status:** Accepted · 2026-07-31 · *Supplements ADR-0022, ADR-0024, ADR-0025, ADR-0031, ADR-0033;
-records data for a future regfile ADR without pre-deciding it*
+**Status:** Accepted · 2026-07-31 · *Supplements ADR-0004, ADR-0017, ADR-0022, ADR-0025, ADR-0031,
+ADR-0033, ADR-0036, ADR-0038; records data for a future regfile ADR without pre-deciding it*
 
 ## Context
 
@@ -10,9 +10,9 @@ blocks timing closure on the up5k (it is on `docs/adr/README.md`'s deferred list
 The brief assumed such a regfile would force `clk2fflogic` on the riscv-formal ladder and risk a slow
 or inconclusive `reg_ch0`.
 
-A follow-up investigation reported something worse. Driving yosys directly —
-`prep -flatten -nordff` then `write_btor`, which is what the generated `.sby` files' `[script]`
-section ends with — a negedge `$dff` is accepted **with no warning**, and in the emitted btor2 `clk`
+A follow-up investigation reported something worse. Driving yosys directly — `prep -flatten -nordff`
+(how every generated `.sby`'s `[script]` section ends) followed straight by `write_btor` —
+a negedge `$dff` is accepted **with no warning**, and in the emitted btor2 `clk`
 is declared an input and never used while the read register and the storage array advance on the
 same step. The half-cycle relationship is silently discarded. If that survived into the ladder, the
 ladder would go green in the same wall time against a circuit that is not the RTL:
@@ -22,9 +22,10 @@ the brief worried about.
 This ADR is the measured answer. It changes no RTL, and it does **not** decide whether to build a
 negedge regfile — that decision is still deferred, and this is the data it should be made with.
 
-Everything below was measured on one 10-core machine at `f98f92f`, `-j10`, `btor btormc`
-(ADR-0024), under `RISCV_FORMAL_ALTOPS` (ADR-0010). The negedge and posedge-read regfiles are
-scratch experiments — the spike's instrument, not its deliverable — and are not in the tree.
+Everything below was measured on one 10-core machine at `317b86c` — whose `rtl/` is byte-identical
+to `f98f92f`'s — with `btor btormc` (ADR-0024) under `RISCV_FORMAL_ALTOPS` (ADR-0010). Full-ladder
+runs used `-j10`; single-check runs were serial. The negedge and posedge-read regfiles are scratch
+experiments — the spike's instrument, not its deliverable — and are not in the tree.
 
 ## Finding 1: the polarity loss is real, and the ladder never takes that path
 
@@ -41,8 +42,11 @@ Node 2 appears nowhere else in the file as an operand — its only other occurre
 register and `next` for the storage array sit on the same step. Confirmed.
 
 **But sby does not hand the `[script]` section's output straight to `write_btor`.** It runs its own
-`prep` model step first (`sby_core.py`'s `make_model`), and with `multiclock` off — the default, and
-not settable from `checks.cfg`, see Finding 3 — that step is:
+`prep` model step first (`sby_core.py`'s `make_model`), and with `multiclock` off — the default,
+and not settable from `checks.cfg` at all: genchecks' `[options]` parser ends in
+`else: print(line); assert 0`, so `multiclock on` there is an `AssertionError`, and nothing but
+`mode`/`expect`/`append`/`depth`/`skip` is ever emitted into a generated `.sby`'s `[options]` —
+that step is:
 
 ```
 async2sync
@@ -115,10 +119,19 @@ ADR-0031 forbids and `make -C formal genchecks-check` enforces — or post-proce
 script would be a new, unenforced, load-bearing piece of the oracle, and a `.sby` it silently missed
 would be a check that passes without checking. That is the same class of defect as Finding 4.
 
-The cost, on top of that: with the horizon corrected, the deleted-bypass probe takes **186s** where
-the stock ladder settles the same question in 13.9s — 13× for the same verdict on the same check.
-The full ladder under `clk2fflogic` with every depth rescaled had completed **1 of 82** checks after
-10 minutes at `-j10`, against **310s for all 82** on the stock ladder.
+The cost, on top of that. Two clean serial single-check comparisons, same machine, same check, only
+the model and the horizon differing:
+
+| check, regfile | stock ladder | `clk2fflogic` + corrected horizon | ratio |
+|---|---|---|---|
+| `reg_ch0`, rs2 bypass deleted | 13.9s → counterexample | 186.0s → counterexample | 13× |
+| `reg_ch0`, posedge-read model | 3.3s → counterexample | 47.0s → counterexample | 14× |
+
+Extrapolating 13–14× onto the stock ladder's 310s puts a correctly-configured `clk2fflogic` ladder
+somewhere around an hour. The full-ladder run attempted here is consistent with that but is **not** a
+clean measurement and should not be quoted as one: it had completed 4 of 82 checks after roughly 20
+minutes at `-j10`, on a machine whose load average was above 30 from concurrent work, and it was
+stopped rather than finished. The serial per-check ratios above are the defensible numbers.
 
 ## Finding 4: `make -C formal check` could not re-run the ladder
 
@@ -146,6 +159,17 @@ Run 2 printed `ERROR: Directory '<name>' already exists` for all 82 and every st
 was byte-identical to run 1's. **It reported a verdict it had not computed** — about RTL that, in
 the general case, has changed underneath it since. `docs/THREAT_MODEL.md` category 1, and the
 highest-value class of finding that document names.
+
+With the fix, two consecutive `make -C formal check` invocations from the same tree:
+
+| | wall | status files written | `already exists` lines | reported |
+|---|---|---|---|---|
+| run A | 322s | 82 | 0 | 82 checks: 82 pass, 0 fail |
+| run B | 428s | 82 | 0 | 82 checks: 82 pass, 0 fail |
+
+**Status files sharing an mtime between A and B: 0.** Every check re-executed; both runs match
+`EXPECTED_CHECKS` and `EXPECTED_FAIL` in both directions and exit 0. (The 322s/428s spread is this
+machine, not the change — see Consequences.)
 
 ## Decision
 
@@ -191,7 +215,7 @@ above is uninterpretable — a fast green and a vacuous green look identical. Th
 prompted this ticket reported that deleting the rs2 write-through bypass **passes** `reg_ch0` on the
 shipping design, which would have meant `reg_ch0` does not cover invariant 6.
 
-**That does not reproduce.** Measured against `rtl/regfile.v` at `f98f92f`, stock ladder
+**That does not reproduce.** Measured against `rtl/regfile.v` at `317b86c`, stock ladder
 configuration:
 
 | mutation to `rtl/regfile.v` | `reg_ch0` | wall |
@@ -216,15 +240,23 @@ land in `regs[0]`, but the read mux returns 0 for `rs1`/`rs2 == 0` unconditional
 value is unreachable by construction and there is no architectural difference for any check to find.
 It is recorded here so the next reader does not spend the same hour on it.
 
+**Read "counterexample" above as sby status `ERROR`, not `FAIL`.** `btorsim` is absent from this
+environment, so once btormc reports `bad state property N reachable at bound k = M SATISFIABLE` the
+`engine_0.trace` step dies with `COMMAND NOT FOUND` and sby exits `DONE (ERROR, rc=16)` — the check
+genuinely failed and only the witness is missing. Same mechanical caveat ADR-0025 records for its
+raised sweep. `check-baseline.sh` counts `ERROR` as non-PASS, so nothing is laundered; but ADR-0036's
+open gap is that `formal/EXPECTED_FAIL` matches on names only, so grep for the `reachable at bound`
+line rather than trusting the status word when using the probe.
+
 ## Consequences
 
 - **`make -C formal check` now always re-runs.** A partial ladder can no longer be resumed; every
   invocation is a fresh run. That is the right trade for a gate, and `check-baseline` covers the
   re-grade case. Wall cost of the regeneration is about a second on a ~5-minute run.
 - **Two full-ladder wall times on the same machine and the same tree: 310.4s and 532.1s.** Run-to-run
-  spread on this hardware is a factor of 1.7, so no ladder-level timing comparison in this repo
-  should be read as meaningful below about 2×. The single-check numbers above were taken serially
-  and are much tighter.
+  spread on this hardware is a factor of 1.7 — this box runs several worktrees at once — so no
+  ladder-level timing comparison in this repo should be read as meaningful below about 2×. Prefer
+  serial single-check comparisons, as the tables above do, and say which kind a number is.
 - **A standing warning for bespoke yosys scripts.** `formal/equiv.sh` — and anything else that drives
   yosys directly and ends in `write_btor` or `write_smt2` rather than going through sby's `prep`
   model step — does not get `formalff -clk2ff`'s polarity guard. Today the RTL is entirely posedge so

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -43,6 +43,7 @@ and what it costs. Reversing one is fine — write a new ADR that supersedes it.
 | [0036](0036-three-gate-hardening-decisions-ratified-at-integration.md) | Three gate-hardening decisions ratified at integration, and a correction to ADR-0031 | Accepted |
 | [0037](0037-an-empty-baseline-is-not-m2.md) | An empty formal baseline is not M2, and the milestone criterion said it was | Accepted |
 | [0038](0038-area-is-measured-in-logic-cells-and-two-levers-are-rejected.md) | Area is measured in logic cells, Fmax is declared at 12 MHz, and two area levers are rejected | Accepted |
+| [0040](0040-the-ladder-refuses-a-negedge-regfile-and-make-check-was-re-grading.md) | The ladder refuses a negedge regfile rather than mis-modelling one, and `make check` had been re-grading the previous run | Accepted |
 
 0001–0007 came from the design brief
 ([`docs/ideas/finish-the-rewrite.md`](../ideas/finish-the-rewrite.md)). 0008–0011 came out of
@@ -78,7 +79,12 @@ recorded integrating those three gate changes together: it ratifies putting `han
 that never retires), corrects 0031 on how the `csrc_*` family is actually reached, and closes the
 `case_default` question by measuring that yosys already errors on the latch. It also records a
 gap it did not close: `formal/EXPECTED_FAIL` still matches on names only, so a red check that flips
-from `FAIL` to `ERROR` keeps the ladder green — 0035's lesson, unapplied to the formal side.
+from `FAIL` to `ERROR` keeps the ladder green — 0035's lesson, unapplied to the formal side. 0040 is
+0038's question asked of the verification harness rather than of the area: it measures whether the
+riscv-formal ladder can model the negedge regfile 0038 recommends, finds that it refuses to rather
+than mis-modelling it, rejects `clk2fflogic` as the remedy on measured vacuity, and — applying 0033's
+lens once more — fixes a `make -C formal check` that could not re-run the ladder and had been
+re-grading the previous run's verdict.
 
 ## Deferred decisions
 
@@ -97,7 +103,11 @@ trades away simplicity the current design depends on.
   take the core from not placing to roughly 84–89%, and its combinational read path measures 86%
   routing. Recommended by [`docs/ideas/fit-the-core-on-the-up5k.md`](../ideas/fit-the-core-on-the-up5k.md),
   gated on suite-wide Sail co-simulation rather than on M2, and still needs its own ADR — deliberately
-  not written in advance of the spike data (ADR-0038).
+  not written in advance of the spike data (ADR-0038). The verification-side half of that data is
+  [ADR-0040](0040-the-ladder-refuses-a-negedge-regfile-and-make-check-was-re-grading.md): the ladder
+  will **not** silently mis-model a negedge read — sby's `formalff -clk2ff` fails closed on mixed
+  polarity — so the cost is a standalone equivalence proof plus a named posedge substitution in
+  `formal/wrapper.v`, not a `clk2fflogic` ladder, which measures vacuous at genchecks' own depths.
 - **FPGA timing closure / nextpnr flow** — including ADR-0003's second ROM read becoming interleaved
   16-bit banks. Post-M4.
 - **Interrupts** (`mie`/`mip` real rather than read-only zero) — no interrupt sources exist.

--- a/formal/Makefile
+++ b/formal/Makefile
@@ -52,9 +52,10 @@ check-baseline: check-baseline.sh EXPECTED_FAIL EXPECTED_CHECKS
 # the full run (ADR-0033).
 #
 # `checks` is PHONY and starts by deleting the directory, and both halves of
-# that are load-bearing. It used to be a plain file target whose recipe was
-# just `python3 $<`, and in that form `make check` could not re-run the
-# ladder at all -- it silently re-graded the PREVIOUS run's verdict:
+# that are load-bearing (ADR-0040). It used to be a plain file target whose
+# recipe was just `python3 $<`, and in that form `make check` could not
+# re-run the ladder at all -- it silently re-graded the PREVIOUS run's
+# verdict:
 #
 #   1. `checks` is a DIRECTORY, and a directory's mtime bumps whenever an
 #      entry is created inside it. `sby` creates checks/<name>/ for every

--- a/formal/Makefile
+++ b/formal/Makefile
@@ -30,7 +30,7 @@ all: complete check dmemcheck imemcheck components_decoder components_executor
 # sub-make really failed to run shows up as a missing status file, which
 # check-baseline counts as non-PASS.
 check: checks $(RISCV_FORMAL_DIR)
-	-$(MAKE) -BC $< -j$(JOBS) -k
+	-$(MAKE) -C $< -j$(JOBS) -k
 	$(MAKE) check-baseline
 
 # Set equality against BOTH baselines, in both directions: EXPECTED_CHECKS
@@ -50,7 +50,47 @@ check-baseline: check-baseline.sh EXPECTED_FAIL EXPECTED_CHECKS
 # equalities in both directions. It fails in about a second, which is the
 # point -- check-baseline catches the same shrunken ladder, but only after
 # the full run (ADR-0033).
+#
+# `checks` is PHONY and starts by deleting the directory, and both halves of
+# that are load-bearing. It used to be a plain file target whose recipe was
+# just `python3 $<`, and in that form `make check` could not re-run the
+# ladder at all -- it silently re-graded the PREVIOUS run's verdict:
+#
+#   1. `checks` is a DIRECTORY, and a directory's mtime bumps whenever an
+#      entry is created inside it. `sby` creates checks/<name>/ for every
+#      check it runs, so after one ladder run checks/ is newer than
+#      checks.cfg, genchecks-local.py and EXPECTED_CHECKS all at once, and
+#      make reports it up to date forever. Editing checks.cfg between two
+#      runs therefore did NOT regenerate the ladder.
+#   2. genchecks-local.py:72 is `sbycmd = "sby"` with no `-f`, and the
+#      makefile it emits hardcodes that string. sby refuses to overwrite an
+#      existing workdir, so every re-invocation aborted with "Directory
+#      '<name>' already exists" and left the prior `status` file untouched.
+#      `make -BC checks` -- which this target used to pass -- forces the
+#      RULE, not sby, so it made the aborts louder without making anything
+#      re-run.
+#
+# Measured on this repo at 317b86c, both runs from the same tree: run 1 took
+# 310s and wrote 82 status files; run 2 took 22s, printed "Directory already
+# exists" for all 82, and check-baseline still reported "82 checks: 82 pass".
+# Every status file's mtime was byte-identical between the two. A ladder that
+# reports a verdict it did not compute is docs/THREAT_MODEL.md's category 1,
+# and it is a verdict about RTL that may since have changed underneath it.
+#
+# genchecks-local.py must not be patched to add `-f` (ADR-0031 constrains that
+# vendored copy to differ from the pin by `basedir` only, and
+# `make genchecks-check` enforces it), so the fix is here: throw the run
+# directories away, regenerate, and let every status file be built by a real
+# sby invocation. Regeneration costs about a second. `-B` is correspondingly
+# gone from `check` above -- with no status file on disk every rule fires on
+# its own, and keeping a flag that forces rules rather than reruns is what
+# made this look handled for as long as it did.
+#
+# Re-grading a finished ladder without re-running it is still available, and
+# is what `make check-baseline` is for.
+.PHONY: checks
 checks: genchecks-audit.py genchecks-local.py checks.cfg EXPECTED_CHECKS | $(RISCV_FORMAL_DIR)
+	rm -rf $@
 	python3 $<
 
 # genchecks-local.py is vendored from the pin and may differ from it only by


### PR DESCRIPTION
Closes JEF-664

A time-boxed spike: **does the riscv-formal ladder model a negedge regfile at all?** No RTL lands.
`git diff origin/main -- rtl/` is empty.

## TL;DR

**The ticket's premise inverted on measurement, twice, and the fourth defect is real and worse than
described.**

1. The ladder does **not** silently mis-model a negedge regfile. sby's own `prep` model step runs
   `formalff -clk2ff`, which **fails closed** with the remedy named in the message. There is no
   false green to prevent.
2. `clk2fflogic` — the remedy — **is** the false green, and it is inexpressibly broken at the
   `checks.cfg` seam. **Recommendation: (b), no-go on (a).**
3. `reg_ch0` **does** cover invariant 6. The rs2-bypass mutation the ticket reported as passing
   fails at k=20, on the correct assertion. It is now this repo's `reg_ch0` liveness probe.
4. `make -C formal check` could not re-run the ladder. **Fixed** — the one code change here.

Everything below is measured output on one 10-core box at `317b86c`, `btor btormc`, under
`RISCV_FORMAL_ALTOPS`. Full record in
[`docs/adr/0040`](docs/adr/0040-the-ladder-refuses-a-negedge-regfile-and-make-check-was-re-grading.md).

## 1. Soundness — the polarity loss is real, and the ladder never takes that path

The reported btor2 shape reproduces **exactly**, against the negedge regfile alone:

```
$ yosys -p "read_verilog -sv regfile_negedge.v; prep -flatten -nordff -top regfile; write_btor iso.btor"
$ grep -n clk iso.btor
3:2 input 1 clk ; regfile_negedge.v:10.23-10.26
```

Node 2 appears nowhere else as an operand (its only other occurrence is `43 sort bitvec 2`, a
width). `clk` is declared and never used.

**But sby does not hand `[script]`'s output to `write_btor`.** It runs its own model step first,
and with `multiclock` off that is `async2sync` … `formalff -setundef -clk2ff -ff2anyinit
-hierarchy`. On the full `rvfi_testbench`:

```
prep: ERROR: CLK clock on $flatten\wrapper.\dut.\regfile.$procdff$2308 ($dff) from module
             rvfi_testbench also used with opposite polarity, run clk2fflogic instead.
prep: finished (returncode=1)
DONE (ERROR, rc=16)
```

`reg_ch0` dies in **1.0s**; `check-baseline.sh` counts non-`PASS` as red. A negedge regfile is a
**hard stop**, not a silent green.

The hazard is real, but scoped: it lives wherever this repo drives yosys itself instead of through
sby. **`formal/equiv.sh` is one such place**, and a standalone regfile proof written as a yosys
script would be another. Recorded in the ADR as a standing warning.

## 2. Vacuity and depth — `clk2fflogic` is the thing that produces a false green

Serial single-check runs, `reg_ch0`:

| regfile under test | `[script-link]` | depths | verdict | wall |
|---|---|---|---|---|
| shipping | none | stock | PASS | 25.6s |
| **rs2 bypass deleted** (probe) | none | stock | **counterexample, property 1, k=20** | 13.9s |
| posedge-read (stale reads) | none | stock | counterexample, property 0, k=20 | 3.3s |
| negedge two-array | none | stock | **ERROR — `prep` refuses** | 1.0s |
| shipping | `clk2fflogic` | stock | PASS | 4.3s |
| negedge | `clk2fflogic` | stock | PASS | 4.6s |
| **posedge-read (BROKEN)** | `clk2fflogic` | stock | **PASS** | 4.3s |
| **rs2 bypass deleted (probe)** | `clk2fflogic` | stock | **PASS** | 5.4s |
| **posedge-read (BROKEN)** | `clk2fflogic` | `reg 30 40` | **PASS** | 67.2s |
| posedge-read (BROKEN) | `clk2fflogic` | depth 43/skip 40, CHECK_CYCLE 20 | counterexample, k=41 | 47.0s |
| rs2 bypass deleted (probe) | `clk2fflogic` | depth 43/skip 40, CHECK_CYCLE 20 | counterexample, property 1, k=41 | 186.0s |

**The vacuity is structural and `checks.cfg` cannot express the fix.** genchecks derives all three
of `skip`, `depth` and `` `define RISCV_FORMAL_CHECK_CYCLE `` from the *single* `[depth]` column
(`skip == CHECK_CYCLE`, `depth == CHECK_CYCLE + 1`, in both `check_insn` and `check_cons`).
`clk2fflogic` makes one clock cycle two BMC steps, so the check cycle lands at step
`2·CHECK_CYCLE + 1` — **measured: exactly k=41 for CHECK_CYCLE 20** — and the assertion is never
reached inside the horizon. Raising the column raises both numbers together, which is why
`reg 30 40` stayed green on a provably broken regfile.

Decoupling them needs either a `genchecks-local.py` fork (**ADR-0031 forbids it**, and
`make -C formal genchecks-check` enforces that — verified still passing) or a new `.sby` rewriter
that would itself be unenforced, load-bearing oracle machinery.

`multiclock on` is not an escape either: genchecks' `[options]` parser ends in
`else: print(line); assert 0`, so it is a hard `AssertionError` — verified by running it.

**Cost:** 13–14× per check, serially measured (13.9s → 186.0s; 3.3s → 47.0s). Extrapolated onto the
stock ladder's 310s that is roughly an hour. The full-ladder attempt is *not* quoted as a clean
number — the box was above load 30 from concurrent worktrees and it was stopped, not finished.

## Recommendation: **(b)**, go. **(a)**, no-go.

- **(a) `clk2fflogic` + re-derived depths — NO.** Not reachable from `checks.cfg`; the only routes
  are forbidden or unenforced; and its default-configured behaviour is a silent false green on
  designs the stock ladder catches in seconds. **Adopting it would introduce the failure mode this
  spike was chartered to rule out.**
- **(b) standalone regfile equivalence proof, ladder wrapper on a posedge model — YES**, if a
  negedge regfile is ever built.

Per acceptance criterion 2, the ADR pins the shape without building it (there is no negedge regfile
on main, and ADR-0038 deliberately declines to pre-decide one):

- the substitution lives at **one named seam in `formal/wrapper.v`** — an explicit, by-name
  instantiation with a comment saying the ladder proves the core against a posedge model and naming
  the proof that discharges the difference. **Not** a swapped `read_verilog` line in
  `[script-sources]`: that is invisible from the RTL and is drift-by-construction arriving through
  the harness instead of through an `ifdef`.
- the equivalence proof **states its read-timing assumption explicitly (ADR-0017)** — that
  `rs1`/`rs2` are stable from before the falling edge to the sampling rising edge. Nothing on the
  ladder checks that; it is a timing-closure property.
- and per finding 1, that proof **must not** be a bespoke yosys script ending in `write_btor`.

## 3. The non-vacuity probe, and the `reg_ch0` / invariant-6 finding

The ticket reported that deleting the rs2 write-through bypass **passes** `reg_ch0`. **It does not
reproduce.** Against `rtl/regfile.v`, stock ladder:

| mutation | `reg_ch0` | wall |
|---|---|---|
| *(none)* | PASS | 25.6s |
| rs2 write-through bypass deleted | counterexample, **bad state property 1** (the rs2 assertion), k=20 | 13.9s |
| rs1 write-through bypass deleted | counterexample, property 0, k=20 | 6.3s |
| both deleted | counterexample, property 0, k=20 | 6.2s |
| `regs[waddr] <= wdata + 1` | counterexample, property 0, k=20 | 5.1s |
| `waddr != 0` write suppression removed | PASS | 48.4s |

`reg_ch0` covers invariant 6 in **both** directions and distinguishes them — the rs2 mutation trips
property **1** specifically. **Deleting the rs2 write-through bypass is adopted as this repo's
`reg_ch0` liveness probe.** It is what established finding 2 rather than assuming it.

The one passing mutation is **not** a coverage hole: writes land in `regs[0]` but the read mux
returns 0 for `rs1`/`rs2 == 0` unconditionally, so the value is unreachable by construction.
Recorded so nobody re-spends the hour.

**Caveat carried into the ADR:** every "counterexample" above reports sby status `ERROR`, not
`FAIL`, because `btorsim` is absent and the witness step dies with `COMMAND NOT FOUND` — the same
mechanical caveat ADR-0025 records. `check-baseline.sh` counts `ERROR` as non-PASS so nothing is
laundered, but grep the `reachable at bound` line rather than trusting the status word
(ADR-0036's open name-only-matching gap).

## 4. The stale-run-directory defect — fixed

Two defects compounding:

1. `checks` was a plain file target naming a **directory**, whose mtime bumps whenever an entry is
   created inside it. `sby` creates `checks/<name>/` per check, so after one run `checks/` is newer
   than `checks.cfg`, `genchecks-local.py` and `EXPECTED_CHECKS` at once. **Editing `checks.cfg`
   between two runs did not regenerate the ladder.**
2. `genchecks-local.py:72` is `sbycmd = "sby"` with no `-f`, hardcoded into the emitted makefile, so
   every re-invocation aborted inside sby leaving the prior `status`. `make -BC checks` forces the
   **rule**, not sby.

Before, two `make -C formal check` invocations from the same tree:

| | wall | status files written | reported |
|---|---|---|---|
| run 1 (fresh) | 310.4s | 82 | `82 checks: 82 pass, 0 fail` |
| run 2 (immediately after) | **22.0s** | **0** | `82 checks: 82 pass, 0 fail` |

Run 2 printed `ERROR: Directory '<name>' already exists` for all 82 and **every status file's mtime
was byte-identical to run 1's**. It reported a verdict it had not computed, about RTL that in the
general case has changed underneath it — `docs/THREAT_MODEL.md` category 1, the highest-value class
of finding that document names.

`genchecks-local.py` is **not** patched (ADR-0031). `checks` becomes `.PHONY` and deletes the run
directories before regenerating; `-B` comes off the `check` sub-make in the same change, since with
no status file on disk every rule fires on its own and a flag that forces rules rather than reruns
is what made this look handled. Regeneration costs ~1s.

**Verified — two consecutive `make -C formal check` invocations, same tree, with the fix:**

| | wall | status files written | `already exists` lines | reported |
|---|---|---|---|---|
| run A | 322s | 82 | 0 | `82 checks: 82 pass, 0 fail` |
| run B | 428s | 82 | 0 | `82 checks: 82 pass, 0 fail` |

**Status files sharing an mtime between A and B: 0.** Every check re-executed rather than being
re-graded. Both runs exit 0 and match `EXPECTED_CHECKS` and `EXPECTED_FAIL` in both directions.

## Scope and risks

- **`make -C formal check` is now always a fresh run.** A partial ladder can no longer be resumed.
  Right trade for a gate; `make -C formal check-baseline` still re-grades a finished run without
  re-running it (ADR-0022), and CI is fresh anyway.
- Ladder wall time on this box varies 310.4s–532.1s run to run (several worktrees at once), so no
  ladder-level timing comparison here should be read as meaningful below ~2×. Serial single-check
  comparisons are the defensible ones and are labelled as such.
- The negedge and posedge-read regfiles were scratch instruments outside the repo tree and are not
  in this branch. `git diff origin/main -- rtl/` is empty.
- `make -C formal genchecks-check` verified still passing.
- **No regfile ADR is written here.** ADR-0038 declines to pre-decide it and that deferral is the
  point; ADR-0040 supplies the verification-side data and the seam shape for whoever does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
