### PR TITLE
Correct the falsified reg_ch0 claims in the area brief, and ADR-0041 (JEF-662 / JEF-663 / JEF-664 integration)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -584,10 +584,12 @@ not against an oracle. An empty baseline is loudest exactly where the ladder is 
 
 - Design brief: [`docs/ideas/finish-the-rewrite.md`](docs/ideas/finish-the-rewrite.md)
 - Area/fit brief: [`docs/ideas/fit-the-core-on-the-up5k.md`](docs/ideas/fit-the-core-on-the-up5k.md) —
-  the core does **not** currently place on the up5k (6659/5280 logic cells, 126%). Read ADR-0038
-  before quoting any area number: yosys cell counts are blind to unpaired flip-flops and have
-  produced two wrong estimates already.
-- Decisions: [`docs/adr/`](docs/adr/) — forty accepted ADRs, plus a deferred list
+  the core does **not** currently place on the up5k: **6971/5280 logic cells, 132%**, which is what
+  `make fit` prints today (ADR-0038's 6659/126% was measured before trap entry; +312 cells is what
+  trap entry cost). Read ADR-0038 before quoting any area number: yosys cell counts are blind to
+  unpaired flip-flops and have produced two wrong estimates already. **The brief's two `reg_ch0`
+  claims are false and are struck in place** — see ADR-0040.
+- Decisions: [`docs/adr/`](docs/adr/) — forty-one accepted ADRs, plus a deferred list
 - Reference text from the old core: `git show 1709433^:rtl/riscv.v` (RVFI retire block),
   `git show e67875c^:rtl/alu.v` (arithmetic)
 - Work is tracked in Linear, project **Little CPU** (team JEF). Named here so you know where the

--- a/docs/adr/0040-the-ladder-refuses-a-negedge-regfile-and-make-check-was-re-grading.md
+++ b/docs/adr/0040-the-ladder-refuses-a-negedge-regfile-and-make-check-was-re-grading.md
@@ -240,6 +240,34 @@ land in `regs[0]`, but the read mux returns 0 for `rs1`/`rs2 == 0` unconditional
 value is unreachable by construction and there is no architectural difference for any check to find.
 It is recorded here so the next reader does not spend the same hour on it.
 
+### The contradiction is explained: it was the stale run directory
+
+The spike could say the earlier measurement did not reproduce, but not *why*. It does now — tested
+at integration, on the pre-fix `formal/Makefile`, against `rtl/regfile.v` at `f98f92f`:
+
+| step | action | wall | `checks/reg_ch0/status` |
+|---|---|---|---|
+| 1 | `rm -rf checks`, regenerate, run `reg_ch0` on the **unmutated** regfile | 22s | `PASS 0 21` |
+| 2 | delete the rs2 write-through bypass | — | — |
+| 3 | re-run **without** removing the workdir (what `make -BC checks` did) | **0s** | `PASS 0 21`, *byte- and mtime-identical to step 1* |
+| 4 | `rm -rf checks`, regenerate, re-run the **same** mutation | 9s | `ERROR 16 0`, `bad state property 1 reachable at bound k = 20 SATISFIABLE` |
+
+Step 3 printed `ERROR: Directory 'reg_ch0' already exists` and nothing else. The mutated regfile was
+never evaluated, and `check-baseline.sh` graded the unmutated run's verdict in its place. That is
+exactly the reading the earlier investigation reported, obtained the same way, and it is the second
+independent demonstration of this defect's severity: finding 4 shows the ladder reporting a verdict
+it did not compute, and this shows that verdict actively laundering a known-broken regfile as green.
+
+Note the asymmetry in cost. The bad path is the *fast* one — 0s against 9s — so a re-run that looks
+suspiciously quick is the symptom, and "the ladder got faster" is the shape of the lie. Wall time
+alone cannot distinguish it from a genuinely easy proof, which is why the probe below is stated in
+terms of a specific bad state property rather than a duration.
+
+The corollary is that **any formal result in this repo taken from a repeated run in one tree, before
+this ADR, is suspect.** `docs/ideas/fit-the-core-on-the-up5k.md` carried two such claims — that
+`reg_ch0` does not cover invariant 6, and that `reg_ch0` passes on a negedge regfile (which finding 1
+shows is impossible) — and both are corrected there.
+
 **Read "counterexample" above as sby status `ERROR`, not `FAIL`.** `btorsim` is absent from this
 environment, so once btormc reports `bad state property N reachable at bound k = M SATISFIABLE` the
 `engine_0.trace` step dies with `COMMAND NOT FOUND` and sby exits `DONE (ERROR, rc=16)` — the check

--- a/docs/adr/0041-integration-decisions-from-the-fit-cosim-and-negedge-wave.md
+++ b/docs/adr/0041-integration-decisions-from-the-fit-cosim-and-negedge-wave.md
@@ -1,0 +1,72 @@
+# ADR-0041: Integration decisions from the fit / co-simulation / negedge wave
+
+**Status:** Accepted · 2026-08-01 · *Supplements ADR-0008, ADR-0032, ADR-0038, ADR-0039, ADR-0040;
+records two things the three merged changes decided but did not write down*
+
+## Context
+
+Three changes landed together: `make fit` (ADR-0038's measurement), suite-wide Sail co-simulation
+with a baseline (ADR-0039), and the negedge-regfile spike plus the `formal/Makefile` stale-run fix
+(ADR-0040). Reviewing them raised five judgement calls. Three are already recorded where they
+belong — the two baselined co-simulation divergences in `test/COSIM_EXPECTED_FAIL`'s header, the
+`formal/wrapper.v` substitution seam in ADR-0040 decision 2, and `make fit`'s tolerance of a failed
+placement in ADR-0038 decision 1a. Two are not recorded anywhere, and this ADR is where they go.
+
+## Decision 1: the `tohost` doubleword changes 382 register *values* and zero register *events*
+
+`test/asm/riscv_test.h` is included by every program in the suite, so ADR-0039's change to it is the
+widest-blast-radius change in the wave. Its own comment says the sequence of architectural
+register-file states "is unchanged by this pair" of stores. That is true and is the load-bearing
+claim — but it is easy to read as the broader "nothing changed", which is false, and a future reader
+diffing traces across that commit will find 51 of 52 programs differing and needs to know why before
+they go looking for a bug.
+
+Measured at integration by replaying all 52 programs through `test/cosim.cc`'s architectural-register
+tracer on both sides of the change (`rtl/` is byte-identical across it, so one `cosim` binary serves
+both and only the assembled images differ):
+
+- **7076 register-change events before, 7076 after**, and **no program's event count differs.** The
+  two added `sw`s contribute no architectural register change at all. The precise claim holds.
+- **Every** field that does differ is a pure address relabeling: `.data` +4 (348 register values,
+  200 PCs) and `.text` +8 (34 register values, 105 PCs). `.text` grows by exactly the two 4-byte
+  stores; `.data` by the four bytes of `tohost` padding. **Zero differences outside those two
+  deltas.**
+
+Both sides of the co-simulation read the same ELF, so the relabeling is invisible to it by
+construction. Recorded here as a number rather than an argument, because "one extra store, no
+register writes" is the kind of claim that is cheap to assert and was worth ten minutes to measure.
+
+## Decision 2: the co-simulation nightly is owed work, not a dropped item
+
+ADR-0032's integration list had three items. ADR-0039 landed two — the `tohost` doubleword and the
+`COSIM_EXPECTED_FAIL` baseline — and deliberately omitted the third, a nightly job, on the grounds
+that ADR-0037's `tee`/pipefail trap makes an untestable workflow a poor thing to add blind. **That
+reasoning is ratified.** A nightly whose graded step cannot go red is worse than no nightly: it is
+ADR-0022's failure exactly, and this repo has already paid for it once.
+
+It is **owed, not dropped**, and it is recorded here so that it stops depending on anyone's memory.
+The preconditions, all of which are now met or nearly so:
+
+1. The graded command must not sit in a pipeline in a `run:` block, and both failure directions must
+   be demonstrated on real runs before the job is called done (ADR-0037's general rule).
+2. It must grade against `test/COSIM_EXPECTED_FAIL` by the same set equality in both directions that
+   `make cosim-suite` already applies, so an unexpected *agreement* is caught too.
+3. It must not join the required check set. Putting co-simulation on branch protection is what
+   ADR-0032 forbids and ADR-0039 restates; a nightly is the only shape this leg gets.
+
+Until it exists, the way a change gates on this leg is by carrying `make cosim-suite`'s pre- and
+post- output in its pull request. That is the mechanism the regfile change is expected to use.
+
+## Consequences
+
+- **The suite has a second baseline file to keep honest.** `test/COSIM_EXPECTED_FAIL` joins
+  `test/EXPECTED_FAIL` and `formal/EXPECTED_FAIL`/`EXPECTED_CHECKS`. All four are set equalities in
+  both directions (ADR-0014) over name-and-status pairs (ADR-0035); none is regenerated wholesale
+  from a run. Three of the four are enforced by a required check. The co-simulation one is not, by
+  decision 2 above, and that asymmetry is the price of the leg staying opt-in.
+- **`make fit` is the fourth thing that is not a leg**, alongside co-simulation. It gates nothing and
+  is not in CI. Its number moves whenever the RTL does, and nothing notices; ADR-0038 accepted that.
+- **Nothing in this wave touched `rtl/`.** `git diff` over the three merges is 0 lines under `rtl/`
+  and `test/monitor.v` is byte-identical, so invariants 1–8 are untouched by construction rather
+  than by inspection. The one change to shared behaviour is `test/asm/riscv_test.h`, measured in
+  decision 1.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -45,6 +45,7 @@ and what it costs. Reversing one is fine — write a new ADR that supersedes it.
 | [0038](0038-area-is-measured-in-logic-cells-and-two-levers-are-rejected.md) | Area is measured in logic cells, Fmax is declared at 12 MHz, and two area levers are rejected | Accepted |
 | [0039](0039-co-simulation-runs-the-whole-suite-against-a-baseline.md) | Co-simulation runs the whole suite against a baseline, and `tohost` becomes a doubleword | Accepted |
 | [0040](0040-the-ladder-refuses-a-negedge-regfile-and-make-check-was-re-grading.md) | The ladder refuses a negedge regfile rather than mis-modelling one, and `make check` had been re-grading the previous run | Accepted |
+| [0041](0041-integration-decisions-from-the-fit-cosim-and-negedge-wave.md) | Integration decisions from the fit / co-simulation / negedge wave | Accepted |
 
 0001–0007 came from the design brief
 ([`docs/ideas/finish-the-rewrite.md`](../ideas/finish-the-rewrite.md)). 0008–0011 came out of
@@ -89,7 +90,10 @@ amendment to 0008, and the one change here that touches what both existing sim l
 riscv-formal ladder can model the negedge regfile 0038 recommends, finds that it refuses to rather
 than mis-modelling it, rejects `clk2fflogic` as the remedy on measured vacuity, and — applying 0033's
 lens once more — fixes a `make -C formal check` that could not re-run the ladder and had been
-re-grading the previous run's verdict.
+re-grading the previous run's verdict. 0041 came out of integrating those three together: it
+measures what 0039's `tohost` change actually did to the architectural register trace (382 values,
+zero events), and records the co-simulation nightly 0039 deliberately omitted as owed work with its
+preconditions, so it stops depending on anyone's memory.
 
 ## Deferred decisions
 

--- a/docs/ideas/fit-the-core-on-the-up5k.md
+++ b/docs/ideas/fit-the-core-on-the-up5k.md
@@ -4,6 +4,16 @@
 were subsequently checked by building and measuring each variant — see "Measured" immediately below,
 which supersedes them where they disagree.** ADR-0038 carries the same table.
 
+> **Two of this brief's formal claims were measured again and are FALSE.** Both concerned
+> `reg_ch0`, both are corrected in place below, and both had the same cause: the stale-run-directory
+> defect in `formal/Makefile` that ADR-0040 found and fixed. Before that fix, re-running a check in
+> an existing `checks/<name>/` aborted inside sby and left the *previous* run's `status` file for
+> `check-baseline.sh` to re-grade — so a mutated or re-synthesised design could be reported PASS
+> having never been evaluated. Any other formal result in this brief taken from a repeated run in
+> one tree is suspect for the same reason and should be re-measured before it is relied on.
+> **[ADR-0040](../adr/0040-the-ladder-refuses-a-negedge-regfile-and-make-check-was-re-grading.md)
+> supersedes this brief on everything to do with the ladder and a negedge regfile.**
+
 ## Measured — this supersedes the estimates in the body
 
 All `nextpnr-ice40 --up5k --package sg48`, `littlecpu`, memories external, post-trap-entry:
@@ -16,9 +26,17 @@ All `nextpnr-ice40 --up5k --package sg48`, `littlecpu`, memories external, post-
 | + both | 3998 | 75% | 4/30 |
 
 The negedge variant was built and run, not projected: **52/52 `.S` tests pass under cxxrtl with the
-per-retire monitor live**, `reg_ch0` passes, and yosys infers `4 × SB_RAM40_4K` from a plain
+per-retire monitor live**, ~~`reg_ch0` passes~~, and yosys infers `4 × SB_RAM40_4K` from a plain
 two-array negedge-read model — no `SB_RAM40_4KNR`, no attribute. **EBR inference is a non-risk;
 delete it from the spike's scope.**
+
+**`reg_ch0` cannot pass on a negedge regfile, and did not** (ADR-0040 finding 1). sby runs its own
+`prep` model step after the `.sby`'s `[script]`, and `formalff -clk2ff` there fails closed on mixed
+clock polarity in the full `rvfi_testbench`: *"CLK clock ... also used with opposite polarity, run
+clk2fflogic instead"*, `DONE (ERROR, rc=16)`, in about a second. `check-baseline.sh` counts that as
+red. The PASS recorded here was the previous run's status file being re-graded, not a verdict about
+the negedge design. The area and `.S`-suite numbers in this table were measured by other means and
+stand.
 
 Four corrections to the body:
 
@@ -31,6 +49,17 @@ Four corrections to the body:
    ADR-0038 decision 1a resolves this.
 
 ## The real formal risk — soundness, not runtime
+
+> **Superseded by [ADR-0040](../adr/0040-the-ladder-refuses-a-negedge-regfile-and-make-check-was-re-grading.md).**
+> The polarity loss described below is real *in isolation*, and the warning it draws for bespoke
+> yosys scripts — `formal/equiv.sh` is one — is correct and worth keeping. But the conclusion is
+> not: **the generated ladder never takes that path**, because sby inserts a `prep` model step that
+> a hand-written script does not, and that step fails closed. The ladder refuses to run rather than
+> going green. Two further numbers here are also wrong: `multiclock on` cannot be set from
+> `checks.cfg` at all (genchecks' `[options]` parser ends in `assert 0`, so it is an
+> `AssertionError`), and the measured cost of a correctly-configured `clk2fflogic` run is **13–14×**
+> per check, not the ~3.6× below. Read the section for the isolated-`write_btor` finding; take
+> nothing from it about the ladder.
 
 The body says a negedge read forces `clk2fflogic` and risks a slow or inconclusive `reg_ch0`.
 Neither happens, and what does happen is worse.
@@ -58,15 +87,32 @@ because riscv-formal's depths are in **clock cycles** and `clk2fflogic` makes a 
 steps. At doubled depth it takes 84 s, **~3.6× baseline**. So the real cost is a re-derivation of
 every depth in `checks.cfg` (ADR-0025 territory) plus ~4× ladder runtime.
 
-## `reg_ch0` does not cover invariant 6 today
+## ~~`reg_ch0` does not cover invariant 6 today~~ — FALSE. It covers it, in both directions.
 
-Deleting the rs2 write-through bypass — a direct violation of the invariant this work re-words —
-**passes `reg_ch0`**. The `.S` suite catches it instantly (52 × `MONITOR-ERROR`).
+**This section's claim was measured again and does not reproduce** (ADR-0040). Against
+`rtl/regfile.v` in stock ladder configuration, deleting the rs2 write-through bypass produces a
+counterexample on **bad state property 1** — which is `rvfi_reg_check.sv`'s rs2 assertion
+specifically, not a generic failure — at k=20, in about 14 seconds. Deleting the rs1 bypass, both
+bypasses, and `regs[waddr] <= wdata + 1` all fail too, on property 0. The only mutation that passes
+is removing the `waddr != 0` write-suppression guard, and that is benign by construction: the read
+mux returns 0 for `rs1`/`rs2 == 0` unconditionally, so the written value is unreachable and there is
+no architectural difference for any check to find.
 
-So the formal ladder is not the oracle for the write-through bypass; the simulation legs are. That
-independently strengthens the decision to gate on co-simulation rather than on M2, and it is an
-unrecorded assurance gap of exactly the kind ADR-0033 exists to name. It belongs in the regfile ADR
-whichever path the spike picks.
+**Why this brief said otherwise**, confirmed by reproduction at integration rather than inferred: the
+stale-run-directory defect described at the top of this file. Running `reg_ch0` clean gives PASS in
+22s; deleting the rs2 bypass and re-running *without* removing `checks/reg_ch0/` aborts inside sby in
+0s with `ERROR: Directory 'reg_ch0' already exists` and leaves a byte-and-mtime-identical
+`PASS 0 21` behind, which `check-baseline.sh` then re-grades as a pass. Removing the directory first
+and re-running the identical mutation gives `bad state property 1 reachable at bound k = 20
+SATISFIABLE`. The mutation was never evaluated; the previous run's verdict was reported in its place.
+
+**So the formal ladder IS an oracle for the write-through bypass.** Deleting the rs2 bypass is now
+this repo's liveness probe for `reg_ch0` — one line, a direct invariant-6 violation, ~14 seconds —
+and is the thing to reach for before believing any `reg_ch0` result taken under a changed
+configuration. The decision to gate the regfile change on co-simulation rather than on M2 still
+stands, but it no longer rests on this argument: it rests on ADR-0032's mutation experiment, where
+an injected architectural write outside the retiring instruction's `rd` was missed by the whole
+ladder and caught by the co-sim.
 
 ## Three things the body missed
 
@@ -214,9 +260,17 @@ suite-wide Sail co-simulation, which ADR-0032 already scoped as future work.
 
 The regfile change is gated on:
 
-1. Sail co-sim wired across the full `.S` suite and green at the pre-change SHA
-2. `reg_ch0` PASS immediately before and after
-3. Full ladder + `formal/EXPECTED_CHECKS` set equality unchanged
+1. Sail co-sim wired across the full `.S` suite and green at the pre-change SHA — **available now**
+   as `make cosim-suite`, graded against `test/COSIM_EXPECTED_FAIL` (ADR-0039)
+2. ~~`reg_ch0` PASS immediately before and after~~ — **not achievable as written, and ADR-0040
+   decision 2 replaces it.** A negedge regfile makes sby's `prep` step fail closed, so there is no
+   "after" reading to take. The gate becomes instead: the ladder wrapper instantiates the posedge
+   regfile explicitly and by name at a seam visible from `formal/wrapper.v`, `reg_ch0` PASSes against
+   *that*, and a standalone equivalence proof — not written as a bespoke yosys script ending in
+   `write_btor`, per ADR-0040 finding 1 — discharges the difference while stating its read-timing
+   assumption explicitly (ADR-0017)
+3. Full ladder + `formal/EXPECTED_CHECKS` set equality unchanged, from a **fresh** run — `make -C
+   formal check` re-runs from scratch as of ADR-0040 and no longer needs to be argued about
 4. `make test`, `test-units`, lint green in both sim legs
 
 That converts "wait for verification" from a vibe into a checklist item.
@@ -253,7 +307,11 @@ invariant 1 or 6, and must bring an ADR.
 
 ## Risks
 
-- **Formal runtime is the load-bearing unknown, not correctness.** A negedge read register forces
+- ~~**Formal runtime is the load-bearing unknown, not correctness.**~~ **Settled, and the other way
+  round** (ADR-0040): correctness of the *model* was the unknown, and runtime is not the issue
+  because the ladder declines to run at all rather than running slowly. The fallback this bullet
+  names — a standalone equivalence proof with the ladder's wrapper on a posedge model — is the
+  option that was chosen. A negedge read register forces
   `clk2fflogic`, roughly doubling modeled state per cycle. `reg_ch0` — the exact check tying RVFI to
   the real regfile — was inconclusive for months under yices and passes in ~8–12 s under btormc
   (ADR-0024). It is the check most likely to regress to inconclusive. **Settled by a half-day spike

--- a/test/asm/riscv_test.h
+++ b/test/asm/riscv_test.h
@@ -85,7 +85,13 @@ _start:                                                                      \
 //
 // Neither store writes a register, so the sequence of architectural
 // register-file states -- which is what ADR-0032's co-simulation compares --
-// is unchanged by this pair.
+// is unchanged by this pair. Read that narrowly: measured across the whole
+// suite, the register-change EVENT COUNT is identical (7076 before, 7076
+// after, no program differing), which is the claim. What does move is 382
+// register VALUES that are addresses, because .text grows by these two stores
+// and .data by tohost's padding -- .data addresses by +4, .text addresses by
+// +8, and nothing by anything else (ADR-0041). Both sides of the
+// co-simulation read the same ELF, so none of it is visible there.
 #define RVTEST_PASS                                                          \
         li      TESTNUM, 1;                                                 \
         la      t0, tohost;                                                 \


### PR DESCRIPTION
Integration follow-up to the three merged changes (#56, #57, #58). Docs and one
comment; no `rtl/`, no build behaviour.

## The area brief carries two false claims, and they had one cause

`docs/ideas/fit-the-core-on-the-up5k.md` (merged in `681b682`) asserts that `reg_ch0` does not cover
invariant 6, and separately that `reg_ch0` passes on the negedge regfile variant. Both were measured
again. Neither reproduces, and the cause is the stale-run-directory defect ADR-0040 found and #58
fixed.

**The stale-run hypothesis was tested, and it holds.** Against the pre-fix `formal/Makefile`:

| step | action | wall | `checks/reg_ch0/status` |
|---|---|---|---|
| 1 | clean regenerate, run `reg_ch0`, unmutated | 22s | `PASS 0 21` |
| 2 | delete the rs2 write-through bypass | — | — |
| 3 | re-run **without** removing the workdir | **0s** | `PASS 0 21`, byte- and mtime-identical to step 1 |
| 4 | `rm -rf checks`, regenerate, re-run the same mutation | 9s | `ERROR 16 0`, `bad state property 1 reachable at bound k = 20 SATISFIABLE` |

Step 3 printed `ERROR: Directory reg_ch0 already exists` and nothing else. The mutated regfile was
never evaluated and the unmutated run""s verdict was graded in its place. That is a second,
independent demonstration of the defect: ADR-0040 finding 4 showed the ladder reporting a verdict it
had not computed; this shows that verdict laundering a known-broken regfile as green. The bad path
is also the *fast* one, so wall time cannot distinguish it — which is why the liveness probe is
stated as a bad state property, not a duration.

The brief is corrected in place, not deleted. Its isolated `write_btor` polarity finding stands and
the warning it draws for bespoke yosys scripts (`formal/equiv.sh`) is worth keeping.

## ADR-0041

Two decisions the merged wave made without recording:

1. **The `tohost` doubleword, measured.** Replaying all 52 programs through `test/cosim.cc`""s
   architectural-register tracer on both sides: **7076 register-change events before, 7076 after,
   no program""s count differing** — the two added stores contribute no architectural register
   change. Every differing field is a pure address relabeling, `.data` +4 and `.text` +8, zero
   exceptions. The narrow claim in `riscv_test.h` is exactly right; the comment now says so in terms
   that cannot be read as the broader one.
2. **The co-simulation nightly is owed, not dropped.** Omitting it rather than adding it blind
   against ADR-0037""s `tee`/pipefail trap is ratified, and recorded with its three preconditions.

## Also

`CLAUDE.md`""s area number, falsified by `make fit` the moment it landed: **6971/5280 logic cells,
132%**, not 6659/126%. The older figure predates trap entry; +312 cells is what trap entry cost.

## Gates on this branch

`make test` 52/52 · `make test-units` green · `make lint` clean both passes · `make monitor-check`
clean · `make cosim-suite` 50/52, matches baseline · `make -C formal check` 82/82.

🤖 Generated with [Claude Code](https://claude.com/claude-code)