### PR TITLE
JEF-666: give exec_tb the shift vectors it never had, and trim littlesoc's dead scaffolding

### DIFF
--- a/.svlint.toml
+++ b/.svlint.toml
@@ -46,15 +46,19 @@
 # and see the Makefile's `lint` target for the two passes (with and without
 # `RISCV_FORMAL`) and why both are needed.
 
-[option]
-# rtl/littlesoc.v is dead scaffolding: it synthesises to 2 LUT4s, carries a
-# `mem_valid`/`mem_ready` handshake the current core does not use, and has a
-# `// TODO SPI mem`. It is also the ONLY file in rtl/ with a genuine finding
-# (four `inout` ports with no `tri` datakind). Deleting it is probably right,
-# but that is its own decision and must not ride in on a lint change; excluding
-# it here keeps `inout_with_tri` LIVE for any inout port added to real RTL,
-# which is the version of that rule worth having.
-exclude_paths = ["rtl/littlesoc\\.v"]
+# NO exclude_paths, deliberately. There used to be one, for rtl/littlesoc.v:
+# that file was the only source of a genuine finding in rtl/ (four `inout`
+# flash pins with no `tri` datakind), and it was excluded so that
+# `inout_with_tri` could stay LIVE for any inout port added to real RTL rather
+# than being switched off wholesale. The flash pins were scaffolding for an SPI
+# controller nobody wrote, and they are gone, so the exclusion has nothing left
+# to exclude and the gate now covers every file in rtl/ without exception.
+# Measured after that trim: zero findings in both passes with no exclusion.
+#
+# Putting a file back on an exclude list is the same move as switching a rule
+# off, and the house rule at the top of this file applies to it: a path
+# excluded without a written reason is indistinguishable from someone getting
+# tired of the noise.
 
 # ---------------------------------------------------------------------------
 # Text rules -- all off.
@@ -115,7 +119,8 @@ generate_for_with_label = true
 generate_if_with_label = true
 parameter_default_value = true
 parameter_in_generate = true
-inout_with_tri = true                 # live: littlesoc.v, its only source, is excluded above
+inout_with_tri = true                 # live over ALL of rtl/: its only source, littlesoc.v's
+                                      # flash pins, is deleted rather than excluded (see above)
 
 # ---------------------------------------------------------------------------
 # ENABLED -- expression and statement traps.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,17 @@ core: with the sanitizer rule in place `div.S`/`rem.S` pass. `test/monitor.sim.v
 sites to make the arithmetic self-determined. **`test/EXPECTED_FAIL` is not the place to park a
 monitor defect** — read ADR-0019 before adding a line back for one.
 
+**That defect is a repo-wide hazard, not a monitor bug, and it has now caught work here twice** —
+the generated monitor's DIV and REM spec models above, and then `test/exec_tb.v`'s new SRA
+reference, whose natural one-line form
+(`cond ? ... : $signed(a) >>> sh`) reported six mismatches against RTL that was correct. **Any
+signed arithmetic written into a *reference model* in this repo must be a self-determined statement
+of its own, never an arm of a conditional expression.** `exec_tb`'s shift references are written
+that way with the reasoning in place, and a `ref_selftest` block pins all three against
+hand-computed literals *before* a single RTL vector runs, so a reference that degraded would say
+`ORACLE BROKEN` and stop rather than blaming the core. An oracle that is wrong is worse than no
+oracle: it fails correct hardware and teaches the reader to distrust the bench.
+
 **ADR-0003's dual-word combinational fetch window lands, closing the gap ADR-0021 found.**
 `rtl/fetcher.v` now reads two adjacent words every cycle (`imem_addr`/`imem_addr2 = imem_addr + 4`)
 and windows the 32 bits starting at `pc` out of them — stateless, so a 32-bit instruction straddling
@@ -307,7 +318,11 @@ signal and is the single entry on the `elaborate` gate's allowlist; everything e
 `Warning:` is promoted to an error there (`.github/workflows/ci.yml`, which cross-references this
 note). It is not zero, and this line said zero until ADR-0037. The
 cxxrtl binary builds and runs, the whole `.S` suite passes under it with `test/EXPECTED_FAIL`
-empty, `make test-units` passes (six benches: `exec_tb`, `mem_tb`, `decoder_tb`,
+empty, `make test-units` passes (six benches: `exec_tb` — 10,000 randomized differential vectors
+per op across `mul`/`mulh`/`mulhu`/`mulhsu`/`div`/`divu`/`rem`/`remu` **and**
+`sll`/`srl`/`sra`, plus 384 directed shift vectors per shift op sweeping every amount 0-31 with a
+clean and a dirty rs2 so the `rs2[4:0]` mask is checked rather than coincided with — `mem_tb`,
+`decoder_tb`,
 `regfile_tb` — which covers the write-through bypass and x0 semantics — `csr_tb`, which covers
 `rtl/csrs.v`'s read mux, its `implemented` address set, its WARL masks and its trap-entry/`mret`
 port, and `monitor_tb`, which checks the oracle itself rather than the core), and the decoder and
@@ -589,6 +604,22 @@ not against an oracle. An empty baseline is loudest exactly where the ladder is 
   trap entry cost). Read ADR-0038 before quoting any area number: yosys cell counts are blind to
   unpaired flip-flops and have produced two wrong estimates already. **The brief's two `reg_ch0`
   claims are false and are struck in place** — see ADR-0040.
+- **`make fit` has a churn floor of roughly ±50 cells, and a ratchet has to sit above it.**
+  Measured by sweeping `rtl/executor.v`'s `mul_div_counter` across four widths that are all
+  functionally identical — the counter's range is 0..32 and yosys already constant-folds every bit
+  above 5, so the **flip-flop count is byte-identical in all four** (1757). The logic cells are not:
+  `[6:0]` (what is checked in) → **6971**, `[5:0]` → 7008, `[7:0]` → 7027, `[8:0]` → 7024 —
+  non-monotonic, spanning 56 cells, entirely LUT4 churn from ABC re-mapping and nextpnr packing
+  (LUT4-only 5159 → 5198, LUT4+DFF 587 → 587, DFF-only 1170 → 1170, CARRY 41 → 39 for the first
+  two). Each figure is reproducible run to run; it is the *edit* the number is unstable under, not
+  the tool. Two consequences: **a `make fit` delta smaller than ~50 cells is not evidence of
+  anything**, and ADR-0038 decision 1a's utilisation ratchet needs a margin wider than this floor
+  or it will go red on changes that synthesize to the same hardware.
+  This is also why `mul_div_counter` is still `[6:0]` for a value that never exceeds 32. Narrowing
+  it is a legibility change that removes no register and **costs 37 cells measured**; ADR-0038
+  rejected the shifter merge at 19 cells *saved* on legibility grounds, and accepting a hygiene
+  change at 37 cells *spent* would cut against that ruling. Read this before proposing the
+  narrowing again — it is measured and declined, not overlooked.
 - Decisions: [`docs/adr/`](docs/adr/) — forty-one accepted ADRs, plus a deferred list
 - Reference text from the old core: `git show 1709433^:rtl/riscv.v` (RVFI retire block),
   `git show e67875c^:rtl/alu.v` (arithmetic)

--- a/rtl/littlesoc.v
+++ b/rtl/littlesoc.v
@@ -1,32 +1,23 @@
 `timescale 1 ns / 1 ps
 `default_nettype none
+// The SoC wrapper: the core plus the two memories it talks to, and nothing
+// else. What used to sit above the instances was scaffolding for an SPI flash
+// controller nobody ever wrote -- a chip select and a free-running `flash_clk`
+// divider driving four `inout` flash pins, plus `mem_valid`/`mem_ready` wires
+// no module read -- and it is gone. The real memory system (SPRAM data RAM,
+// ROM banking, byte strobes) and the pinout that goes with it are the work
+// that will give this module ports again; until then it deliberately has none
+// beyond clk/reset.
+//
+// This is NOT the synthesis top for area. ADR-0038 measures `littlecpu` with
+// its memories external, because the two memories below are placeholders whose
+// real implementation will be SPRAM/EBR and will not consume logic cells.
 module littlesoc (
   input  clk,
-  input  reset,
-  output flash_cs,
-  output flash_clk,
-  inout  flash_io0,
-  inout  flash_io1,
-  inout  flash_io2,
-  inout  flash_io3
+  input  reset
 );
-  logic int_flash_clk;
-  assign flash_clk = int_flash_clk;
-  // TODO SPI mem
-  always_ff @(posedge clk) begin
-   if (reset) begin
-     flash_cs <= 0;
-     int_flash_clk <= 0;
-   end else begin
-     flash_cs <= 1;
-     int_flash_clk <= !int_flash_clk;
-   end
-  end
-
   // Internal mem
-  logic        mem_valid;
   logic        trap;
-  logic        mem_ready;
   logic [31:0] mem_addr;
   logic [31:0] mem_wdata;
   logic [3:0]  mem_wstrb;

--- a/test/exec_tb.v
+++ b/test/exec_tb.v
@@ -8,6 +8,13 @@
 // checks it. Drives `executor` directly (no decoder/pipeline involved) and
 // compares against SystemVerilog `*`, `/`, `%` with RISC-V divide-by-zero and
 // INT_MIN / -1 semantics. Exits non-zero (via $fatal) on any mismatch.
+//
+// It also covers the three shift arms -- SLL / SRL / SRA -- on the same
+// randomized differential footing. Those had no coverage here at all until
+// this bench grew it, despite SRA being the one arm in the executor whose
+// correctness depends on a signedness that IEEE 1800 will silently take away
+// from you; read the comment above the shift reference model below before
+// touching it.
 module exec_tb;
   localparam int RANDOM_VECTORS = 10000;
   localparam logic [1:0] DIVIDE_STATE = 2'b10; // must match executor.v's `divide` state
@@ -94,10 +101,86 @@ module exec_tb;
     end
   endfunction
 
+  // ---- reference model: shifts ----------------------------------------
+  //
+  // READ THIS BEFORE EDITING THE THREE FUNCTIONS BELOW.
+  //
+  // Every shift here is computed in a STATEMENT OF ITS OWN, into a local whose
+  // signedness is declared, and is never an arm of a `?:` or any other
+  // conditional expression. That is not a style preference, it is the whole
+  // reason these functions are shaped the way they are.
+  //
+  // IEEE 1800 sign-context propagation makes a conditional expression unsigned
+  // if any of its operands is unsigned, and then pushes that unsignedness DOWN
+  // into the context-determined operands. A `$signed(a) >>> sh` sitting in one
+  // arm of such a conditional therefore evaluates as a LOGICAL shift -- with no
+  // warning, and only for negative operands, so every non-negative vector still
+  // agrees. The assignment target cannot rescue it: an expression's type does
+  // not depend on its left-hand side.
+  //
+  // This is not hypothetical, and it is not new here. ADR-0019 is the same
+  // defect at two sites in the generated riscv-formal monitor -- its DIV and
+  // REM spec models, where `-7 / 2` scored as `0x7ffffffc` and failed `div.S`
+  // and `rem.S` against a correct core, until the sanitizer made the
+  // arithmetic self-determined. It then happened AGAIN, here, while these very
+  // vectors were being written: the natural one-line `ref_sra` written as a
+  // `?:` arm reported six mismatches, and the thing that was wrong was the
+  // oracle. A bench whose oracle is broken is worse than no bench -- it blames
+  // the hardware and teaches the reader to distrust the bench. Keep each of
+  // these a standalone statement, and see `ref_selftest` below, which pins
+  // them against hand-computed literals that cannot degrade along with the
+  // expression.
+  //
+  // The `b[4:0]` masks are this reference's own model of the RV32I rule that
+  // the shift amount is rs2[4:0] and the upper 27 bits are ignored (spec Vol I
+  // 2.4.2, and rtl/executor.v's comment on the same). The vectors drive rs2
+  // values far above 31 so the RTL has to agree rather than merely coincide.
+  function automatic logic [31:0] ref_sll(input logic [31:0] a, input logic [31:0] b);
+    logic [31:0] v;
+    begin
+      v = a << b[4:0];
+      ref_sll = v;
+    end
+  endfunction
+
+  function automatic logic [31:0] ref_srl(input logic [31:0] a, input logic [31:0] b);
+    logic [31:0] v;
+    begin
+      v = a >> b[4:0];
+      ref_srl = v;
+    end
+  endfunction
+
+  function automatic logic [31:0] ref_sra(input logic [31:0] a, input logic [31:0] b);
+    logic signed [31:0] sa;
+    logic signed [31:0] v;
+    begin
+      sa = $signed(a);
+      v  = sa >>> b[4:0];
+      ref_sra = v;
+    end
+  endfunction
+
   task automatic clear_in;
     begin
       in = '0;
       in.rd = 5'd1;
+    end
+  endtask
+
+  // Checks the shift ORACLE, not the core -- no RTL is involved. An SRA
+  // reference that had silently degraded to a logical shift (see the comment
+  // above the shift functions) agrees with a correct one on every non-negative
+  // operand, so it would pass thousands of randomized vectors and then report
+  // mismatches against correct hardware. These expected values are computed by
+  // hand and written as literals, so they cannot degrade along with it.
+  task automatic ref_selftest(input string what, input logic [31:0] got,
+                               input logic [31:0] want);
+    begin
+      if (got !== want) begin
+        $display("ORACLE BROKEN: %s got=%08x expected=%08x", what, got, want);
+        errors++;
+      end
     end
   endtask
 
@@ -135,6 +218,15 @@ module exec_tb;
       else if (op_name == "divu") in.is_divu = 1'b1;
       else if (op_name == "rem") in.is_rem = 1'b1;
       else if (op_name == "remu") in.is_remu = 1'b1;
+      else if (op_name == "sll") in.is_sll = 1'b1;
+      else if (op_name == "srl") in.is_srl = 1'b1;
+      else if (op_name == "sra") in.is_sra = 1'b1;
+      else begin
+        // A typo in an op name would otherwise issue an all-zero decoder_output
+        // and silently compare against whatever the executor left on rd_data.
+        $display("BENCH BUG: unknown op name '%s'", op_name);
+        $fatal(1);
+      end
       @(posedge clk); // issue edge
       #1;
       guard = 0;
@@ -155,12 +247,38 @@ module exec_tb;
   logic [31:0] a, b;
   int i;
 
+  // Shift patterns chosen so that a lost sign bit, a dropped mask or an
+  // off-by-one fill is visible: INT_MIN, all-ones, INT_MAX, a negative
+  // non-trivial value, a positive alternating one, and 1 (which walks a single
+  // bit off each end).
+  localparam int SHIFT_PATTERNS = 6;
+  logic [31:0] pattern [0:SHIFT_PATTERNS-1];
+  int p, sh;
+  logic [31:0] rs2_masked, rs2_dirty;
+
   initial begin
     reset = 1;
     clear_in();
     repeat (2) @(posedge clk);
     #1;
     reset = 0;
+
+    // The oracle is checked before it is trusted to judge anything.
+    ref_selftest("sra(80000000,4)",  ref_sra(32'h80000000, 32'd4),  32'hf8000000);
+    ref_selftest("sra(80000000,31)", ref_sra(32'h80000000, 32'd31), 32'hffffffff);
+    ref_selftest("sra(deadbeef,8)",  ref_sra(32'hdeadbeef, 32'd8),  32'hffdeadbe);
+    ref_selftest("sra(ffffffff,1)",  ref_sra(32'hffffffff, 32'd1),  32'hffffffff);
+    ref_selftest("sra(7fffffff,1)",  ref_sra(32'h7fffffff, 32'd1),  32'h3fffffff);
+    ref_selftest("sra(80000000,0)",  ref_sra(32'h80000000, 32'd0),  32'h80000000);
+    ref_selftest("srl(80000000,4)",  ref_srl(32'h80000000, 32'd4),  32'h08000000);
+    ref_selftest("sll(00000001,31)", ref_sll(32'h00000001, 32'd31), 32'h80000000);
+    // ...including the reference's own rs2[4:0] masking, on both sides of 32.
+    ref_selftest("sra(80000000,36)", ref_sra(32'h80000000, 32'd36), 32'hf8000000);
+    ref_selftest("sll(00000001,32)", ref_sll(32'h00000001, 32'd32), 32'h00000001);
+    if (errors != 0) begin
+      $display("FAILED: the shift reference model is broken; no core result below means anything");
+      $fatal(1);
+    end
 
     // Required directed vectors (ADR-0010): exactly the cases the swapped sign
     // enables get wrong.
@@ -176,7 +294,35 @@ module exec_tb;
     run_op("div",  32'h80000000, 32'hffffffff, 32'h80000000);
     run_op("rem",  32'h80000000, 32'hffffffff, 32'h00000000);
 
+    // Directed shift sweep: every shift amount 0..31 against each pattern,
+    // driven TWICE -- once with a clean rs2 and once with all 27 upper bits
+    // set. $random alone reaches every amount with overwhelming probability but
+    // does not guarantee it, and the two forms together are what turns "the
+    // masking happens to work on random inputs" into "the same amount with and
+    // without garbage above bit 4 gives the same answer", which is the actual
+    // rs2[4:0] rule (rtl/executor.v).
+    pattern[0] = 32'h80000000;
+    pattern[1] = 32'hffffffff;
+    pattern[2] = 32'h7fffffff;
+    pattern[3] = 32'hdeadbeef;
+    pattern[4] = 32'h55555555;
+    pattern[5] = 32'h00000001;
+    for (p = 0; p < SHIFT_PATTERNS; p++) begin
+      for (sh = 0; sh < 32; sh++) begin
+        rs2_masked = {27'b0, sh[4:0]};
+        rs2_dirty  = {27'h7ffffff, sh[4:0]};
+        run_op("sll", pattern[p], rs2_masked, ref_sll(pattern[p], rs2_masked));
+        run_op("srl", pattern[p], rs2_masked, ref_srl(pattern[p], rs2_masked));
+        run_op("sra", pattern[p], rs2_masked, ref_sra(pattern[p], rs2_masked));
+        run_op("sll", pattern[p], rs2_dirty,  ref_sll(pattern[p], rs2_masked));
+        run_op("srl", pattern[p], rs2_dirty,  ref_srl(pattern[p], rs2_masked));
+        run_op("sra", pattern[p], rs2_dirty,  ref_sra(pattern[p], rs2_masked));
+      end
+    end
+
     // Randomized differential coverage: >=10,000 vectors per operation.
+    // $random's rs2 is a full 32-bit word, so the great majority of shift
+    // vectors here also carry a shift amount above 31.
     for (i = 0; i < RANDOM_VECTORS; i++) begin
       a = $random;
       b = $random;
@@ -188,13 +334,20 @@ module exec_tb;
       run_op("divu",   a, b, ref_divu(a, b));
       run_op("rem",    a, b, ref_rem(a, b));
       run_op("remu",   a, b, ref_remu(a, b));
+      run_op("sll",    a, b, ref_sll(a, b));
+      run_op("srl",    a, b, ref_srl(a, b));
+      run_op("sra",    a, b, ref_sra(a, b));
     end
 
     if (errors != 0) begin
       $display("FAILED: %0d mismatches", errors);
       $fatal(1);
     end else begin
-      $display("PASSED: %0d randomized vectors per op (mul/mulh/mulhu/mulhsu/div/divu/rem/remu), 0 mismatches", RANDOM_VECTORS);
+      $display("PASSED: %0d randomized vectors per op (mul/mulh/mulhu/mulhsu/div/divu/rem/remu/sll/srl/sra),",
+                RANDOM_VECTORS);
+      $display("        plus %0d directed shift vectors per shift op (amounts 0-31, clean and dirty rs2),",
+                SHIFT_PATTERNS * 32 * 2);
+      $display("        0 mismatches");
       $finish;
     end
   end


### PR DESCRIPTION
Closes JEF-666

The shifter merge is **not** in this PR. ADR-0038 measured it at 19 logic cells on top of the EBR regfile, and CLAUDE.md line 4 says legibility decides — three one-line operators read better than `bitrev()` plus a 33-bit signed shift with an explicit fill bit. No barrel shifter was written.

The `mul_div_counter` narrowing is **also not in this PR** — measured, declined, and recorded. See §4.

## 1. Shift vectors in `exec_tb`

`test/exec_tb.v` had 10,000 randomized vectors per mul/div op and **zero** shift coverage, for as long as the executor has existed. Now:

| | per op |
|---|---|
| randomized differential (`sll` / `srl` / `sra`) | **10,000** each |
| directed sweep (amounts 0–31 × 6 patterns × clean and dirty rs2) | **384** each |

Patterns are `80000000`, `ffffffff`, `7fffffff`, `deadbeef`, `55555555`, `00000001`. Each amount is driven twice — once as `{27'b0, sh}` and once as `{27'h7ffffff, sh}` — so the `rs2[4:0]` rule is *checked* rather than coincided with. `$random`'s rs2 in the randomized loop is a full 32-bit word, so the great majority of those carry an amount above 31 as well.

```
== exec_tb ==
PASSED: 10000 randomized vectors per op (mul/mulh/mulhu/mulhsu/div/divu/rem/remu/sll/srl/sra),
        plus 384 directed shift vectors per shift op (amounts 0-31, clean and dirty rs2),
        0 mismatches
```

`run_op` also grew an `else` that `$fatal`s on an unknown op name — without it a typo would issue an all-zero `decoder_output` and compare against whatever `rd_data` happened to hold.

## 2. The reference model — the criterion that matters

Every shift reference is computed in a **self-determined statement**, into a local of declared signedness, never as an arm of a conditional. The reasoning is written out above the three functions in the file.

Writing it the natural way reproduces ADR-0019's defect exactly, and this was hit live rather than anticipated: a `cond ? ... : $signed(a) >>> sh` draft reported six mismatches against RTL that was correct. IEEE 1800 sign-context propagation makes the conditional unsigned and pushes that down into its context-determined operands, so the arithmetic shift evaluates logically — silently, and only for negative operands, so every non-negative vector still agrees.

A `ref_selftest` block pins all three references against **hand-computed literals** before a single RTL vector runs, and aborts if any fails. Demonstrated by restoring the naive `ref_sra`:

```
ORACLE BROKEN: sra(80000000,4) got=08000000 expected=f8000000
ORACLE BROKEN: sra(80000000,31) got=00000001 expected=ffffffff
ORACLE BROKEN: sra(deadbeef,8) got=00deadbe expected=ffdeadbe
ORACLE BROKEN: sra(ffffffff,1) got=7fffffff expected=ffffffff
ORACLE BROKEN: sra(80000000,36) got=08000000 expected=f8000000
FAILED: the shift reference model is broken; no core result below means anything
vvp exit: 1
```

It stops before comparing against the core at all, so it cannot blame correct hardware.

And the other direction — the vectors do catch real RTL defects. Two mutations of `rtl/executor.v`'s SRA arm:

```
# `>>> rs2` (mask dropped)
MISMATCH sra rs1=80000000 rs2=ffffffe0 got=ffffffff expected=80000000
MISMATCH sra rs1=80000000 rs2=ffffffe4 got=ffffffff expected=f8000000

# `rs1 >> rs2[4:0]` ($signed dropped)
MISMATCH sra rs1=80000000 rs2=00000001 got=40000000 expected=c0000000
MISMATCH sra rs1=80000000 rs2=00000002 got=20000000 expected=e0000000
```

The dirty-rs2 form is what catches the first one.

## 3. `littlesoc.v` trim, and the svlint exclusion — **it came out**

Deleted: `flash_cs`, the free-running `flash_clk` divider and `int_flash_clk`, the four `inout` flash pins, `mem_valid`, `mem_ready`, and the `// TODO SPI mem`. The module stays — it is the wrapper that instantiates the memories — and no target synthesizes or elaborates it (`make fit` uses `littlecpu` with memories external per ADR-0038; `imemory.v` cannot elaborate standalone anyway, it needs the testbench's `rom.mem`, and that is true before and after this change).

`.svlint.toml`'s `exclude_paths` is **gone entirely** — not silently emptied, replaced with a comment saying why there is no longer one, per that file's own house rule. The four `inout_with_tri` findings were its only reason to exist.

Verified live rather than assumed — svlint with the **new** config, run against the **pre-trim** file:

```
Fail  littlesoc.v:8:3   inout  flash_io0,  hint: Specify `tri` datakind on `inout` ports.
Fail  littlesoc.v:9:3   inout  flash_io1,  ...
Fail  littlesoc.v:10:3  inout  flash_io2,  ...
Fail  littlesoc.v:11:3  inout  flash_io3   ...
exit: 1
```

The rule is live over all of `rtl/` with no exceptions; the findings are gone because the ports are gone.

```
== svlint: rtl/, RVFI off ==
== svlint: rtl/, RVFI on ==
svlint: clean in both passes
make lint exit: 0
```

## 4. `make fit` — unchanged at 6971, and the counter narrowing is declined

**`make fit` is `6971 → 6971`, delta 0.** It has to be: `rtl/littlesoc.v` is not among `FIT_SRCS`, and nothing else in this PR touches `rtl/`.

The `mul_div_counter` `[6:0]` → `[5:0]` narrowing was implemented, measured, and then **reverted**. It costs **+37 logic cells** and removes no register. ADR-0038 rejected the shifter merge at 19 cells *saved* on legibility grounds; accepting a hygiene change at 37 cells *spent* would cut against that ruling, so the counter stays `[6:0]` and CLAUDE.md records the measurement so it is not proposed again as an oversight.

**The measurement it produced is the most broadly useful thing in this PR, and it stays.** A sweep across four functionally identical widths (range is 0..32, so yosys constant-folds every bit above 5):

| `mul_div_counter` | logic cells | flip-flops |
|---|---|---|
| `[6:0]` (checked in) | **6971** | 1757 |
| `[5:0]` | 7008 | 1757 |
| `[7:0]` | 7027 | 1757 |
| `[8:0]` | 7024 | 1757 |

Non-monotonic, spanning 56 cells, with a **byte-identical flip-flop count** in all four. nextpnr's own breakdown for the first two confirms it is entirely LUT4: `5159 → 5198` LUT4-only, `587 → 587` LUT4+DFF, `1170 → 1170` DFF-only, `41 → 39` CARRY. Each figure is reproducible run to run — it is the *edit* the number is unstable under, not the tool.

**This constrains the ratchet.** ADR-0038 decision 1a puts a ratchet on LC utilisation, and the regfile work is flipping `make fit` to one. A ratchet tighter than ~±50 cells will go red on changes that synthesize to the same hardware, and a `make fit` delta smaller than that is not evidence of anything. Recorded in CLAUDE.md's fit pointer.

## 5. Gates (all re-run after the revert)

| gate | result |
|---|---|
| `make fit` | 6971/5280, 132% — **unchanged from main** |
| `make test` | **52/52**, failure list matches `test/EXPECTED_FAIL` exactly |
| `make test-units` | six benches green (`exec_tb`, `mem_tb`, `decoder_tb`, `regfile_tb`, `csr_tb`, `monitor_tb`) |
| `make lint` | clean in both passes, exclusion removed |
| `make -C formal check` | **82 checks: 82 pass, 0 fail**; matches `EXPECTED_FAIL` and `EXPECTED_CHECKS` exactly, both directions |
| `make -C formal components_executor` | `DONE (PASS, rc=0)` — successful proof by k-induction |
| yosys strict elaborate (CI's pipeline) | 0 promoted warnings |
| iverilog `sorry:` | **20**, unchanged; no other diagnostics |

## Scope

The `rtl/` diff is now **exactly one file** — `rtl/littlesoc.v`, deletions only, no behaviour change. No ADR: nothing here decides anything ADR-0038 has not already decided, and the churn-floor measurement is recorded in CLAUDE.md as a fact about the metric. CLAUDE.md gains three additive edits: the churn floor plus the declined narrowing, the `exec_tb` bench description, and a note generalizing ADR-0019's sign-context hazard to reference models.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
