### PR TITLE
Correct four claims the regfile measurement disproved

### DIFF
--- a/docs/adr/0040-the-ladder-refuses-a-negedge-regfile-and-make-check-was-re-grading.md
+++ b/docs/adr/0040-the-ladder-refuses-a-negedge-regfile-and-make-check-was-re-grading.md
@@ -70,10 +70,20 @@ remedy named in the message. It is not a silent green.** The reported green was 
 regfile in isolation; the extrapolation to the full testbench does not hold, and the difference is
 one yosys pass that sby inserts and a bespoke script does not.
 
-That last clause is the part worth carrying forward. **The hazard is real wherever this repo drives
-yosys itself rather than through sby.** `formal/equiv.sh` does exactly that, and any standalone
-regfile equivalence proof written as a yosys script would too. In those places a negedge `$dff` will
-be modelled as a posedge one, silently, and nothing will say so.
+That last clause is the part worth carrying forward. **The hazard is real wherever this repo lowers a
+design to a word-level model without sby's `prep` step** — that is, a bespoke yosys script ending in
+`write_btor` or `write_smt2`, which drops the clock and assumes every `$dff` is posedge. A standalone
+regfile equivalence proof written that way would be exposed, and so would any future BMC script.
+
+> **Correction, ratified at integration (ADR-0042's wave).** This paragraph originally named
+> `formal/equiv.sh` as an instance, and **that was wrong**. `equiv.sh` has **no backend**: it ends in
+> `equiv_make` / `equiv_simple` / `equiv_induct` / `equiv_status -assert`, which reason over the
+> `$dff` cells in yosys's own representation with their clock and polarity intact, and never emit a
+> word-level model at all. It is therefore not exposed to the polarity loss described here, now or
+> after a negedge cell is introduced. **There is no script in this repo today that the warning
+> applies to** — it is a rule for scripts not yet written, which is still worth stating, but it must
+> not be read as a defect in `equiv.sh`. (`equiv.sh` has a real limitation, and it is a different
+> one: it does not converge. See ADR-0020.)
 
 ## Finding 2: `clk2fflogic` is what produces the false green
 
@@ -285,11 +295,13 @@ line rather than trusting the status word when using the probe.
   spread on this hardware is a factor of 1.7 — this box runs several worktrees at once — so no
   ladder-level timing comparison in this repo should be read as meaningful below about 2×. Prefer
   serial single-check comparisons, as the tables above do, and say which kind a number is.
-- **A standing warning for bespoke yosys scripts.** `formal/equiv.sh` — and anything else that drives
-  yosys directly and ends in `write_btor` or `write_smt2` rather than going through sby's `prep`
-  model step — does not get `formalff -clk2ff`'s polarity guard. Today the RTL is entirely posedge so
-  nothing is lost; the moment that stops being true, those scripts model a different circuit and say
-  nothing about it.
+- **A standing warning for bespoke yosys scripts.** Anything that drives yosys directly and ends in
+  `write_btor` or `write_smt2`, rather than going through sby's `prep` model step, does not get
+  `formalff -clk2ff`'s polarity guard: the moment the RTL stops being entirely posedge, such a script
+  models a different circuit and says nothing about it. **This entry used to name `formal/equiv.sh`
+  and that was wrong** — corrected in Finding 1 above. `equiv.sh` emits no word-level model; its
+  `equiv_*` passes reason on the cells directly, polarity included. **No script in this repo is
+  currently exposed.**
 - **ADR-0025's depth derivation is unaffected**, because `clk2fflogic` is not adopted. Had it been,
   every number in that derivation would have needed doubling *and* decoupling from
   `RISCV_FORMAL_CHECK_CYCLE`, and the second half is not expressible in `checks.cfg`.

--- a/docs/ideas/fit-the-core-on-the-up5k.md
+++ b/docs/ideas/fit-the-core-on-the-up5k.md
@@ -22,13 +22,31 @@ All `nextpnr-ice40 --up5k --package sg48`, `littlecpu`, memories external, post-
 |---|---|---|---|
 | Baseline | **6971** | **132%** | 0/30 |
 | + merged shifter | 6835 | 129% | 0/30 |
-| **+ negedge-EBR regfile** | **4017** | **76%** | **4/30** |
-| + both | 3998 | 75% | 4/30 |
+| **+ negedge-EBR regfile** | ~~**4017**~~ ~4100 | ~78% | **4/30** |
+| + both | ~~3998~~ ~4100 | ~78% | 4/30 |
 
 The negedge variant was built and run, not projected: **52/52 `.S` tests pass under cxxrtl with the
-per-retire monitor live**, ~~`reg_ch0` passes~~, and yosys infers `4 × SB_RAM40_4K` from a plain
-two-array negedge-read model — no `SB_RAM40_4KNR`, no attribute. **EBR inference is a non-risk;
-delete it from the spike's scope.**
+per-retire monitor live**, ~~`reg_ch0` passes~~, and yosys infers **`4 × SB_RAM40_4KNR`** from a
+plain two-array negedge-read model — no attribute needed. **EBR inference is a non-risk; delete it
+from the spike's scope.**
+
+> **Two corrections to the four lines above, ratified at integration (ADR-0042's wave).**
+>
+> **1. The primitive is `SB_RAM40_4KNR`, not `SB_RAM40_4K`.** This paragraph asserted the opposite,
+> by name. Re-measured directly — `synth_ice40` on a two-array negedge-read model reports
+> `4 × SB_RAM40_4KNR`, the negative-edge-read-clock variant, which is exactly what a negedge read
+> should infer. The *conclusion* the sentence was written to support is unchanged and if anything
+> stronger: inference works, needs no attribute, and is not a risk. But the cell name was wrong, and
+> it is the kind of wrong that sends the next reader looking for a bug that is not there.
+>
+> **2. Do not quote either figure to four digits.** ADR-0042's wave re-measured the same lever on the
+> same baseline and got **4137**, against the **4017** here — 120 cells, 2.3% of the part. The
+> baseline (6971) reproduces exactly, so this is not a different tree; the earlier figure came from a
+> scratch variant that is not in the repo and cannot be diffed, so the two are not comparable at that
+> resolution. **Neither number is trustworthy in its last two digits.** The conclusion is unaffected:
+> the regfile alone closes the area problem, and all three ways of doing it land within 86 cells of
+> each other. See also this repo's own ±~50-cell churn floor — a `make fit` delta smaller than that
+> is not evidence of anything.
 
 **`reg_ch0` cannot pass on a negedge regfile, and did not** (ADR-0040 finding 1). sby runs its own
 `prep` model step after the `.sby`'s `[script]`, and `formalff -clk2ff` there fails closed on mixed

--- a/test/sail/rv32imc_zicsr.json
+++ b/test/sail/rv32imc_zicsr.json
@@ -31,12 +31,25 @@
 // map). Nothing here was chosen because it made a test pass.
 //
 // WHAT THIS FILE CANNOT SAY. Three implementation-defined values remain
-// different because sail-riscv 0.13.1 has no knob for them, and they are
-// handled in test/cosim.py's NONCOMPARABLE_CSRS instead of by pretending:
-// `mcycle`/`mcycleh` (an ISA model has no pipeline), `mie` (the model
-// hardwires MSIE/MTIE/MEIE writable; ADR-0002 makes them read-only zero) and
-// `mip` (the model's mtime keeps ticking with the CLINT unmapped and raises
-// MTIP; this core has no timer). See docs/adr/0043.
+// different because sail-riscv 0.13.1 has no knob for them, and they are NOT
+// all handled the same way -- the difference matters:
+//
+//   * `mcycle`/`mcycleh` (an ISA model has no pipeline) are exempted by name
+//     in test/cosim.py's NONCOMPARABLE_CSRS, keyed on the CSR encoding and
+//     scoped to one register at one comparison point.
+//
+//   * `mie` (the model hardwires MSIE/MTIE/MEIE writable; ADR-0002 makes them
+//     read-only zero) and `mip` (the model's mtime keeps ticking with the
+//     CLINT unmapped and raises MTIP; this core has no timer) are NOT in
+//     NONCOMPARABLE_CSRS and cannot be -- a value exemption cannot help here,
+//     because a program asserting they read zero takes a DIFFERENT BRANCH on
+//     the two machines rather than reading a different value. Those assertions
+//     live in test/csr_tb.v instead, against rtl/csrs.v, where there is no
+//     reference model to disagree. test/cosim.py's own comment above
+//     NONCOMPARABLE_CSRS says this correctly; this header used to claim all
+//     three were exempted there, and that was wrong.
+//
+// See docs/adr/0043.
 {
   "base": {
     "xlen": 32,


### PR DESCRIPTION
Ratified at integration of the regfile / Sail-config / shift-vector wave. Docs
and one comment block; no RTL, no gate, no behaviour change.

* **ADR-0040 named `formal/equiv.sh` as exposed to the `clk2ff` polarity loss.
  It is not.** `equiv.sh` has no backend — it ends in `equiv_status -assert`,
  and the `equiv_*` passes reason over the `$dff` cells with polarity intact
  rather than emitting a word-level model. The general warning survives (a
  script ending in `write_btor`/`write_smt2` would be exposed); the claim that
  a script in this repo is exposed does not.
* **The area brief had the EBR primitive backwards.** Re-measured: a negedge-read
  model infers `4 x SB_RAM40_4KNR`, not `SB_RAM40_4K`. The shipped posedge
  regfile infers `4 x SB_RAM40_4K` — that is the contrast the brief inverted.
* **The brief's 4017/3998 are quoted to four digits and should not be.** The same
  lever re-measures at 4137 on a baseline (6971) that reproduces exactly. Struck
  in place, because why they disagree is the useful part.
* **`test/sail/rv32imc_zicsr.json`'s header misdescribed what the oracle exempts.**
  It claimed `mcycle`, `mie` and `mip` are all in `NONCOMPARABLE_CSRS`. Only
  `mcycle`/`mcycleh` are — `mie`/`mip` cause a control-flow divergence no value
  exemption can reach, which is why those assertions live in `test/csr_tb.v`.
  `cosim.py`'s own comment said this correctly and the header contradicted it.

Full gates run on merged main before opening this: `test` 52/52, `test-units`
all six benches, `monitor-check` clean, `lint` clean both passes, `fit`
4236/5280 (80%) ratchet OK, `formal check` 82/82 with both baselines exact,
`cosim-suite` 52/52 agreed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)