### PR TITLE
JEF-691: Census every formal assume and vacuity-check every compound assert guard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -235,6 +235,24 @@ What does not work right now:
   `components_accessor`, and `components_writeback` contain no assertions at all, only reset
   assumptions, so they "pass" meaninglessly. CI deliberately does not run them; ADR-0006 slates
   them for deletion. A green run of one of those is not a result.
+- **`components_executor` is green and does not check the multiplier's sign logic, its high half,
+  or the signed divider at all** (ADR-0048). The divide invariant's two *unguarded*
+  `always_comb assume(in.rs1 <= 32'h0000000f)` statements are proof-global, so with operands in
+  0..15 every high half and every sign bit is zero. Measured by mutation, each PASSING the task:
+  zeroing `multiply[63:32]`, `mul_sign_x = 1'b0`, `mul_sign_y = 1'b0`, MULHSU-treats-rs2-as-signed,
+  and deleting the signed sign-restore from *both* the `op_is_div` and `op_is_rem` captures. A
+  low-half off-by-one and a sign-from-bit-0 are still caught in 0.5s, so the assertions are
+  narrowed rather than dead and the task reads green either way. `test/exec_tb.v` is what actually
+  covers this (ADR-0010 already calls it the primary guarantee); the component proof adds nothing
+  to it on these points.
+- **`formal/pcloop.sv` is RED, and no `make` target or CI job runs it** (ADR-0048). Measured at
+  `18d17a2`: `sby -f components.sby pcloop` → `DONE (FAIL, rc=2)` in 0.67s at `pcloop.sv:273`. The
+  cause is exact — `f_may_stall` is documented as an over-approximation of `rtl/decoder.v`'s
+  `stall` and lists four of its five terms, because ADR-0042 added `operand_stall` and this was
+  never widened; the counterexample is the first post-reset cycle, where `operand_stall` legitimately
+  holds the pc. `operand_stall` reaches no port, so it cannot be widened from pcloop's own nets.
+  This is the check that discharges `rtl/decoder.v`'s `assume(in.pc == pc)`, so that assumption is
+  currently discharged by a check nobody runs.
 
 **The ladder now asserts its own shape, so a green ladder can no longer shrink quietly**
 (ADR-0033's gap 1). `formal/checks.cfg`'s `[depth]` table is the list of checks that *exist*, not a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -240,7 +240,7 @@ What does not work right now:
   always 0. **ADR-0022's central guarantee had never held.** `1961234` fixed both copies of the step
   (nightly and the new PR-gate `formal` job) and demonstrated both failure directions on real runs.
 - **`components_executor` is green and does not check the multiplier's sign logic, its high half,
-  or the signed divider at all** (ADR-0048). The divide invariant's two *unguarded*
+  or the signed divider at all** (ADR-0049). The divide invariant's two *unguarded*
   `always_comb assume(in.rs1 <= 32'h0000000f)` statements are proof-global, so with operands in
   0..15 every high half and every sign bit is zero. Measured by mutation, each PASSING the task:
   zeroing `multiply[63:32]`, `mul_sign_x = 1'b0`, `mul_sign_y = 1'b0`, MULHSU-treats-rs2-as-signed,

--- a/docs/adr/0048-every-formal-assume-names-its-scope-and-its-discharge.md
+++ b/docs/adr/0048-every-formal-assume-names-its-scope-and-its-discharge.md
@@ -1,0 +1,249 @@
+# ADR-0048: Every formal `assume` names its scope as well as its discharge
+
+**Status:** Accepted · 2026-08-01 · *Supplements ADR-0017; scopes ADR-0010, ADR-0025*
+
+## Context
+
+ADR-0017 requires that every `assume` added to a component proof "states the structural fact it
+models and where that fact is itself checked." The rule has never been audited against the tree.
+This ADR is that audit, and it found the rule to be missing a third clause.
+
+`rtl/executor.v`'s
+
+```verilog
+always_comb assume(in.rs1 <= 32'h0000000f);
+always_comb assume(in.rs2 <= 32'h0000000f);
+```
+
+is an honest, well-documented assumption. It names its fact (ADR-0010's "restrict it… record the
+restriction"), it says why the restriction exists (keeping the divide invariant's intermediate
+arithmetic inside 64 bits), and it sits directly above the invariant it was written for. It is also
+**proof-global**: an `always_comb assume` with no guard constrains every assertion in the module,
+not the ones near it. The four multiply assertions forty lines above it are therefore asserting
+about operands in 0..15, where every high half is zero and every sign bit is zero — so they hold
+whatever the multiplier's sign logic does.
+
+Measured, not argued. Each row is one mutation of `rtl/executor.v` in a scratch copy, run as
+`sby -f components.sby executor` (the tree is untouched; `components_executor` is PASS at
+`18d17a2` in 6.6s):
+
+| mutant | what it breaks | verdict |
+|---|---|---|
+| `multiply & 64'h0000_0000_ffff_ffff` | MULH/MULHU/MULHSU all return 0 | **PASS** |
+| `mul_sign_y = rs2[31] & (is_mulh \| is_mulhsu)` | MULHSU treats rs2 as signed | **PASS** |
+| `mul_sign_x = 1'b0` | MULH/MULHSU stop sign-extending rs1 | **PASS** |
+| `mul_sign_y = 1'b0` | MULH stops sign-extending rs2 | **PASS** |
+| `multiply + 1` (control) | the low half | FAIL, 0.5s |
+| `mul_sign_x = rs1[0] & …` | sign taken from bit 0 | FAIL, 0.5s |
+
+Three of the four defects ADR-0010 names by hand — "the sign enables are also swapped (MULHSU is
+signed × unsigned, the code has it backwards), and the sign bits are taken from bit 0 rather than
+bit 31" — survive the proof that was written to catch them. The two that are caught are what makes
+this insidious: the multiply assertions are not dead, they are *narrowed*, and a green
+`components_executor` reads exactly the same either way.
+
+This is not a bug in the assumption. The assumption is correct and necessary for the property it
+was written for. It is a bug in what the *reader* is told: nothing at the site says which other
+assertions it also constrains.
+
+## Decision
+
+**ADR-0017's rule gains a third clause. An `assume` must state:**
+
+1. **the structural fact it models** (ADR-0017, unchanged);
+2. **where that fact is discharged** — a named check, a named test, or the word **nowhere**
+   (ADR-0017, unchanged, with "nowhere" made an explicitly acceptable and expected answer);
+3. **its scope** — which assertions it is in force over, and whether that set is larger than the
+   one it was written for.
+
+Clause 3 is the new one, and it is the one this audit exists to add. An unguarded `always_comb
+assume` inside a shared `` `ifdef FORMAL `` block is in force over *every* assertion in that
+module. That is a fact about SystemVerilog, not about the design, and it is invisible from the
+lines around the assume.
+
+**Two ways to satisfy clause 3**, and the choice is the author's:
+
+- **Narrow the assume** to the assertions it was written for — guard it, or move it into the
+  `if (…)` of the property that needs it. Preferred where it costs nothing.
+- **Write the scope down** at the site. Required where narrowing would change the proof.
+
+`rtl/executor.v`'s operand cap takes the second route in this change (the first would alter what
+`components_executor` proves, and that file's divide invariants are owned by in-flight work — see
+Consequences). The rest of the tree's assumes are annotated in place.
+
+**No assume in this repo may be deleted or weakened to make a check pass.** ADR-0010 already says
+the remedy for an intractable proof is to restrict it *and record the restriction*; this ADR adds
+that the record must include who else the restriction binds.
+
+## The census
+
+Every `assume` in `formal/*.sv`, `formal/wrapper.v`, and the `` `ifdef FORMAL `` blocks of `rtl/`,
+at `18d17a2`. There are 24 sites in 6 files. "Discharged" is where the modelled fact is *checked*,
+not where it is *believed*.
+
+### `formal/wrapper.v` — the full-core ladder harness
+
+| site | fact modelled | discharged | scope |
+|---|---|---|---|
+| `wrapper.v:83` | instruction memory is a function of its address: same `imem_addr` two cycles running ⇒ same `imem_data` | **nowhere.** Structural: `rtl/imemory.v` is a `$readmemh` ROM with no write port, and ADR-0044 keeps it that way. No check asserts it | **all 82 generated checks.** Written for `hang` and `liveness_ch0` (ADR-0042 measured both red without it); also in force over all 70 `insn_*`, `reg`, `pc_fwd`/`pc_bwd`, `causal*`, `unique` and `cover` |
+| `wrapper.v:84` | the same, for the fetch window's second port `imem_addr2`/`imem_data2` (ADR-0003) | as above | as above |
+
+`RISCV_FAIRNESS` is an explicitly empty block with its reasoning written out — the correct shape
+for "there is nothing to assume here", and it already reads the way clause 3 asks for.
+
+### `formal/imemcheck.sv` — fetch against a pinned halfword
+
+| site | fact modelled | discharged | scope |
+|---|---|---|---|
+| `imemcheck.sv:60` | the fetch bus answers from memory: the low half of the word at `uut_imem_addr` is the checker's pinned halfword | **nowhere.** Structural, same ROM as above. `rvfi_imem_check` asserts the *core's* consistency with it, never the environment's | the task's one `rvfi_imem_check` assertion |
+| `imemcheck.sv:62` | same, upper half of the first fetch port | as above | as above |
+| `imemcheck.sv:64` | same, low half of the second port (ADR-0003) | as above | as above |
+| `imemcheck.sv:66` | same, upper half of the second port | as above | as above |
+
+Sound because all four constrain **DUT inputs** (`uut_imem_data`/`uut_imem_data2`) against a
+`rand_const_reg` pair, i.e. they narrow the environment and never the core. The scope is narrow by
+construction: the task has exactly one assertion, inside riscv-formal's unmodified checker.
+
+### `formal/dmemcheck.sv` — loads against a one-address shadow
+
+| site | fact modelled | discharged | scope |
+|---|---|---|---|
+| `dmemcheck.sv:86` | the data bus returns, one cycle after the request, whatever was last stored to that address | **nowhere**, and unlike the imem cases there is no clean structural argument either: `rtl/memory.v` is in no test path at all and ADR-0010 records a read-override bug in it. The modelled memory is not the memory this repo has | the task's one `rvfi_dmem_check` assertion |
+
+### `formal/complete.sv` — the whole-ISA walk *(out of scope for edit; owned by the `complete` exclusion-set work)*
+
+| site | fact modelled | discharged | scope |
+|---|---|---|---|
+| `complete.sv:59` | store-then-reload forwarding for the most recent store only | **nowhere**, same as `dmemcheck.sv:86` and with the same missing structural backing | `complete`'s single `assert(spec_valid && !spec_trap)` |
+
+### `formal/pcloop.sv` — the composed fetcher+decoder proof *(out of scope for edit; a depths PR is mid-merge)*
+
+| site | fact modelled | discharged | scope |
+|---|---|---|---|
+| `pcloop.sv:126` | reset is asserted before the first clock edge | **nowhere.** Structural: `test/testbench.v` and `formal/*.sv` all drive `reset = 1` initially | the whole `pcloop` task |
+| `pcloop.sv:127` | the same, restated for the pre-`clocked` window | as above | as above |
+| `pcloop.sv:128` | reset is a once-at-the-start pulse and never returns | **nowhere.** True of every harness in the tree; asserted by none of them | the whole `pcloop` task. Larger than written for: it was written for the two pc-history assertions and also binds the echo, the hold and both redirect assertions |
+
+### `rtl/decoder.v` — `components_decoder`
+
+| site | fact modelled | discharged | scope |
+|---|---|---|---|
+| `decoder.v:1005` | reset holds before the first clock edge | **nowhere** (structural, as above) | the whole task |
+| `decoder.v:1006` | the same, restated for the pre-`clocked` window | **nowhere** | the whole task |
+| `decoder.v:1013` | reset is a once-at-the-start pulse | **nowhere** | the whole task — written for the two pc-increment assertions, also in force over the ADR-0028/ADR-0030 trap-arm assertions added later |
+| `decoder.v:1023` | `in.pc == pc`: the fetcher echoes the decoder's own pc combinationally (`rtl/fetcher.v`'s `out.pc = pc`, wired pc→pc in `rtl/littlecpu.v`) | **`formal/pcloop.sv:261`** asserts exactly this — but see finding F2: that task is red and no `make` target runs it, so today the fact is discharged by a check nobody runs | the whole task. ADR-0017 analysed its effect on the pc-increment pair; it is also in force over the bubble, hazard, `one_of`, trap-cause and trap-arm assertions |
+
+### `rtl/executor.v` — `components_executor`
+
+| site | fact modelled | discharged | scope |
+|---|---|---|---|
+| `executor.v:266` | reset holds before the first clock edge | **nowhere** (structural) | the whole task |
+| `executor.v:267` | the same, restated for the pre-`clocked` window | **nowhere** | the whole task |
+| `executor.v:279` | reset is a once-at-the-start pulse and cannot be re-asserted mid-divide | **nowhere** | the whole task — written for the divide assertions, also in force over the four multiply assertions and the ADR-0015 freeze block |
+| `executor.v:330` | the decoder emits at most one op-select flag (`$onehot0` over all 29 `is_*` fields of `decoder_output`) | **`rtl/decoder.v`'s own `one_of` assertion** (`components_decoder`, `assert($onehot(…))` under `instr_valid`) — the one assume in the tree with a real, running discharge | the whole task. Written for the arithmetic assertions; also in force over the freeze block and every divide invariant. Verified complete against `rtl/structs.v`: all 29 flags listed, `is_valid_instr` correctly excluded |
+| `executor.v:392` | ADR-0010's recorded restriction: operands in 0..15 keep the divide invariant's intermediate arithmetic inside 64 bits | **nowhere.** It is a restriction, not a fact about the design — nothing discharges it and nothing should | **the whole task, including the four multiply assertions it was not written for.** See F1 |
+| `executor.v:393` | the same, for `in.rs2` | as above | as above |
+| `executor.v:408-413` (6 sites) | ADR-0009's stall protocol: decode holds `in` steady for the duration of a multi-cycle divide | **nowhere.** `rtl/decoder.v`'s own task asserts the pc holds on a stalled cycle, not that `decoder_out` holds | guarded (`state == divide \|\| $past(state) == divide`), so genuinely scoped to the divide assertions. The one guarded `assume` in `rtl/` |
+
+## Findings
+
+**F1 — `rtl/executor.v`'s operand cap makes three of ADR-0010's four named multiplier defects
+invisible.** The table at the top of this ADR is the demonstration. Recorded, not fixed: the
+divide-invariant assumes are owned by in-flight work, and fixing this correctly means narrowing the
+cap to the divide assertions, which changes what `components_executor` proves and belongs with that
+work. The site carries a scope statement in the meantime — clause 3's second route.
+
+**F2 — `formal/pcloop.sv` is RED on `main`, and nothing runs it.** Measured at `18d17a2`:
+`sby -f components.sby pcloop` → `DONE (FAIL, rc=2)` in 0.67s, `failed assertion … at
+pcloop.sv:273 step 3`. The cause is exact and is in this ADR's own class: `f_may_stall` is
+documented as an over-approximation of `rtl/decoder.v`'s `stall`, and it lists four of the five
+terms — ADR-0042 added `operand_stall` and `f_may_stall` was never widened. The counterexample is
+the first post-reset cycle, where `operand_stall = 1`, `stall = 1` and the pc legitimately holds
+while `prev_may_stall` reads 0 the next cycle. `operand_stall` is decoder-*internal* and reaches no
+port, so `f_may_stall` **cannot** be widened from pcloop's own nets: closing this needs `stall`
+exposed as a decoder output, or the equivalent re-derived, which is decode duplication `pcloop.sv`
+explicitly refuses. Compounding it, `formal/Makefile` has `components_decoder` and
+`components_executor` targets and no `components_pcloop`, and `.github/workflows/ci.yml`'s
+`components` job runs the two that exist — so the only way to reach this task is to type the `sby`
+line by hand. A red proof nobody runs is the same defect as a green proof that checks nothing
+(ADR-0033, ADR-0037), and it is the check that discharges `decoder.v:1023`.
+
+**F3 — the two divide-completion assertions are unreachable in the base case.** `components.sby`
+sets no `depth`, so `mode prove`'s basecase runs to 20 steps. The real divider needs 33 cycles from
+issue, so `$past(state) == divide && state == init` cannot occur in any concrete trace the basecase
+explores. Demonstrated: replacing `assert(out.rd_data == divu_ref)` (and the `remu_ref` twin) with
+`assert(1'b0)` gives **basecase = pass**, induction = FAIL — where every other assertion guard in
+the module gives basecase = FAIL in 0.5s. Those two assertions are the *only* place the divide
+invariants are tied to `out.rd_data`, so the end-to-end divide result rests entirely on the
+induction step and on the invariant chain feeding it; no concrete trace ever computes a division.
+Per ADR-0025 this is recorded as a fact about the depth **and** the guard, and neither is raised
+here — raising the basecase past 33 is a depth change requiring its own empirical evidence, and the
+ladder-depths work is in flight.
+
+**F4 — four of the six memory-model assumes are discharged nowhere and have no structural backing
+either.** `imemcheck.sv` and `wrapper.v` model a ROM, and `rtl/imemory.v` really is one, so
+"nowhere" there is fine. `dmemcheck.sv:86` and `complete.sv:59` model a *writable* memory whose
+only implementation in the tree, `rtl/memory.v`, is in no test path and carries a known
+read-override bug (ADR-0010). The gap is not that the assumes are unsound — they constrain DUT
+inputs — but that ADR-0044's memory system, when it is built, has no check anywhere that will hold
+it to what these two proofs assumed of it.
+
+## Vacuity: every compound `assert` guard, demonstrated
+
+Method: replace the assertion body with `assert(1'b0)` under its existing guard and rerun the task.
+**basecase = FAIL is a reachability witness** — the solver produced a concrete trace in which the
+guard holds. basecase = pass means the guard is not reachable within the basecase depth, which is
+finding F3's shape. No assume was touched to produce any of these.
+
+`components_executor` (`sby -f components.sby executor`), all twelve guards:
+
+| guard | verdict |
+|---|---|
+| `clocked && !reset && !$past(reset) && $past(accessor_stall)` (ADR-0015 freeze) | FAIL 0.6s — reachable |
+| `… && !$past(accessor_stall) && $past(state)==init && $past(in.is_mul)` | FAIL 0.5s — reachable |
+| the same for `is_mulh` / `is_mulhu` / `is_mulhsu` | FAIL 0.5s each — reachable |
+| `state == divide` (op-latch tie-back) | FAIL 0.5s — reachable |
+| `state == divide` (counter bound) | FAIL 0.5s — reachable |
+| `state == divide && mul_div_counter > 0` (`mul_div_y` scaling) | FAIL 0.5s — reachable |
+| `state == divide` (division identity) | FAIL 0.5s — reachable |
+| `state == divide` (quotient bound) | FAIL 0.5s — reachable |
+| `$past(state)==divide && state==init && $past(in.is_divu)` | **basecase pass** — F3 |
+| the same for `is_remu` | **basecase pass** — F3 |
+
+`components_decoder` and `formal/complete.sv`/`formal/cover.sv` results are in the pull request that
+landed this ADR; `cover.sv`'s five `cover property` statements are themselves the reachability
+demonstration for the full-core harness and all five are reported reached (ADR-0006, `86e2721`).
+
+## Rationale
+
+The alternative to clause 3 was a lint: forbid unguarded `always_comb assume` in a shared FORMAL
+block outright. Rejected — `executor.v:330`'s `$onehot0` is exactly such an assume, is correct, and
+*should* be proof-global, because the decoder really does emit at most one flag on every cycle of
+every assertion. A rule that flags the good case and the bad case identically teaches people to
+silence it. What distinguishes the two is not the syntax but whether the author knew the scope, and
+the only way to check that is to make them write it down.
+
+Making "nowhere" an explicit and expected answer is the other half. ADR-0017's phrasing — "say
+which higher-level check discharges it" — reads as though a discharge always exists, and eleven of
+the twenty-four sites here have none. An audit that had to invent a discharging check for each of
+those would have produced twenty-four plausible sentences and no information.
+
+## Consequences
+
+- Every `assume` site in `formal/wrapper.v`, `formal/imemcheck.sv`, `formal/dmemcheck.sv`,
+  `rtl/decoder.v` and `rtl/executor.v` carries fact / discharge / scope at the site.
+  `formal/complete.sv` and `formal/pcloop.sv` are censused here but not annotated: both are owned
+  by in-flight work, and this ADR's table is their record until that work lands.
+- **F1 is handed to the executor real-arithmetic work**, which owns those lines. The fix is to
+  narrow the cap to the divide assertions; the four multiply assertions need no cap (a single
+  combinational stage, full 32-bit correctness is provable directly, as the comment above them
+  already says).
+- **F2 is handed to whoever owns `formal/pcloop.sv`.** Two separable halves: the red itself
+  (`f_may_stall` needs `operand_stall`, which needs a port), and the fact that no `make` target and
+  no CI job reaches the task.
+- **F3 is a standing caveat on `components_executor`**, in the same family as ADR-0010's ALTOPS
+  caveat: the divide result is proved inductively and never simulated. It is not a reason to raise
+  the depth without evidence (ADR-0025).
+- ADR-0017 is supplemented, not superseded. Its `in.pc == pc` analysis stands; this ADR adds that
+  the same assume is also in force over the trap-arm assertions written into that block two
+  milestones later, which is exactly the kind of quiet scope growth clause 3 exists to catch.

--- a/docs/adr/0048-every-formal-assume-names-its-scope-and-its-discharge.md
+++ b/docs/adr/0048-every-formal-assume-names-its-scope-and-its-discharge.md
@@ -193,6 +193,16 @@ so it does not discharge this either.) ADR-0044 rules the placeholder out as a s
 does not replace it, so when the real memory system is built there is no check anywhere that will
 hold it to what these two proofs assumed of it.
 
+**F5 — the same operand cap blanks the signed divide path, and that one needs new assertions
+rather than a narrower assume.** With operands in 0..15, `op_sign_x` and `op_sign_y` are constant
+zero, so `assert(op_sign_x == in.rs1[31])` and its twin read `assert(0 == 0)`, and the only
+completion assertions in the task are the *unsigned* pair (`divu_ref` / `remu_ref`). Nothing
+asserts that the signed sign-restore happens at all. Measured: deleting
+`op_sign_x != op_sign_y ? -mul_div_store[31:0] :` from the `op_is_div` capture **PASSES**, and
+deleting `op_sign_x ? -mul_div_x[31:0] :` from the `op_is_rem` capture **PASSES**. ADR-0012's sign
+wrapper — the reason this divider is allowed to be unsigned at all — has no formal coverage here.
+`test/exec_tb.v` covers it; the component proof does not, and did not appear not to.
+
 ## Vacuity: every compound `assert` guard, demonstrated
 
 Method: replace the assertion body with `assert(1'b0)` under its existing guard and rerun the task.

--- a/docs/adr/0048-every-formal-assume-names-its-scope-and-its-discharge.md
+++ b/docs/adr/0048-every-formal-assume-names-its-scope-and-its-discharge.md
@@ -180,13 +180,18 @@ Per ADR-0025 this is recorded as a fact about the depth **and** the guard, and n
 here — raising the basecase past 33 is a depth change requiring its own empirical evidence, and the
 ladder-depths work is in flight.
 
-**F4 — four of the six memory-model assumes are discharged nowhere and have no structural backing
-either.** `imemcheck.sv` and `wrapper.v` model a ROM, and `rtl/imemory.v` really is one, so
-"nowhere" there is fine. `dmemcheck.sv:86` and `complete.sv:59` model a *writable* memory whose
-only implementation in the tree, `rtl/memory.v`, is in no test path and carries a known
-read-override bug (ADR-0010). The gap is not that the assumes are unsound — they constrain DUT
-inputs — but that ADR-0044's memory system, when it is built, has no check anywhere that will hold
-it to what these two proofs assumed of it.
+**F4 — the two writable-memory assumes are true of a memory this repo does not have.**
+`imemcheck.sv` and `wrapper.v` model a ROM, and `rtl/imemory.v` really is one at every address, so
+"nowhere" there costs nothing. `dmemcheck.sv:86` and `complete.sv:59` model a *writable* memory.
+The only one in the tree is `rtl/memory.v`, and it answers any address at or past `4*RAM` with
+`mem_rdata <= mem_wdata` rather than with stored data. `dmem_addr` and `mem_addr` are free 32-bit
+values in both harnesses, so the assumed model and the real module disagree over the overwhelming
+majority of the address space. (ADR-0010's "`rtl/memory.v` has the same shape of problem: it is in
+**no** current test path" is stale as of `test/mem_tb.v`, which is on `make test-units` — but that
+bench only asserts an out-of-range read does not *alias* `ram[0]`; it never says what one returns,
+so it does not discharge this either.) ADR-0044 rules the placeholder out as a starting point and
+does not replace it, so when the real memory system is built there is no check anywhere that will
+hold it to what these two proofs assumed of it.
 
 ## Vacuity: every compound `assert` guard, demonstrated
 
@@ -210,9 +215,38 @@ finding F3's shape. No assume was touched to produce any of these.
 | `$past(state)==divide && state==init && $past(in.is_divu)` | **basecase pass** — F3 |
 | the same for `is_remu` | **basecase pass** — F3 |
 
-`components_decoder` and `formal/complete.sv`/`formal/cover.sv` results are in the pull request that
-landed this ADR; `cover.sv`'s five `cover property` statements are themselves the reachability
-demonstration for the full-core harness and all five are reported reached (ADR-0006, `86e2721`).
+`components_decoder` (`sby -f components.sby decoder`), all seventeen guards. Ten of them are
+`always_comb` with no `clocked` term, so those were run twice: once with `assert(1'b0)` and again
+with `assert(!(clocked && !reset))`, which forces the witness to be a real post-reset cycle rather
+than the pre-reset step 0. Both rounds FAIL for every one:
+
+| guard | verdict |
+|---|---|
+| `clocked && !branch_jump && !prev_stall && !prev_reset && prev_uncompressed` | FAIL @ step 4 |
+| the same with `!prev_uncompressed` | FAIL @ step 4 |
+| `clocked && prev_stall && !prev_reset` | FAIL @ step 3 |
+| `clocked && !out.valid` | FAIL @ step 1 |
+| `rs1 == 0` / `rs2 == 0` | FAIL @ step 1 (post-reset witness) |
+| `instr_valid` | FAIL @ step 1 (post-reset witness) |
+| `instr_illegal` / `instr_ebreak` / `instr_ecall` / `load_misaligned` / `store_misaligned` | FAIL @ step 1 each (post-reset witness) |
+| `!trap_pending` / `trap_pending` | FAIL @ step 1 each (post-reset witness) |
+| `clocked && !prev_reset && prev_trap_entry` (→ `mtvec`, and → `out.rd == 0`) | FAIL @ step 3 |
+| `clocked && !prev_reset && prev_mret_entry` | FAIL @ step 3 |
+
+`components_pcloop` (task red on main, so the sequential-advance assertion is neutralised to
+`assert(1'b1)` first and the guard under test carries the probe): the echo guard FAILs at step 1,
+`prev_hard_stall` at step 3, both redirect guards at step 4. The sequential-advance guard itself is
+demonstrated reachable **in both width branches** — `assert(!prev_uncompressed)` and
+`assert(prev_uncompressed)` under it both FAIL at step 3 — so neither the 4-byte nor the 2-byte arm
+is vacuous.
+
+`formal/cover.sv` is the full-core harness's own reachability demonstration and needs no mutation.
+Re-measured for this audit rather than quoted: `make -C formal cover` → `DONE (PASS, rc=0)` in 12s,
+all five goals reached, including the compound one (`mem_read >= 2 && mem_write >= 2 &&
+long_insns >= 2 && comp_insns >= 2`) at step 11.
+
+`formal/complete.sv`'s single guard (`!reset && rvfi_valid && !rvfi_trap`) needs no mutation either:
+the check is red today (M2 term 5), and a counterexample is a reachability witness by construction.
 
 ## Rationale
 

--- a/docs/adr/0048-every-formal-assume-names-its-scope-and-its-discharge.md
+++ b/docs/adr/0048-every-formal-assume-names-its-scope-and-its-discharge.md
@@ -116,7 +116,7 @@ construction: the task has exactly one assertion, inside riscv-formal's unmodifi
 |---|---|---|---|
 | `complete.sv:59` | store-then-reload forwarding for the most recent store only | **nowhere**, same as `dmemcheck.sv:86` and with the same missing structural backing | `complete`'s single `assert(spec_valid && !spec_trap)` |
 
-### `formal/pcloop.sv` — the composed fetcher+decoder proof *(out of scope for edit; a depths PR is mid-merge)*
+### `formal/pcloop.sv` — the composed fetcher+decoder proof *(not edited here; `bb6e228` owns this file)*
 
 | site | fact modelled | discharged | scope |
 |---|---|---|---|
@@ -131,7 +131,7 @@ construction: the task has exactly one assertion, inside riscv-formal's unmodifi
 | `decoder.v:1005` | reset holds before the first clock edge | **nowhere** (structural, as above) | the whole task |
 | `decoder.v:1006` | the same, restated for the pre-`clocked` window | **nowhere** | the whole task |
 | `decoder.v:1013` | reset is a once-at-the-start pulse | **nowhere** | the whole task — written for the two pc-increment assertions, also in force over the ADR-0028/ADR-0030 trap-arm assertions added later |
-| `decoder.v:1023` | `in.pc == pc`: the fetcher echoes the decoder's own pc combinationally (`rtl/fetcher.v`'s `out.pc = pc`, wired pc→pc in `rtl/littlecpu.v`) | **`formal/pcloop.sv:261`** asserts exactly this — but see finding F2: that task is red and no `make` target runs it, so today the fact is discharged by a check nobody runs | the whole task. ADR-0017 analysed its effect on the pc-increment pair; it is also in force over the bubble, hazard, `one_of`, trap-cause and trap-arm assertions |
+| `decoder.v:1023` | `in.pc == pc`: the fetcher echoes the decoder's own pc combinationally (`rtl/fetcher.v`'s `out.pc = pc`, wired pc→pc in `rtl/littlecpu.v`) | **`formal/pcloop.sv`** asserts exactly this, and as of `bb6e228` it is a real, running discharge — `make -C formal components_pcloop`, in CI, PASS in 2.7s. It was red and unrun for the whole period this audit ran; see F2 | the whole task. ADR-0017 analysed its effect on the pc-increment pair; it is also in force over the bubble, hazard, `one_of`, trap-cause and trap-arm assertions |
 
 ### `rtl/executor.v` — `components_executor`
 
@@ -153,20 +153,41 @@ divide-invariant assumes are owned by in-flight work, and fixing this correctly 
 cap to the divide assertions, which changes what `components_executor` proves and belongs with that
 work. The site carries a scope statement in the meantime — clause 3's second route.
 
-**F2 — `formal/pcloop.sv` is RED on `main`, and nothing runs it.** Measured at `18d17a2`:
-`sby -f components.sby pcloop` → `DONE (FAIL, rc=2)` in 0.67s, `failed assertion … at
-pcloop.sv:273 step 3`. The cause is exact and is in this ADR's own class: `f_may_stall` is
-documented as an over-approximation of `rtl/decoder.v`'s `stall`, and it lists four of the five
-terms — ADR-0042 added `operand_stall` and `f_may_stall` was never widened. The counterexample is
-the first post-reset cycle, where `operand_stall = 1`, `stall = 1` and the pc legitimately holds
-while `prev_may_stall` reads 0 the next cycle. `operand_stall` is decoder-*internal* and reaches no
-port, so `f_may_stall` **cannot** be widened from pcloop's own nets: closing this needs `stall`
-exposed as a decoder output, or the equivalent re-derived, which is decode duplication `pcloop.sv`
-explicitly refuses. Compounding it, `formal/Makefile` has `components_decoder` and
-`components_executor` targets and no `components_pcloop`, and `.github/workflows/ci.yml`'s
-`components` job runs the two that exist — so the only way to reach this task is to type the `sby`
-line by hand. A red proof nobody runs is the same defect as a green proof that checks nothing
-(ADR-0033, ADR-0037), and it is the check that discharges `decoder.v:1023`.
+**F2 — `formal/pcloop.sv` was red and unrun. FOUND INDEPENDENTLY HERE; FIXED CONCURRENTLY BY
+`bb6e228` (ADR-0046).** This audit measured it at `18d17a2` as `sby -f components.sby pcloop` →
+`DONE (FAIL, rc=2)` in 0.67s at `pcloop.sv:273 step 3`, and attributed it from the counterexample
+VCD: the failing cycle's predecessor is the first post-reset cycle, where `operand_stall = 1`,
+`stall = 1` and the pc legitimately holds, while `prev_may_stall` reads 0 because `f_may_stall`
+lists **four** of `rtl/decoder.v`'s **five** stall terms. ADR-0042 added `operand_stall`; the
+over-approximation was never widened, so it had stopped being one. Same class as F1 one level up: a
+guard whose excused set is smaller than the RTL's.
+
+The ladder-depths work landed the fix while this was in flight, reaching the same attribution
+independently, and it went further than this finding did in two ways worth recording:
+
+- **The fix needed no new port, and this ADR's first draft said it did.** That claim was wrong.
+  `rs1`/`rs2` are decoder *output ports*, so `pcloop.sv` transcribes `rtl/decoder.v`'s
+  `prev_rs1`/`prev_rs2`/`read_taken` register into the harness and over-approximates at the
+  comparison, exactly as every other `f_may_stall` term does. Recorded because "this cannot be done
+  from the module's own nets" is the kind of claim that closes off a fix, and it was written without
+  being checked.
+- **The task is wired up now**: `formal/Makefile` has a `components_pcloop` target and
+  `.github/workflows/ci.yml`'s `components` job runs it. Re-measured on the merged tree for this
+  ADR: `DONE (PASS, rc=0)` by k-induction in 2.7s.
+
+What survives, and is why this stays in the census rather than being deleted: **the defect was
+invisible for as long as it was because nothing ran the task.** `rtl/decoder.v:1023`'s
+`assume(in.pc == pc)` was, for that whole period, discharged by a check nobody invoked — and a
+discharge like that reads identically in the source to a real one. That is the durable lesson, and
+it is why clause 2 asks *where* rather than merely *whether*.
+
+One methodological correction, because it was nearly published as a finding: a sandbox diagnostic
+asking whether widening `f_may_stall` closes the red was run twice and returned no verdict, and the
+draft inferred from that that widening "makes the query dramatically harder." **That inference was
+wrong and the measurement was an artefact.** `formal/components.sby` now pins `pcloop: smtbmc
+boolector` precisely because the default solver sits on this task for over fourteen minutes without
+returning, which is what both attempts hit. Solver choice, not problem hardness — a non-answer is
+not evidence about the problem.
 
 **F3 — the two divide-completion assertions are unreachable in the base case.** `components.sby`
 sets no `depth`, so `mode prove`'s basecase runs to 20 steps. The real divider needs 33 cycles from
@@ -243,12 +264,14 @@ than the pre-reset step 0. Both rounds FAIL for every one:
 | `clocked && !prev_reset && prev_trap_entry` (→ `mtvec`, and → `out.rd == 0`) | FAIL @ step 3 |
 | `clocked && !prev_reset && prev_mret_entry` | FAIL @ step 3 |
 
-`components_pcloop` (task red on main, so the sequential-advance assertion is neutralised to
-`assert(1'b1)` first and the guard under test carries the probe): the echo guard FAILs at step 1,
-`prev_hard_stall` at step 3, both redirect guards at step 4. The sequential-advance guard itself is
-demonstrated reachable **in both width branches** — `assert(!prev_uncompressed)` and
-`assert(prev_uncompressed)` under it both FAIL at step 3 — so neither the 4-byte nor the 2-byte arm
-is vacuous.
+`components_pcloop`, re-measured on the merged tree where the task is green (the first pass was
+taken while it was red, which needed the sequential-advance assertion neutralised first; that
+scaffolding is gone and the numbers below are the clean ones): echo guard FAIL @ step 1,
+`prev_hard_stall` @ step 3, both redirect guards @ step 4. The sequential-advance guard is reachable
+**in both width branches** — `assert(!prev_uncompressed)` and `assert(prev_uncompressed)` under it
+both FAIL @ step 4 — so neither the 4-byte nor the 2-byte arm is vacuous. The witnesses moved out by
+one step relative to the red-tree run, which is the operand-fetch cycle `f_may_stall` now accounts
+for.
 
 `formal/cover.sv` is the full-core harness's own reachability demonstration and needs no mutation.
 Re-measured for this audit rather than quoted: `make -C formal cover` → `DONE (PASS, rc=0)` in 12s,
@@ -282,9 +305,10 @@ those would have produced twenty-four plausible sentences and no information.
   narrow the cap to the divide assertions; the four multiply assertions need no cap (a single
   combinational stage, full 32-bit correctness is provable directly, as the comment above them
   already says).
-- **F2 is handed to whoever owns `formal/pcloop.sv`.** Two separable halves: the red itself
-  (`f_may_stall` needs `operand_stall`, which needs a port), and the fact that no `make` target and
-  no CI job reaches the task.
+- **F2 is closed, by `bb6e228` rather than by this ADR** — both halves: `f_may_stall` carries the
+  operand-fetch term, and `components_pcloop` is a `make` target and a CI job. It is kept in the
+  census because the *shape* is the point: an assume whose discharge is a task nothing invokes looks
+  exactly like an assume whose discharge is real.
 - **F3 is a standing caveat on `components_executor`**, in the same family as ADR-0010's ALTOPS
   caveat: the divide result is proved inductively and never simulated. It is not a reason to raise
   the depth without evidence (ADR-0025).

--- a/docs/adr/0049-every-formal-assume-names-its-scope-and-its-discharge.md
+++ b/docs/adr/0049-every-formal-assume-names-its-scope-and-its-discharge.md
@@ -1,4 +1,4 @@
-# ADR-0048: Every formal `assume` names its scope as well as its discharge
+# ADR-0049: Every formal `assume` names its scope as well as its discharge
 
 **Status:** Accepted · 2026-08-01 · *Supplements ADR-0017; scopes ADR-0010, ADR-0025*
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -52,6 +52,7 @@ and what it costs. Reversing one is fine — write a new ADR that supersedes it.
 | [0046](0046-the-ladder-depths-are-re-derived-and-the-derivation-is-measured.md) | The ladder's depths are re-derived for the five-reason pipeline, and the derivation is measured | Accepted · supersedes 0025 |
 | [0044](0044-what-the-memory-system-has-to-be.md) | What the memory system has to be, and why today's placeholders cannot be it | Accepted |
 | [0047](0047-non-perturbation-is-proved-structurally-and-equiv-sh-is-retired.md) | The RVFI non-perturbation guarantee is proved structurally, and `equiv.sh` is retired | Accepted |
+| [0049](0049-every-formal-assume-names-its-scope-and-its-discharge.md) | Every formal `assume` names its scope as well as its discharge | Accepted · supplements 0017 |
 
 0001–0007 came from the design brief
 ([`docs/ideas/finish-the-rewrite.md`](../ideas/finish-the-rewrite.md)). 0008–0011 came out of

--- a/formal/dmemcheck.sv
+++ b/formal/dmemcheck.sv
@@ -67,6 +67,24 @@ module testbench (
     end
   end
 
+  // FACT       the data bus returns, one cycle after the request, whatever was
+  //            last written to that address -- an ordinary memory, modelled at
+  //            one address because that is all rvfi_dmem_check pins.
+  // DISCHARGED NOWHERE, and this one has no structural backing either, which
+  //            is what separates it from the imem assumes in wrapper.v and
+  //            imemcheck.sv. Those model rtl/imemory.v, a ROM that really does
+  //            behave this way. The only writable memory in this tree is
+  //            rtl/memory.v, which is on NO test path at all and carries a
+  //            known read-override bug (ADR-0010's closing bullet). So the
+  //            memory this proof assumes is not a memory this repo has
+  //            checked, and when ADR-0044's memory system is built there is no
+  //            check anywhere that will hold it to this. Recorded rather than
+  //            papered over (ADR-0048 F4).
+  // SCOPE      the one rvfi_dmem_check assertion this task contains -- what it
+  //            was written for, and nothing more. Like imemcheck.sv's four,
+  //            this constrains a DUT INPUT (mem_rdata), so it narrows the
+  //            environment and can never excuse the core.
+  //
   // Read side is genuinely one cycle behind the request, unlike the
   // wave-0 handshake harness this replaces: ADR-0015's load turnaround
   // registers mem_rdata the cycle *after* the address is presented, and

--- a/formal/dmemcheck.sv
+++ b/formal/dmemcheck.sv
@@ -70,16 +70,22 @@ module testbench (
   // FACT       the data bus returns, one cycle after the request, whatever was
   //            last written to that address -- an ordinary memory, modelled at
   //            one address because that is all rvfi_dmem_check pins.
-  // DISCHARGED NOWHERE, and this one has no structural backing either, which
-  //            is what separates it from the imem assumes in wrapper.v and
-  //            imemcheck.sv. Those model rtl/imemory.v, a ROM that really does
-  //            behave this way. The only writable memory in this tree is
-  //            rtl/memory.v, which is on NO test path at all and carries a
-  //            known read-override bug (ADR-0010's closing bullet). So the
-  //            memory this proof assumes is not a memory this repo has
-  //            checked, and when ADR-0044's memory system is built there is no
-  //            check anywhere that will hold it to this. Recorded rather than
-  //            papered over (ADR-0048 F4).
+  // DISCHARGED PARTIALLY, and only for part of the address space, which is
+  //            what separates it from the imem assumes in wrapper.v and
+  //            imemcheck.sv (those model rtl/imemory.v, a ROM that really does
+  //            behave this way at every address). test/mem_tb.v checks
+  //            rtl/memory.v's read-after-write behaviour directly and is on
+  //            `make test-units` -- ADR-0010's "in no current test path" is
+  //            stale, and mem_tb.v's own header repeats it. But rtl/memory.v
+  //            answers an address at or past 4*RAM with `mem_rdata <=
+  //            mem_wdata`, not with stored data, and mem_tb.v only asserts
+  //            that such a read does not ALIAS ram[0] -- it never says what it
+  //            returns. `dmem_addr` here is a free 32-bit value, so the model
+  //            this proof assumes and the only writable memory this repo has
+  //            disagree over most of the address space. ADR-0044 rules the
+  //            placeholder out as a starting point and does not replace it, so
+  //            when the real memory system is built there is no check anywhere
+  //            that will hold it to what this proof assumed (ADR-0048 F4).
   // SCOPE      the one rvfi_dmem_check assertion this task contains -- what it
   //            was written for, and nothing more. Like imemcheck.sv's four,
   //            this constrains a DUT INPUT (mem_rdata), so it narrows the

--- a/formal/dmemcheck.sv
+++ b/formal/dmemcheck.sv
@@ -85,7 +85,7 @@ module testbench (
   //            disagree over most of the address space. ADR-0044 rules the
   //            placeholder out as a starting point and does not replace it, so
   //            when the real memory system is built there is no check anywhere
-  //            that will hold it to what this proof assumed (ADR-0048 F4).
+  //            that will hold it to what this proof assumed (ADR-0049 F4).
   // SCOPE      the one rvfi_dmem_check assertion this task contains -- what it
   //            was written for, and nothing more. Like imemcheck.sv's four,
   //            this constrains a DUT INPUT (mem_rdata), so it narrows the

--- a/formal/imemcheck.sv
+++ b/formal/imemcheck.sv
@@ -45,6 +45,21 @@ module testbench (
   logic [3:0]  mem_wstrb;
   logic [31:0] mem_rdata;
 
+  // FACT       the fetch bus answers from memory: whenever either of the two
+  //            fetch ports covers the halfword `checker_inst` has pinned, the
+  //            data the core sees there is that halfword.
+  // DISCHARGED NOWHERE. rvfi_imem_check asserts that the CORE is consistent
+  //            with the pinned halfword; nothing asserts that the environment
+  //            is. The backing is structural and is the same one
+  //            formal/wrapper.v:83 rests on -- rtl/imemory.v is a $readmemh
+  //            ROM (ADR-0044) -- and is likewise believed, not proved.
+  // SCOPE      the one rvfi_imem_check assertion this task contains, which is
+  //            also everything it was written for. All four assumes constrain
+  //            DUT INPUTS (uut_imem_data/uut_imem_data2), so they narrow the
+  //            environment and can never excuse the core; the checker's own
+  //            imem_addr/imem_data are rand_const, so there is no cycle
+  //            history for the scope to leak across either.
+  //
   // No mem_valid/mem_ready to gate on: rtl/fetcher.v drives imem_addr/
   // imem_addr2 = {pc[31:2],2'b00}/+4 and out.instr = the windowed pair
   // combinationally, unconditionally, every non-reset cycle (CLAUDE.md

--- a/formal/wrapper.v
+++ b/formal/wrapper.v
@@ -40,7 +40,7 @@ module rvfi_wrapper (
   //            it. The backing is structural: rtl/imemory.v is a $readmemh ROM
   //            with no write port, and ADR-0044 keeps the instruction side
   //            read-only. Believed, not proved -- which is the honest answer
-  //            and, per ADR-0048, an acceptable one.
+  //            and, per ADR-0049, an acceptable one.
   // SCOPE      ALL 82 GENERATED CHECKS. This is an unguarded `assume` in the
   //            harness every check instantiates, so it is in force over every
   //            insn_*, reg, pc_fwd/pc_bwd, causal*, unique and cover check --

--- a/formal/wrapper.v
+++ b/formal/wrapper.v
@@ -34,6 +34,21 @@ module rvfi_wrapper (
 
   // INSTRUCTION MEMORY IS A FUNCTION OF ITS ADDRESS (ADR-0042, ADR-0017).
   //
+  // FACT       instruction memory is a function of its address, across two
+  //            consecutive cycles.
+  // DISCHARGED NOWHERE. There is no check anywhere in this repo that asserts
+  //            it. The backing is structural: rtl/imemory.v is a $readmemh ROM
+  //            with no write port, and ADR-0044 keeps the instruction side
+  //            read-only. Believed, not proved -- which is the honest answer
+  //            and, per ADR-0048, an acceptable one.
+  // SCOPE      ALL 82 GENERATED CHECKS. This is an unguarded `assume` in the
+  //            harness every check instantiates, so it is in force over every
+  //            insn_*, reg, pc_fwd/pc_bwd, causal*, unique and cover check --
+  //            not only the two it was written for (`hang` and `liveness_ch0`,
+  //            measured red without it below). That set is much larger than the
+  //            one it was written for, and the paragraph headed WHAT IT COSTS
+  //            is what those other 80 checks are paying.
+  //
   // The structural fact being modelled: a ROM asked twice for the same address,
   // with no write port anywhere in this design that could reach it, answers the
   // same both times. That is a property of memory, not a convenience -- and

--- a/rtl/decoder.v
+++ b/rtl/decoder.v
@@ -1044,13 +1044,14 @@ module decoder (
   //            ASSERTS the echo (`assert(fetcher_out.pc == pc)`) instead of
   //            assuming it. ADR-0017 relocated this obligation to M2's
   //            full-core wrapper; pcloop.sv now discharges it directly and at
-  //            component level, which is better. BUT: measured at 18d17a2,
-  //            that task is RED (`sby -f components.sby pcloop` -> DONE
-  //            (FAIL, rc=2) in 0.67s, at pcloop.sv:273) and there is no
-  //            `components_pcloop` make target and no CI job that runs it --
-  //            so today this fact is discharged by a check nobody runs
-  //            (ADR-0048 finding F2). That is a statement about pcloop.sv's
-  //            stall model, not about this assume, which remains sound.
+  //            component level, which is better. This is a REAL, RUNNING
+  //            discharge as of `bb6e228` (ADR-0046): `make -C formal
+  //            components_pcloop` is a target, it is in CI's `components` job,
+  //            and it passes by k-induction in 2.7s. It was red and unrun
+  //            while this audit was in flight -- see ADR-0048 F2 for what that
+  //            looked like and why it went unnoticed, which is worth reading
+  //            before adding another assume whose discharge is a task nothing
+  //            invokes.
   // SCOPE      the whole task -- LARGER than what it was written for.
   //            ADR-0017 analysed its effect on the pc-increment pair; it is
   //            also in force over the bubble, hazard, `one_of`, trap-cause and

--- a/rtl/decoder.v
+++ b/rtl/decoder.v
@@ -1001,6 +1001,12 @@ module decoder (
   logic clocked;
   initial clocked = 0;
   always_ff @(posedge clk) clocked <= 1;
+  // FACT       reset is asserted before the first clock edge.
+  // DISCHARGED NOWHERE. Structural: every harness that instantiates this core
+  //            drives reset high initially. No check asserts it (ADR-0048).
+  // SCOPE      the whole task. Unguarded, and that is what it was written for:
+  //            before the first edge `out` and the pc history registers have
+  //            no defined value, so nothing below is meaningful without it.
   // assume we've reset at clk 0
   initial assume(reset);
   always_comb if(!clocked) assume(reset);
@@ -1010,6 +1016,16 @@ module decoder (
   // below — which reason about "pc advanced by pc_inc since last cycle" —
   // would have to separately account for every point reset could jump pc
   // back to 0.
+  //
+  // FACT       reset never returns after the first cycle.
+  // DISCHARGED NOWHERE. True of every harness in the tree; asserted by none.
+  // SCOPE      the whole task -- LARGER than what it was written for. The
+  //            paragraph above is about the pc-increment assertions; this is
+  //            an unguarded `always_comb assume`, so it is equally in force
+  //            over the ADR-0028 / ADR-0030 trap-arm assertions added to this
+  //            block two milestones later. Harmless (those already carry their
+  //            own `!prev_reset` guards) but written down rather than left to
+  //            be inferred from proximity (ADR-0048 clause 3).
   always_comb if (clocked) assume(!reset);
 
   // This component proof stands alone (no real fetcher instantiated), so
@@ -1020,6 +1036,29 @@ module decoder (
   // bears no relation to what this decoder itself last drove, and the
   // pc-increment assertions below are unprovable against a fetcher that
   // isn't behaving like this design's actual one.
+  //
+  // FACT       the fetcher echoes the decoder's own pc combinationally --
+  //            rtl/fetcher.v's `out.pc = pc;`, wired pc -> pc in
+  //            rtl/littlecpu.v.
+  // DISCHARGED formal/pcloop.sv, which instantiates the real fetcher and
+  //            ASSERTS the echo (`assert(fetcher_out.pc == pc)`) instead of
+  //            assuming it. ADR-0017 relocated this obligation to M2's
+  //            full-core wrapper; pcloop.sv now discharges it directly and at
+  //            component level, which is better. BUT: measured at 18d17a2,
+  //            that task is RED (`sby -f components.sby pcloop` -> DONE
+  //            (FAIL, rc=2) in 0.67s, at pcloop.sv:273) and there is no
+  //            `components_pcloop` make target and no CI job that runs it --
+  //            so today this fact is discharged by a check nobody runs
+  //            (ADR-0048 finding F2). That is a statement about pcloop.sv's
+  //            stall model, not about this assume, which remains sound.
+  // SCOPE      the whole task -- LARGER than what it was written for.
+  //            ADR-0017 analysed its effect on the pc-increment pair; it is
+  //            also in force over the bubble, hazard, `one_of`, trap-cause and
+  //            trap-arm assertions below, all of which were written after it.
+  //            None of those reason about `in.pc`, so the widening is inert
+  //            today; it is recorded so that an assertion added later that
+  //            DOES read `in.pc` is not silently handed a fetcher it never
+  //            asked for.
   always_comb assume(in.pc == pc);
 
   // pc increment logic. Skipped for a cycle whose *previous* cycle was

--- a/rtl/decoder.v
+++ b/rtl/decoder.v
@@ -1003,7 +1003,7 @@ module decoder (
   always_ff @(posedge clk) clocked <= 1;
   // FACT       reset is asserted before the first clock edge.
   // DISCHARGED NOWHERE. Structural: every harness that instantiates this core
-  //            drives reset high initially. No check asserts it (ADR-0048).
+  //            drives reset high initially. No check asserts it (ADR-0049).
   // SCOPE      the whole task. Unguarded, and that is what it was written for:
   //            before the first edge `out` and the pc history registers have
   //            no defined value, so nothing below is meaningful without it.
@@ -1025,7 +1025,7 @@ module decoder (
   //            over the ADR-0028 / ADR-0030 trap-arm assertions added to this
   //            block two milestones later. Harmless (those already carry their
   //            own `!prev_reset` guards) but written down rather than left to
-  //            be inferred from proximity (ADR-0048 clause 3).
+  //            be inferred from proximity (ADR-0049 clause 3).
   always_comb if (clocked) assume(!reset);
 
   // This component proof stands alone (no real fetcher instantiated), so
@@ -1048,7 +1048,7 @@ module decoder (
   //            discharge as of `bb6e228` (ADR-0046): `make -C formal
   //            components_pcloop` is a target, it is in CI's `components` job,
   //            and it passes by k-induction in 2.7s. It was red and unrun
-  //            while this audit was in flight -- see ADR-0048 F2 for what that
+  //            while this audit was in flight -- see ADR-0049 F2 for what that
   //            looked like and why it went unnoticed, which is worth reading
   //            before adding another assume whose discharge is a task nothing
   //            invokes.

--- a/rtl/executor.v
+++ b/rtl/executor.v
@@ -266,7 +266,7 @@ module executor(
   // DISCHARGED NOWHERE. Structural: every harness that instantiates this core
   //            (test/testbench.v, formal/*.sv, the generated ladder's
   //            RISCV_FORMAL_RESET_CYCLES) drives reset high initially. No
-  //            check asserts it, and "nowhere" is the honest answer (ADR-0048).
+  //            check asserts it, and "nowhere" is the honest answer (ADR-0049).
   // SCOPE      the whole task. Unguarded, so in force over every assertion in
   //            this block -- which is what it was written for: without it no
   //            assertion here is meaningful, since `state` and the mul_div
@@ -294,7 +294,7 @@ module executor(
   //            four multiply assertions and the ADR-0015 freeze block from
   //            ever seeing a mid-trace reset. That is harmless here (a
   //            re-asserted reset is not a real environment) and is written
-  //            down because ADR-0048 clause 3 requires the reader to be told
+  //            down because ADR-0049 clause 3 requires the reader to be told
   //            the scope rather than left to infer it from proximity.
   always_comb if (clocked) assume(!reset);
 
@@ -353,7 +353,7 @@ module executor(
   //            under `instr_valid`, in components_decoder, which runs in CI
   //            (.github/workflows/ci.yml's `components` job). This is the ONE
   //            assume in this repo with a real, running discharge; every other
-  //            one is believed on structural grounds (ADR-0048's census).
+  //            one is believed on structural grounds (ADR-0049's census).
   // SCOPE      the whole task, and deliberately so. It was written for the
   //            arithmetic assertions but is equally correct over the ADR-0015
   //            freeze block and every divide invariant, because the decoder
@@ -371,7 +371,7 @@ module executor(
     in.is_ecall, in.is_ebreak}));
 
   // THESE FOUR ASSERTIONS DO NOT SEE 32-BIT OPERANDS TODAY, DESPITE THE
-  // PARAGRAPH BELOW (ADR-0048 finding F1). The divide invariant further down
+  // PARAGRAPH BELOW (ADR-0049 finding F1). The divide invariant further down
   // caps operands with two UNGUARDED `always_comb assume(in.rs1 <= 32'h0f)`
   // statements, and an unguarded assume is proof-global: it constrains every
   // assertion in this module, including these. With operands in 0..15 every
@@ -394,7 +394,7 @@ module executor(
   // those lines are owned by in-flight work on the executor's real arithmetic,
   // and narrowing them changes what this proof proves.
   //
-  // THE SAME CAP ALSO BLANKS THE SIGNED DIVIDE PATH (ADR-0048 finding F5), and
+  // THE SAME CAP ALSO BLANKS THE SIGNED DIVIDE PATH (ADR-0049 finding F5), and
   // that one is not fixed by narrowing the cap to "the divide assertions" --
   // it needs new assertions. With operands in 0..15, `op_sign_x` and
   // `op_sign_y` are constant zero, so the two `assert(op_sign_* == in.rs*[31])`

--- a/rtl/executor.v
+++ b/rtl/executor.v
@@ -262,6 +262,15 @@ module executor(
   logic clocked;
   initial clocked = 0;
   always_ff @(posedge clk) clocked <= 1;
+  // FACT       reset is asserted before the first clock edge.
+  // DISCHARGED NOWHERE. Structural: every harness that instantiates this core
+  //            (test/testbench.v, formal/*.sv, the generated ladder's
+  //            RISCV_FORMAL_RESET_CYCLES) drives reset high initially. No
+  //            check asserts it, and "nowhere" is the honest answer (ADR-0048).
+  // SCOPE      the whole task. Unguarded, so in force over every assertion in
+  //            this block -- which is what it was written for: without it no
+  //            assertion here is meaningful, since `state` and the mul_div
+  //            registers have no defined value before the first edge.
   // assume we've reset at clk 0
   initial assume(reset);
   always_comb if(!clocked) assume(reset);
@@ -276,6 +285,17 @@ module executor(
   // divider) and "complete" a division in a handful of steps. Reset is a
   // once-at-the-start pulse everywhere else in this design, so assume it
   // stays low for the remainder of the trace.
+  //
+  // FACT       reset never returns after the first cycle.
+  // DISCHARGED NOWHERE. True of every harness in the tree; asserted by none.
+  // SCOPE      the whole task -- LARGER than what it was written for. The
+  //            paragraph above is about the divide-family assertions, but this
+  //            is an unguarded `always_comb assume`, so it equally excuses the
+  //            four multiply assertions and the ADR-0015 freeze block from
+  //            ever seeing a mid-trace reset. That is harmless here (a
+  //            re-asserted reset is not a real environment) and is written
+  //            down because ADR-0048 clause 3 requires the reader to be told
+  //            the scope rather than left to infer it from proximity.
   always_comb if (clocked) assume(!reset);
 
   // This component proof stands alone (no accessor instantiated), so
@@ -327,6 +347,22 @@ module executor(
   // by the decoder in the real pipeline; this component proof stands alone, so
   // that has to be an explicit environmental assumption or the solver can pick
   // nonsensical combinations no real instruction produces.
+  //
+  // FACT       the decoder emits at most one op-select flag per instruction.
+  // DISCHARGED rtl/decoder.v's `one_of` assertion -- `assert($onehot(...))`
+  //            under `instr_valid`, in components_decoder, which runs in CI
+  //            (.github/workflows/ci.yml's `components` job). This is the ONE
+  //            assume in this repo with a real, running discharge; every other
+  //            one is believed on structural grounds (ADR-0048's census).
+  // SCOPE      the whole task, and deliberately so. It was written for the
+  //            arithmetic assertions but is equally correct over the ADR-0015
+  //            freeze block and every divide invariant, because the decoder
+  //            really does emit at most one flag on every cycle of all of
+  //            them. Checked against rtl/structs.v while auditing: all 29
+  //            `is_*` fields of `decoder_output` are listed, and
+  //            `is_valid_instr` is correctly not among them. Adding a flag to
+  //            the struct without adding it here silently widens the
+  //            environment for every assertion below.
   always_comb assume($onehot0({in.is_add, in.is_sub, in.is_xor, in.is_or, in.is_and,
     in.is_sll, in.is_slt, in.is_sltu, in.is_srl, in.is_sra, in.is_lui,
     in.is_mul, in.is_mulh, in.is_mulhu, in.is_mulhsu,
@@ -334,6 +370,30 @@ module executor(
     in.is_lb, in.is_lbu, in.is_lh, in.is_lhu, in.is_lw, in.is_sb, in.is_sh, in.is_sw,
     in.is_ecall, in.is_ebreak}));
 
+  // THESE FOUR ASSERTIONS DO NOT SEE 32-BIT OPERANDS TODAY, DESPITE THE
+  // PARAGRAPH BELOW (ADR-0048 finding F1). The divide invariant further down
+  // caps operands with two UNGUARDED `always_comb assume(in.rs1 <= 32'h0f)`
+  // statements, and an unguarded assume is proof-global: it constrains every
+  // assertion in this module, including these. With operands in 0..15 every
+  // product's high half is zero and every operand's bit 31 is zero, so
+  // MULH/MULHU/MULHSU here assert `out.rd_data == 0` and nothing more.
+  //
+  // Measured by mutation (scratch copy, `sby -f components.sby executor`):
+  // forcing `multiply[63:32]` to zero PASSES; `mul_sign_x = 1'b0` PASSES;
+  // `mul_sign_y = 1'b0` PASSES; making MULHSU treat rs2 as signed PASSES.
+  // Three of the four multiplier defects ADR-0010 names by hand survive the
+  // proof written to catch them. A low-half off-by-one and taking the sign
+  // from bit 0 are still caught in 0.5s, which is what makes it insidious:
+  // these assertions are narrowed, not dead, and the task reads green either
+  // way. test/exec_tb.v -- ADR-0010's PRIMARY guarantee -- is what actually
+  // covers this today, over 10,000 randomized vectors per op with the
+  // directed MULH(-1,-1)/MULHSU(-1,1)/MULHU(-1,-1) cases.
+  //
+  // The fix is to guard the cap down to the divide assertions, which is
+  // exactly what the paragraph below says these do not need. Not done here:
+  // those lines are owned by in-flight work on the executor's real arithmetic,
+  // and narrowing them changes what this proof proves.
+  //
   // Multiply: a single combinational stage, so full 32-bit-operand correctness
   // is provable directly (no restriction needed). Independently re-derives
   // MUL/MULH/MULHU/MULHSU against plain SystemVerilog signed/unsigned

--- a/rtl/executor.v
+++ b/rtl/executor.v
@@ -394,6 +394,19 @@ module executor(
   // those lines are owned by in-flight work on the executor's real arithmetic,
   // and narrowing them changes what this proof proves.
   //
+  // THE SAME CAP ALSO BLANKS THE SIGNED DIVIDE PATH (ADR-0048 finding F5), and
+  // that one is not fixed by narrowing the cap to "the divide assertions" --
+  // it needs new assertions. With operands in 0..15, `op_sign_x` and
+  // `op_sign_y` are constant zero, so the two `assert(op_sign_* == in.rs*[31])`
+  // tie-backs below read `assert(0 == 0)`, and the only completion assertions
+  // in this proof are the UNSIGNED pair (`divu_ref` / `remu_ref`). There is no
+  // assertion anywhere that the signed DIV/REM sign restore happens at all.
+  // Measured the same way: deleting `op_sign_x != op_sign_y ? -...` from the
+  // `op_is_div` capture PASSES, and deleting `op_sign_x ? -...` from the
+  // `op_is_rem` capture PASSES. ADR-0012's sign wrapper -- the whole reason
+  // this divider can be unsigned -- has no formal coverage in this task.
+  // test/exec_tb.v covers it; nothing here does.
+  //
   // Multiply: a single combinational stage, so full 32-bit-operand correctness
   // is provable directly (no restriction needed). Independently re-derives
   // MUL/MULH/MULHU/MULHSU against plain SystemVerilog signed/unsigned


### PR DESCRIPTION
Closes JEF-691

Audits every `assume` in `formal/*.sv`, `formal/wrapper.v` and the `` `ifdef FORMAL `` blocks of
`rtl/` against ADR-0017's rule, and vacuity-checks every compound `assert` guard by mutation.
**No RTL behaviour changes. No assume is deleted or weakened.** The only non-comment additions are
`docs/adr/0048` and two bullets in CLAUDE.md.

The headline is that ADR-0017's rule is missing a clause, and the ticket's exemplar is not an
isolated slip: `rtl/executor.v`'s `always_comb assume(in.rs1 <= 32'h0000000f)` is correct,
documented, and **proof-global**, so it silently governs assertions written for other purposes.
ADR-0048 adds clause 3 — an assume must state its **scope** — and makes "discharged nowhere" an
explicitly acceptable answer (11 of the 24 sites have no discharge, and inventing one for each
would have produced 24 plausible sentences and no information).

---

## Census

24 `assume` sites in 6 files, at `18d17a2`. Full table with reasoning in
`docs/adr/0048-every-formal-assume-names-its-scope-and-its-discharge.md`.

| site | fact modelled | discharged where | scope |
|---|---|---|---|
| `formal/wrapper.v:83` | imem is a function of its address, across consecutive cycles | **nowhere** — structural (`rtl/imemory.v` is a ROM, ADR-0044) | **all 82 generated checks**; written for `hang`/`liveness_ch0` only |
| `formal/wrapper.v:84` | the same for the fetch window's 2nd port | **nowhere** | as above |
| `formal/imemcheck.sv:60,62,64,66` | the fetch bus answers from memory: both ports agree with the checker's pinned halfword | **nowhere** — same ROM | the task's one `rvfi_imem_check` assertion = what it was written for |
| `formal/dmemcheck.sv:86` | a load returns, one cycle later, what was last stored there | **partially**, and only in-range — see F4 | the task's one `rvfi_dmem_check` assertion |
| `formal/complete.sv:59` *(no edit — owned)* | store-then-reload forwarding, most recent store only | **nowhere**, same gap as F4 | `complete`'s single assert |
| `formal/pcloop.sv:126,127` *(no edit — `bb6e228` owns it)* | reset is asserted before the first edge | **nowhere** — structural | the whole task |
| `formal/pcloop.sv:128` *(no edit — `bb6e228` owns it)* | reset never returns | **nowhere** | whole task; written for the pc-history assertions, also binds the echo, the hold and both redirect assertions |
| `rtl/decoder.v:1005,1006` | reset before the first edge | **nowhere** — structural | the whole task = what it was written for |
| `rtl/decoder.v:1013` | reset never returns | **nowhere** | whole task; written for the pc-increment pair, also binds the ADR-0028/0030 trap arms added two milestones later |
| `rtl/decoder.v:1023` | `in.pc == pc` — the fetcher echoes the decoder's pc | **`formal/pcloop.sv` asserts it**, and as of `bb6e228` that is a real running discharge (make target + CI, PASS 2.7s). It was red and unrun for the whole period this audit ran (**F2**) | whole task; ADR-0017 analysed the pc pair, it also binds bubble/hazard/`one_of`/trap-cause/trap-arm |
| `rtl/executor.v:266,267` | reset before the first edge | **nowhere** — structural | the whole task = what it was written for |
| `rtl/executor.v:279` | reset never returns | **nowhere** | whole task; written for the divide assertions, also binds the 4 multiply assertions and the ADR-0015 freeze block |
| `rtl/executor.v:330` | the decoder emits ≤ 1 op-select flag | **`rtl/decoder.v`'s `one_of` assertion, in `components_decoder`, in CI** — the only site in the repo with a real running discharge | whole task, correctly. All 29 `is_*` fields of `decoder_output` verified present |
| `rtl/executor.v:392,393` *(no edit — owned)* | ADR-0010's recorded operand restriction (0..15) | **nowhere** — it is a restriction, not a fact; nothing should discharge it | **whole task, including the 4 multiply assertions and the signed divide path it was not written for** (**F1**, **F5**) |
| `rtl/executor.v:408-413` (6 sites) *(no edit — owned)* | ADR-0009: decode holds `in` steady across a multi-cycle divide | **nowhere** | guarded on `state == divide \|\| $past(state) == divide` — the only genuinely scoped assume in `rtl/` |

---

## Findings

### F1 — the operand cap makes three of ADR-0010's four named multiplier defects invisible

`always_comb assume(in.rs1 <= 32'h0000000f)` is unguarded, so it caps operands for the four
multiply assertions forty lines above it. With operands in 0..15 every product's high half is zero
and every sign bit is zero. Each row is one mutation of `rtl/executor.v` in a scratch copy, run as
`sby -f components.sby executor` (baseline PASS, 6.6s):

| mutant | what it breaks | verdict |
|---|---|---|
| `multiply & 64'h0000_0000_ffff_ffff` | MULH/MULHU/MULHSU all return 0 | **PASS 6.1s** |
| `mul_sign_y = rs2[31] & (is_mulh \| is_mulhsu)` | MULHSU treats rs2 as signed | **PASS 5.3s** |
| `mul_sign_x = 1'b0` | MULH/MULHSU stop sign-extending rs1 | **PASS 5.6s** |
| `mul_sign_y = 1'b0` | MULH stops sign-extending rs2 | **PASS 5.5s** |
| `multiply + 1` (control) | the low half | FAIL 0.5s |
| `mul_sign_x = rs1[0] & …` | sign taken from bit 0 | FAIL 0.5s |

The last two are what makes this insidious: the assertions are **narrowed, not dead**, and the task
reads green either way. `test/exec_tb.v` is what actually covers this.

### F2 — `formal/pcloop.sv` was red and unrun — FOUND HERE, FIXED CONCURRENTLY BY #67 (`bb6e228`)

**Status: closed, and not by this PR.** Recorded because the shape matters, and because this PR's
first draft got one thing about it wrong.

Measured at `18d17a2`: `sby -f components.sby pcloop` → `DONE (FAIL, rc=2)` in 0.67s at
`pcloop.sv:273 step 3`. Attributed from the counterexample VCD — the failing cycle's predecessor is
the first post-reset cycle, where `operand_stall = 1`, `stall = 1` and the pc legitimately holds,
while `prev_may_stall` reads 0 because `f_may_stall` lists **four** of `rtl/decoder.v`'s **five**
stall terms. ADR-0042 added `operand_stall`; the over-approximation was never widened, so it had
stopped being one. Same class as F1, one level up.

#67 landed the fix while this audit was in flight, reaching the same attribution independently, and
went further in two ways:

- **It needed no new decoder port — my draft claimed it did, and that was wrong.** `rs1`/`rs2` are
  decoder *output ports*, so `pcloop.sv` transcribes `rtl/decoder.v`'s
  `prev_rs1`/`prev_rs2`/`read_taken` into the harness and over-approximates at the comparison, like
  every other `f_may_stall` term. Flagging it because "this can't be done from the module's own
  nets" is the kind of claim that closes off a fix, and I wrote it without checking.
- **The task is wired up**: `components_pcloop` is a `make` target and a CI job. Re-measured here on
  the merged tree: `DONE (PASS, rc=0)` by k-induction in **2.7s**.

What survives is the reason it stays in ADR-0048's census: **the defect was invisible for as long as
it was because nothing ran the task**, and for that whole period `rtl/decoder.v:1023`'s
`assume(in.pc == pc)` was discharged by a check nobody invoked — which reads identically in the
source to a real discharge. That is why clause 2 asks *where*, not merely *whether*.

**One retracted inference.** An earlier revision of this PR body reported that a diagnostic asking
whether widening `f_may_stall` closes the red returned no verdict twice, and inferred that widening
"makes the query dramatically harder." **That inference was wrong and the measurement was an
artefact.** #67's `components.sby` pins `pcloop: smtbmc boolector` precisely because the default
solver sits on this task for 14+ minutes without returning — which is exactly what both of my
attempts hit. Solver choice, not problem hardness. A non-answer is not evidence about the problem,
and I nearly published it as though it were.

### F3 — the two divide-completion assertions are unreachable in the base case

`formal/components.sby` sets no `depth`, so `mode prove`'s basecase runs to 20 steps; the real
divider needs 33 cycles from issue. `assert(1'b0)` under
`$past(state) == divide && state == init && $past(in.is_divu)` gives **basecase = pass**, where all
ten other guards in the module give basecase = FAIL in 0.5s. Those two are the only place the divide
invariants are tied to `out.rd_data`, so the end-to-end divide result rests entirely on induction —
no concrete trace ever computes a division. Per ADR-0025 this is recorded as a fact about the depth
**and** the guard, and neither is raised: the ladder-depths work is in flight and depths move only
on empirical evidence.

### F4 — the two writable-memory assumes model a memory this repo does not have

`dmemcheck.sv:86` and `complete.sv:59` assume a memory that returns stored data. `rtl/memory.v`
answers any address at or past `4*RAM` with `mem_rdata <= mem_wdata`, and `dmem_addr`/`mem_addr` are
free 32-bit values in both harnesses, so model and module disagree over most of the address space.
(ADR-0010's "`rtl/memory.v` … is in **no** current test path" is **stale** — `test/mem_tb.v` is on
`make test-units`, and `test/mem_tb.v`'s own header repeats the stale claim — but that bench only
asserts an out-of-range read does not *alias* `ram[0]`; it never says what one returns.) ADR-0044
rules the placeholder out as a starting point and does not replace it, so when the real memory
system is built nothing will hold it to what these two proofs assumed.

### F5 — the same cap blanks the signed divide path, and this one needs new assertions

With operands in 0..15, `op_sign_x`/`op_sign_y` are constant zero, so
`assert(op_sign_x == in.rs1[31])` and its twin read `assert(0 == 0)`, and the only completion
assertions in the task are the **unsigned** pair. Nothing asserts the signed sign-restore happens:

| mutant | verdict |
|---|---|
| delete `op_sign_x != op_sign_y ? -… :` from the `op_is_div` capture | **PASS 5.8s** |
| delete `op_sign_x ? -… :` from the `op_is_rem` capture | **PASS 6.2s** |

ADR-0012's sign wrapper — the reason this divider is allowed to be unsigned — has no formal coverage
in this task. Unlike F1, narrowing the cap does not fix this; it needs assertions that do not exist.

---

## Vacuity: every compound `assert` guard, demonstrated

Method: replace the assertion body with `assert(1'b0)` under its existing guard and re-run.
**basecase = FAIL is a reachability witness** — the solver produced a concrete trace in which the
guard holds. No assume was touched to produce any of these.

**`components_executor` — 12 guards, 10 reachable, 2 are F3.** Freeze (`$past(accessor_stall)`)
FAIL 0.6s; the four multiply guards FAIL 0.5s each; `state == divide` (op-latch tie-back, counter
bound, division identity, quotient bound) FAIL 0.5s each; `state == divide && mul_div_counter > 0`
FAIL 0.5s; the `is_divu` and `is_remu` completion guards **basecase pass** (F3).

**`components_decoder` — 17 guards, all reachable.** Ten are `always_comb` with no `clocked` term,
so those were run twice: once with `assert(1'b0)`, again with `assert(!(clocked && !reset))` so the
witness must be a real post-reset cycle rather than step 0. Both rounds FAIL for every one.
pc+4 @ step 4 · pc+2 @ step 4 · stalled-holds-pc @ step 3 · bubble-rd-zero @ step 1 ·
`rs1==0`/`rs2==0` @ step 1 · `instr_valid` @ step 1 · all five trap causes @ step 1 ·
`!trap_pending`/`trap_pending` @ step 1 · `prev_trap_entry`→`mtvec` and →`rd==0` @ step 3 ·
`prev_mret_entry`→`mepc` @ step 3.

**`components_pcloop` — 4 guards + both width branches, all reachable.** Re-measured on the merged
tree where the task is green; the first pass was taken while it was red and needed the
sequential-advance assertion neutralised first, and that scaffolding is gone. Echo @ step 1 ·
`prev_hard_stall` @ step 3 · both redirect guards @ step 4. The sequential-advance guard is
reachable **in both width branches** — `assert(!prev_uncompressed)` and `assert(prev_uncompressed)`
under it both FAIL @ step 4 — so neither the 4-byte nor the 2-byte arm is vacuous. The witnesses
moved out by one step versus the red-tree run: that is the operand-fetch cycle `f_may_stall` now
accounts for.

**`formal/cover.sv` — the full-core harness's own demonstration, re-measured rather than quoted.**
`make -C formal cover` → `DONE (PASS, rc=0)` in 12s, all five goals reached, including the compound
one (`mem_read >= 2 && mem_write >= 2 && long_insns >= 2 && comp_insns >= 2`) at step 11.

**`formal/complete.sv`** needs no mutation: its guard `!reset && rvfi_valid && !rvfi_trap` produces
a counterexample today (`DONE (FAIL, rc=2)` at `complete.sv:113` step 5, 9s), and a counterexample
is a reachability witness by construction. This is M2 term 5, unchanged by this PR.

**No guard was found unreachable except F3's two**, and that one is a depth fact as much as a guard
fact.

---

## Predicted blind spots — for the mutation campaign

Five of these are already confirmed here; they are listed anyway so the campaign has the mutant text.

1. **MULH/MULHU/MULHSU sign handling has no formal coverage** — `mul_sign_x = 1'b0` in
   `rtl/executor.v`. **Confirmed: PASS.**
2. **The multiplier's high 32 bits have no formal coverage** — mask `multiply` with
   `64'h0000_0000_ffff_ffff`. **Confirmed: PASS.**
3. **The signed DIV/REM sign restore has no formal coverage** — delete
   `op_sign_x != op_sign_y ? -mul_div_store[31:0] :` from the `op_is_div` capture.
   **Confirmed: PASS.**
4. **The ALTOPS divide branch has zero coverage in either direction** — `components.sby` reads
   `executor.v` *without* `RISCV_FORMAL_ALTOPS` and the ladder runs *with* it, so neither sees the
   other's branch; `assign div_alt_rs1 = 32'b0;` **confirmed PASS** against `components_executor`,
   and CLAUDE.md already records that the ALTOPS arm reads stale operands with no formal coverage
   in any form.
5. **The divider's final capture is caught only by induction, never by a trace** —
   `op_is_divu: out.rd_data <= mul_div_store[31:0] + 1;` gives **basecase pass / induction FAIL**
   (`DONE = UNKNOWN`), so a future change that made induction pass would leave nothing.
6. **A new `is_*` flag added to `decoder_output` silently widens `components_executor`'s
   environment** — add a flag to the struct and to `rtl/decoder.v` but not to `executor.v:330`'s
   `$onehot0`; predicted PASS while the executor's `case (1'b1)` could take two arms.
7. **`rtl/memory.v`'s out-of-range read is invisible to every formal harness** — change
   `mem_rdata <= mem_wdata` to `mem_rdata <= 32'hdeadbeef`; predicted invisible to the whole ladder
   (memory.v is in no formal harness) and to `make test` (the cxxrtl top has its own inline memory),
   caught only incidentally by `test/mem_tb.v`'s alias check.
8. **`wrapper.v`'s imem-stability assume hides any defect that needs the same address to answer
   differently in consecutive cycles** — no RTL mutant can confirm this, which is itself the point;
   the harness-side confirmation is deleting the assume, which ADR-0042 already measured as `hang`
   and `liveness_ch0` going red at k=30.
9. **Nothing checks `operand_stall` itself (invariant 9) at component level** — delete the
   `!read_taken` term; predicted missed by `components_decoder` (which asserts only that a stalled
   cycle holds pc, and `stall` stays high for the other reasons) and caught by `test/regfile_tb.v`
   / `make test`.

---

## Gates

| gate | result |
|---|---|
| `make lint` | `svlint: clean in both passes`, exit 0 |
| `make test-units` | exit 0 — all six benches (`exec_tb`, `mem_tb`, `decoder_tb`, `regfile_tb`, `csr_tb`, `monitor_tb`) |
| `make test` | **52/52**, `Failure list matches test/EXPECTED_FAIL exactly (name and status)`, exit 0 |
| `make -C formal components_executor` | `DONE (PASS, rc=0)`, 6.6s — re-run after every edit to `rtl/executor.v` |
| `make -C formal components_decoder` | `DONE (PASS, rc=0)`, 3.1s — re-run after every edit to `rtl/decoder.v` |
| `make -C formal imemcheck` | `DONE (PASS, rc=0)` |
| `make -C formal dmemcheck` | `DONE (PASS, rc=0)` |
| `make -C formal cover` | `DONE (PASS, rc=0)`, 12s, 5/5 goals |
| `make -C formal complete` | `DONE (FAIL, rc=2)` — **unchanged from `main`**, M2 term 5 |
| `make -C formal components_pcloop` | `DONE (PASS, rc=0)`, 2.7s — green after the `origin/main` merge (#67); it was red when this audit started, which is F2 |

The full 82-check ladder was **not** run: this PR changes only comments in `rtl/`, both component
proofs and all four standalone harness tasks were re-run green, and the ladder is the nightly's job.

## Scope and risks

- **Comments only in `rtl/`.** `rtl/executor.v` and `rtl/decoder.v` gain fact/discharge/scope
  blocks; no expression changes. Both component proofs re-run PASS after each edit.
- **Carve-outs respected.** `formal/complete.sv`, `formal/pcloop.sv`, `formal/checks.cfg`,
  `formal/components.sby`, `formal/Makefile`, `rtl/executor.v`'s divide-invariant assumes and
  `$past` hold block, and `rtl/decoder.v`'s trap-arm block are **censused but not edited**. Nothing
  under `test/` is touched.
- **`origin/main` was merged in mid-audit** (#67, the ladder-depths PR, which owns four of those
  carved-out files). It changed no `rtl/`, so every annotation and gate here is unaffected — but it
  **closed F2 and invalidated part of what this PR said about it**, so F2 was re-measured and
  rewritten rather than left standing, and the pcloop vacuity numbers were re-taken on the green
  tree. F3 was re-checked on the merged tree and is unchanged (`components.sby` still sets no
  `depth`; the two completion guards still give basecase = pass while the control gives FAIL in
  0.5s).
- **Acceptance criterion 2 is met by the second route for `rtl/executor.v:392-393`.** Those lines
  are carved out, so the required "written statement of the assertions it also constrains" is placed
  at the *assertion* end of the same file — a block above the four multiply assertions — plus
  ADR-0048's census and findings F1/F5. **Recommendation for the owning ticket, not committed
  here:** guard the cap down to the divide assertions, which is exactly what the comment above the
  multiply assertions already says they do not need — and separately add signed DIV/REM completion
  assertions, because F5 is not fixed by narrowing.
- `docs/adr/0048` is numbered after `0047`; `0046` does not exist in the tree and was not created by
  this PR.
