### PR TITLE
JEF-689: measure that the per-retire monitor actually observed something in every `make test` program

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,6 +144,28 @@ trap and CSR tests assert on values their own handler recorded. Error 133 ("expe
 trap") stays unreachable in this single-channel config — `shadow_pc_valid <= !rvfi_trap` gates 130
 and 133 off for the retire after a trap — so `rvfi_intr` hardwired to 0 does not break anything.
 
+**`make test` now measures that its oracle fired, instead of inferring it.** The monitor is the
+gate's per-retire oracle and **nothing counted whether it ever looked**: `test/cxxrtl.cc` sampled
+the errcode and counted nothing, so a monitor whose `rvfi_valid` never asserted — ADR-0037's
+under-sensitivity class, an `ifdef` that dropped the shadow payload, a `write_cxxrtl` that optimised
+the instance away — left all 52 programs PASSing off `tohost` alone, with an empty
+`test/EXPECTED_FAIL` and so no red entry whose disappearance would say otherwise. `test/testbench.v`
+counts retires (`rvfi_valid`) and spec-checked retires (`spec_valid`, from a **second
+`monitor_isa_spec`** instantiated in the bench — `test/monitor.v` is generated-but-tracked and a
+yosys hierarchical reference silently *implicitly declares* the name rather than resolving it, both
+measured); the runner prints `RETIRES <n> SPEC-CHECKED <m>` and adds **exit 6** for zero of either;
+`test/run_tests.sh` labels that `MONITOR-SILENT`, carries both counts as a third table column, and
+grades them against **`test/OBSERVED_FLOOR`** — names by set equality both ways, numbers by `>=`,
+because instruction counts legitimately move and a 52-number ratchet is one nobody would keep.
+**The probe is one line and both directions are measured**: `assign rvfi_valid_observed = 1'b0;` in
+`test/testbench.v` gives 52 × `MONITOR-SILENT` (`retires=0 spec-checked=0`) and exit 1 here, and the
+same blinding on the pre-change tree gave **52/52 and exit 0** — every program still reaches
+`tohost` and still passes its own assertions, which is the whole defect. `rvfi_valid_observed` is
+the single wire the monitor, the probe and the counters all read, so they cannot go blind
+independently. **A low spec-checked count is the pin's coverage boundary, not a bug** — no spec
+model exists for `ecall`/`ebreak`/`mret`/`csrr*`, so `csr.S` is 108/82, `minstret.S` 42/31 and
+`trap.S` 303/259; that is written at `test/OBSERVED_FLOOR` so nobody has to rediscover it.
+
 **M3 opens: `rtl/csrs.v` lands the CSR file and the Zicsr access path.** ADR-0005's set, exactly —
 RW `mstatus` (MIE/MPIE, MPP WARL→`2'b11`), `mtvec` (direct mode, 4-byte-aligned base, resets to 0
 per ADR-0029), `mepc` (bit 0 only, because C makes 2-byte targets legal), `mcause`, `mscratch`,
@@ -497,7 +519,9 @@ preference. See ADR-0002 and ADR-0003.
 
 ```sh
 make setup          # install the RISC-V toolchain (brew on macOS)
-make test           # assemble test/asm/*.S, run under cxxrtl, pass/fail table
+make test           # assemble test/asm/*.S, run under cxxrtl, pass/fail table with
+                    # per-program retire / spec-checked-retire counts, graded against
+                    # test/EXPECTED_FAIL (set equality) and test/OBSERVED_FLOOR (>=)
 make waves          # iverilog + VCD (testbench.vvp's baked-in program) -> waves.vcd
 make monitor-check  # regenerate test/monitor.v at the pin and diff
 make fit            # the ONE area number: nextpnr logic cells on up5k/sg48 (ADR-0038).

--- a/Makefile
+++ b/Makefile
@@ -523,7 +523,7 @@ test-units: test/monitor.sim.v
 # gate today, against the current (still-broken, see CLAUDE.md) core.
 .PHONY: test
 test: sim test-units
-	@./test/run_tests.sh ./sim test/asm test/EXPECTED_FAIL
+	@./test/run_tests.sh ./sim test/asm test/EXPECTED_FAIL test/OBSERVED_FLOOR
 
 # ---------------------------------------------------------------------------
 # `make fit` -- the repo's one and only area measurement (ADR-0038).

--- a/test/OBSERVED_FLOOR
+++ b/test/OBSERVED_FLOOR
@@ -1,0 +1,116 @@
+# How much the per-retire RVFI monitor was OBSERVED to do on each program.
+#
+# WHY THIS FILE EXISTS. `make test` is the merge gate and test/monitor.sim.v is
+# its per-retire oracle, but nothing in the gate measured whether the oracle
+# ever fired. test/cxxrtl.cc sampled the monitor's errcode and counted nothing,
+# so a monitor whose `rvfi_valid` never asserted — an under-sensitivity defect
+# of exactly the kind ADR-0037 found in the iverilog leg, an `ifdef` that
+# dropped the shadow payload, a `write_cxxrtl` that optimised the instance
+# away — left every program here reporting PASS off `tohost` alone. ADR-0032
+# had already measured that end-state checking on its own is blind to real
+# architectural corruption, and test/EXPECTED_FAIL is empty, so there was no
+# red entry whose disappearance would have said otherwise either. This file
+# turns observation into a graded quantity instead of an inference.
+#
+# FORMAT — three fields:
+#
+#     <test>.S  <retires>  <spec-checked retires>
+#
+# `retires` is the number of cycles the monitor examined (`rvfi_valid` high).
+# `spec-checked` is the subset of those whose VALUES it compared against its
+# spec model (`spec_valid` high as well). Both are counted in test/testbench.v,
+# printed by test/cxxrtl.cc as `RETIRES <n> SPEC-CHECKED <m>`, and graded by
+# test/run_tests.sh, which also prints them as the table's third column.
+#
+# GRADED WITH `>=`, NOT SET EQUALITY — that is the difference between this file
+# and test/EXPECTED_FAIL or formal/EXPECTED_CHECKS, and it is deliberate. The
+# numbers move for legitimate reasons: the assembler is free to compress
+# differently, a test gains an instruction, a macro in test/asm/riscv_test.h
+# grows one. An exact ratchet over 52 numbers is one nobody would keep, and a
+# ratchet nobody keeps gets raised until it means nothing. What must not happen
+# is a program going QUIET, and `>=` catches exactly that.
+#
+# The NAME set, on the other hand, IS a set equality in both directions, the
+# same contract ADR-0014 puts on the two files above. A program in test/asm
+# with no line here reports NO-FLOOR and fails; a line here naming a program
+# that no longer exists is an error at the end of the run. Adding a program to
+# test/asm means adding its measured line here, in the same commit.
+#
+# ZERO IS NEVER A FLOOR. Zero of either count is MONITOR-SILENT — the runner's
+# own exit 6 — before this file is ever consulted, so a line of `0 0` cannot
+# be used to excuse a blind oracle. There is no way to write "this program is
+# allowed not to be checked" here, on purpose.
+#
+# A LOW SPEC-CHECKED NUMBER IS EXPECTED AND IS NOT A DEFECT. riscv-formal ships
+# NO SPEC MODEL AT ALL for `ecall`, `ebreak`, `mret` or the `csrr*` family at
+# the pinned SHA (formal/pin.mk), so `spec_valid` is 0 for every one of those
+# retires by design and the monitor's whole semantic block is skipped for them.
+# The behaviour M3 added is checked by test/asm/trap.S, test/csr_tb.v and
+# test/decoder_tb.v instead, against assertions this repo wrote rather than
+# against an oracle. csr.S, minstret.S and trap.S therefore show the widest gap
+# between the two columns, and that gap is the pin's coverage boundary, not a
+# bug in this core. Whoever first sees a low number here should not have to
+# rediscover that — CLAUDE.md says the same thing next to the EXPECTED_FAIL
+# contract.
+#
+# HOW TO RE-MEASURE. Run `make test` and copy the table's third column. Record
+# the commit SHA it was measured at in the PR that changes a number, the way
+# every other measurement in this repo is recorded. Numbers only ever go DOWN
+# by accident; if one legitimately drops (a different binutils compressing more
+# aggressively, a test deliberately shortened), lower it in the same commit as
+# the change that caused it and say which.
+#
+# Measured at 18d17a2 (the branch point) with riscv64-elf-gcc, the pinned
+# riscv-formal monitor, and CYCLES=5000 in test/run_tests.sh.
+add.S               429    429
+addi.S              206    206
+and.S               449    449
+andi.S              162    162
+auipc.S              26     26
+beq.S               255    255
+bge.S               273    273
+bgeu.S              298    298
+blt.S               255    255
+bltu.S              280    280
+bne.S               255    255
+csr.S               108     82
+div.S                60     60
+divu.S               61     61
+hazard.S             49     49
+jal.S                19     19
+jalr.S               73     73
+lb.S                209    209
+lbu.S               209    209
+lh.S                221    221
+lhu.S               228    228
+lui.S                29     29
+lw.S                231    231
+minstret.S           42     31
+mul.S               423    423
+mulh.S              423    423
+mulhsu.S            423    423
+mulhu.S             423    423
+or.S                452    452
+ori.S               169    169
+rem.S                60     60
+remu.S               60     60
+rvc.S               184    184
+sb.S                394    394
+sh.S                447    447
+simple.S              5      5
+sll.S               457    457
+slli.S              205    205
+slt.S               423    423
+slti.S              201    201
+sltiu.S             201    201
+sltu.S              423    423
+sra.S               476    476
+srai.S              220    220
+srl.S               470    470
+srli.S              214    214
+straddle.S           18     18
+sub.S               421    421
+sw.S                454    454
+trap.S              303    259
+xor.S               451    451
+xori.S              171    171

--- a/test/cxxrtl.cc
+++ b/test/cxxrtl.cc
@@ -11,7 +11,22 @@
 // in the pipeline's own bookkeeping, not the test program's assertions),
 // 5 = trap taken with mtvec == 0 (ADR-0029 — the program has silently
 // restarted at `_start`; distinct from 2 because the timeout that would
-// otherwise result says nothing about the fault that caused it).
+// otherwise result says nothing about the fault that caused it),
+// 6 = the per-retire monitor observed nothing: zero retires, or zero retires
+// whose values its spec model checked. See the counter block in
+// test/testbench.v for why that is a failure and not a curiosity — a monitor
+// that never fires leaves every program passing off `tohost` alone, which
+// ADR-0032 measured to be blind to real architectural corruption.
+//
+// Every run that actually simulates prints one machine-readable line before
+// it exits:
+//
+//     RETIRES <n> SPEC-CHECKED <m>
+//
+// test/run_tests.sh parses it into the pass/fail table and grades it against
+// test/OBSERVED_FLOOR. Making observation a printed, graded quantity rather
+// than something inferred from a green run is the whole point of the two
+// counters; a number nobody reads is the defect this closes, not a fix for it.
 #include <cxxrtl/cxxrtl_vcd.h>
 #include "rtl.cc"
 
@@ -200,6 +215,56 @@ int main(int argc, char **argv) {
     return 3;
   }
 
+  // The observation counters (test/testbench.v). `rvfi_retires` counts the
+  // cycles the monitor examined; `rvfi_spec_retires` counts the subset whose
+  // values it actually compared against its spec model. Looked up the same way
+  // and for the same reason as the two items above: a silently absent counter
+  // would report the exact false green this exists to prevent, so missing is a
+  // setup error rather than something to skip.
+  const cxxrtl::debug_item *retires = nullptr;
+  const cxxrtl::debug_item *spec_retires = nullptr;
+  try {
+    retires = &all_debug_items.at("rvfi_retires").at(0);
+    spec_retires = &all_debug_items.at("rvfi_spec_retires").at(0);
+  } catch (const std::out_of_range &) {
+    std::fprintf(stderr,
+                  "error: the monitor observation counters ('rvfi_retires', "
+                  "'rvfi_spec_retires') were not found in the simulated design "
+                  "-- did test/testbench.v lose the (* keep *) on them?\n");
+    return 3;
+  }
+
+  // Printed on every path that reaches the simulation loop. Setup failures
+  // above return before this point on purpose: nothing ran, so there is no
+  // observation to report, and a "RETIRES 0" line for a run that never started
+  // would be a claim rather than a measurement.
+  auto report_counts = [&]() {
+    std::printf("RETIRES %u SPEC-CHECKED %u\n", retires->curr[0],
+                 spec_retires->curr[0]);
+  };
+
+  // Silence outranks the run's own verdict. A run whose oracle never fired has
+  // no verdict worth reporting: `tohost` saying PASS is exactly what a blind
+  // monitor looks like, and a FAIL from such a run cannot be attributed either.
+  // Exit 4 is the one exception and does NOT come through here — an errcode is
+  // direct evidence that the monitor fired, which is stronger and more specific
+  // than any count.
+  auto finish = [&](int code) {
+    report_counts();
+    uint32_t r = retires->curr[0];
+    uint32_t s = spec_retires->curr[0];
+    if (r == 0 || s == 0) {
+      std::fprintf(stderr,
+                    "the RVFI monitor observed nothing this run: %u retires, %u "
+                    "of them spec-checked. The per-retire oracle was blind, so "
+                    "this run's verdict (exit %d) means nothing -- see the "
+                    "counter block in test/testbench.v.\n",
+                    r, s, code);
+      return 6;
+    }
+    return code;
+  };
+
   std::unique_ptr<cxxrtl::vcd_writer> vcd;
   std::ofstream vcd_out;
   if (!args.vcd_path.empty()) {
@@ -232,6 +297,7 @@ int main(int argc, char **argv) {
     uint32_t errcode = monitor_errcode->curr[0] & 0xffff;
     if (errcode != 0) {
       std::fprintf(stderr, "RVFI monitor error %u at cycle %ld\n", errcode, cycle);
+      report_counts();
       return 4;
     }
 
@@ -241,21 +307,21 @@ int main(int argc, char **argv) {
                     "never installed and the program has restarted at _start "
                     "(ADR-0029)\n",
                     cycle);
-      return 5;
+      return finish(5);
     }
 
     uint32_t tohost = ram_data[tohost_index];
     if (tohost != 0) {
       if (tohost == 1) {
         std::printf("PASS\n");
-        return 0;
+        return finish(0);
       }
       uint32_t testnum = tohost >> 1;
       std::printf("FAIL %u\n", testnum);
-      return 1;
+      return finish(1);
     }
   }
 
   std::printf("TIMEOUT\n");
-  return 2;
+  return finish(2);
 }

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -3,10 +3,10 @@
 # and checks the resulting pass/fail table against test/EXPECTED_FAIL — the
 # sprint-1 baseline (ADR-0007, ADR-0008, ADR-0014). Invoked by `make test`.
 #
-# Usage: run_tests.sh <sim-binary> <asm-dir> <expected-fail-file>
+# Usage: run_tests.sh <sim-binary> <asm-dir> <expected-fail-file> <floor-file>
 #
 # This script is the merge gate, so the failure mode that matters is a FALSE
-# GREEN — reporting success without having tested anything. Three properties
+# GREEN — reporting success without having tested anything. Four properties
 # below exist only for that (ADR-0035):
 #
 #   * every build step's exit status is checked, and the simulator runs only
@@ -19,20 +19,34 @@
 #     assembly, a crashing runner, a timeout — is a red gate, not a match;
 #   * `set -e` is on and mktemp is fatal. Without it a failed mktemp leaves
 #     $tmp empty, every artifact path collapses to the filesystem root, and a
-#     later run can pick up the previous run's stale image.
+#     later run can pick up the previous run's stale image;
+#   * OBSERVATION IS COUNTED, NOT INFERRED. The RVFI monitor is this gate's
+#     per-retire oracle and nothing measured whether it ever fired. A monitor
+#     that never saw a retire — an under-sensitivity defect of the ADR-0037
+#     kind, an `ifdef` that dropped the shadow payload, a `write_cxxrtl` that
+#     optimised the instance away — left every program reporting PASS off
+#     `tohost` alone, and with test/EXPECTED_FAIL empty there was no red entry
+#     whose disappearance would say so. ADR-0032 measured that end-state
+#     checking on its own is blind to real architectural corruption. So the
+#     runner now prints how many retires the monitor examined and how many of
+#     those its spec model checked, and this script grades both: zero of either
+#     is MONITOR-SILENT (the runner's own exit 6), and a drop below
+#     test/OBSERVED_FLOOR is BELOW-FLOOR. Both are failing statuses in the same
+#     name-and-status set as everything else.
 #
 # Any nonzero exit that is *expected* is handled at its own call site (`if !`,
 # `|| status=$?`) so that error-exit stays on everywhere else.
 set -euo pipefail
 
-if [ "$#" -ne 3 ]; then
-  echo "usage: run_tests.sh <sim-binary> <asm-dir> <expected-fail-file>" >&2
+if [ "$#" -ne 4 ]; then
+  echo "usage: run_tests.sh <sim-binary> <asm-dir> <expected-fail-file> <floor-file>" >&2
   exit 1
 fi
 
 SIM=$1
 ASM_DIR=$2
 EXPECTED_FAIL=$3
+OBSERVED_FLOOR=$4
 CYCLES=5000
 
 # Read before running anything: a mistyped or missing baseline path used to
@@ -42,6 +56,28 @@ CYCLES=5000
 if [ ! -f "$EXPECTED_FAIL" ] || [ ! -r "$EXPECTED_FAIL" ]; then
   echo "error: baseline '$EXPECTED_FAIL' does not exist or is not readable." >&2
   echo "The gate compares the failure set against it; without it there is no gate." >&2
+  exit 1
+fi
+
+# Same treatment, and for the same reason: a missing floor file would make
+# every per-program floor lookup miss, and a lookup that always misses is a
+# check that never runs.
+if [ ! -f "$OBSERVED_FLOOR" ] || [ ! -r "$OBSERVED_FLOOR" ]; then
+  echo "error: floor file '$OBSERVED_FLOOR' does not exist or is not readable." >&2
+  echo "It records how much each program was observed to retire; without it" >&2
+  echo "there is nothing to compare this run's observation against." >&2
+  exit 1
+fi
+
+# Read once, comments stripped, whitespace normalised — the same treatment the
+# baseline gets below. Three fields, not two: name, retire floor, spec-checked
+# floor. A malformed line is named rather than silently skipped, because a line
+# this loop cannot parse is a floor that is not enforced.
+floors=$(sed -e 's/#.*//' "$OBSERVED_FLOOR" | awk 'NF { $1=$1; print }')
+malformed_floor=$(printf '%s\n' "$floors" | awk 'NF && (NF != 3 || $2 !~ /^[0-9]+$/ || $3 !~ /^[0-9]+$/) { print }')
+if [ -n "$malformed_floor" ]; then
+  echo "error: $OBSERVED_FLOOR has lines that are not '<test>.S <retires> <spec-checked>':" >&2
+  printf '  %s\n' "$malformed_floor" >&2
   exit 1
 fi
 
@@ -96,6 +132,11 @@ for src in "$ASM_DIR"/*.S; do
   ram_hex="$tmp/$base.ram.hex"
 
   status="PASS"
+  # Cleared per iteration, not merely assigned when the runner produces them: a
+  # carried-over value from the previous program would let a run that printed no
+  # counts be graded against its predecessor's.
+  retires=""
+  spec_retires=""
   if ! "$CC" -march=rv32imc_zicsr -mabi=ilp32 -nostdlib -I "$ASM_DIR" \
        -T "$ASM_DIR/sections.lds" "$src" -o "$elf" > "$build_log" 2>&1; then
     status="ASSEMBLE-ERROR"
@@ -162,8 +203,54 @@ for src in "$ASM_DIR"/*.S; do
       4) code=$(awk '/RVFI monitor error/{print $4; exit}' "$tmp/$base.run.log")
          status="MONITOR-ERROR${code:+ $code}" ;;
       5) status="TRAP-TO-ZERO" ;;
+      6) status="MONITOR-SILENT" ;;
       *) status="RUNNER-ERROR $sim_status" ;;
     esac
+
+    # The runner prints exactly one `RETIRES <n> SPEC-CHECKED <m>` line on every
+    # path that reached the simulation loop, whatever its verdict, so these are
+    # available for the table even when the program failed.
+    set -- $(awk '/^RETIRES /{print $2, $4; exit}' "$tmp/$base.run.log")
+    retires=${1:-}
+    spec_retires=${2:-}
+  fi
+
+  # A PASS with no counts line is not a pass. It means the binary this gate ran
+  # is not the runner this script grades — a stale `sim` from before the
+  # counters existed, or one whose output was truncated — and every one of the
+  # observation checks below would then silently not run. Naming it is the
+  # difference between a gate and a formality.
+  if [ "$status" = "PASS" ] && { [ -z "$retires" ] || [ -z "$spec_retires" ]; }; then
+    status="NO-COUNTS"
+  fi
+
+  # THE FLOOR, graded with `>=` and not set equality. The counts move for
+  # legitimate reasons — the assembler is free to compress differently, a test
+  # gains an instruction — and an exact ratchet on 52 numbers is one nobody
+  # would keep. What must not happen is a program going quiet: retiring nothing,
+  # or having its retires stop being spec-checked. `>=` catches that and
+  # tolerates the rest. Only PASS programs are graded; anything already failing
+  # has a more specific status, and overwriting it would lose the real reason.
+  if [ "$status" = "PASS" ]; then
+    floor=$(printf '%s\n' "$floors" | awk -v n="$name" '$1 == n { print $2, $3; found = 1 } END { exit !found }') || floor=""
+    if [ -z "$floor" ]; then
+      # Not a warning. A program with no floor is a program whose observation
+      # nothing defends, and adding one to test/asm without recording what it
+      # was measured to observe is exactly how this file would rot into
+      # decoration. The fix is one line in $OBSERVED_FLOOR.
+      status="NO-FLOOR"
+    else
+      set -- $floor
+      floor_retires=$1
+      floor_spec=$2
+      if [ "$retires" -lt "$floor_retires" ]; then
+        status="BELOW-FLOOR retires"
+        echo "$name: $retires retires, floor is $floor_retires ($OBSERVED_FLOOR)" >&2
+      elif [ "$spec_retires" -lt "$floor_spec" ]; then
+        status="BELOW-FLOOR spec-checked"
+        echo "$name: $spec_retires spec-checked retires, floor is $floor_spec ($OBSERVED_FLOOR)" >&2
+      fi
+    fi
   fi
 
   if [ "$status" = "PASS" ]; then
@@ -175,12 +262,35 @@ for src in "$ASM_DIR"/*.S; do
       cat "$build_log" >&2
     fi
   fi
-  table+=("$(printf '%-16s %s' "$name" "$status")")
+  # The observation counts are a THIRD column, deliberately outside the
+  # name-and-status pair the baseline matches on (ADR-0035): they are a measured
+  # quantity that moves, not a verdict, and putting them in the failure set
+  # would make every baseline entry unmatchable the first time an instruction
+  # count changed. The verdict they imply — MONITOR-SILENT, BELOW-FLOOR,
+  # NO-COUNTS, NO-FLOOR — is in the status, where the gate can pin it.
+  table+=("$(printf '%-16s %-22s %s' "$name" "$status" \
+    "retires=${retires:--} spec-checked=${spec_retires:--}")")
 done
 
 printf '%s\n' "${table[@]}"
 echo
 echo "$passed/${#table[@]} passed"
+
+# The OTHER direction of the floor file's name set (ADR-0014's contract, the
+# same one EXPECTED_FAIL and formal/EXPECTED_CHECKS are under). A floor line for
+# a program that no longer exists is dead weight that reads as coverage, and it
+# is the direction nothing else here would notice: the per-program lookup above
+# only ever asks whether a program HAS a floor.
+suite_names=$(printf '%s\n' "${table[@]}" | awk '{print $1}' | sort)
+floor_names=$(printf '%s\n' "$floors" | awk 'NF {print $1}' | sort)
+orphan_floors=$(comm -23 <(printf '%s\n' "$floor_names") <(printf '%s\n' "$suite_names"))
+if [ -n "$orphan_floors" ]; then
+  echo >&2
+  echo "error: $OBSERVED_FLOOR names programs that are not in $ASM_DIR:" >&2
+  printf '  %s\n' "$orphan_floors" >&2
+  echo "Remove the line in the same commit that removes the program." >&2
+  exit 1
+fi
 
 # Both sides are name-and-status pairs, whitespace-normalised so the baseline
 # can stay readable. `NF` must gate the rebuild rather than follow it: awk

--- a/test/testbench.v
+++ b/test/testbench.v
@@ -165,6 +165,114 @@ module testbench(
     .rvfi_mem_wdata(rvfi_mem_wdata),
     .errcode(rvfi_monitor_errcode)
   );
+
+  // ---------------------------------------------------------------------------
+  // DID THE ORACLE EVER LOOK?
+  //
+  // The monitor above is a per-retire oracle only on the cycles it actually
+  // examines. It examines a cycle when `rvfi_valid` is high, and it compares
+  // that retire's VALUES only when its spec model recognises the instruction
+  // (`ch0_spec_valid`). Neither was measured. `test/cxxrtl.cc` sampled the
+  // monitor's `errcode` and counted nothing, so a monitor that never saw a
+  // single retire — an under-sensitivity defect of exactly the kind ADR-0037
+  // found in the iverilog leg, an `ifdef` that dropped the shadow payload, a
+  // `write_cxxrtl` that optimised the instance away — left every program in
+  // test/asm reporting PASS off `tohost` alone. `test/EXPECTED_FAIL` is empty,
+  // so there was no red entry whose disappearance would have said otherwise
+  // either, and ADR-0032 already measured that end-state checking on its own
+  // misses real architectural corruption.
+  //
+  // So observation is a GRADED QUANTITY here, not an inference. These two
+  // counters are read by debug-item name in test/cxxrtl.cc, printed on every
+  // run, and graded by test/run_tests.sh: zero of either is MONITOR-SILENT, a
+  // failing status, and a count below test/OBSERVED_FLOOR is BELOW-FLOOR.
+  //
+  // WHY A SECOND `monitor_isa_spec` INSTEAD OF LOOKING INSIDE THE MONITOR.
+  // `ch0_spec_valid` is internal to the monitor, and test/monitor.v is
+  // generated-but-tracked (CLAUDE.md invariant 7) — it may not be hand-edited
+  // to export it, and giving test/sanitize_monitor.py a fourth rule for
+  // telemetry would perturb the most carefully built content assertions in the
+  // repo for no correctness gain. A hierarchical reference is not an option
+  // either, and fails in the worst possible way: yosys does not resolve one, it
+  // IMPLICITLY DECLARES the name and carries on ("Warning: Identifier
+  // `\monitor.ch0_spec_valid' is implicitly declared"), so the counter would
+  // read a dangling constant while the build stayed clean. This instead
+  // instantiates the same module the monitor instantiates, from the same wires
+  // its own instance is wired from, so `probe_spec_valid` is `ch0_spec_valid`
+  // by construction: one combinational function, one set of inputs. KEEP THE
+  // TWO PORT MAPS IDENTICAL — rewiring one and not the other is the one way
+  // this could start counting retires the monitor never checked.
+  //
+  // A LOW SPEC-CHECKED COUNT IS EXPECTED, AND IS NOT A DEFECT. riscv-formal
+  // ships no spec model at all for `ecall`, `ebreak`, `mret` or the `csrr*`
+  // family at the pinned SHA (formal/pin.mk), so `spec_valid` is 0 for every
+  // one of those retires BY DESIGN and the monitor's whole semantic block is
+  // skipped for them — the behaviour M3 added is checked by test/asm/trap.S,
+  // test/csr_tb.v and test/decoder_tb.v instead, against assertions this repo
+  // wrote. csr.S, minstret.S and trap.S therefore show the widest gap between
+  // the two counts, and that gap is the pin's coverage boundary, not a bug.
+  // Only ZERO is a failure.
+  logic       probe_spec_valid;
+  logic       probe_spec_trap;
+  logic [4:0] probe_spec_rs1_addr;
+  logic [4:0] probe_spec_rs2_addr;
+  logic [4:0] probe_spec_rd_addr;
+  logic [31:0] probe_spec_rd_wdata;
+  logic [31:0] probe_spec_pc_wdata;
+  logic [31:0] probe_spec_mem_addr;
+  logic [3:0]  probe_spec_mem_rmask;
+  logic [3:0]  probe_spec_mem_wmask;
+  logic [31:0] probe_spec_mem_wdata;
+
+  monitor_isa_spec spec_probe (
+    .rvfi_valid(rvfi_valid),
+    .rvfi_insn(rvfi_insn),
+    .rvfi_pc_rdata(rvfi_pc_rdata),
+    .rvfi_rs1_rdata(rvfi_rs1_rdata),
+    .rvfi_rs2_rdata(rvfi_rs2_rdata),
+    .rvfi_mem_rdata(rvfi_mem_rdata),
+    .spec_valid(probe_spec_valid),
+    .spec_trap(probe_spec_trap),
+    .spec_rs1_addr(probe_spec_rs1_addr),
+    .spec_rs2_addr(probe_spec_rs2_addr),
+    .spec_rd_addr(probe_spec_rd_addr),
+    .spec_rd_wdata(probe_spec_rd_wdata),
+    .spec_pc_wdata(probe_spec_pc_wdata),
+    .spec_mem_addr(probe_spec_mem_addr),
+    .spec_mem_rmask(probe_spec_mem_rmask),
+    .spec_mem_wmask(probe_spec_mem_wmask),
+    .spec_mem_wdata(probe_spec_mem_wdata)
+  );
+
+  // `(* keep *)` for the same reason `trap_to_zero` below carries one: these
+  // are read by debug-item name from test/cxxrtl.cc and nothing inside the
+  // design reads them, so without it yosys is free to optimise both away and
+  // the runner would report a setup error it cannot distinguish from a real
+  // one. 32 bits is far more than the 5000-cycle budget in test/run_tests.sh
+  // can ever need, so no wrap is possible.
+  //
+  // The gating mirrors the monitor's own outer condition exactly
+  // (`if (!reset && ch0_rvfi_valid) ... if (ch0_spec_valid)`), so these count
+  // the retires it looked at and the subset whose values it compared — not an
+  // approximation of them.
+  //
+  // Plain `always @(posedge clk)`, not `always_ff`, because the `initial`
+  // below assigns the same variables; that is the pattern every other
+  // bookkeeping block in this file uses and nothing here is synthesised.
+  (* keep *) logic [31:0] rvfi_retires;
+  (* keep *) logic [31:0] rvfi_spec_retires;
+  initial begin
+    rvfi_retires = 32'b0;
+    rvfi_spec_retires = 32'b0;
+  end
+  always @(posedge clk) begin
+    if (!reset && rvfi_valid) begin
+      rvfi_retires <= rvfi_retires + 32'd1;
+      if (probe_spec_valid) begin
+        rvfi_spec_retires <= rvfi_spec_retires + 32'd1;
+      end
+    end
+  end
  `endif
   initial begin
     rom[0] = 32'h 3fc00093; //       li      x1,1020

--- a/test/testbench.v
+++ b/test/testbench.v
@@ -141,10 +141,33 @@ module testbench(
    `endif
   );
  `ifdef RISCV_FORMAL
+  // THE ONE WIRE EVERY RETIRE OBSERVER IN THIS BENCH READS. The monitor below,
+  // the spec probe that feeds the observation counters, and the counters
+  // themselves all take `rvfi_valid` through here rather than each reaching for
+  // the DUT's port separately. That is not decoration: a counter that could
+  // stay high while the monitor went blind would be telemetry about itself
+  // rather than about the oracle, and the whole point of the counters is that
+  // "the monitor observed nothing" cannot happen quietly. Wiring them together
+  // makes the two go blind together, structurally, instead of by promise.
+  //
+  // It is also what makes this repo's liveness probe for the counters a single
+  // line. To watch the gate go red on a blind oracle:
+  //
+  //     assign rvfi_valid_observed = 1'b0;   // instead of = rvfi_valid
+  //
+  // then `make test`. Every program still reaches `tohost` and still PASSes on
+  // its own assertions; the gate reports 52 x MONITOR-SILENT and exits 1. The
+  // same edit on the tree before the counters existed reports 52/52 and exits
+  // 0, which is the defect this closes. Same idea as deleting the rs2
+  // write-through bypass to check that reg_ch0 can still fail: reach for it
+  // before believing a green `make test` means the oracle looked.
+  logic rvfi_valid_observed;
+  assign rvfi_valid_observed = rvfi_valid;
+
   monitor monitor (
     .clock(clk),
     .reset(reset),
-    .rvfi_valid(rvfi_valid),
+    .rvfi_valid(rvfi_valid_observed),
     .rvfi_order(rvfi_order),
     .rvfi_insn(rvfi_insn),
     .rvfi_trap(rvfi_trap),
@@ -199,9 +222,12 @@ module testbench(
   // read a dangling constant while the build stayed clean. This instead
   // instantiates the same module the monitor instantiates, from the same wires
   // its own instance is wired from, so `probe_spec_valid` is `ch0_spec_valid`
-  // by construction: one combinational function, one set of inputs. KEEP THE
-  // TWO PORT MAPS IDENTICAL — rewiring one and not the other is the one way
-  // this could start counting retires the monitor never checked.
+  // by construction: one combinational function, one set of inputs. The one
+  // input that decides whether a retire is observed at all is shared through
+  // `rvfi_valid_observed` above, so the two cannot go blind independently.
+  // KEEP THE REMAINING FIVE PORT CONNECTIONS IDENTICAL TO THE MONITOR'S —
+  // rewiring one and not the other is the only way left for this to start
+  // counting retires the monitor never checked.
   //
   // A LOW SPEC-CHECKED COUNT IS EXPECTED, AND IS NOT A DEFECT. riscv-formal
   // ships no spec model at all for `ecall`, `ebreak`, `mret` or the `csrr*`
@@ -225,7 +251,7 @@ module testbench(
   logic [31:0] probe_spec_mem_wdata;
 
   monitor_isa_spec spec_probe (
-    .rvfi_valid(rvfi_valid),
+    .rvfi_valid(rvfi_valid_observed),
     .rvfi_insn(rvfi_insn),
     .rvfi_pc_rdata(rvfi_pc_rdata),
     .rvfi_rs1_rdata(rvfi_rs1_rdata),
@@ -266,7 +292,7 @@ module testbench(
     rvfi_spec_retires = 32'b0;
   end
   always @(posedge clk) begin
-    if (!reset && rvfi_valid) begin
+    if (!reset && rvfi_valid_observed) begin
       rvfi_retires <= rvfi_retires + 32'd1;
       if (probe_spec_valid) begin
         rvfi_spec_retires <= rvfi_spec_retires + 32'd1;


### PR DESCRIPTION
Closes JEF-689

## The hole

`make test` is the merge gate and `test/monitor.sim.v` is its per-retire oracle, but **nothing in
the gate measured whether the oracle ever fired.** `test/cxxrtl.cc` sampled the monitor's errcode
each cycle and counted nothing.

A monitor whose `rvfi_valid` never asserted — an under-sensitivity defect of exactly the ADR-0037
kind, a struct field lost behind an `ifdef`, a `write_cxxrtl` that optimised the instance away —
left all 52 programs reporting PASS off `tohost` alone. ADR-0032 already measured that `tohost`
end-state checking misses an injected extra architectural write across the whole suite, and
`test/EXPECTED_FAIL` is empty, so there was no red entry whose disappearance would have noticed
either.

## The change

Observation is a **graded quantity** now, not an inference.

* **`test/testbench.v`** counts retires (`rvfi_valid`) and spec-checked retires (`spec_valid`) in
  two `(* keep *)` registers.
* **`test/cxxrtl.cc`** prints `RETIRES <n> SPEC-CHECKED <m>` on every path that reaches the
  simulation loop, and gains **exit 6** for zero of either.
* **`test/run_tests.sh`** labels exit 6 `MONITOR-SILENT`, carries both counts as the table's third
  column, and grades them against **`test/OBSERVED_FLOOR`**.
* No `rtl/` file changed. `test/monitor.v` untouched (invariant 7); `test/sanitize_monitor.py`
  gains no fourth rule.

### Where `spec_valid` comes from, and the one thing that surprised me

`ch0_spec_valid` is internal to the monitor, which is generated-but-tracked. A hierarchical
reference looked like the obvious answer and **fails in the worst possible way** — yosys does not
resolve one, it *implicitly declares the name and carries on*:

```
h.v:9: Warning: Identifier `\u.secret' is implicitly declared.
```

so the counter would have read a dangling constant while the build stayed clean. Measured on a
throwaway module before committing to anything.

Instead the bench instantiates a **second `monitor_isa_spec`** — the same module the monitor
instantiates, from the same wires its own instance is wired from, so `probe_spec_valid` is
`ch0_spec_valid` by construction. Cost: **+2.1s** on `make sim` (24.6s → 26.7s), measured both ways.

The follow-on commit routes the monitor, the probe and the counters through one
`rvfi_valid_observed` wire, so a counter cannot keep counting while the monitor goes blind. That is
what makes the probe below one line, and it removes the only way the two could have disagreed about
whether a retire happened.

### The floor file

`test/OBSERVED_FLOOR` is in the `EXPECTED_CHECKS` idiom: a name and two integers. **Names by set
equality in both directions** (a program with no line is `NO-FLOOR`; a line with no program is an
error at the end of the run), **numbers by `>=`** — instruction counts legitimately move and an
exact ratchet over 52 numbers is one nobody would keep. Zero is never a floor: `MONITOR-SILENT`
fires before the file is consulted, so there is no way to write "this program is allowed not to be
checked".

Measured at `18d17a2`, the branch point. The three programs whose columns differ are the pin's
coverage boundary, not a defect — riscv-formal ships no spec model for `ecall`/`ebreak`/`mret`/
`csrr*`, so `spec_valid` is 0 for those retires by design. That is stated at `test/OBSERVED_FLOOR`,
at the counter block in `test/testbench.v`, and in CLAUDE.md, so whoever first sees a low number
does not have to rediscover it:

```
csr.S               108     82
minstret.S           42     31
trap.S              303    259
```

## Criterion 3 — the named liveness probe, on real runs

One line in `test/testbench.v`:

```verilog
assign rvfi_valid_observed = 1'b0;   // instead of = rvfi_valid
```

then `make test`. Every program still reaches `tohost` and still passes its own assertions, which is
exactly the defect.

**Pre-change tree** (`test/cxxrtl.cc`, `test/run_tests.sh`, `test/testbench.v`, `Makefile` restored
to `18d17a2`, with the equivalent one-line blinding `.rvfi_valid(1'b0)` at the monitor
instantiation, since `rvfi_valid_observed` does not exist there):

```
add.S            PASS
addi.S           PASS
and.S            PASS
andi.S           PASS
...
xor.S            PASS
xori.S           PASS

52/52 passed
Failure list matches test/EXPECTED_FAIL exactly (name and status).
EXIT=0
```

**Post-change tree**, same blinding:

```
add.S            MONITOR-SILENT         retires=0 spec-checked=0
addi.S           MONITOR-SILENT         retires=0 spec-checked=0
and.S            MONITOR-SILENT         retires=0 spec-checked=0
andi.S           MONITOR-SILENT         retires=0 spec-checked=0
auipc.S          MONITOR-SILENT         retires=0 spec-checked=0
beq.S            MONITOR-SILENT         retires=0 spec-checked=0
...
EXIT=1
```

52 of 52 rows, verified by `uniq -c`:

```
  52 MONITOR-SILENT
```

The probe is recorded in the rs2-bypass-probe style at `test/testbench.v` and in CLAUDE.md — one
line, the command, the expected red.

## Every new failure branch is demonstrated reachable

A status label no code path can emit is the same defect this ticket closes, so each was fired on a
real run (two-program scratch suite for the last four):

| Branch | Fired by | Output |
|---|---|---|
| `MONITOR-SILENT` | the probe above | 52 rows, `retires=0 spec-checked=0`, exit 1 |
| `NO-FLOOR` | the first measurement run, before the floors were written | 52 rows, exit 1 |
| `BELOW-FLOOR retires` | floor `simple.S 9999 5` | `simple.S: 5 retires, floor is 9999` |
| `BELOW-FLOOR spec-checked` | floor `add.S 429 9999` | `add.S: 429 spec-checked retires, floor is 9999` |
| `NO-COUNTS` | a `$SIM` wrapper that strips the `RETIRES` line | `retires=- spec-checked=-`, exit 1 |
| orphan floor line | floor naming `ghost.S` | `names programs that are not in <dir>: ghost.S` |
| malformed floor line | `simple.S 5` | `has lines that are not '<test>.S <retires> <spec-checked>'` |

## Gates

| Gate | Result |
|---|---|
| `make test` | **52/52 passed**, `test/EXPECTED_FAIL` matched exactly, exit 0 |
| `make test-units` | six benches — `exec_tb`, `mem_tb`, `decoder_tb`, `regfile_tb`, `csr_tb`, `monitor_tb` (`monitor_tb: all vectors passed`), exit 0 |
| `make lint` | `svlint: clean in both passes`, exit 0 |
| `make monitor-check` | no diff, exit 0 |
| `make testbench.vvp` | exit 0, **`sorry:` count exactly 20**, no other warning or error |
| yosys elaboration | one warning, `Deep recursion in AST simplifier` — the single allowlisted entry |

## Scope and risks

* Files touched: `test/testbench.v`, `test/cxxrtl.cc`, `test/run_tests.sh`, `test/OBSERVED_FLOOR`
  (new), `Makefile` (one line — the fourth argument), `CLAUDE.md` (one paragraph + the `make test`
  comment). No `rtl/`, no `formal/`, no `test/asm/`, no baseline file.
* **Build cost**: `make sim` 24.6s → 26.7s from the second `monitor_isa_spec`. `cosim` pays the same,
  since both share `test/rtl.cc`.
* **The floors are toolchain-sensitive.** They are instruction counts, so they are stable against
  cycle-level RTL changes but not against a binutils that compresses differently. A legitimate drop
  is re-measured and lowered in the same commit, with the SHA — the procedure is in the file header.
* **Interaction with the sibling that owns `test/asm/`**: adding a program without a floor line
  reports `NO-FLOOR` and fails. That is deliberate (a program whose observation nothing defends is
  how the file would rot into decoration) and the fix is one line, but whoever merges second pays
  it. `make test` prints the numbers to copy.
* **Known follow-up, deliberately not done here**: `test/EXPECTED_FAIL`'s header enumerates the
  statuses `run_tests.sh` can print, and that list is now missing `MONITOR-SILENT`, `NO-COUNTS`,
  `NO-FLOOR` and `BELOW-FLOOR`. That file is owned by a parallel branch this sprint, so it is left
  alone rather than conflicted. It is a comment, not a check — the gate itself matches on whatever
  the table prints.

## Decisions taken rather than asked

* **Silence outranks the run's own verdict** (exit 6 wins over 0/1/2/5). `tohost` saying PASS is
  exactly what a blind monitor looks like, and a FAIL from a blind run cannot be attributed either.
  **Exit 4 is the one exception** and does not go through that check: an errcode is direct evidence
  the monitor fired, which is stronger and more specific than any count.
* **No ADR.** This is a gate-mechanism change in the ADR-0033/0035/0037 family and would ordinarily
  earn one, but two siblings are running this sprint and an ADR number is a guaranteed conflict.
  The reasoning is written at the three files and in CLAUDE.md instead. Worth a retro-ADR if the
  architect wants one at merge.
* **Set equality on floor *names*, `>=` on floor *numbers*.** The ticket's `>=` is about the
  numbers moving; nothing about it argues for letting a program have no floor at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJ77ZZJ6pDiL3vj3Qw9hKs
