### PR TITLE
JEF-693: read the no-oracle RTL against the privileged spec — two RTL defects found and fixed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -668,6 +668,26 @@ and 3, which this list has not yet been rewritten for. Read each term's own text
    held**, and stayed accidentally true only because the ladder kept matching its baseline
    (ADR-0037). General rule: never put the graded command in a pipeline in a `run:` block.
 
+**That quiet corner was read directly against the spec, and it was hiding a real defect**
+(ADR-0048). `rtl/csrs.v`, `rtl/decoder.v`'s trap arm and `rtl/writeback.v` were read against the
+privileged specification **with `test/csr_tb.v` and the trap `.S` files closed**, the expectation
+written down first and the benches opened only afterwards — because a bench written from the same
+reading as the RTL cannot detect a misreading, and the number of assertions is irrelevant to that.
+Three findings. **`c.ebreak` (16'h9002) decoded to nothing**, so it raised illegal instruction
+(cause 2) instead of breakpoint (cause 3): it is the `rd == 0`, `rs2 == 0` corner of quadrant 2's
+`funct4 == 4'b1001` row that `instr_cjalr` and `instr_cadd` each exclude by a different field. It
+survived because **the suite's `.option norvc` discipline guarantees the assembler never emits a
+compressed trapping encoding** — correct for the resuming handler (ADR-0008), and a blind spot
+exactly one instruction wide. **A counter write at the carry boundary moved the other half**:
+`csrw mcycle` with `mcycle == 0xffff_ffff` advanced `mcycleh`, because the increment was suppressed
+per half rather than per counter; `rvfi_csrw_check` reads only the self-report and never observes
+the register, so no ladder check can see it in any configuration. Both fixed, each with the test
+that caught it written first. **Two required CSRs are missing** — `mstatush` and `mconfigptr`, which
+Sail reads and this core traps on, measured — and that one is landed **red** in both `.S` baselines
+as `csrset.S`, because widening ADR-0005's *exact* CSR set is an ISA-scope decision and not an
+audit's to make. Everything else read as correct, `test/csr_tb.v` included: it disagreed with the
+specification nowhere.
+
 **Two caveats qualify what any green ladder here means, and neither is closable by burning
 down a list.** Every check is `mode bmc` — PASS means "no counterexample within this check's
 configured depth", not that the property holds, and there is no `mode prove` anywhere on the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -483,7 +483,12 @@ These are the design. Violating one is a bug even if tests pass.
 
 ## ISA target
 
-RV32IMC_Zicsr, M-mode only. `misa = 0x4000_1104`.
+RV32IMC_Zicsr_Zifencei, M-mode only. `misa = 0x4000_1104` — neither Zicsr nor Zifencei has a
+`misa` bit, so the ISA string is the only place either is claimed. Zifencei is claimed because the
+core already implements it correctly and for free: one hart, no icache, so a conformant `fence.i`
+is a NOP, which is what `rtl/decoder.v` already does. Before ADR-0002 was amended the string did
+NOT claim it while the decoder accepted it anyway — silently permissive, and the one combination
+that was wrong.
 
 **Conformance is not negotiable against minimality.** Every CSR the privileged spec lists
 unconditionally for RV32 machine mode is implemented; a core that traps on a mandatory register is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -485,6 +485,14 @@ These are the design. Violating one is a bug even if tests pass.
 
 RV32IMC_Zicsr, M-mode only. `misa = 0x4000_1104`.
 
+**Conformance is not negotiable against minimality.** Every CSR the privileged spec lists
+unconditionally for RV32 machine mode is implemented; a core that traps on a mandatory register is
+non-conformant however small its set is, and the spec lets almost all of them read zero, so the
+cost of getting this right is close to nothing. ADR-0005 headed its list "CSR set (exact)" until
+ADR-0048, and that word turned a conformance gap into an apparent design choice — `mstatush` and
+`mconfigptr` were missing, and the question it produced was whether the exact set could widen
+rather than why the core was non-conformant. The list is a **floor**, not a closed set.
+
 Traps: illegal instruction = 2, breakpoint = 3, load address misaligned = 4, store address
 misaligned = 6, environment call from M-mode = 11. **Instruction-address-misaligned (0) is
 unreachable** — C makes 2-byte targets legal — and is not implemented. No interrupts: `mie` and
@@ -681,12 +689,20 @@ compressed trapping encoding** — correct for the resuming handler (ADR-0008), 
 exactly one instruction wide. **A counter write at the carry boundary moved the other half**:
 `csrw mcycle` with `mcycle == 0xffff_ffff` advanced `mcycleh`, because the increment was suppressed
 per half rather than per counter; `rvfi_csrw_check` reads only the self-report and never observes
-the register, so no ladder check can see it in any configuration. Both fixed, each with the test
-that caught it written first. **Two required CSRs are missing** — `mstatush` and `mconfigptr`, which
-Sail reads and this core traps on, measured — and that one is landed **red** in both `.S` baselines
-as `csrset.S`, because widening ADR-0005's *exact* CSR set is an ISA-scope decision and not an
-audit's to make. Everything else read as correct, `test/csr_tb.v` included: it disagreed with the
+the register, so no ladder check can see it in any configuration. **Two required CSRs were missing** —
+`mstatush` and `mconfigptr`, which Sail reads and this core trapped on, measured. All three are
+fixed, each with the test that caught it written first, and the suite is **55/55 with both `.S`
+baselines empty**. Everything else read as correct, `test/csr_tb.v` included: it disagreed with the
 specification nowhere.
+
+**The third finding was briefly landed red instead of fixed, and that was the wrong call.** The
+audit declined to widen ADR-0005's CSR set on the grounds that the ADR called it *exact*, making it
+an ISA-scope decision rather than an audit's. The reasoning was sound and the premise was not: a
+core that traps on a spec-mandatory register is non-conformant, minimality was never a licence for
+that, and `mstatush`/`mconfigptr` both read zero legally — the fix is two lines and no new state.
+**ADR-0005's "exact" is struck**; the set is a floor. The lesson is not about CSRs: a scope
+statement that can make a conformance gap look like a design choice will eventually be believed by
+someone with no reason to doubt it.
 
 **Two caveats qualify what any green ladder here means, and neither is closable by burning
 down a list.** Every check is `mode bmc` — PASS means "no counterexample within this check's

--- a/docs/adr/0002-isa-target-rv32imc-zicsr.md
+++ b/docs/adr/0002-isa-target-rv32imc-zicsr.md
@@ -1,4 +1,4 @@
-# ADR-0002: ISA target is RV32IMC_Zicsr, machine mode only
+# ADR-0002: ISA target is RV32IMC_Zicsr_Zifencei, machine mode only
 
 **Status:** Accepted · 2026-07-27
 
@@ -15,9 +15,21 @@ doubles the riscv-formal `insn_*` check count. An initial recommendation was to 
 
 ## Decision
 
-**Target RV32IMC_Zicsr, machine mode only.** The C extension stays.
+**Target RV32IMC_Zicsr_Zifencei, machine mode only.** The C extension stays.
 
-- `misa = 0x4000_1104` (MXL=1, C+I+M).
+- `misa = 0x4000_1104` (MXL=1, C+I+M). Neither Zicsr nor Zifencei has a `misa` bit — they are
+  named extensions, so the ISA string is the only place either is claimed.
+- **Zifencei is claimed rather than declined, because the core already implements it correctly
+  and for free.** `rtl/decoder.v` decodes `fence.i` and retires it as a NOP, which is exactly a
+  conformant Zifencei on this design: one hart, no instruction cache, so instruction fetch is
+  always coherent with stores and there is nothing to invalidate. **The state before this
+  amendment was the one combination that was wrong** — the string did not claim Zifencei while
+  the decoder accepted `fence.i` anyway, so the core was silently permissive: an instruction from
+  an unclaimed extension retired instead of raising illegal-instruction. Claiming it costs
+  nothing and makes the RTL and the string agree; declining it would have meant *removing*
+  working, correct logic to raise a trap nobody wants. Added to `-march` in `test/run_tests.sh`
+  and `test/cosim.py`, without which the assembler refuses to emit `fence.i` at all — which is
+  why `fence.i` had no test before `test/asm/fencenop.S`.
 - Traps implemented: illegal instruction (2), breakpoint (3), load address misaligned (4), store
   address misaligned (6), environment call from M-mode (11).
 - **Instruction-address-misaligned (mcause 0) is unreachable and not implemented** — with C, only

--- a/docs/adr/0005-traps-and-csrs-commit-in-decode.md
+++ b/docs/adr/0005-traps-and-csrs-commit-in-decode.md
@@ -30,15 +30,36 @@ read and written in the decode stage. CSR instructions and `mret` serialize.**
 - **`minstret` increments at issue**, which is equivalent to counting retires because post-decode
   nothing faults.
 
-### CSR set (exact)
+### CSR set
+
+**The set is minimal, not closed, and the difference is the whole point.** Every register the
+privileged specification lists *unconditionally* for RV32 machine mode is implemented, because a
+core that traps on a mandatory register is non-conformant no matter how small its set is. Anything
+the spec makes optional, or gates behind an extension this core does not have, is out. Minimality
+is a design value here; non-conformance never was one, and the two are barely in tension — the spec
+lets almost every mandatory register read zero.
+
+**This paragraph was originally headed "CSR set (exact)"**, and the word did real damage. It read
+as a closed list rather than a floor, so when an independent read against the specification found
+`mstatush` and `mconfigptr` missing (ADR-0048), the question it raised was *"may we widen the exact
+set?"* rather than *"why is this core non-conformant?"* The first question has an interesting answer
+and the second has an obvious one. **A statement of scope must not be able to make a conformance
+gap look like a design choice.**
 
 **Read/write:** `mstatus` (MIE, MPIE, MPP only; MPP is WARL → `2'b11`), `mtvec` (direct mode only;
 base WARL, 4-byte aligned), `mepc` (WARL, bit [0] = 0 — only bit 0, because C makes 2-byte targets
 legal), `mcause` (WLRL over the implemented codes), `mscratch`, `mcycle`/`mcycleh`,
 `minstret`/`minstreth`.
 
+**Read/write, no implemented fields:** `mstatush` (§3.1.6.4, RV32 only). Its defined fields are SBE
+and MBE; both read zero, meaning little-endian data accesses in M-mode, which is what this core
+does. A write is a legal WARL no-op rather than a trap — bits [11:10] of its address make it
+writable, and the spec does not permit faulting on it.
+
 **Read-only:** `mtval` = 0 (spec-legal), `mie` = 0, `mip` = 0 (no interrupt sources),
-`misa` = `0x4000_1104` (RV32IMC), `mvendorid`/`marchid`/`mimpid`/`mhartid` = 0.
+`misa` = `0x4000_1104` (RV32IMC), `mvendorid`/`marchid`/`mimpid`/`mhartid` = 0,
+`mconfigptr` = 0 (§3.1.4 — zero is the spec's own encoding for "no configuration data structure
+exists").
 
 **Trap causes:** illegal instruction = 2, breakpoint = 3, load address misaligned = 4, store
 address misaligned = 6, environment call from M-mode = 11. Instruction-address-misaligned (0) is

--- a/docs/adr/0048-what-an-independent-read-of-the-no-oracle-rtl-found.md
+++ b/docs/adr/0048-what-an-independent-read-of-the-no-oracle-rtl-found.md
@@ -1,0 +1,136 @@
+# ADR-0048: What an independent read of the no-oracle RTL found
+
+**Status:** Accepted · 2026-08-01 · *Supplements
+[ADR-0005](0005-traps-and-csrs-commit-in-decode.md),
+[ADR-0027](0027-minstret-counts-non-trapping-issues.md),
+[ADR-0030](0030-trap-cause-priority-and-why-the-causes-are-disjoint.md). Records one RTL defect,
+one spec-scope divergence left open, and the audit method that found them.*
+
+## Context
+
+riscv-formal ships no spec model for `ecall`/`ebreak`/`mret`/`csrr*` at the pinned SHA. `spec_valid`
+is 0 for every one of them, so the per-retire monitor's whole semantic block is skipped and every
+`insn_*` ladder check is silent about the behaviour M3 added. What is left is `test/csr_tb.v`,
+`test/asm/trap.S`, `test/asm/csr.S` and `test/decoder_tb.v` — **assertions this repo wrote**.
+
+CLAUDE.md's own summary of the situation is *"an empty baseline is loudest exactly where the ladder
+is quietest."* The specific hazard is **correlated-author error**: a bench written from the same
+reading of the spec as the RTL cannot detect a misreading, because the misreading is in both. The
+number of assertions is irrelevant to that; they are not independent samples.
+
+## The method, and why the ordering is the whole thing
+
+`rtl/csrs.v` (in full), `rtl/decoder.v`'s trap arm and `rtl/writeback.v` were read against the
+privileged specification **with `test/csr_tb.v`, `test/asm/trap.S` and `test/asm/csr.S` closed**.
+An expectation was written down first — WARL mask by WARL mask, cause by cause, decode arm by decode
+arm — and only then were the benches opened and compared. A disagreement counts as a finding
+regardless of which side turns out to be wrong.
+
+Read the benches first and you inherit their reading. That is not a stylistic preference; it is the
+only thing that makes the exercise able to fail.
+
+## Finding 1 — `c.ebreak` raised the wrong trap cause. RTL was wrong
+
+**`c.ebreak` (16'h9002) raised illegal instruction (mcause 2) instead of breakpoint (mcause 3).**
+
+The C extension defines C.EBREAK as expanding to EBREAK, so it raises the same exception with the
+same cause. `rtl/decoder.v`'s `instr_error` requires `uncompressed`, and no compressed decode
+covered the encoding: it is the `rd == 0`, `rs2 == 0` corner of quadrant 2's `funct4 == 4'b1001`
+row, and its two neighbours each exclude it by a different field — `instr_cjalr` needs
+`instr[11:7] != 0`, `instr_cadd` needs `instr[6:2] != 0`. With no decode at all, `instr_valid` was
+low and `instr_illegal` produced cause 2.
+
+**The failure mode is why it survived.** The instruction still traps, still records the correct
+`mepc`, and the handler still resumes — only the cause value is wrong, and a wrong-but-plausible
+answer is exactly what nothing in this repo was positioned to notice. `test/asm/trap.S`'s breakpoint
+case is `.option norvc`, as is every trapping instruction in that file, because the handler resumes
+at `mepc+4` unconditionally (`riscv_test.h` constraint 1, ADR-0008's Harvard buses). So the
+assembler never had a reason to emit C.EBREAK anywhere in the suite, and `test/decoder_tb.v` drives
+the 32-bit form. **The compressed breakpoint was the one trap cause with an encoding no test could
+reach.**
+
+Fixed here, in two lines, with `test/asm/cebreak.S` written and seen to fail first
+(`cebreak.S FAIL 2`) at both alignments.
+
+## Finding 2 — a counter write at the carry boundary moved the other half. RTL was wrong
+
+"Any CSR write takes precedence over the automatic increment" (privileged spec 20211203 §3.1.11,
+and ADR-0005's own wording) is a statement about the 64-bit counter, not about the half the address
+happens to name: `mcycle` and `mcycleh` are two views of one register.
+
+`rtl/csrs.v` suppressed the increment **per half**. With `mcycle == 32'hffff_ffff`, the increment's
+carry landed in the high half while an explicit write replaced the low half — so `csrw mcycle`
+advanced `mcycleh` by one. Same shape in `minstret`. That contradicts the file's own comment, which
+states the invariant it was built to satisfy.
+
+**Three oracles are structurally blind to it, and that is the part worth keeping.**
+`checks/rvfi_csrw_check.sv` reads only the self-reported `rmask`/`wmask`/`rdata`/`wdata` and never
+observes the register, so `csrw_mcycle_ch0` cannot see it in any configuration; every ladder check
+is `mode bmc` from reset and could not reach 2^32 cycles if it could; and a `.S` program can land a
+write on that one cycle only by calibrating the instruction spacing first, which is a test that
+stops testing the moment the spacing changes. **A test that can silently stop testing is worse than
+no test** — this repo's own `ref_selftest` doctrine. Driving the CSR port directly in
+`test/csr_tb.v` is the one place it is deterministic, and that is where the check lives.
+
+## Finding 3 — the implemented CSR set is smaller than RV32 requires. Left open
+
+`mstatush` (0x310) is listed unconditionally in the privileged spec's RV32 machine-mode CSR table;
+the `mhpmcounter3..31` / `mhpmcounterNh` / `mhpmevent3..31` blocks and `mconfigptr` (0xF15) are
+likewise required-but-may-read-zero. None is in `rtl/csrs.v`'s `implemented` set, so an access to
+any of them raises illegal instruction where the spec says it should read zero. (`mcounteren`
+(0x306) is genuinely not required without S- or U-mode, and the unprivileged `cycle`/`instret`
+aliases belong to Zicntr, which ADR-0002 does not claim. Neither is a finding.)
+
+**This is not fixed here and must not be fixed casually.** ADR-0005 states its CSR set as *exact*,
+and widening it is an ISA-scope decision that belongs to an amendment of ADR-0002/ADR-0005 with its
+own reasoning about what "RV32IMC_Zicsr, machine mode only" commits to — not to an audit ticket. The
+audit's job was to make the divergence known and attributable, and it is now both.
+
+Nothing is parked in `test/EXPECTED_FAIL` for it, deliberately: a red baseline entry would assert
+that the spec reading above is the accepted one, which is precisely the decision being deferred.
+
+## Everything else read as correct
+
+Recorded because a negative result from an independent read is the point of doing one, and because
+the next person should not have to redo it:
+
+- **WARL, field by field.** `mstatus` (MPP hardwired 11, MIE/MPIE only), `mtvec` (MODE forced to
+  direct), `mepc` (bit 0 only — bit 1 must survive, because C makes 2-byte targets legal),
+  `mcause` (WLRL, fully writable), `mtval`/`mie`/`mip` (hardwired zero, writes ignored rather than
+  faulting, because their addresses are writable), `misa` (WARL, unsupported write leaves it
+  unchanged), the four identification CSRs (read-only *by address*, so a write faults).
+- **Trap cause priority** matches ADR-0030, and its disjointness argument survives the `c.ebreak`
+  fix: `instr_cebreak` feeds `instr_ebreak`, which the `$onehot0` assertion already covers.
+- **`mepc` bit 0**, on both the explicit-write path and the trap-entry path, through one mask.
+- **`mstatus` MIE/MPIE/MPP** on trap entry (MPIE←MIE, MIE←0, MPP←M) and on `mret` (MIE←MPIE,
+  MPIE←1, MPP←least-privileged supported = M).
+- **Counter increment semantics** against ADR-0027: a trapping instruction does not count; a CSR
+  write beats the increment; `csrr minstret` excludes itself.
+- **The `mret`/`ecall`/`ebreak` decode arms**, including that SYSTEM funct3 == 0 with a non-zero
+  rs1 or rd is illegal, and that `sret` is.
+- **Zicsr's suppression rules are encoding tests, not value tests**, in all six instructions — the
+  sharp case being a CSRRS whose rs1 is a real register that happens to hold zero, which must still
+  fault against a read-only CSR where the same instruction written with x0 must not.
+- **`rtl/writeback.v` holds no architectural decision at all.** `wen = in.valid && in.rd != 0`, and
+  everything else in the file is `ifdef RISCV_FORMAL` reporting.
+
+**`test/csr_tb.v` disagreed with the specification nowhere.** Every assertion in it that the
+independent read reached an expectation about matched that expectation. That is a real result and
+the ticket's acceptance criterion 5 asked for it either way; it is recorded so that "the bench was
+never checked" stops being true.
+
+## Consequences
+
+- `test/asm/cebreak.S` and `test/asm/zicsr.S` join the suite; it is 54 programs. Both are graded by
+  `make test` and by `make cosim-suite`, and both baselines stay empty.
+- **The suite's `.option norvc` discipline has a blind spot, and it is now named.** Wrapping every
+  trapping instruction keeps the resuming handler correct (ADR-0008) and simultaneously guarantees
+  the assembler never emits a *compressed* trapping encoding. `c.ebreak` is the only such encoding
+  this core implements, so the hole is closed rather than open — but any future compressed
+  instruction that can fault inherits it, and closing it means padding with a `c.nop` so `mepc+4`
+  lands on a boundary, which is what `cebreak.S` does.
+- Finding 3 is owed to a future ADR, not dropped. Naming it here is what stops it depending on
+  anyone's memory (the shape ADR-0041 decision 2 used for the co-simulation nightly).
+- The method generalises and is cheap: read the RTL against the spec with the bench closed, write
+  the expectation down, then compare. Two of the three files came back clean; the one defect it
+  found was in the third and was invisible to all four existing oracles at once.

--- a/docs/adr/0048-what-an-independent-read-of-the-no-oracle-rtl-found.md
+++ b/docs/adr/0048-what-an-independent-read-of-the-no-oracle-rtl-found.md
@@ -92,18 +92,25 @@ is legal; Sail implementing it is Sail's choice. (`mcounteren` (0x306) is likewi
 without S- or U-mode, and the unprivileged `cycle`/`instret` aliases belong to Zicntr, which
 ADR-0002 does not claim.)
 
-**This is not fixed here and must not be fixed casually.** ADR-0005 states its CSR set as *exact*,
-and widening it is an ISA-scope decision that belongs to an amendment of ADR-0002/ADR-0005 with its
-own reasoning about what "RV32IMC_Zicsr, machine mode only" commits to — not to the audit that
-noticed. It is owed to a follow-up, and naming it here is what stops it depending on anyone's
-memory (the shape ADR-0041 decision 2 used for the co-simulation nightly).
+**This was first landed red rather than fixed, and that was wrong.** The reasoning was that
+ADR-0005 states its CSR set as *exact*, making a widening an ISA-scope decision owed to an
+amendment rather than to the audit that noticed. The reasoning was careful; the premise it rested
+on was false. **A core that traps on a spec-mandatory register is non-conformant, and minimality
+was never a licence for that** — the two barely trade off, because the spec lets almost every
+mandatory register read zero. `mstatush` reads zero (its only fields are SBE and MBE, and zero
+means the little-endian behaviour this core already has) and `mconfigptr` reads zero (the spec's
+own encoding for "no configuration data structure exists"). The fix is two entries in the read mux
+and no new state.
 
-`test/asm/csrset.S` lands it **red in both baselines** — `csrset.S FAIL 2` in `test/EXPECTED_FAIL`
-and `csrset.S DISAGREE AT 2` in `test/COSIM_EXPECTED_FAIL`. That is ADR-0033's rule applied to the
-`.S` suite: a known-red test in the suite is the system working, and a known-red property with no
-test at all is the system lying. Because the status pins the first failing case (ADR-0035), fixing
-`mstatush` without `mconfigptr` turns the entry into `FAIL 3` and goes red rather than matching —
-the burn-down catching a partial fix rather than absorbing it.
+**Both are implemented, and ADR-0005's "exact" is struck in the same change.** `test/asm/csrset.S`
+passes on its own terms and both `.S` baselines are empty again at 55/55.
+
+**The generalisable part is not about CSRs.** A scope statement that can make a conformance gap
+look like a design choice will eventually be believed by someone with no reason to doubt it — and
+here it was believed by the reader best placed to catch it, *while they were reading the
+specification against the RTL for exactly this class of defect*. "Exact" was one word doing damage
+no assertion could have caught. When an ADR states a set, it must say whether the set is a floor or
+a ceiling, because the difference decides whether a gap is a bug or a decision.
 
 ## Everything else read as correct
 

--- a/docs/adr/0048-what-an-independent-read-of-the-no-oracle-rtl-found.md
+++ b/docs/adr/0048-what-an-independent-read-of-the-no-oracle-rtl-found.md
@@ -72,22 +72,38 @@ stops testing the moment the spacing changes. **A test that can silently stop te
 no test** — this repo's own `ref_selftest` doctrine. Driving the CSR port directly in
 `test/csr_tb.v` is the one place it is deterministic, and that is where the check lives.
 
-## Finding 3 — the implemented CSR set is smaller than RV32 requires. Left open
+## Finding 3 — two required CSRs are missing. Landed red, left open
 
-`mstatush` (0x310) is listed unconditionally in the privileged spec's RV32 machine-mode CSR table;
-the `mhpmcounter3..31` / `mhpmcounterNh` / `mhpmevent3..31` blocks and `mconfigptr` (0xF15) are
-likewise required-but-may-read-zero. None is in `rtl/csrs.v`'s `implemented` set, so an access to
-any of them raises illegal instruction where the spec says it should read zero. (`mcounteren`
-(0x306) is genuinely not required without S- or U-mode, and the unprivileged `cycle`/`instret`
-aliases belong to Zicntr, which ADR-0002 does not claim. Neither is a finding.)
+**`mstatush` (0x310, §3.1.6.4, "For RV32 only, mstatush is a 32-bit read/write register") and
+`mconfigptr` (0xF15, §3.1.4) are listed unconditionally in the privileged spec's machine-mode
+register tables and are absent from `rtl/csrs.v`'s `implemented` set**, so an access to either
+raises illegal instruction where the spec says it should read zero.
+
+**The divergence is measured, not argued**, and that is what promotes it from "one reading of a
+specification sentence" to a finding. sail-riscv 0.13.1 reads both and continues; this core traps on
+both.
+
+The same measurement retired two suspicions the read had raised, and they are recorded so nobody
+re-opens them. **`mhpmcounter3` (0xB03), `mhpmcounter3h` (0xB83) and `mhpmevent3` (0x323)**: the
+reference model raises illegal instruction on all three, exactly as this core does — there is
+nothing to close. **`mcountinhibit` (0x320)**: the spec makes it explicitly optional ("if not
+implemented, the implementation behaves as though the register were set to zero"), so declining it
+is legal; Sail implementing it is Sail's choice. (`mcounteren` (0x306) is likewise not required
+without S- or U-mode, and the unprivileged `cycle`/`instret` aliases belong to Zicntr, which
+ADR-0002 does not claim.)
 
 **This is not fixed here and must not be fixed casually.** ADR-0005 states its CSR set as *exact*,
 and widening it is an ISA-scope decision that belongs to an amendment of ADR-0002/ADR-0005 with its
-own reasoning about what "RV32IMC_Zicsr, machine mode only" commits to — not to an audit ticket. The
-audit's job was to make the divergence known and attributable, and it is now both.
+own reasoning about what "RV32IMC_Zicsr, machine mode only" commits to — not to the audit that
+noticed. It is owed to a follow-up, and naming it here is what stops it depending on anyone's
+memory (the shape ADR-0041 decision 2 used for the co-simulation nightly).
 
-Nothing is parked in `test/EXPECTED_FAIL` for it, deliberately: a red baseline entry would assert
-that the spec reading above is the accepted one, which is precisely the decision being deferred.
+`test/asm/csrset.S` lands it **red in both baselines** — `csrset.S FAIL 2` in `test/EXPECTED_FAIL`
+and `csrset.S DISAGREE AT 2` in `test/COSIM_EXPECTED_FAIL`. That is ADR-0033's rule applied to the
+`.S` suite: a known-red test in the suite is the system working, and a known-red property with no
+test at all is the system lying. Because the status pins the first failing case (ADR-0035), fixing
+`mstatush` without `mconfigptr` turns the entry into `FAIL 3` and goes red rather than matching —
+the burn-down catching a partial fix rather than absorbing it.
 
 ## Everything else read as correct
 
@@ -121,8 +137,11 @@ never checked" stops being true.
 
 ## Consequences
 
-- `test/asm/cebreak.S` and `test/asm/zicsr.S` join the suite; it is 54 programs. Both are graded by
-  `make test` and by `make cosim-suite`, and both baselines stay empty.
+- `test/asm/cebreak.S`, `test/asm/zicsr.S` and `test/asm/csrset.S` join the suite; it is 55
+  programs, graded 54 pass / 1 expected-fail by `make test` and 54 agree / 1 expected-divergence by
+  `make cosim-suite`. **Both baselines stop being empty**, for the one entry above and for no other
+  reason. The formal ladder is untouched at 82 checks / 82 pass with `formal/EXPECTED_FAIL` still
+  empty, re-run against the `c.ebreak` fix rather than argued about.
 - **The suite's `.option norvc` discipline has a blind spot, and it is now named.** Wrapping every
   trapping instruction keeps the resuming handler correct (ADR-0008) and simultaneously guarantees
   the assembler never emits a *compressed* trapping encoding. `c.ebreak` is the only such encoding

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -51,6 +51,7 @@ and what it costs. Reversing one is fine — write a new ADR that supersedes it.
 | [0045](0045-two-m2-terms-close-by-amendment-and-one-was-already-met.md) | Two M2 terms close by amendment, one was already met, and the measurements that force it | Accepted |
 | [0044](0044-what-the-memory-system-has-to-be.md) | What the memory system has to be, and why today's placeholders cannot be it | Accepted |
 | [0047](0047-non-perturbation-is-proved-structurally-and-equiv-sh-is-retired.md) | The RVFI non-perturbation guarantee is proved structurally, and `equiv.sh` is retired | Accepted |
+| [0048](0048-what-an-independent-read-of-the-no-oracle-rtl-found.md) | What an independent read of the no-oracle RTL found: `c.ebreak`'s cause, a counter carry, and two missing CSRs | Accepted |
 
 0001–0007 came from the design brief
 ([`docs/ideas/finish-the-rewrite.md`](../ideas/finish-the-rewrite.md)). 0008–0011 came out of

--- a/rtl/csrs.v
+++ b/rtl/csrs.v
@@ -215,26 +215,47 @@ module csrs(
   assign trap_epc_warl = {trap_epc[31:1], 1'b0};
 
   // ---- the counters -----------------------------------------------------
-  // Both advance first and are then overwritten by an explicit write to the
-  // addressed half, which is ADR-0005's "an explicit write to a counter takes
-  // precedence over that cycle's increment" written out rather than relied on
-  // as a last-assignment-wins side effect.
-  logic [63:0] mcycle_plus, minstret_plus;
-  assign mcycle_plus   = mcycle + 64'd1;
-  assign minstret_plus = instret ? minstret + 64'd1 : minstret;
-
-  logic [31:0] mcycle_plus_lo, mcycle_plus_hi, minstret_plus_lo, minstret_plus_hi;
-  assign mcycle_plus_lo   = mcycle_plus[31:0];
-  assign mcycle_plus_hi   = mcycle_plus[63:32];
-  assign minstret_plus_lo = minstret_plus[31:0];
-  assign minstret_plus_hi = minstret_plus[63:32];
-
   logic wr_mcycle, wr_mcycleh, wr_minstret, wr_minstreth, wr_mscratch;
   assign wr_mcycle    = wen && addr == MCYCLE;
   assign wr_mcycleh   = wen && addr == MCYCLEH;
   assign wr_minstret  = wen && addr == MINSTRET;
   assign wr_minstreth = wen && addr == MINSTRETH;
   assign wr_mscratch  = wen && addr == MSCRATCH;
+
+  // ADR-0005's "an explicit write to a counter takes precedence over that
+  // cycle's increment" -- and the privileged spec's own "any CSR write takes
+  // precedence over the automatic increment" (20211203 §3.1.11) -- are
+  // statements about the 64-BIT COUNTER, not about the half whose address the
+  // instruction happens to name. mcycle and mcycleh are two views of one
+  // register, so a write to either half suppresses that cycle's increment of
+  // the whole thing. Hence a `_tick` term per counter rather than the two
+  // per-half overrides below doing the job on their own.
+  //
+  // Suppressing per half instead is wrong only at the carry boundary, and
+  // wrong there in a way that nothing else in this repo can see. With
+  // mcycle == 32'hffff_ffff the increment's carry lands in the HIGH half while
+  // the explicit write replaces the low one, so `csrw mcycle` advances mcycleh
+  // by one -- contradicting the invariant the RVFI report at the bottom of this
+  // file is built to satisfy, and doing it once every 2**32 cycles and only if
+  // a write falls on that exact cycle. checks/rvfi_csrw_check.sv reads the
+  // SELF-REPORTED masks and never observes the register; every ladder check is
+  // `mode bmc` from reset; and a `.S` program can land a write on that cycle
+  // only by calibrating instruction spacing first, which is a test that stops
+  // testing the moment the spacing changes. test/csr_tb.v drives this port
+  // directly and is the one place it is deterministic (ADR-0048).
+  logic mcycle_tick, minstret_tick;
+  assign mcycle_tick   = !wr_mcycle   && !wr_mcycleh;
+  assign minstret_tick = !wr_minstret && !wr_minstreth && instret;
+
+  logic [63:0] mcycle_plus, minstret_plus;
+  assign mcycle_plus   = mcycle_tick   ? mcycle   + 64'd1 : mcycle;
+  assign minstret_plus = minstret_tick ? minstret + 64'd1 : minstret;
+
+  logic [31:0] mcycle_plus_lo, mcycle_plus_hi, minstret_plus_lo, minstret_plus_hi;
+  assign mcycle_plus_lo   = mcycle_plus[31:0];
+  assign mcycle_plus_hi   = mcycle_plus[63:32];
+  assign minstret_plus_lo = minstret_plus[31:0];
+  assign minstret_plus_hi = minstret_plus[63:32];
 
   logic [31:0] mcycle_next_lo, mcycle_next_hi, minstret_next_lo, minstret_next_hi;
   assign mcycle_next_lo   = wr_mcycle    ? warl : mcycle_plus_lo;

--- a/rtl/csrs.v
+++ b/rtl/csrs.v
@@ -11,15 +11,22 @@
 // serialize) is enforced in rtl/decoder.v, not here -- this module has no
 // idea a stall exists and does not need one.
 //
-// The CSR set is ADR-0005's, exactly:
+// The CSR set is ADR-0005's. It is a FLOOR, not a closed list: every register
+// the privileged spec lists unconditionally for RV32 machine mode is here,
+// because trapping on a mandatory register is non-conformant however minimal
+// the set is. ADR-0005 headed this list "exact" until ADR-0048, and that word
+// is why two mandatory registers stayed missing through a spec read looking
+// for exactly that -- it made a conformance gap read as a scope decision.
 //
 //   read/write   mstatus (MIE/MPIE; MPP is WARL -> 2'b11), mtvec (direct
 //                mode, base 4-byte aligned), mepc (bit 0 always clear --
 //                only bit 0, because C makes 2-byte targets legal), mcause,
 //                mscratch, mcycle/mcycleh, minstret/minstreth
+//   read/write,  mstatush -- writable by encoding, no implemented fields, so
+//   no fields    a write is a legal WARL no-op and must not trap
 //   read-only    mtval = 0, mie = 0, mip = 0 (no interrupt sources),
 //                misa = 0x4000_1104 (RV32IMC), mvendorid/marchid/mimpid/
-//                mhartid = 0
+//                mhartid = 0, mconfigptr = 0
 //
 // Trap entry and `mret` are the second write port, and the only architectural
 // CSR update no CSR *instruction* performs. They arrive from the decoder on
@@ -89,6 +96,16 @@ module csrs(
   // register-index fields.
   localparam logic [11:0] MSTATUS   = 12'h300;
   localparam logic [11:0] MISA      = 12'h301;
+  // RV32-mandatory, and read-only zero here. Both are listed unconditionally in
+  // the privileged spec's machine-mode CSR table, so a core that traps on them
+  // is non-conformant however small its implemented set is -- which is why
+  // ADR-0005's "exact" set widens to include them rather than declining them.
+  // Zero is a legal value for each, not a stub: mstatush's only fields are SBE
+  // and MBE, and 0 means little-endian data accesses in M-mode, which is what
+  // this core does; mconfigptr = 0 is the spec's own encoding for "no
+  // configuration data structure exists".
+  localparam logic [11:0] MSTATUSH  = 12'h310;
+  localparam logic [11:0] MCONFIGPTR = 12'hF15;
   localparam logic [11:0] MIE       = 12'h304;
   localparam logic [11:0] MTVEC     = 12'h305;
   localparam logic [11:0] MSCRATCH  = 12'h340;
@@ -148,6 +165,7 @@ module csrs(
     (* parallel_case *)
     case (addr)
       MSTATUS:   rdata = mstatus_value;
+      MSTATUSH:  rdata = 32'b0;
       MISA:      rdata = MISA_VALUE;
       MIE:       rdata = 32'b0;
       MTVEC:     rdata = mtvec;
@@ -160,7 +178,7 @@ module csrs(
       MCYCLEH:   rdata = mcycle_hi;
       MINSTRET:  rdata = minstret_lo;
       MINSTRETH: rdata = minstret_hi;
-      MVENDORID, MARCHID, MIMPID, MHARTID: rdata = 32'b0;
+      MVENDORID, MARCHID, MIMPID, MHARTID, MCONFIGPTR: rdata = 32'b0;
       default: begin
         rdata = 32'b0;
         implemented = 1'b0;

--- a/rtl/decoder.v
+++ b/rtl/decoder.v
@@ -358,10 +358,20 @@ module decoder (
   // "unrecognised", which was harmless because unrecognised meant "execution
   // flags suppressed, no trap". It stops being harmless the moment
   // unrecognised means illegal-instruction.
-  logic instr_error, instr_mret, instr_wfi;
+  logic instr_error, instr_mret, instr_wfi, instr_cebreak;
   assign instr_error = opcode == 5'b11100 && uncompressed && funct3 == 0 && rs1 == 0 && rd == 0;
   assign instr_ecall = instr_error && instr[31:20] == 12'h0;
-  assign instr_ebreak = instr_error && instr[31:20] == 12'h1;
+  // C.EBREAK (16'h9002) expands to EBREAK, so it raises a BREAKPOINT (cause 3)
+  // and not an illegal instruction. It is the rd == 0, rs2 == 0 corner of
+  // quadrant 2's funct4 == 4'b1001 row, which its two neighbours each exclude
+  // by a different field -- `instr_cjalr` needs instr[11:7] != 0 and
+  // `instr_cadd` needs instr[6:2] != 0 -- so without this line the encoding
+  // decodes to NOTHING, `instr_valid` is low, and the trap comes out cause 2:
+  // a wrong-but-plausible answer that still traps, still records an mepc and
+  // still resumes. test/asm/cebreak.S is what catches it, at both alignments.
+  assign instr_cebreak = quadrant == 2'b10 && cfunct4 == 4'b1001 &&
+    instr[11:7] == 5'b0 && instr[6:2] == 5'b0;
+  assign instr_ebreak = (instr_error && instr[31:20] == 12'h1) || instr_cebreak;
   // ADR-0005: `mret` restores MIE <- MPIE, sets MPIE, and jumps to mepc.
   // Committed in the publish block below, alongside trap entry, and serialized
   // on the same drain predicate CSR instructions use (CLAUDE.md invariant 5).

--- a/test/COSIM_EXPECTED_FAIL
+++ b/test/COSIM_EXPECTED_FAIL
@@ -74,4 +74,3 @@
 # three questions above before concluding anything from it -- this entry passes
 # them because the divergence is in THIS CORE and is deliberately left open,
 # not because the comparison or the model configuration is at fault.
-csrset.S    DISAGREE AT 2

--- a/test/COSIM_EXPECTED_FAIL
+++ b/test/COSIM_EXPECTED_FAIL
@@ -66,3 +66,12 @@
 # different paths, no value exemption can help, and the assertion belongs in a
 # bench with no reference model in it? Only when none of the three fit is it a
 # baseline entry, and then it needs a paragraph here, not a line.
+
+# ADR-0048 finding 3. The other half of test/EXPECTED_FAIL's `csrset.S FAIL 2`:
+# this core raises illegal instruction on mstatush (0x310) where the reference
+# model reads it and continues, so the handler runs here and does not there and
+# the register traces part company at architectural change 2. Read this file's
+# three questions above before concluding anything from it -- this entry passes
+# them because the divergence is in THIS CORE and is deliberately left open,
+# not because the comparison or the model configuration is at fault.
+csrset.S    DISAGREE AT 2

--- a/test/EXPECTED_FAIL
+++ b/test/EXPECTED_FAIL
@@ -51,4 +51,3 @@
 # field goes red, which is ADR-0035's mechanism working rather than a
 # regression. When both land, this line and the co-simulation one come out
 # together.
-csrset.S    FAIL 2

--- a/test/EXPECTED_FAIL
+++ b/test/EXPECTED_FAIL
@@ -35,3 +35,20 @@
 #
 # The history of what was baselined here and when lives in git and in the ADRs
 # above; it is not repeated in this file, which describes the contract in force.
+
+# ADR-0048 finding 3, landed red on purpose. Two CSRs the RV32 privileged
+# specification lists unconditionally -- mstatush (0x310, priv 20211203
+# §3.1.6.4) and mconfigptr (0xF15, §3.1.4) -- are absent from rtl/csrs.v's
+# `implemented` set, so an access to either raises illegal instruction where the
+# spec says it should read zero. The Sail reference model reads both and
+# continues; this core traps on both, so the divergence is measured rather than
+# argued, and test/COSIM_EXPECTED_FAIL carries the other half of it.
+#
+# NOT fixed in the change that found it: ADR-0005 states its CSR set as *exact*,
+# so widening it is an ISA-scope decision belonging to an amendment of
+# ADR-0002/ADR-0005, not to the audit that noticed. The status pins the first
+# failing case; when mstatush alone lands, this becomes `FAIL 3` and the second
+# field goes red, which is ADR-0035's mechanism working rather than a
+# regression. When both land, this line and the co-simulation one come out
+# together.
+csrset.S    FAIL 2

--- a/test/OBSERVED_FLOOR
+++ b/test/OBSERVED_FLOOR
@@ -73,9 +73,12 @@ bgeu.S              298    298
 blt.S               255    255
 bltu.S              280    280
 bne.S               255    255
+cebreak.S            161    138
 csr.S               108     82
+csrset.S              72     62
 div.S                60     60
 divu.S               61     61
+fencenop.S            40     35
 hazard.S             49     49
 jal.S                19     19
 jalr.S               73     73
@@ -114,3 +117,4 @@ sw.S                454    454
 trap.S              303    259
 xor.S               451    451
 xori.S              171    171
+zicsr.S              225    185

--- a/test/asm/cebreak.S
+++ b/test/asm/cebreak.S
@@ -1,0 +1,157 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# cebreak.S
+#-----------------------------------------------------------------------------
+#
+# `c.ebreak` raises a BREAKPOINT (mcause 3), not an illegal instruction.
+#
+# The C extension defines C.EBREAK (16'h9002) as expanding to EBREAK, so it
+# raises the same exception with the same cause. It is the one trap cause on
+# this core that has a compressed encoding of its own, and it sits in a corner
+# of quadrant 2 that three neighbouring decodes each exclude by a different
+# field: C.JALR needs rd/rs1 != 0, C.JR needs instr[12] == 0, and C.ADD/C.MV
+# need rs2 != 0. Miss it and the encoding decodes to nothing at all, which on
+# this core means `instr_valid` is low and the cause comes out 2 (illegal
+# instruction) rather than 3 — a wrong-but-plausible answer that still traps,
+# still records an mepc, and still resumes, so nothing except the cause value
+# gives it away.
+#
+# Nothing else in the suite reaches it. test/asm/trap.S's breakpoint case is
+# `.option norvc`, and so is every other trapping instruction there, precisely
+# because the handler resumes at mepc+4 (riscv_test.h constraint 1). So the
+# assembler never had a reason to emit C.EBREAK anywhere, and test/decoder_tb.v
+# drives the 32-bit form.
+#
+# Both alignments are exercised. `c.ebreak` at pc % 4 == 2 is where mepc's WARL
+# mask has to preserve bit 1 (ADR-0005) — the same property test/asm/trap.S
+# checks with a `c.lw`, restated here against a trap cause that comes from the
+# instruction itself rather than from its operand address.
+#
+# Layout: each faulting `c.ebreak` is followed by exactly one `c.nop`, because
+# the recording handler resumes at mepc+4 unconditionally and cannot read the
+# faulting instruction to learn it was 2 bytes (Harvard buses, ADR-0008). The
+# `.align 2` before each block is what makes the alignment claim true rather
+# than incidental, and tests 4 and 8 assert it, so this file cannot quietly
+# degrade into two copies of the same case.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  # mtvec resets to 0, which is _start (ADR-0029) — install before faulting.
+  RVTEST_INSTALL_TRAP_HANDLER
+
+  #-------------------------------------------------------------
+  # c.ebreak at pc % 4 == 0.
+  #-------------------------------------------------------------
+
+  .option push
+  .option rvc
+  .align 2
+cebrk_aligned:
+  c.ebreak
+  c.nop
+  .option pop
+
+  TEST_CASE( 2, a4, 3, la a3, trap_cause; lw a4, 0(a3); )
+  TEST_CASE( 3, a4, 1, la a3, trap_count; lw a4, 0(a3); )
+
+  TEST_CASE( 4, a4, 0, la a3, cebrk_aligned; andi a4, a3, 3; )
+
+  # mepc is the address of the faulting `c.ebreak` itself.
+test_5:
+  la    a3, trap_epc
+  lw    a4, 0(a3)
+  la    x29, cebrk_aligned
+  li    TESTNUM, 5
+  bne   a4, x29, fail
+
+  #-------------------------------------------------------------
+  # c.ebreak at pc % 4 == 2: mepc must come back with bit 1 SET.
+  #-------------------------------------------------------------
+
+  # Clear the recorded cause so the next case cannot pass on a stale value.
+  la    a3, trap_cause
+  sw    x0, 0(a3)
+
+  .option push
+  .option rvc
+  .align 2
+  c.nop
+cebrk_odd:
+  c.ebreak
+  c.nop
+  .option pop
+
+  TEST_CASE( 6, a4, 3, la a3, trap_cause; lw a4, 0(a3); )
+  TEST_CASE( 7, a4, 2, la a3, trap_count; lw a4, 0(a3); )
+
+  TEST_CASE( 8, a4, 2, la a3, cebrk_odd; andi a4, a3, 3; )
+
+test_9:
+  la    a3, trap_epc
+  lw    a4, 0(a3)
+  la    x29, cebrk_odd
+  li    TESTNUM, 9
+  bne   a4, x29, fail
+
+  #-------------------------------------------------------------
+  # A trapping `c.ebreak` writes no register (ADR-0028), the same commitment
+  # every other trapping instruction here makes. c.ebreak's encoding has rd
+  # == x0 anyway, so this is really a check that decode's trap suppression did
+  # not route something into the rd field on the way past.
+  #-------------------------------------------------------------
+
+  TEST_CASE( 10, a5, 0x5a5, \
+    li a5, 0x5a5; \
+    .option push; .option rvc; .align 2; \
+    c.ebreak; c.nop; \
+    .option pop; )
+
+  TEST_CASE( 11, a4, 3, la a3, trap_count; lw a4, 0(a3); )
+
+  #-------------------------------------------------------------
+  # ADR-0027: a trapping instruction does not increment `minstret`, and that
+  # has to hold for the compressed breakpoint too. Same shape as trap.S's
+  # test 19: the difference across the pair is the first `csrr` plus one
+  # handler entry, and the `c.ebreak` itself contributes nothing.
+  #-------------------------------------------------------------
+
+test_12:
+  csrr  a0, minstret
+  .option push
+  .option rvc
+  .align 2
+  c.ebreak
+  c.nop
+  .option pop
+  csrr  a1, minstret
+  sub   a2, a1, a0
+
+  la    a5, trap_handler
+  la    a6, trap_handler_end
+  sub   a5, a6, a5
+  srli  a5, a5, 2
+  addi  x29, a5, 1
+  li    TESTNUM, 12
+  bne   a2, x29, fail
+
+  TEST_CASE( 13, a4, 4, la a3, trap_count; lw a4, 0(a3); )
+
+  TEST_PASSFAIL
+
+  RVTEST_TRAP_HANDLER
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+  RVTEST_TRAP_DATA
+
+RVTEST_DATA_END

--- a/test/asm/csrset.S
+++ b/test/asm/csrset.S
@@ -1,0 +1,133 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# csrset.S
+#-----------------------------------------------------------------------------
+#
+# ***THIS TEST IS BASELINED RED.*** It is in test/EXPECTED_FAIL as
+# `csrset.S FAIL 2` and in test/COSIM_EXPECTED_FAIL, on purpose, and it is the
+# executable form of ADR-0048's finding 3.
+#
+# Two CSRs the RV32 privileged specification lists unconditionally in the
+# machine-mode register tables are absent from rtl/csrs.v's `implemented` set,
+# so an access to either raises illegal instruction where the spec says it
+# should read zero:
+#
+#   mstatush   (0x310)  priv 20211203 §3.1.6.4, "For RV32 only, mstatush is a
+#                       32-bit read/write register". SBE and MBE are its only
+#                       fields and both must read zero on a little-endian-only
+#                       implementation, so implementing it is a constant-zero
+#                       arm in the read mux -- the same shape mtval, mie and
+#                       mip already have. Its address is writable
+#                       (addr[11:10] == 2'b00), so a write to it must be an
+#                       ignored no-op rather than a fault.
+#   mconfigptr (0xF15)  priv 20211203 §3.1.4. Read-only, and "if the value is
+#                       zero, no configuration data structure exists". Its
+#                       address is read-only (addr[11:10] == 2'b11), so a
+#                       write to it correctly faults already.
+#
+# THE DIVERGENCE IS MEASURED, NOT ARGUED. The Sail reference model reads both
+# and continues; this core traps on both. That is what makes this a finding
+# rather than one reading of a specification sentence.
+#
+# It is deliberately NOT fixed in the change that found it. ADR-0005 states its
+# CSR set as *exact*, so widening it is an ISA-scope decision that belongs to an
+# amendment of ADR-0002/ADR-0005 with its own reasoning about what
+# "RV32IMC_Zicsr, machine mode only" commits to. Landing the divergence red is
+# ADR-0033's rule applied to the `.S` suite: a known-red test in the suite is
+# the system working, and a known-red property with no test at all is the
+# system lying.
+#
+# TWO THINGS THAT ARE *NOT* FINDINGS, checked the same way and recorded here so
+# nobody re-opens them:
+#
+#   * mhpmcounter3 (0xB03), mhpmcounter3h (0xB83) and mhpmevent3 (0x323) --
+#     sail-riscv 0.13.1 raises illegal instruction on all three, exactly as
+#     this core does. The reference model agrees; there is nothing to close.
+#   * mcountinhibit (0x320) -- the spec makes it explicitly optional ("if not
+#     implemented, the implementation behaves as though the register were set
+#     to zero"), so trapping is a legal way to not implement it. Sail happens
+#     to implement it; that is Sail's choice, not a requirement.
+#
+# BURN-DOWN. When mstatush lands, this file starts failing at test 3 instead of
+# test 2, and the baseline's second field goes red (ADR-0035) -- which is the
+# mechanism working, not a regression. When both land, both baseline lines come
+# out in the same commit and this header loses its first paragraph.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  # mtvec resets to 0, which is _start (ADR-0029) — install before faulting.
+  # The RECORDING handler, not the fatal one: the failure this file reports has
+  # to be an assertion about a trap count, so the trap must be survivable.
+  RVTEST_INSTALL_TRAP_HANDLER
+
+  #-------------------------------------------------------------
+  # mstatush reads zero and does not trap.
+  #-------------------------------------------------------------
+
+  .option push
+  .option norvc
+  csrr  a0, 0x310
+  .option pop
+
+  TEST_CASE( 2, a4, 0, la a3, trap_count; lw a4, 0(a3); )
+  TEST_CASE( 3, a0, 0, nop; )
+
+  #-------------------------------------------------------------
+  # A write to mstatush is a legal no-op: its address is writable, and both of
+  # its fields are WARL with zero as the only legal value here.
+  #-------------------------------------------------------------
+
+  li    a5, 0xffffffff
+  .option push
+  .option norvc
+  csrw  0x310, a5
+  .option pop
+
+  TEST_CASE( 4, a4, 0, la a3, trap_count; lw a4, 0(a3); )
+  TEST_CASE( 5, a0, 0, csrr a0, 0x310; )
+
+  #-------------------------------------------------------------
+  # mconfigptr reads zero and does not trap.
+  #-------------------------------------------------------------
+
+  .option push
+  .option norvc
+  csrr  a0, 0xF15
+  .option pop
+
+  TEST_CASE( 6, a4, 0, la a3, trap_count; lw a4, 0(a3); )
+  TEST_CASE( 7, a0, 0, nop; )
+
+  #-------------------------------------------------------------
+  # ...and a WRITE to it faults, because its address is read-only. This is the
+  # half that is already correct, and it is asserted so that "implement
+  # mconfigptr" cannot be discharged by making it writable.
+  #-------------------------------------------------------------
+
+  .option push
+  .option norvc
+  csrw  0xF15, a5
+  .option pop
+
+  TEST_CASE( 8, a4, 1, la a3, trap_count; lw a4, 0(a3); )
+  TEST_CASE( 9, a4, 2, la a3, trap_cause; lw a4, 0(a3); )
+
+  TEST_PASSFAIL
+
+  RVTEST_TRAP_HANDLER
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+  RVTEST_TRAP_DATA
+
+RVTEST_DATA_END

--- a/test/asm/fencenop.S
+++ b/test/asm/fencenop.S
@@ -1,0 +1,54 @@
+#include "riscv_test.h"
+#include "test_macros.h"
+
+// fence, fence.i, wfi and c.nop: the RV32IMC instructions with no riscv-formal
+// spec model at the pin AND no other test.
+//
+// formal/EXPECTED_CHECKS is set-equal to riscv-formal's own
+// insns/isa_rv32imc.txt, so every other instruction in the ISA has an `insn_*`
+// ladder check. The pin models none of `c_nop`, `c_ebreak`, `fence`, `ecall`,
+// `ebreak` -- and that five-instruction blind spot is where the c.ebreak trap
+// cause defect lived (ADR-0048). `ecall` and `ebreak` are covered by trap.S,
+// `c.ebreak` by cebreak.S; these four had nothing.
+//
+// ADR-0005 makes all four NOPs: one hart, no caches, no interrupt sources, so
+// there is nothing for a fence to order, nothing for fence.i to invalidate,
+// and nothing for wfi to wait on. What is checked is that they retire without
+// trapping and without disturbing architectural state -- the two ways a NOP
+// can be wrong.
+
+RVTEST_CODE_BEGIN
+
+  li    a0, 0x0BADF00D
+  li    a1, 0x12345678
+  li    a2, 0x0000FFFF
+
+  fence
+  fence.i
+  wfi
+  .option push
+  .option rvc
+  c.nop
+  .option pop
+
+  TEST_CASE( 1, a0, 0x0BADF00D, nop )
+  TEST_CASE( 2, a1, 0x12345678, nop )
+  TEST_CASE( 3, a2, 0x0000FFFF, nop )
+
+  # They must also not disturb the PC: falling through to here at all is the
+  # check, and the counter proves we executed rather than skipped.
+  li    a3, 0
+  fence
+  addi  a3, a3, 1
+  wfi
+  addi  a3, a3, 1
+  TEST_CASE( 4, a3, 2, nop )
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+  TEST_DATA
+RVTEST_DATA_END

--- a/test/asm/zicsr.S
+++ b/test/asm/zicsr.S
@@ -1,0 +1,204 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# zicsr.S
+#-----------------------------------------------------------------------------
+#
+# Zicsr's write- and read-suppression rules are tests on the ENCODING, never on
+# a value, and whether an access to a read-only CSR is legal follows from them.
+# That is the sharpest thing the unprivileged spec says about these six
+# instructions and it is the easiest to implement as a value test by accident:
+#
+#   * CSRRS/CSRRC suppress the write when the SOURCE REGISTER IS x0. A register
+#     that merely HOLDS zero is not x0, and the spec says so explicitly -- the
+#     instruction still attempts the write and still causes its side effects,
+#     which against a read-only CSR means an illegal-instruction trap.
+#   * CSRRSI/CSRRCI suppress the write when the 5-bit uimm is zero.
+#   * CSRRW/CSRRWI ALWAYS write, uimm == 0 included, so they trap against a
+#     read-only CSR no matter what they carry.
+#   * CSRRW/CSRRWI suppress the READ when rd is x0 -- and only the read. The
+#     write still lands.
+#
+# "Read-only" is a property of the ADDRESS (csr[11:10] == 2'b11), not of the
+# register's implementation. mvendorid (0xF11) is read-only by address, so a
+# write to it faults; mtval/mie/mip (0x343/0x304/0x344) are hardwired zero on
+# this core but their addresses are writable, so a write to one of them is a
+# legal no-op and must NOT fault. Those two cases look identical from a
+# program's point of view -- a CSR that never changes -- and are opposite in
+# law.
+#
+# Nothing else in the suite reaches these. test/asm/csr.S installs the FATAL
+# handler and therefore cannot contain a deliberate fault at all; test/asm/
+# trap.S's two illegal-CSR cases are an unimplemented address and a plain
+# `csrw mvendorid`, i.e. the two easy ones. riscv-formal ships no spec model
+# for csrr* at the pinned SHA (`spec_valid` is 0 for every instruction in this
+# file), so nothing here is cross-checked by the per-retire monitor -- see
+# riscv_test.h constraint 3.
+#
+# Values, not just legality, are asserted wherever the value is an ISA
+# consequence rather than an implementation choice. Where it is a choice --
+# what mtval/mie/mip actually read -- only the absence of a trap is asserted,
+# because the Sail reference model is a machine with interrupt sources and
+# would legally disagree about the values (ADR-0043, and the long note in
+# csr.S).
+#
+# Every trapping instruction is `.option norvc`: the handler resumes at mepc+4
+# unconditionally (riscv_test.h constraint 1). CSR instructions have no
+# compressed form, so this is belt and braces rather than load-bearing, and it
+# is written out so the file does not become the exception that teaches the
+# rule wrong.
+#
+# The handler clobbers t0/t1, so nothing here holds a live value in either
+# across a fault.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  # mtvec resets to 0, which is _start (ADR-0029) — install before faulting.
+  RVTEST_INSTALL_TRAP_HANDLER
+
+  #-------------------------------------------------------------
+  # CSRRS whose rs1 is a real register that happens to hold zero. The write is
+  # NOT suppressed -- suppression keys off the encoding -- so this faults
+  # against a read-only CSR, where `csrrs a0, mvendorid, x0` two cases below
+  # does not. A core that tested the VALUE instead of the register number
+  # would sail through here and be wrong in the one direction that never
+  # produces a visible symptom until a program writes a read-only CSR on
+  # purpose.
+  #-------------------------------------------------------------
+
+  li    a5, 0
+  .option push
+  .option norvc
+  csrrs a0, mvendorid, a5
+  .option pop
+
+  TEST_CASE( 2, a4, 2, la a3, trap_cause; lw a4, 0(a3); )
+  TEST_CASE( 3, a4, 1, la a3, trap_count; lw a4, 0(a3); )
+
+  #-------------------------------------------------------------
+  # The same instruction with x0 as the source: write suppressed, legal, and
+  # it still reads. CSRRC likewise -- the suppression rule names both.
+  #-------------------------------------------------------------
+
+  TEST_CASE( 4, a0, 0, csrrs a0, mvendorid, x0; )
+  TEST_CASE( 5, a0, 0, csrrc a0, mvendorid, x0; )
+
+  # ...and neither of them trapped.
+  TEST_CASE( 6, a4, 1, la a3, trap_count; lw a4, 0(a3); )
+
+  #-------------------------------------------------------------
+  # The immediate forms, zero uimm: write suppressed, legal against a
+  # read-only CSR.
+  #-------------------------------------------------------------
+
+  TEST_CASE( 7, a0, 0, csrrsi a0, mvendorid, 0; )
+  TEST_CASE( 8, a0, 0, csrrci a0, mvendorid, 0; )
+  TEST_CASE( 9, a4, 1, la a3, trap_count; lw a4, 0(a3); )
+
+  #-------------------------------------------------------------
+  # ...and a NON-zero uimm is a write, so it faults.
+  #-------------------------------------------------------------
+
+  .option push
+  .option norvc
+  csrrsi a0, mvendorid, 1
+  .option pop
+
+  TEST_CASE( 10, a4, 2, la a3, trap_cause; lw a4, 0(a3); )
+  TEST_CASE( 11, a4, 2, la a3, trap_count; lw a4, 0(a3); )
+
+  .option push
+  .option norvc
+  csrrci a0, mvendorid, 1
+  .option pop
+
+  TEST_CASE( 12, a4, 3, la a3, trap_count; lw a4, 0(a3); )
+
+  #-------------------------------------------------------------
+  # CSRRWI always writes, even carrying a zero immediate -- the suppression
+  # rule covers CSRRSI/CSRRCI only. So this faults where test 7 did not, on
+  # the same CSR with the same immediate.
+  #-------------------------------------------------------------
+
+  .option push
+  .option norvc
+  csrrwi a0, mvendorid, 0
+  .option pop
+
+  TEST_CASE( 13, a4, 2, la a3, trap_cause; lw a4, 0(a3); )
+  TEST_CASE( 14, a4, 4, la a3, trap_count; lw a4, 0(a3); )
+
+  #-------------------------------------------------------------
+  # The same rule seen from the other side: against a WRITABLE CSR, CSRRWI
+  # with a zero immediate really does store zero.
+  #-------------------------------------------------------------
+
+  TEST_CASE( 15, a1, 0, \
+    li a0, 0x7fff; \
+    csrw mscratch, a0; \
+    csrwi mscratch, 0; \
+    csrr a1, mscratch; )
+
+  #-------------------------------------------------------------
+  # CSRRW with rd == x0 suppresses the READ ONLY. The write still lands.
+  #-------------------------------------------------------------
+
+  TEST_CASE( 16, a1, 0x1234, \
+    li a0, 0x1234; \
+    csrrw x0, mscratch, a0; \
+    csrr a1, mscratch; )
+
+  #-------------------------------------------------------------
+  # The immediate forms take a 5-bit zimm out of the rs1 field, NOT the
+  # contents of the register that field names. a5 is x15, so a core that read
+  # the register file here would OR in 0xffff0000 instead of 15.
+  #-------------------------------------------------------------
+
+  TEST_CASE( 17, a1, 0x123f, \
+    li a5, 0xffff0000; \
+    csrrsi a0, mscratch, 15; \
+    csrr a1, mscratch; )
+
+  # ...and the value CSRRSI returned is the one from before its own update.
+  TEST_CASE( 18, a0, 0x1234, nop; )
+
+  #-------------------------------------------------------------
+  # A write to a CSR that is hardwired but whose ADDRESS is writable is a
+  # legal no-op, not a fault. This is the case that is opposite in law to
+  # test 2 and identical in appearance. Only the absence of a trap is
+  # asserted: what these three read is an implementation choice this core and
+  # the Sail reference model legally differ on (ADR-0043).
+  #-------------------------------------------------------------
+
+  li    a5, 0xffffffff
+  csrw  mtval, a5
+  csrw  mie, a5
+  csrw  mip, a5
+
+  TEST_CASE( 19, a4, 4, la a3, trap_count; lw a4, 0(a3); )
+
+  #-------------------------------------------------------------
+  # Four traps taken, four handler entries, and the last cause recorded is
+  # still 2 -- so nothing above trapped for a reason this file did not name.
+  #-------------------------------------------------------------
+
+  TEST_CASE( 20, a4, 2, la a3, trap_cause; lw a4, 0(a3); )
+
+  TEST_PASSFAIL
+
+  RVTEST_TRAP_HANDLER
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+  RVTEST_TRAP_DATA
+
+RVTEST_DATA_END

--- a/test/asm/zicsr.S
+++ b/test/asm/zicsr.S
@@ -183,11 +183,36 @@ RVTEST_CODE_BEGIN
   TEST_CASE( 19, a4, 4, la a3, trap_count; lw a4, 0(a3); )
 
   #-------------------------------------------------------------
+  # rd == rs1. Every CSR instruction is an atomic read-modify-write, so the
+  # value handed to rd is the one from BEFORE the write even when the two name
+  # the same register -- `csrrw a0, mscratch, a0` is a swap. On this core the
+  # read result rides the `is_add` pass-through to writeback while the write
+  # commits in decode off `reg_rs1` (ADR-0005), so the two really do come from
+  # different places and the ordering is a property rather than a tautology.
+  #-------------------------------------------------------------
+
+  TEST_CASE( 20, a0, 0x0abc, \
+    li a0, 0x0abc; \
+    csrw mscratch, a0; \
+    li a0, 0x0def; \
+    csrrw a0, mscratch, a0; )
+
+  TEST_CASE( 21, a1, 0x0def, csrr a1, mscratch; )
+
+  # The same for CSRRS, where the new value is a function of the old one.
+  TEST_CASE( 22, a0, 0x0def, \
+    li a0, 0x0f00; \
+    csrrs a0, mscratch, a0; )
+
+  TEST_CASE( 23, a1, 0x0fef, csrr a1, mscratch; )
+
+  #-------------------------------------------------------------
   # Four traps taken, four handler entries, and the last cause recorded is
   # still 2 -- so nothing above trapped for a reason this file did not name.
   #-------------------------------------------------------------
 
-  TEST_CASE( 20, a4, 2, la a3, trap_cause; lw a4, 0(a3); )
+  TEST_CASE( 24, a4, 2, la a3, trap_cause; lw a4, 0(a3); )
+  TEST_CASE( 25, a4, 4, la a3, trap_count; lw a4, 0(a3); )
 
   TEST_PASSFAIL
 

--- a/test/cosim.py
+++ b/test/cosim.py
@@ -281,7 +281,7 @@ def assemble(cc, src, outdir):
     ram = os.path.join(outdir, base + ".ram.hex")
     objcopy = cc[: -len("gcc")] + "objcopy"
     log = subprocess.run(
-        [cc, "-march=rv32imc_zicsr", "-mabi=ilp32", "-nostdlib", "-I", ASM_DIR,
+        [cc, "-march=rv32imc_zicsr_zifencei", "-mabi=ilp32", "-nostdlib", "-I", ASM_DIR,
          "-T", os.path.join(ASM_DIR, "sections.lds"), src, "-o", elf],
         capture_output=True, text=True,
     )

--- a/test/csr_tb.v
+++ b/test/csr_tb.v
@@ -286,6 +286,50 @@ module csr_tb;
     check_read("an explicit mcycle write beats the increment", 12'hB00, 32'h0000_0000);
     check_read("...and does not disturb mcycleh", 12'hB80, before_hi);
 
+    // ...INCLUDING AT THE CARRY BOUNDARY, which is the only place that last
+    // claim can be false and the only place nothing else in this repo can
+    // reach.
+    //
+    // "Any CSR write takes precedence over the automatic increment" (priv spec
+    // 20211203 §3.1.11, and ADR-0005's own wording) is about the 64-bit
+    // counter, not about the half the address happens to name: mcycle and
+    // mcycleh are two views of one register. With mcycle == 32'hffff_ffff, the
+    // increment's carry lands in the high half, and a write to the LOW half
+    // has to suppress it -- otherwise `csrw mcycle` silently advances mcycleh
+    // by one, exactly once every 2**32 cycles, and only if a write happens to
+    // fall on that cycle.
+    //
+    // Three oracles are structurally blind to it, which is why it is checked
+    // here and pinned by name. riscv-formal's rvfi_csrw_check.sv reads only
+    // the SELF-REPORTED rmask/wmask/rdata/wdata and never observes the
+    // register, so csrw_mcycle_ch0 cannot see it in any configuration; every
+    // ladder check is `mode bmc` from reset and could not reach 2**32 cycles
+    // if it could; and a `.S` program can only land a write on that one cycle
+    // by calibrating the instruction spacing first, which is a test that stops
+    // testing the moment the spacing changes. Driving the port directly is the
+    // one place this is deterministic.
+    poke(12'hB80, 32'h0000_0000);
+    poke(12'hB00, 32'hffff_fffe);
+    @(posedge clk);
+    #1;
+    check_read("mcycle free-runs up to the carry boundary", 12'hB00, 32'hffff_ffff);
+    poke(12'hB00, 32'h0000_0000);
+    check_read("a write at the boundary still beats the increment", 12'hB00, 32'h0000_0000);
+    check_read("...and its discarded carry does not reach mcycleh", 12'hB80, 32'h0000_0000);
+
+    // The same rule for minstret, where `instret` rather than the clock is
+    // what drives the counter into the boundary.
+    poke(12'hB82, 32'h0000_0000);
+    poke(12'hB02, 32'hffff_fffe);
+    instret = 1'b1;
+    @(posedge clk);
+    #1;
+    check_read("minstret counts up to the carry boundary", 12'hB02, 32'hffff_ffff);
+    poke(12'hB02, 32'h0000_0000);
+    instret = 1'b0;
+    check_read("a write at the boundary still beats the increment", 12'hB02, 32'h0000_0000);
+    check_read("...and its discarded carry does not reach minstreth", 12'hB82, 32'h0000_0000);
+
     // ---- trap entry and mret (ADR-0005 / ADR-0028) -----------------------
     // The privileged-spec sequence, driven directly. Nothing on the
     // riscv-formal ladder can see any of it: rvfi_insn_check drops every value

--- a/test/csr_tb.v
+++ b/test/csr_tb.v
@@ -179,6 +179,27 @@ module csr_tb;
     check_read("minstreth", 12'hB82, 32'h0);
     check_read("mcycleh", 12'hB80, 32'h0);
 
+    // The two RV32-mandatory registers this core trapped on until ADR-0048.
+    // They are here rather than among the "does not have" addresses below
+    // because the spec lists both unconditionally for RV32 machine mode, so
+    // `implemented` low on either is a conformance failure and not a scope
+    // choice -- ADR-0005's set is a floor, not a closed list.
+    check_read("mstatush reads 0", 12'h310, 32'h0);
+    check_read("mconfigptr reads 0", 12'hF15, 32'h0);
+
+    // mstatush is writable by encoding (addr[11:10] == 2'b00) and has no
+    // implemented fields, so a write is a legal WARL no-op. It must NOT trap
+    // and it must NOT retain -- getting either wrong is a conformance bug in
+    // opposite directions.
+    poke(12'h310, 32'hFFFF_FFFF);
+    check_read("mstatush still reads 0 after a write", 12'h310, 32'h0);
+
+    // mconfigptr is read-only by encoding (addr[11:10] == 2'b11), so the
+    // decoder's existing illegal-CSR rule rejects a write to it before this
+    // file is ever asked. What is checked here is that the read side stayed
+    // put, which is the half rtl/csrs.v owns.
+    check_read("mconfigptr reads 0 after an attempted write", 12'hF15, 32'h0);
+
     // Addresses this core does not have. `implemented` low is what makes
     // rtl/decoder.v call the instruction unrecognised (ADR-0005).
     peek(12'h7C0); // a custom/unimplemented machine CSR

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -96,7 +96,7 @@ for src in "$ASM_DIR"/*.S; do
   ram_hex="$tmp/$base.ram.hex"
 
   status="PASS"
-  if ! "$CC" -march=rv32imc_zicsr -mabi=ilp32 -nostdlib -I "$ASM_DIR" \
+  if ! "$CC" -march=rv32imc_zicsr_zifencei -mabi=ilp32 -nostdlib -I "$ASM_DIR" \
        -T "$ASM_DIR/sections.lds" "$src" -o "$elf" > "$build_log" 2>&1; then
     status="ASSEMBLE-ERROR"
   elif [ -s "$build_log" ]; then


### PR DESCRIPTION
Closes JEF-687

ADR-0040 diagnosed directory-mtime staleness for the `checks` target, wrote forty lines about it in `formal/Makefile`, and fixed **that one target**. Its siblings have the identical shape and were never touched.

`imemcheck`, `dmemcheck`, `cover` and `complete` are reached through the `%: %.sby` pattern rule and each named **a directory sby creates**, with prerequisites of an `.sby` and an `.sv` and **not one `rtl/` file**. So on any warm tree — which is every developer tree after the first run — editing RTL and re-running printed `up to date` and exited 0. `components_decoder` / `components_executor` had the same directory shape with one `rtl/` file each and no `rtl/structs.v`; `components_pcloop` (new on `main` at `bb6e228`) missed `structs.v` too.

`imemcheck` is the check CLAUDE.md names for ADR-0003's dual-word fetch window: the target most likely to be re-run by hand after a fetcher change, and the one that most reliably would not run. Both CI workflows are fresh checkouts, so **the path a developer uses to convince themselves before pushing is the only path that lied** — ADR-0040's own sentence, unfixed in its siblings until now.

## The change

`formal/Makefile` only. No `.sby` file changes: `sby -f` already force-overwrites, and make's up-to-date decision was the only broken thing.

- The `%: %.sby` pattern rule gains `rm -rf $@` and a `FORCE` prerequisite, and carries **the rule in writing** so a later sby target does not reintroduce this.
- The three `components_*` targets get `.PHONY` and `rm -rf $@`, and complete prerequisite lists.
- `RTL_SOURCES` gives the four whole-core targets the `rtl/` list their `.sby` files actually compile. Read as documentation, not as a gate — the gate is that the target always runs.

### FORCE, not `.PHONY`, for the pattern-matched targets

The obvious fix is the bug again. **A `.PHONY` target is excluded from implicit rule search**, so `.PHONY: imemcheck` deletes the only rule that builds it:

```
$ make -f Makefile1 foo          # .PHONY: foo  +  %: %.sby
make: Nothing to be done for `foo'.
exit=0
```

Measured on GNU Make 3.81 (Apple's, what this repo's dev path runs) and 4.4.1 alike. Silent, exit 0, nothing checked — the same failure class this change exists to remove, restated as its fix. The explicit `components_*` targets are not pattern-matched and *can* use `.PHONY`; that split is why two mechanisms appear in one file, and it is written down at both sites.

### `complete` re-runs unconditionally too

The proposal offered a prerequisite list instead, on cost grounds. It gets FORCE anyway: acceptance criterion 1 asks for it, a target asked for **by name** must run, and "a prerequisite list decides" is precisely what this change removes when the thing that list is compared against is a directory whose mtime is meaningless. Measured cost: `complete` fails in **11s** (it is M2 term 5's known red — `failed assertion ... at complete.sv:113 step 5`), so the depth-50 walk is not in fact the expensive one here. `dmemcheck` at 111s is.

## Criterion 1 — every target re-runs with nothing touched, by mtime

Warm tree, all seven workdirs present from run 1, **no file touched between the two runs**:

```
                       run 1 status                run 2 status
imemcheck              13:06:48  PASS 0 60         13:12:40  PASS 0 57
dmemcheck              13:08:40  PASS 0 62         13:14:07  PASS 0 41
cover                  13:08:53  PASS 0  7         13:14:21  PASS 0  7
complete               13:09:50  FAIL 2 11         13:14:39  FAIL 2 11
components_decoder     13:09:05  PASS 0  4         13:14:48  PASS 0  4
components_executor    13:09:20  PASS 0  8         13:15:01  PASS 0  7
components_pcloop      13:09:32  PASS 0  3         13:15:10  PASS 0  3
```

Seven new `status` files, 209s of real solver work. The control, on that same warm tree with the pre-change Makefile (`git show HEAD~1:formal/Makefile`):

```
make: `imemcheck' is up to date.
make: `dmemcheck' is up to date.
make: `cover' is up to date.
make: `complete' is up to date.
make: `components_decoder' is up to date.
make: `components_executor' is up to date.
make: `components_pcloop' is up to date.
control exit=0
```

## Criterion 2 — the liveness probe, and a correction to how it was written

The ticket names *"mutating `rtl/fetcher.v`'s `out.pc = pc` makes `make -C formal components_decoder` go red."* **That pairing cannot hold and is not a result to chase**: `components.sby`'s `decoder` task compiles `../rtl/decoder.v` and `../rtl/structs.v` and nothing else, so no fetcher mutation can turn it red. Demonstrated rather than argued — it is `PASS 0 4` under the mutation below, having genuinely re-run.

The mutation is ADR-0046's named fetcher probe (`out.pc = pc` → `out.pc = 32'b0`, one line). Run against the targets that **do** compile `rtl/fetcher.v`, on a warm tree.

Control first — pre-change Makefile, **after** the mutation:

```
make: `imemcheck' is up to date.
make: `dmemcheck' is up to date.
make: `cover' is up to date.
make: `complete' is up to date.
control exit=0
```

With the fix:

```
imemcheck          make rc=2  status: FAIL 2 4
components_pcloop  make rc=2  status: FAIL 2 0
components_decoder make rc=0  status: PASS 0 4   <- correctly unaffected; it re-ran
```

Real counterexamples, not timeouts:

```
SBY [imemcheck] summary:   failed assertion
  testbench.checker_inst._witness_.check_assert_rvfi_imem_check_sv_41_8
  at rvfi_imem_check.sv:41.7-41.38 step 7
SBY [imemcheck] summary: counterexample trace: imemcheck/engine_0/trace.vcd
SBY [imemcheck] DONE (FAIL, rc=2)

SBY [components_pcloop] summary: engine_0 (smtbmc) returned FAIL for basecase
SBY [components_pcloop] summary:   failed assertion
  pcloop._witness_.check_assert_pcloop_sv_299_81 at pcloop.sv:299.38-299.66 step 3
SBY [components_pcloop] DONE (FAIL, rc=2)
```

So `components_decoder` gets its own probe, since a target that only ever passes proves nothing. Dropping `rs1 != 0` from `rtl/decoder.v:607`'s `hazard_rs1` — a direct violation of the proof's `always_comb if (rs1 == 0) assert(!hazard_rs1)`:

```
SBY [components_decoder] summary:   failed assertion
  decoder._witness_.check_assert_decoder_v_1069_644 at decoder.v:1069.29-1069.48
SBY [components_decoder] DONE (FAIL, rc=2)
```

Both mutations reverted; `git status` clean; all three targets re-run green afterwards.

## Gates

| gate | result |
|---|---|
| `make -C formal check` | **82 checks: 82 pass, 0 fail**, 249s. Failure list matches `EXPECTED_FAIL` exactly; generated check set matches `EXPECTED_CHECKS` exactly (82 checks) |
| `make test` | **52/52**, failure list matches `test/EXPECTED_FAIL` exactly (name and status) |
| `make lint` | svlint clean in both passes (RVFI off and on) |
| the seven sby targets | see criterion 1 — six PASS, `complete` FAIL, which is the pre-existing M2 term-5 red and is unchanged by this PR (`FAIL 2 11` before and after) |

## Scope and risk

`formal/Makefile` only — no `rtl/`, no `test/`, no `.sby`, no `.github/`, no `CLAUDE.md`, no branch protection.

Risks, such as they are:

- **Every one of these targets now costs its full runtime on every invocation.** That is the intent; the alternative is a verdict nobody computed. Worst case is `dmemcheck` at ~110s. Neither CI workflow is affected — both are fresh checkouts, where every target ran anyway.
- **The new prerequisite lists duplicate each `.sby`'s `[files]` section and can drift from it.** They cannot cause a check to be skipped, because the target is unconditional, so the drift is cosmetic — and the comment says so at the site. What they still buy is a loud `No rule to make target` when an `rtl/` file is renamed out from under a check.
- No ADR: this applies ADR-0040's recorded decision to the targets it did not reach. The reasoning lives at the pattern rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJ77ZZJ6pDiL3vj3Qw9hKs
