### PR TITLE
JEF-687: Make every formal/ sby target re-run instead of reporting a verdict it did not compute

### DIFF
--- a/formal/Makefile
+++ b/formal/Makefile
@@ -13,7 +13,39 @@ endif
 
 all: complete check dmemcheck imemcheck components_decoder components_executor components_pcloop
 
-%: %.sby
+# THE RULE FOR EVERY sby TARGET IN THIS FILE, INCLUDING ONES ADDED LATER:
+# it re-runs unconditionally, and it throws its workdir away first.
+#
+# Every one of them names a DIRECTORY that sby creates, and make's up-to-date
+# decision on a directory is worthless: a directory's mtime bumps whenever an
+# entry is created inside it, so a workdir is newer than every prerequisite in
+# the list the moment the previous run wrote its first file into it. That is
+# ADR-0040's finding about `checks`, and the identical shape sat unfixed on its
+# siblings for as long again -- with `imemcheck` and `dmemcheck` reachable
+# through this rule and listing NO rtl/ file at all, so `make imemcheck` after
+# a fetcher change printed "`imemcheck' is up to date" and exited 0. Both CI
+# workflows are fresh checkouts and never saw it; the path a developer uses to
+# convince themselves before pushing is the path that lied.
+#
+# `rm -rf $@` is belt to `sby -f`'s braces. `-f` already force-overwrites, so
+# unlike `checks` -- whose generated makefile hardcodes an `sby` with no `-f`
+# (ADR-0040) -- this recipe does not depend on the delete to re-run. It is here
+# so that "the workdir is gone" is a property of THIS file rather than of a
+# flag someone may later move, and so a run interrupted mid-write cannot leave
+# half a workdir that the next run reads as its own output.
+#
+# FORCE, not `.PHONY`. A .PHONY target is EXCLUDED from implicit rule search,
+# so `.PHONY: imemcheck` deletes the only rule that builds it and `make
+# imemcheck` answers "Nothing to be done for `imemcheck'" and exits 0 --
+# measured on GNU Make 3.81 and 4.x alike. That is the same failure this rule
+# exists to remove, restated as a fix, so it must not be reached for here.
+# Explicit targets (components_* below) are not pattern-matched and CAN use
+# .PHONY; the split is deliberate and is why two mechanisms appear in one file.
+FORCE:
+.PHONY: FORCE
+
+%: %.sby FORCE
+	rm -rf $@
 	sby -f $<
 
 # `-k`: without it, GNU make stops scheduling new jobs at the first failing
@@ -104,10 +136,32 @@ checks: genchecks-audit.py genchecks-local.py checks.cfg EXPECTED_CHECKS | $(RIS
 genchecks-check: $(RISCV_FORMAL_DIR)/checks/genchecks.py genchecks-local.py | $(RISCV_FORMAL_DIR)
 	python3 check-genchecks.py $^
 
-dmemcheck: dmemcheck.sby dmemcheck.sv | $(RISCV_FORMAL_DIR)
-imemcheck: imemcheck.sby imemcheck.sv | $(RISCV_FORMAL_DIR)
-complete: complete.sby complete.sv | $(RISCV_FORMAL_DIR)
-cover: cover.sby cover.sv | $(RISCV_FORMAL_DIR)
+# The whole core, in the order every whole-core .sby reads it. These four
+# targets each ran against an `.sby` and an `.sv` and NOTHING ELSE before this
+# list existed, which is how `make imemcheck` -- the check CLAUDE.md names for
+# ADR-0003's dual-word fetch window, and so the one most likely to be re-run by
+# hand after touching rtl/fetcher.v -- could report a verdict about RTL it had
+# never read.
+#
+# Read these lists as DOCUMENTATION of what each task compiles, not as a gate.
+# The gate is the FORCE rule above: the target re-runs whatever this says. What
+# they still buy is a loud `No rule to make target` if an rtl/ file is renamed
+# out from under a check, instead of a confusing failure inside sby.
+RTL_SOURCES := ../rtl/structs.v ../rtl/fetcher.v ../rtl/regfile.v \
+               ../rtl/csrs.v ../rtl/decoder.v ../rtl/executor.v \
+               ../rtl/accessor.v ../rtl/writeback.v ../rtl/littlecpu.v
+
+dmemcheck: dmemcheck.sby dmemcheck.sv $(RTL_SOURCES) | $(RISCV_FORMAL_DIR)
+imemcheck: imemcheck.sby imemcheck.sv $(RTL_SOURCES) | $(RISCV_FORMAL_DIR)
+cover:     cover.sby     cover.sv     $(RTL_SOURCES) | $(RISCV_FORMAL_DIR)
+
+# `complete` is the depth-50 walk and by far the most expensive thing here, so
+# unconditional re-running is the least welcome on it. It gets it anyway: a
+# target asked for BY NAME must run, and the alternative -- a prerequisite list
+# deciding -- is what this whole change removes, because the thing that list is
+# compared against is a directory whose mtime is meaningless. Nothing pulls
+# `complete` in implicitly except `all`.
+complete:  complete.sby  complete.sv  $(RTL_SOURCES) | $(RISCV_FORMAL_DIR)
 
 # ADR-0006 / ADR-0020 / ADR-0047: proves RVFI instrumentation doesn't change
 # core behaviour. Not a .sby task -- it is a structural comparison of two yosys
@@ -136,9 +190,19 @@ nonperturbation: check-nonperturbation.py
 # formal/components.sby tasks were deleted for carrying zero assertions
 # (ADR-0006, ADR-0017) -- a "passing" proof with nothing asserted is not a
 # result.
-components_decoder: components.sby ../rtl/decoder.v
+#
+# These three carry their own recipes rather than reaching the `%: %.sby` rule
+# (they pass a task name), so they are the half of the file that CAN say
+# .PHONY -- implicit rule search is not involved. Same two properties as that
+# rule: always run, delete the workdir first. Before this they named the
+# directory sby creates and listed one rtl/ file each, so a warm tree made
+# `make components_decoder` after a structs.v edit answer "up to date".
+.PHONY: components_decoder components_executor components_pcloop
+components_decoder: components.sby ../rtl/decoder.v ../rtl/structs.v
+	rm -rf $@
 	sby -f $< decoder
-components_executor: components.sby ../rtl/executor.v
+components_executor: components.sby ../rtl/executor.v ../rtl/structs.v
+	rm -rf $@
 	sby -f $< executor
 # The composed fetcher+decoder task. It exists to DISCHARGE the standalone
 # decoder task's `assume(in.pc == pc)` (ADR-0017), which is the one place that
@@ -148,7 +212,9 @@ components_executor: components.sby ../rtl/executor.v
 # sequential-advance assertion covered a cycle on which the decoder legitimately
 # holds the pc. Nothing noticed for the obvious reason (ADR-0046). It runs on CI
 # now; a proof nobody runs is a prose-only guard.
-components_pcloop: components.sby ../rtl/fetcher.v ../rtl/decoder.v pcloop.sv
+components_pcloop: components.sby ../rtl/fetcher.v ../rtl/decoder.v \
+                   ../rtl/structs.v pcloop.sv
+	rm -rf $@
 	sby -f $< pcloop
 
 # The riscv-formal clone rule and its pin guard live in pin.mk, included above,


### PR DESCRIPTION
Closes JEF-687

ADR-0040 diagnosed directory-mtime staleness for the `checks` target, wrote forty lines about it in `formal/Makefile`, and fixed **that one target**. Its siblings have the identical shape and were never touched.

`imemcheck`, `dmemcheck`, `cover` and `complete` are reached through the `%: %.sby` pattern rule and each named **a directory sby creates**, with prerequisites of an `.sby` and an `.sv` and **not one `rtl/` file**. So on any warm tree — which is every developer tree after the first run — editing RTL and re-running printed `up to date` and exited 0. `components_decoder` / `components_executor` had the same directory shape with one `rtl/` file each and no `rtl/structs.v`; `components_pcloop` (new on `main` at `bb6e228`) missed `structs.v` too.

`imemcheck` is the check CLAUDE.md names for ADR-0003's dual-word fetch window: the target most likely to be re-run by hand after a fetcher change, and the one that most reliably would not run. Both CI workflows are fresh checkouts, so **the path a developer uses to convince themselves before pushing is the only path that lied** — ADR-0040's own sentence, unfixed in its siblings until now.

## The change

`formal/Makefile` only. No `.sby` file changes: `sby -f` already force-overwrites, and make's up-to-date decision was the only broken thing.

- The `%: %.sby` pattern rule gains `rm -rf $@` and a `FORCE` prerequisite, and carries **the rule in writing** so a later sby target does not reintroduce this.
- The three `components_*` targets get `.PHONY` and `rm -rf $@`, and complete prerequisite lists.
- `RTL_SOURCES` gives the four whole-core targets the `rtl/` list their `.sby` files actually compile. Read as documentation, not as a gate — the gate is that the target always runs.

### FORCE, not `.PHONY`, for the pattern-matched targets

The obvious fix is the bug again. **A `.PHONY` target is excluded from implicit rule search**, so `.PHONY: imemcheck` deletes the only rule that builds it:

```
$ make -f Makefile1 foo          # .PHONY: foo  +  %: %.sby
make: Nothing to be done for `foo'.
exit=0
```

Measured on GNU Make 3.81 (Apple's, what this repo's dev path runs) and 4.4.1 alike. Silent, exit 0, nothing checked — the same failure class this change exists to remove, restated as its fix. The explicit `components_*` targets are not pattern-matched and *can* use `.PHONY`; that split is why two mechanisms appear in one file, and it is written down at both sites.

### `complete` re-runs unconditionally too

The proposal offered a prerequisite list instead, on cost grounds. It gets FORCE anyway: acceptance criterion 1 asks for it, a target asked for **by name** must run, and "a prerequisite list decides" is precisely what this change removes when the thing that list is compared against is a directory whose mtime is meaningless. Measured cost: `complete` fails in **11s** (it is M2 term 5's known red — `failed assertion ... at complete.sv:113 step 5`), so the depth-50 walk is not in fact the expensive one here. `dmemcheck` at 111s is.

## Criterion 1 — every target re-runs with nothing touched, by mtime

Warm tree, all seven workdirs present from run 1, **no file touched between the two runs**:

```
                       run 1 status                run 2 status
imemcheck              13:06:48  PASS 0 60         13:12:40  PASS 0 57
dmemcheck              13:08:40  PASS 0 62         13:14:07  PASS 0 41
cover                  13:08:53  PASS 0  7         13:14:21  PASS 0  7
complete               13:09:50  FAIL 2 11         13:14:39  FAIL 2 11
components_decoder     13:09:05  PASS 0  4         13:14:48  PASS 0  4
components_executor    13:09:20  PASS 0  8         13:15:01  PASS 0  7
components_pcloop      13:09:32  PASS 0  3         13:15:10  PASS 0  3
```

Seven new `status` files, 209s of real solver work. The control, on that same warm tree with the pre-change Makefile (`git show HEAD~1:formal/Makefile`):

```
make: `imemcheck' is up to date.
make: `dmemcheck' is up to date.
make: `cover' is up to date.
make: `complete' is up to date.
make: `components_decoder' is up to date.
make: `components_executor' is up to date.
make: `components_pcloop' is up to date.
control exit=0
```

## Criterion 2 — the liveness probe, and a correction to how it was written

The ticket names *"mutating `rtl/fetcher.v`'s `out.pc = pc` makes `make -C formal components_decoder` go red."* **That pairing cannot hold and is not a result to chase**: `components.sby`'s `decoder` task compiles `../rtl/decoder.v` and `../rtl/structs.v` and nothing else, so no fetcher mutation can turn it red. Demonstrated rather than argued — it is `PASS 0 4` under the mutation below, having genuinely re-run.

The mutation is ADR-0046's named fetcher probe (`out.pc = pc` → `out.pc = 32'b0`, one line). Run against the targets that **do** compile `rtl/fetcher.v`, on a warm tree.

Control first — pre-change Makefile, **after** the mutation:

```
make: `imemcheck' is up to date.
make: `dmemcheck' is up to date.
make: `cover' is up to date.
make: `complete' is up to date.
control exit=0
```

With the fix:

```
imemcheck          make rc=2  status: FAIL 2 4
components_pcloop  make rc=2  status: FAIL 2 0
components_decoder make rc=0  status: PASS 0 4   <- correctly unaffected; it re-ran
```

Real counterexamples, not timeouts:

```
SBY [imemcheck] summary:   failed assertion
  testbench.checker_inst._witness_.check_assert_rvfi_imem_check_sv_41_8
  at rvfi_imem_check.sv:41.7-41.38 step 7
SBY [imemcheck] summary: counterexample trace: imemcheck/engine_0/trace.vcd
SBY [imemcheck] DONE (FAIL, rc=2)

SBY [components_pcloop] summary: engine_0 (smtbmc) returned FAIL for basecase
SBY [components_pcloop] summary:   failed assertion
  pcloop._witness_.check_assert_pcloop_sv_299_81 at pcloop.sv:299.38-299.66 step 3
SBY [components_pcloop] DONE (FAIL, rc=2)
```

So `components_decoder` gets its own probe, since a target that only ever passes proves nothing. Dropping `rs1 != 0` from `rtl/decoder.v:607`'s `hazard_rs1` — a direct violation of the proof's `always_comb if (rs1 == 0) assert(!hazard_rs1)`:

```
SBY [components_decoder] summary:   failed assertion
  decoder._witness_.check_assert_decoder_v_1069_644 at decoder.v:1069.29-1069.48
SBY [components_decoder] DONE (FAIL, rc=2)
```

Both mutations reverted; `git status` clean; all three targets re-run green afterwards.

## Gates

| gate | result |
|---|---|
| `make -C formal check` | **82 checks: 82 pass, 0 fail**, 249s. Failure list matches `EXPECTED_FAIL` exactly; generated check set matches `EXPECTED_CHECKS` exactly (82 checks) |
| `make test` | **52/52**, failure list matches `test/EXPECTED_FAIL` exactly (name and status) |
| `make lint` | svlint clean in both passes (RVFI off and on) |
| the seven sby targets | see criterion 1 — six PASS, `complete` FAIL, which is the pre-existing M2 term-5 red and is unchanged by this PR (`FAIL 2 11` before and after) |

## Scope and risk

`formal/Makefile` only — no `rtl/`, no `test/`, no `.sby`, no `.github/`, no `CLAUDE.md`, no branch protection.

Risks, such as they are:

- **Every one of these targets now costs its full runtime on every invocation.** That is the intent; the alternative is a verdict nobody computed. Worst case is `dmemcheck` at ~110s. Neither CI workflow is affected — both are fresh checkouts, where every target ran anyway.
- **The new prerequisite lists duplicate each `.sby`'s `[files]` section and can drift from it.** They cannot cause a check to be skipped, because the target is unconditional, so the drift is cosmetic — and the comment says so at the site. What they still buy is a loud `No rule to make target` when an `rtl/` file is renamed out from under a check.
- No ADR: this applies ADR-0040's recorded decision to the targets it did not reach. The reasoning lives at the pattern rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJ77ZZJ6pDiL3vj3Qw9hKs
