### PR TITLE
JEF-688: Inventory every verification gate, and fix the stale prose claims

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,12 +95,22 @@ jobs:
         # here, and exercises the same from-scratch-clone pin guard
         # ADR-0013 asks CI to run.
         #
-        # iverilog emits ~30 "sorry: constant selects in always_* processes"
-        # notes on this design (constant bit-selects inside always_* blocks
-        # -- a real iverilog limitation, not a bug in this RTL) and still
-        # exits 0. Do not grep for them: they are notes, not warnings, and
-        # CLAUDE.md's technical notes call this out by name as a known,
-        # separately-tracked class this gate must not block on.
+        # iverilog emits exactly 20 "sorry: constant selects in always_*
+        # processes" notes on this design (counted with `make -B
+        # testbench.vvp | grep -c`, all 20 identical and all against
+        # `in[952:0]`, which is rtl/writeback.v's accessor_output -- a real
+        # iverilog limitation, not a bug in this RTL) and still exits 0. Do
+        # not grep for them: they are notes, not warnings, and CLAUDE.md's
+        # engineering rules call this out by name, with the same count, as a
+        # known separately-tracked class this gate must not block on. This
+        # comment said "~30" until the gate inventory counted them.
+        #
+        # THIS STEP BUILDS testbench.vvp AND NEVER RUNS IT, and nothing else
+        # in this workflow runs it either. The full-pipeline iverilog leg --
+        # CLAUDE.md's "microscope" -- is elaborated on every PR and executed
+        # by no gate; `make waves` is the only thing that runs it and is in
+        # no workflow. The iverilog SIMULATION that CI does run is the six
+        # unit benches under `make test-units`, in the `test` job.
         run: make rvfi_macros.vh testbench.vvp
 
       - name: Report job wall time
@@ -115,13 +125,18 @@ jobs:
   # The ADR-0007/ADR-0008 cxxrtl regression gate: builds `sim`, runs
   # test-units (the iverilog RTL-level benches), then every test/asm/*.S
   # under `sim` and checks the pass/fail table against test/EXPECTED_FAIL
-  # (ADR-0014's baseline). `a4662a2` took that baseline to empty; it now
-  # carries three M3 tests (csr.S, minstret.S, trap.S) written ahead of the
-  # RTL that pays them off, so the gate is 49 pass / 3 expected-fail rather
-  # than a plain all-pass. ADR-0014's set-equality check runs in both
-  # directions, so one of those three starting to pass -- which is exactly
-  # what each M3 RTL change is supposed to cause -- fails the gate until its
-  # line comes out of the baseline in the same commit.
+  # (ADR-0014's baseline). That baseline is EMPTY again -- the three M3 tests
+  # written ahead of their RTL (csr.S, minstret.S, trap.S) have all been paid
+  # off -- so the gate is a plain 52 pass / 0 expected-fail today. This
+  # comment described the 49/3 state until the gate inventory re-ran it.
+  # ADR-0014's set-equality check runs in both directions regardless, so a
+  # baselined test starting to pass fails the gate just as loudly as a passing
+  # test starting to fail, until its line moves in the same commit.
+  #
+  # `make test` depends on `test-units`, so this one step is also the only
+  # place any iverilog simulation runs on this workflow (six benches:
+  # exec_tb, mem_tb, decoder_tb, regfile_tb, csr_tb, monitor_tb). Each
+  # $fatal(1)s on a mismatch, so vvp's exit code is the verdict.
   test:
     name: test
     runs-on: little-cpu-runners
@@ -172,8 +187,14 @@ jobs:
             echo "wall time: ${elapsed}s"
           } >> "$GITHUB_STEP_SUMMARY"
 
-  # ADR-0006 scopes component proofs to exactly two: decoder and executor.
-  # Both are run here; both pass by k-induction. The executor proof is under
+  # formal/components.sby carries exactly THREE tasks -- decoder, executor and
+  # pcloop -- and this job runs all three; all three pass by k-induction
+  # (`mode prove`, verified by running each target and reading its sby summary,
+  # not by inference from a green job). ADR-0006 scoped the set to decoder and
+  # executor; ADR-0046 added pcloop. This comment named only the first two
+  # until the gate inventory read the .sby file.
+  #
+  # The executor proof is under
   # a 4-bit operand restriction (ADR-0010). The decoder proof used to FAIL on
   # the `past_pc + 4 == pc` assertion, which was a broken property rather
   # than a decode hole -- `fetcher_pc` was a free input, so nothing tied the
@@ -308,9 +329,18 @@ jobs:
   # no riscv-formal clone, ~9s wall. It is deliberately NOT in the `formal`
   # job, which is GitHub-hosted for memory reasons and takes minutes.
   #
-  # Not in main's branch-protection required set. Adding it there is a
-  # repository-settings change for a human to make deliberately, the same as
-  # `lint` and `formal` (ADR-0036).
+  # NOT in main's branch-protection required set, and as of the gate inventory
+  # it is the ONLY job in this workflow that is not. Read live rather than
+  # remembered:
+  #
+  #   gh api repos/thejefflarson/little-cpu/branches/main/protection \
+  #     -q '.required_status_checks.contexts'
+  #   ["elaborate","test","components","monitor-freshness","lint","formal"]
+  #
+  # `lint` and `formal` have since been promoted; this comment cited both as
+  # fellow non-required jobs, which stopped being true without anything here
+  # noticing. Promoting `nonperturbation` too is a repository-settings change
+  # for a human to make deliberately (ADR-0036) -- never attempted from a PR.
   nonperturbation:
     name: nonperturbation
     runs-on: little-cpu-runners
@@ -438,11 +468,17 @@ jobs:
   # list; ADR-0047 deleted it, and its replacement is the `nonperturbation`
   # job above, which is cheap enough to be a PR gate.
   #
-  # Adding this job to ci.yml does not by itself gate anything: main's
-  # branch-protection required set is elaborate/test/components/
-  # monitor-freshness/lint, and adding `formal` to it is a repository-settings
-  # change for a human to make deliberately (ADR-0036, which says the same of
-  # `lint`). Until then this is advisory.
+  # THIS JOB IS REQUIRED. main's branch-protection required set is
+  # elaborate/test/components/monitor-freshness/lint/formal, read live with
+  #
+  #   gh api repos/thejefflarson/little-cpu/branches/main/protection \
+  #     -q '.required_status_checks.contexts'
+  #
+  # `lint` and `formal` were both promoted after they landed. This comment
+  # still said `formal` was advisory and that the required set ended at
+  # `lint`, which is the drift the gate inventory went looking for: adding a
+  # job to this file does not make it required, and neither does removing one
+  # make it not, so the only trustworthy source is the API above.
   formal:
     name: formal
     # Stays GitHub-hosted, and unlike `test` and `lint` above the reason is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,8 +197,27 @@ rejected (ADR-0040). Serialising the two read ports onto one array was also buil
 and it needs a second bypass level, which is the first step toward the forwarding network invariant 4
 forbids.
 
-What does not work right now:
+What does not work right now — **one live entry, then six resolved ones kept in place.** Five of the
+six are struck through, and every one of those outlived its own fix here by several commits. That is
+the failure this section exists to prevent, so they stay as markers rather than being deleted.
 
+- **Three of this repo's verdicts are computed and then read by nobody.** Found by reading
+  `Makefile`, `formal/Makefile`, both workflows and `test/run_tests.sh` end to end; the full
+  four-column inventory lives in the pull request that added this bullet and is destined for the
+  coverage-map ADR. (1) **`make fit` is a ratchet nothing pulls.** The ratchet itself works —
+  `make fit FIT_MAX_LC=4200` against today's 4236-cell tree exits **2** with "4236 logic cells is
+  over the 4200-cell budget" — but `grep -rn fit .github/workflows/` returns two prose matches
+  about runner memory and **no invocation of `make fit`**, so nothing but a human has ever pulled
+  it. (2) **`make waves` grades nothing.** It runs the full pipeline under iverilog with the
+  per-retire monitor live, but `test/monitor.v`'s error path only sets `errcode` and `$display`s —
+  no `$fatal`, no `$finish` — and on the iverilog leg nothing turns `errcode` into an exit status
+  (`test/testbench.v:55-60` says so in its own comment; `test/cxxrtl.cc` is what reads it, and that
+  is the other leg). `make waves` exits 0 on a monitor mismatch, and it is in no workflow. Note the
+  consequence: **`testbench.vvp` is elaborated on every PR and executed by no gate anywhere.** The
+  iverilog *simulation* CI actually runs is the six `make test-units` benches, which do `$fatal(1)`
+  and are gated. (3) **`make -C formal all` is dead** — no workflow names it. That one is
+  redundancy rather than a hole: every target it lists (`complete`, `check`, `dmemcheck`,
+  `imemcheck`, the three `components_*`) is invoked separately by `ci.yml` or `formal-nightly.yml`.
 - ~~**The ALTOPS divide branch reads stale operands**~~ — **fixed, and this bullet outlived it by
   several commits.** The ALTOPS issue arm latches its operands (`rtl/executor.v:52-60`,
   `div_alt_rs1`/`div_alt_rs2` off `mul_div_x`/`mul_div_y`) exactly as the non-ALTOPS branch does, so
@@ -380,13 +399,20 @@ clean and a dirty rs2 so the `rs2[4:0]` mask is checked rather than coincided wi
 `decoder_tb`,
 `regfile_tb` — which covers the write-through bypass and x0 semantics — `csr_tb`, which covers
 `rtl/csrs.v`'s read mux, its `implemented` address set, its WARL masks and its trap-entry/`mret`
-port, and `monitor_tb`, which checks the oracle itself rather than the core), and the decoder and
-executor component proofs pass
-by k-induction (see ADR-0017 for what the decoder proof does and does not establish). `make waves`
+port, and `monitor_tb`, which checks the oracle itself rather than the core), and **all three**
+component proofs — decoder, executor and `pcloop` — pass by k-induction (`mode prove`; re-run and
+read off each `sby` summary, not inferred from a green job. See ADR-0017 for what the decoder proof
+does and does not establish, and ADR-0046 for what `pcloop` discharges). `make waves`
 now runs the iverilog leg (`testbench.vvp`) instead of the cxxrtl runner, matching the verification
-table below,
-and produces a real `waves.vcd`. CI (`.github/workflows/ci.yml`) runs elaborate / test / components
-/ monitor-freshness on every PR.
+table below, and produces a real `waves.vcd` — **but it grades nothing**; see the first bullet under
+"what does not work" above. CI (`.github/workflows/ci.yml`) runs **seven** jobs on every PR:
+elaborate, test, components, lint, nonperturbation, monitor-freshness and formal. **Six of the seven
+are required** — `elaborate`, `test`, `components`, `monitor-freshness`, `lint`, `formal`, read live
+from `gh api repos/thejefflarson/little-cpu/branches/main/protection -q
+'.required_status_checks.contexts'` rather than from any comment in the workflow — and
+`nonperturbation` is the one that runs without gating. This line named four jobs and stopped there
+until the gate inventory; `lint` and `formal` had both been promoted to required in the meantime,
+and `ci.yml`'s own comments still said otherwise.
 
 **A Sail co-simulation spike measured what the existing oracles structurally cannot see**
 (ADR-0032). Both the RVFI monitor and every `insn_*` ladder check read the core's *self-report*;
@@ -447,8 +473,10 @@ ADR-0015). Of 78 generated checks: **55 of 70 `insn_*` pass**; `pc_fwd`, `pc_bwd
 `unique`, `causal`, `imemcheck` and `dmemcheck` pass; `cover` reaches all five goals, including
 ≥2 loads and ≥2 stores and ≥2 uncompressed and ≥2 compressed retires in one trace — which is what
 rules out a vacuous harness. **Read ADR-0023 before quoting any of these numbers.** Every one of
-the 15 failures is accounted for (9 = the M3 trap gap, 2 = the C.JR defect below, 4 = the ALTOPS
-divide defect below), `reg` is inconclusive, and everything ran under `RISCV_FORMAL_ALTOPS`, so
+the 15 failures is accounted for (9 = the M3 trap gap, 2 = the C.JR/C.JALR defect, 4 = the ALTOPS
+divide defect — all three since fixed, and the last two no longer have bullets of their own above),
+`reg` was inconclusive *under the `smtbmc yices` engine that run used* (ADR-0024 replaced it; see
+the struck bullet above), and everything ran under `RISCV_FORMAL_ALTOPS`, so
 a green `insn_mul` says nothing whatever about multiplication (ADR-0010). **M2 is not reached.**
 
 ## Invariants — do not break these
@@ -515,12 +543,19 @@ preference. See ADR-0002 and ADR-0003.
 ```sh
 make setup          # install the RISC-V toolchain (brew on macOS)
 make test           # assemble test/asm/*.S, run under cxxrtl, pass/fail table
-make waves          # iverilog + VCD (testbench.vvp's baked-in program) -> waves.vcd
+make waves          # iverilog + VCD (testbench.vvp's baked-in program) -> waves.vcd.
+                    # GRADES NOTHING: the per-retire monitor is live but only
+                    # $displays, so this exits 0 on a mismatch. Read the output.
 make monitor-check  # regenerate test/monitor.v at the pin and diff
 make fit            # the ONE area number: nextpnr logic cells on up5k/sg48 (ADR-0038).
                     # Placement always fails (231 SB_IO vs 39) and that is expected --
                     # the utilisation table printed before placement is the measurement.
                     # A RATCHET as of ADR-0042: over FIT_MAX_LC (4400) exits nonzero.
+                    # RATCHET DECLARED, NEVER PULLED: no workflow runs this, so the
+                    # only thing that has ever enforced it is a human typing it. The
+                    # mechanism itself is live -- `make fit FIT_MAX_LC=4200` on the
+                    # 4236-cell tree exits 2 -- so this is an unrun gate, not a
+                    # broken one. Run it by hand on anything that touches rtl/.
 
 make -C formal components_decoder   # component proofs. THREE tasks, all with real assertions:
 make -C formal components_executor  # decoder, executor, pcloop -- the assertion-free fetcher /
@@ -735,7 +770,10 @@ not against an oracle. An empty baseline is loudest exactly where the ladder is 
   rejected the shifter merge at 19 cells *saved* on legibility grounds, and accepting a hygiene
   change at 37 cells *spent* would cut against that ruling. Read this before proposing the
   narrowing again — it is measured and declined, not overlooked.
-- Decisions: [`docs/adr/`](docs/adr/) — forty-five accepted ADRs, plus a deferred list
+- Decisions: [`docs/adr/`](docs/adr/) — **forty-seven ADRs, forty-six of them accepted**, plus a
+  deferred list. Re-derived by counting: `ls docs/adr/*.md | wc -l` is 48, one of which is
+  `README.md`, and the status column in that README carries exactly one non-accepted entry
+  (ADR-0016, superseded by ADR-0018). This line said "forty-five accepted" and was two behind.
 - Reference text from the old core: `git show 1709433^:rtl/riscv.v` (RVFI retire block),
   `git show e67875c^:rtl/alu.v` (arithmetic)
 - Work is tracked in Linear, project **Little CPU** (team JEF). Named here so you know where the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,23 +201,27 @@ What does not work right now — **one live entry, then six resolved ones kept i
 six are struck through, and every one of those outlived its own fix here by several commits. That is
 the failure this section exists to prevent, so they stay as markers rather than being deleted.
 
-- **Three of this repo's verdicts are computed and then read by nobody.** Found by reading
-  `Makefile`, `formal/Makefile`, both workflows and `test/run_tests.sh` end to end; the full
-  four-column inventory lives in the pull request that added this bullet and is destined for the
-  coverage-map ADR. (1) **`make fit` is a ratchet nothing pulls.** The ratchet itself works —
-  `make fit FIT_MAX_LC=4200` against today's 4236-cell tree exits **2** with "4236 logic cells is
-  over the 4200-cell budget" — but `grep -rn fit .github/workflows/` returns two prose matches
-  about runner memory and **no invocation of `make fit`**, so nothing but a human has ever pulled
-  it. (2) **`make waves` grades nothing.** It runs the full pipeline under iverilog with the
-  per-retire monitor live, but `test/monitor.v`'s error path only sets `errcode` and `$display`s —
-  no `$fatal`, no `$finish` — and on the iverilog leg nothing turns `errcode` into an exit status
-  (`test/testbench.v:55-60` says so in its own comment; `test/cxxrtl.cc` is what reads it, and that
-  is the other leg). `make waves` exits 0 on a monitor mismatch, and it is in no workflow. Note the
-  consequence: **`testbench.vvp` is elaborated on every PR and executed by no gate anywhere.** The
+- **Three things this repo treats as gates are reached by no automation, and one of them computes a
+  verdict nothing reads.** Found by reading `Makefile`, `formal/Makefile`, both workflows and
+  `test/run_tests.sh` end to end; the four-column inventory that came out of it lives in the pull
+  request that added this bullet and is destined for the coverage-map ADR. (1) **`make fit` is a
+  ratchet nothing pulls.** The ratchet works — `make fit FIT_MAX_LC=4200` against today's 4236-cell
+  tree exits **2** with "4236 logic cells is over the 4200-cell budget" — but
+  `grep -rn fit .github/workflows/` returns two prose matches about runner memory and **no
+  invocation of `make fit`**, so nothing but a human has ever pulled it. Run it by hand on anything
+  that touches `rtl/`. (2) **`make waves` grades nothing.** It runs the full pipeline under iverilog
+  with the per-retire monitor live, but `ch0_handle_error` only `$display`s and sets `errcode` —
+  there is not one `$fatal`, `$finish` or `$stop` in `test/monitor.v` or `test/monitor.sim.v` — and
+  on the iverilog leg nothing turns `errcode` into an exit status (`test/testbench.v:55-60` says so
+  in its own comment; `test/cxxrtl.cc` is what reads it, and that is the other leg). So `make waves`
+  exits 0 on a monitor mismatch, and it is in no workflow either. The consequence is the part worth
+  keeping: **`testbench.vvp` is elaborated on every PR and executed by no gate anywhere.** The
   iverilog *simulation* CI actually runs is the six `make test-units` benches, which do `$fatal(1)`
   and are gated. (3) **`make -C formal all` is dead** — no workflow names it. That one is
   redundancy rather than a hole: every target it lists (`complete`, `check`, `dmemcheck`,
   `imemcheck`, the three `components_*`) is invoked separately by `ci.yml` or `formal-nightly.yml`.
+  A target that names seven gates and is reached by nothing still reads like coverage, which is why
+  it is written down here rather than left to be rediscovered.
 - ~~**The ALTOPS divide branch reads stale operands**~~ — **fixed, and this bullet outlived it by
   several commits.** The ALTOPS issue arm latches its operands (`rtl/executor.v:52-60`,
   `div_alt_rs1`/`div_alt_rs2` off `mul_div_x`/`mul_div_y`) exactly as the non-ALTOPS branch does, so


### PR DESCRIPTION
Closes JEF-688

`components_pcloop` was red for weeks because nothing observed it. The class is **"a verdict exists
that no set-equality reads."** This PR takes the census, and fixes the prose that had drifted in the
file whose header says to read it before believing anything else.

Two files changed: `CLAUDE.md` and `.github/workflows/ci.yml` (comments only). **No RTL, no
Makefile, no test file, no ADR.** Everything below was filled by reading the tree or querying the
GitHub API, not from memory; where a claim is measured, the command is given.

---

## 1. The gate inventory

Columns, per the ticket: **V** = produces a verdict · **B** = that verdict is compared against a
baseline · **X** = its exit status reaches a job's exit status · **R** = that job is in `main`'s
required set.

The required set is read live, not asserted:

```
$ gh api repos/thejefflarson/little-cpu/branches/main/protection \
    -q '.required_status_checks.contexts'
["elaborate","test","components","monitor-freshness","lint","formal"]
# strict: true, enforce_admins: true
```

### Root `Makefile`

| Target | V | B | X | R | Notes |
|---|---|---|---|---|---|
| `rvfi_macros.vh` | – | – | via consumers | – | generator; failure surfaces in whatever needs it |
| `testbench.vvp` | build only (iverilog exit) | no | yes — `elaborate` | **yes** | **built and never run, anywhere** |
| `waves` / `waves.vcd` | **no** | no | **no workflow** | no | **FINDING 1** — see §3 |
| `sim` | build only (`-Wall -Wextra -Werror`) | no | yes — `test` | **yes** | |
| `sail-setup` | yes (SHA-256, fails closed) | pinned digests in Makefile | no workflow | no | opt-in by design, ADR-0032 |
| `cosim` | build only | no | no workflow | no | opt-in by design |
| `cosim-run` | yes (one program) | no | no workflow | no | opt-in by design |
| `cosim-suite` | yes | **yes** — `test/COSIM_EXPECTED_FAIL`, set equality both directions | no workflow | no | **recorded design, not a finding.** ADR-0032 forbids promotion; the Makefile says so at the target |
| `test/monitor.sim.v` | yes (per-rule site count + content assertions) | assertions inside `test/sanitize_monitor.py` | yes — via `test` | **yes** | ADR-0019 |
| `test/rtl.cc` | build only (yosys) | no | yes — `test` | **yes** | the `elaborate` job runs the stricter promoted-warning variant |
| `test/monitor.v` | – | – | – | – | regenerates the tracked file; `monitor-check` is the graded form |
| `monitor-check` | yes (diff vs from-scratch clone at the pin) | the tracked `test/monitor.v` | yes — `monitor-freshness` | **yes** | |
| `setup` | – | – | – | – | installer |
| `lint` | yes (svlint exit, two passes) | rule set in `.svlint.toml` | yes — `lint` | **yes** | promoted since ADR-0036 was written |
| `lint-setup` | yes (SHA-256, fails closed) | pinned digests | yes — `lint` step | **yes** | |
| `test-units` | yes (6 benches, `$fatal(1)` → vvp exit) | assertions in-bench | yes — via `test` | **yes** | the only iverilog *simulation* CI runs |
| `test` | yes | **yes** — `test/EXPECTED_FAIL`, set equality both directions | yes — `test` | **yes** | |
| `fit.json` | build only (yosys synth) | no | no workflow | no | |
| `fit` | **yes** — `FIT_MAX_LC` ratchet, exits nonzero | **yes** — `FIT_MAX_LC := 4400` | **no workflow** | **no** | **FINDING 2** — see §3 |
| `clean` | – | – | – | – | |

### `formal/Makefile`

| Target | V | B | X | R | Notes |
|---|---|---|---|---|---|
| `all` | aggregate | – | **no workflow names it** | no | **FINDING 3** — dead, but *redundant* rather than a hole: every member is invoked separately below |
| `%: %.sby` | sby exit | per-`.sby` `expect` | via the named targets | – | pattern rule |
| `check` | yes — ends in `check-baseline`, not in sby's exit | **yes** — `EXPECTED_FAIL` + `EXPECTED_CHECKS`, both directions | yes — `formal` | **yes** | also nightly, `continue-on-error` there |
| `check-baseline` | yes | same two files | yes — the `formal` job's gate step invokes `check-baseline.sh` directly | **yes** | exits 2 on an empty ladder, so a swallowed generate cannot pass silently |
| `checks` | yes — `genchecks-audit.py` asserts the ladder's shape *before* any solving | **yes** — `EXPECTED_CHECKS` + `checks.cfg` `#omit`, both directions | yes — via `check` | **yes** | ADR-0033 gap 1 |
| `genchecks-check` | yes (byte equality vs the pin) | the pin's `checks/genchecks.py` | yes — `monitor-freshness` | **yes** | ADR-0031 |
| `dmemcheck` | yes (no `expect` line ⇒ sby exits nonzero on FAIL) | none | yes — nightly step, no `continue-on-error` | no | nightly is `schedule`/`workflow_dispatch` only |
| `imemcheck` | yes | none | yes — nightly step | no | same |
| `cover` | yes (`mode cover`) | none | yes — nightly step | no | same |
| `complete` | yes | none; **known-red**, ADR-0023 | **no** — `continue-on-error: true` | no | deliberately ungated and recorded |
| `nonperturbation` | yes (structural, exits nonzero) | the plain build itself | yes — `nonperturbation` | **no** | the only `ci.yml` job outside the required set |
| `components_decoder` | yes (k-induction) | none | yes — `components` | **yes** | |
| `components_executor` | yes (k-induction) | none | yes — `components` | **yes** | 4-bit operand restriction, ADR-0010 |
| `components_pcloop` | yes (k-induction) | none | yes — `components` | **yes** | the ticket's motivating case; gated since ADR-0046 |
| `clean` | – | – | – | – | |
| `pin.mk` clone + HEAD guard | yes (fails closed on pin mismatch) | `RISCV_FORMAL_SHA` | yes, wherever the clone materialises (`elaborate`, `monitor-freshness`, `formal`) | **yes** | ADR-0013 |

### `.github/workflows/ci.yml` — 7 jobs, on `pull_request` and push to `main`

| Job › step | V | B | X | R |
|---|---|---|---|---|
| **elaborate** › `yosys write_cxxrtl, warnings promoted` | yes — greps `^Warning:` minus one allowlisted line, `exit 1` | the allowlist (`Deep recursion in AST simplifier`) | yes | **yes** |
| **elaborate** › `iverilog full-pipeline elaboration` | build only | no | yes | **yes** |
| **test** › `Verify the toolchain is present` | yes (assertion, not an install) | – | yes | **yes** |
| **test** › `make test` | yes | `test/EXPECTED_FAIL` | yes | **yes** |
| **components** › executor / decoder / pcloop | yes ×3 | none | yes | **yes** |
| **lint** › `lint-setup`, `make lint` | yes | `.svlint.toml` | yes | **yes** |
| **nonperturbation** › `make -C formal nonperturbation` | yes | plain build | yes (status captured off the *unpiped* command) | **no** |
| **monitor-freshness** › `make monitor-check` | yes | tracked `test/monitor.v` | yes | **yes** |
| **monitor-freshness** › `make -C formal genchecks-check` | yes | the pin | yes | **yes** |
| **formal** › `Confirm the BMC toolchain is complete` | yes | yosys/sby/btormc/btorsim must all resolve | yes | **yes** |
| **formal** › `Generate and run the ladder` | yes | – | **no** — `continue-on-error: true`, by design | – |
| **formal** › `Gate on EXPECTED_FAIL + EXPECTED_CHECKS` | yes | both, both directions | **yes — this is the job's verdict** | **yes** |
| every job › `Record job start` / `Report job wall time` | – | – | yes (trivially) | – |
| all `Set up OSS CAD Suite` uses | yes (SHA-256, `sha256sum -c -`) | `OSS_CAD_SUITE_SHA256` | yes | **yes** |

### `.github/workflows/formal-nightly.yml` — 1 job, `schedule` + `workflow_dispatch`

**No step in this workflow can gate a merge**, because the workflow never runs on `pull_request`.
That is its design (ADR-0022), not a finding.

| Step | V | B | X | R |
|---|---|---|---|---|
| `riscv-formal ladder (make -C formal check)` | yes | both baselines | **no** — `continue-on-error: true` | no |
| `Compare ladder results against EXPECTED_{FAIL,CHECKS}` | yes | both, both directions | **yes — the job's verdict** | no |
| `Summarize checks` | reporting only | – | yes (trivially) | no |
| `imemcheck / dmemcheck / cover` | yes ×3 (no `expect` line ⇒ nonzero on FAIL) | none | yes | no |
| `complete (whole-ISA BMC)` | yes | known-red, ADR-0023 | **no** — `continue-on-error: true` | no |
| `Summarize complete` | reporting only | – | yes | no |

### The other two workflows

| Workflow › step | V | B | X | R |
|---|---|---|---|---|
| `dependabot-automerge.yml` › `gh pr merge --auto --squash` | no — it *consumes* the required set rather than producing a verdict | the required set itself | yes | no; `if: github.actor == 'dependabot[bot]'` |
| `soundcheck.yml` › `soundcheck-action` | yes (PR comments) | none | yes | no |

### `test/run_tests.sh`

One verdict, and it is a set equality in both directions over **name-and-status pairs** (ADR-0035),
against `test/EXPECTED_FAIL`. Exit 0 only on an exact match; exit 1 on any mismatch; exit 1 on a
missing or unreadable baseline; exit 1 on a baseline line carrying a name with no status. Every
build step's exit status is checked and `mktemp` is fatal. **Gated** — it is `make test`'s last
step, and `test` is required. No finding.

---

## 2. Stale claims corrected, and how each was checked

| Claim | Where | Status | How checked |
|---|---|---|---|
| "CI … runs elaborate / test / components / monitor-freshness on every PR" | `CLAUDE.md` | **false** — seven jobs, six required | `yaml.safe_load(ci.yml)['jobs']` → 7 keys; protection API for the required set |
| "the decoder and executor component proofs pass by k-induction" | `CLAUDE.md` | **incomplete** — three proofs | `formal/components.sby` `[tasks]`; re-ran all three → `successful proof by k-induction`, `DONE (PASS, rc=0)` each |
| "forty-five accepted ADRs" | `CLAUDE.md` | **false** — 47 ADRs, 46 accepted | `ls docs/adr/*.md \| wc -l` = 48 incl. `README.md`; the README status column has exactly one non-accepted row (0016 → superseded by 0018) |
| "the C.JR defect **below**" / "the ALTOPS divide defect **below**" | `CLAUDE.md`, ladder-port ¶ | **dangling** — neither bullet exists any more | `grep -n 'C\.JR' CLAUDE.md`; the ALTOPS bullet is struck through |
| bare "`reg` is inconclusive" in that same ¶ | `CLAUDE.md` | **false as written** — it was inconclusive under the engine *that run* used | ADR-0024 (engine switch), ADR-0042 §3, ADR-0046's probe; the struck bullet four screens up already says so |
| "What does not work right now:" | `CLAUDE.md` | **the heading was false** — six resolved items, zero live ones | read it |
| "iverilog emits ~30 `sorry:` notes" | `ci.yml`, elaborate | **false** — exactly 20 | `make -B testbench.vvp 2>&1 \| grep -c 'sorry: constant selects'` → `20`, all identical, all against `in[952:0]`. Matches CLAUDE.md's own count |
| "the gate is 49 pass / 3 expected-fail" | `ci.yml`, test | **false** — baseline empty, 52/52 | `make test`; `test/EXPECTED_FAIL` is comments only |
| "ADR-0006 scopes component proofs to exactly two … Both are run here" | `ci.yml`, components | **false** — three tasks, three steps | `formal/components.sby`; the job already had three steps |
| "main's … required set is elaborate/test/components/monitor-freshness/lint, and adding `formal` to it is a repository-settings change" | `ci.yml`, formal | **false** — `formal` **is** required | protection API |
| "Not in main's … required set … the same as `lint` and `formal`" | `ci.yml`, nonperturbation | **half false** — `nonperturbation` is correctly not required; `lint` and `formal` both are | protection API |

Both `ci.yml` comments now cite the API call rather than restating a list, so the next promotion
cannot silently falsify them.

---

## 3. Findings

### FINDING 1 — `make waves` grades nothing, and `testbench.vvp` is executed by no gate anywhere

`test/monitor.v`'s error path sets `errcode` and `$display`s. It never `$fatal`s or `$finish`es
(`grep -n errcode test/monitor.v`). On the cxxrtl leg `test/cxxrtl.cc` reads that debug item and
turns it into exit code 4, which `test/run_tests.sh` labels `MONITOR-ERROR`. **On the iverilog leg
nothing does** — `test/testbench.v:55-60` says as much in its own comment ("under iverilog the
monitor's own `$display` diagnostics … are the loud failure"), which is loud to a human reading
stdout and silent to `make`. Measured: `make waves` exits 0 and writes a 2.5 MB `waves.vcd`.

Compounding it, `ci.yml`'s `elaborate` job **builds** `testbench.vvp` and never runs it, and no other
workflow runs it either. So the full-pipeline iverilog leg — CLAUDE.md's "microscope", the leg
ADR-0037 caught being inert for the whole of M1 — is elaborated on every PR and **simulated by no
gate**. The iverilog simulation CI does run is the six `make test-units` benches, which `$fatal(1)`
properly.

Recorded in `CLAUDE.md` and in `ci.yml`'s elaborate comment. **Not fixed here**: `test/testbench.v`
and `test/cxxrtl.cc` belong to a sibling this sprint.

> **Recommended follow-up.** Give the iverilog leg an errcode consumer — an
> `always @(posedge clk) if (rvfi_monitor_errcode) $fatal(1);` under `ifdef ICARUS` in
> `test/testbench.v` — so `make waves` and any future iverilog runner fail on a monitor mismatch
> instead of printing one. Cheap, and it makes the leg able to fail, which is the bar CLAUDE.md's
> verification table sets.

### FINDING 2 — `make fit`: **ratchet declared, never pulled**

`CLAUDE.md` calls it "A RATCHET as of ADR-0042", and ADR-0042 decision 6 makes it one. The mechanism
is live. Probe:

```
$ make fit FIT_MAX_LC=4200
LOGIC CELLS: 4236 of 5280 (80%)  --  up5k / sg48 / littlecpu, memories external
Placement failed on IO, which is the expected state (ADR-0038 decision 1a);
*** make fit: 4236 logic cells is over the 4200-cell budget.
*** This is a ratchet (ADR-0042), not a suggestion. Find what grew;
$ echo $?
2
```

and `grep -rn fit .github/workflows/` returns **two prose matches about runner memory and no
invocation**. So the ratchet has never been pulled by anything but a human. Recorded as a row and in
`CLAUDE.md`'s `make fit` command block.

> **Why the row and not a `fit` job, which the ticket also allows.** A `fit` job would be the better
> outcome, but the number is toolchain-sensitive in a way I cannot test from here: the 4236 above is
> yosys 0.67+post via homebrew, and CI runs OSS CAD Suite `2026-06-29`. CLAUDE.md already documents
> a ±50-cell churn floor from *edits alone*; a yosys version delta is a bigger lever than that, and
> `FIT_MAX_LC` has only 164 cells of headroom. Landing a job I cannot demonstrate green risks a red
> gate on the first PR that touches nothing. **Recommended follow-up:** add a non-required `fit` job
> in a PR that can watch it run once — measure the cell count under the pinned suite first, and
> re-set `FIT_MAX_LC` from *that* number if the two toolchains disagree.

### FINDING 3 — `make -C formal all` is dead, but harmless

No workflow names it. It is redundancy, not a coverage hole: `complete`, `check`, `dmemcheck`,
`imemcheck` and the three `components_*` are each invoked separately by `ci.yml` or
`formal-nightly.yml`. Recorded, not fixed — `formal/Makefile` belongs to a sibling this sprint.

> **Recommended follow-up:** delete `all`, or make it the local-developer aggregate its name implies
> and say so. A target that names seven gates and is reached by nothing reads like coverage.

### FINDING 4 — `formal/EXPECTED_FAIL`'s header still describes `equiv.sh`

Its header says: *"formal/equiv.sh still does not converge (ADR-0020), so ADR-0006's guarantee that
RVFI instrumentation does not perturb the core remains argued rather than proven."* `formal/equiv.sh`
does not exist (ADR-0047 deleted it), and the guarantee is now mechanised —
`make -C formal nonperturbation` prints `RVFI NON-PERTURBATION: PASS` in seconds and is a PR gate.
**Not fixed here**: both `EXPECTED_FAIL` baselines belong to a sibling this sprint.

### FINDING 5 — two more workflow comments assert a stale required set

Neither file is `ci.yml`, so neither was touched.

- `formal-nightly.yml:8-10` — *"unlike ci.yml's elaborate/test/components/monitor-freshness/lint"*:
  `formal` is missing from that list. The first half of the sentence ("no required-status-check entry
  for this workflow") is correct.
- `formal-nightly.yml:86` — *"the whole 79-check ladder"*: it is **82**
  (`formal/EXPECTED_CHECKS` has 82 non-comment lines).
- `dependabot-automerge.yml:6-8` — *"required status checks (elaborate, test, components,
  monitor-freshness)"*: the set is six, including `lint` and `formal`. `strict: true` is correct.
  This one matters slightly more than the others: the file's own safety argument is *"this workflow
  is only safe because `main` now has required status checks"*, so an understated list understates
  the protection that argument rests on. It is at least stale in the safe direction.

> **Recommended follow-up:** one small PR replacing all three with the `gh api … protection` call,
> the way this PR's `ci.yml` comments now do.

### Not a finding — `make cosim-suite`

Ungated by decision. ADR-0032 forbids putting it on branch protection; the Makefile and CLAUDE.md's
verification section both say so at the point of use, and it *does* carry a real baseline
(`test/COSIM_EXPECTED_FAIL`, set equality both directions). **Recorded design, not a gap.**

---

## 4. `DECISION NEEDED` — none

Two human-only follow-ups, neither attempted from a PR (branch protection is `enforce_admins: true`):

1. Whether to promote `nonperturbation` to the required set. It is the only `ci.yml` job outside it.
2. Whether to add a non-required `fit` job, per FINDING 2's caveat.

---

## 5. Gates

| Gate | Result |
|---|---|
| `make test` | **52/52 passed**, "Failure list matches test/EXPECTED_FAIL exactly", exit 0 |
| `make test-units` | all six benches pass (runs as a `make test` prerequisite; `monitor_tb: all vectors passed`) |
| `make lint` | `svlint: clean in both passes`, exit 0 |
| `make fit` | **`LOGIC CELLS: 4236 of 5280 (80%)`**, `RATCHET: 4236 of 4400 cells budgeted -- OK`, exit 0 |
| `make fit FIT_MAX_LC=4200` (ratchet probe) | exit **2**, "over the 4200-cell budget" |
| `make -C formal components_{decoder,executor,pcloop}` | 3/3 `successful proof by k-induction`, `DONE (PASS, rc=0)` |
| `make -C formal nonperturbation` | `RVFI NON-PERTURBATION: PASS` |
| `make waves` | exit 0, `waves.vcd` written — and that is FINDING 1 |
| `ci.yml` YAML parse | parses; 7 jobs |

The changes are prose and comments only, so nothing could regress on them; the suite was run anyway
because the repo rule says to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJ77ZZJ6pDiL3vj3Qw9hKs
