### PR TITLE
JEF-658: give formal/EXPECTED_FAIL a status field — ERROR must never pass as FAIL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -526,16 +526,22 @@ jobs:
           file: ${{ env.OSS_CAD_SUITE_FILE }}
           sha256: ${{ env.OSS_CAD_SUITE_SHA256 }}
 
-      # Not a formality. check-baseline.sh compares check NAMES, not
-      # statuses: any status that is not PASS lands a check in the actual-
-      # fail set, so ERROR and FAIL are indistinguishable to it. sby's btor
-      # engine solves with btormc and then replays the witness with btorsim,
-      # and btorsim is reached ONLY on a check that found a counterexample --
-      # so on a box without it every red check reports ERROR instead of FAIL,
-      # the name set still matches formal/EXPECTED_FAIL exactly, and this job
-      # goes green on a broken toolchain. (Confirmed: btorsim is absent from
-      # a stock macOS brew install of yosys+sby, where exactly that happens.)
-      # Assert it up front rather than inferring it from a green run.
+      # Not a formality, and it is NOT made redundant by ADR-0036's status
+      # field. sby's btor engine solves with btormc and then replays the
+      # witness with btorsim, and btorsim is reached ONLY on a check that
+      # found a counterexample -- so on a box without it every red check
+      # reports ERROR instead of FAIL. (Confirmed: btorsim is absent from a
+      # stock macOS brew install of yosys+sby.)
+      #
+      # check-baseline.sh now compares NAME AND STATUS, so that flip turns
+      # this job RED rather than green: `ERROR` cannot be baselined at all,
+      # and a baselined `FAIL` no longer matches an `ERROR` on disk. What it
+      # cannot do is notice the missing tool on an ALL-GREEN ladder, which is
+      # the state this repo is in -- no counterexample means btorsim is never
+      # invoked, so its absence is invisible right up until the first check
+      # goes red, at which point the diagnostic is "status changed" rather
+      # than "install btorsim". Assert it up front so the failure names its
+      # own cause.
       - name: Confirm the BMC toolchain is complete
         run: |
           set -euo pipefail

--- a/formal/EXPECTED_FAIL
+++ b/formal/EXPECTED_FAIL
@@ -9,6 +9,58 @@
 # baseline. Removing a line is a claim the same commit backs up. Adding one back
 # is a regression and needs a stated justification in the PR that adds it.
 #
+# FORMAT — two fields, not one (ADR-0036, executing the decision it recorded;
+# ADR-0035 made the identical amendment to test/EXPECTED_FAIL first):
+#
+#     <check>  <STATUS>
+#
+# The status is the FIRST WORD of formal/checks/<check>/status — sby's verdict,
+# without the engine and depth numbers it prints after it (`PASS 0 31`,
+# `ERROR 16 2`). Whitespace between the fields is free, so entries can be column-
+# aligned. A line with only a name is REJECTED with an error naming the format,
+# not half-matched: silently accepting the old spelling would make every legacy
+# entry unmatchable in a way that reads exactly like a regression.
+#
+# THE VOCABULARY IS ENUMERATED, IN BOTH DIRECTIONS, and the two lists differ:
+#
+#   sby can write        PASS  FAIL  ERROR  UNKNOWN  TIMEOUT
+#                        (plus check-baseline.sh's own NO-STATUS, for a check
+#                        with no status file at all — never generated, never
+#                        scheduled, or still running)
+#   MAY BE BASELINED     FAIL  TIMEOUT  UNKNOWN
+#
+# Anything else on a line here is rejected loudly rather than matched:
+#
+#   PASS       cannot appear in a failure set at all, so a line carrying it
+#              could never match anything — a comparison with no reachable
+#              success branch, which is this repo's recurring defect and not a
+#              thing to add on purpose.
+#   ERROR      is sby failing to RUN or to render a trace, not the core failing
+#              a property. ADR-0036's words: "with ERROR never a legitimate
+#              baselined value."
+#   NO-STATUS  is a broken or incomplete harness for the same reason.
+#
+# TIMEOUT and UNKNOWN are legitimate: they are budget exhaustion, a recorded
+# verdict about a check that did not converge, and a change from one to the
+# other is a change worth reporting — which is only possible if both spellings
+# exist.
+#
+# WHY THE STATUS IS HERE AT ALL. Matching on the name alone made this gate blind
+# to *why* a check was red, and ADR-0036 measured the consequence rather than
+# arguing it: a ladder run on a machine without `btorsim` printed "82 checks:
+# 72 pass, 10 fail / Failure list matches EXPECTED_FAIL exactly" and exited 0,
+# with all ten of those checks at `ERROR 16 2`. `btormc` had found the
+# counterexamples correctly; `sby` could not render the traces, because that step
+# shells out to `btorsim`. A real counterexample and a missing trace renderer
+# were the same result to this file. The inverse is the case that matters: if
+# `btorsim` left the nightly's pinned OSS CAD Suite, every red check would flip
+# FAIL → ERROR, the set equality would still match, and the ladder would stay
+# green having stopped distinguishing a proof failure from a tooling failure.
+#
+# CHANGING A LINE'S STATUS IS THE SAME KIND OF CLAIM AS REMOVING THE LINE, and
+# needs the same justification in the PR that does it. That is the whole point of
+# the second field.
+#
 # THIS FILE ANSWERS ONLY HALF THE QUESTION. It reports whether a check's verdict
 # moved. It cannot report whether a check stopped existing — a check with no
 # formal/checks.cfg [depth] line is never generated, so it is absent from the
@@ -33,8 +85,11 @@
 # Everything runs under RISCV_FORMAL_ALTOPS, so a green insn_mul/insn_div/insn_rem
 # says nothing whatever about the real multiplier or divider (ADR-0010).
 #
-# formal/equiv.sh still does not converge (ADR-0020), so ADR-0006's guarantee that
-# RVFI instrumentation does not perturb the core remains argued rather than proven.
+# ADR-0006's guarantee that RVFI instrumentation does not perturb the core is
+# established by `make -C formal nonperturbation`, not by anything on this ladder.
+# (This paragraph named formal/equiv.sh and said it "still does not converge"; that
+# script is deleted as of ADR-0047, which replaced it. The replacement is strictly
+# weaker than sequential equivalence — it proves the instrumentation is UNREAD.)
 #
 # ONLY `mscratch` IS IN checks.cfg's [csrs], and the reason is recorded next to
 # that list: rvfi_csrw_check.sv has no WARL model, so a correctly WARL-masked

--- a/formal/check-baseline.sh
+++ b/formal/check-baseline.sh
@@ -7,7 +7,26 @@
 #   1. SHAPE.  The checks genchecks generated (formal/checks/*.sby) are
 #      exactly the ones formal/EXPECTED_CHECKS names.
 #   2. VERDICT. The checks whose status is not PASS are exactly the ones
-#      formal/EXPECTED_FAIL names.
+#      formal/EXPECTED_FAIL names, WITH THE STATUS EACH ONE CARRIES.
+#
+# (2) matched on the name alone until ADR-0036 was executed, and that made
+# ERROR, TIMEOUT, UNKNOWN and NO-STATUS indistinguishable from FAIL to this
+# gate. ADR-0036 measured the consequence rather than argued it: a ladder run
+# on a machine WITHOUT `btorsim` reported "82 checks: 72 pass, 10 fail /
+# Failure list matches EXPECTED_FAIL exactly" and exited 0, while all ten of
+# those checks had status `ERROR 16 2`. `btormc` had found the
+# counterexamples; `sby` then failed to render the traces, because the step
+# that does so shells out to `btorsim`. "A real counterexample at the
+# configured depth" and "the trace renderer is missing" were the same result.
+# The failure mode that matters is the inverse: if `btorsim` vanished from the
+# nightly's pinned OSS CAD Suite, every red check would flip FAIL -> ERROR,
+# the set equality would still match, and the ladder would stay green having
+# stopped distinguishing a proof failure from a tooling failure. Same shape as
+# ADR-0033's gaps -- a check that can stop checking without anything going red
+# -- one level down, in the status field rather than the check list. This is
+# the identical amendment ADR-0035 made to test/EXPECTED_FAIL, applied to the
+# formal side, and the reasoning is written out in formal/EXPECTED_FAIL's own
+# header.
 #
 # (1) is not decoration. Without it this script could not tell a ladder that
 # shrank from one that passed. formal/checks.cfg's [depth] table is the list
@@ -55,12 +74,114 @@ for f in "$EXPECTED_FAIL" "$EXPECTED_CHECKS"; do
 done
 
 # `#` comments and blank lines out, as both baseline files already allow.
+# Interior whitespace is squeezed too, so EXPECTED_FAIL's two fields can be
+# column-aligned for a human without changing what is compared. `NF` must gate
+# the rebuild rather than follow it: awk forces NF to 1 when $1 is assigned, so
+# `{$1=$1} NF` would resurrect every blank and comment-only line as an empty
+# entry. (Same idiom, same reason, as test/run_tests.sh.)
 strip() {
-  sed -e 's/#.*//' -e 's/[[:space:]]*$//' -e '/^[[:space:]]*$/d' "$1" | sort
+  sed -e 's/#.*//' "$1" | awk 'NF { $1 = $1; print }' | sort
 }
 
 expected_checks=$(strip "$EXPECTED_CHECKS")
 expected_fail=$(strip "$EXPECTED_FAIL")
+
+# THE STATUS VOCABULARY, ENUMERATED IN BOTH DIRECTIONS.
+#
+# `sby` writes its verdict as the first word of <workdir>/status, and the rest
+# of that line is engine bookkeeping (`PASS 0 31`, `ERROR 16 2`) that no
+# baseline should ever pin. Only the first word is compared.
+#
+# known_status: everything sby can write, plus this script's own NO-STATUS for
+# "there is no status file". A status outside this set means sby's output
+# changed under us -- a pin bump, a different engine -- and is reported rather
+# than bucketed into "not PASS", because bucketing is the whole defect this
+# gate just stopped having.
+known_status() {
+  case $1 in
+    PASS | FAIL | ERROR | UNKNOWN | TIMEOUT | NO-STATUS) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# baselineable_status: the strictly smaller set a line in EXPECTED_FAIL may
+# carry. Three are rejected, each for its own reason:
+#
+#   PASS       is unreachable here by construction -- a PASS check never
+#              enters the failure set -- so a line carrying it could never
+#              match anything, which is a comparison whose failure branch is
+#              the only branch.
+#   ERROR      is sby failing to run or to render, not the core failing a
+#              property. ADR-0036: "with ERROR never a legitimate baselined
+#              value". Baselining one would re-create the btorsim hole with
+#              this gate's blessing on it.
+#   NO-STATUS  is "the check was generated and never scheduled, or is still
+#              running". Same argument: a broken harness, not a known-red
+#              property.
+#
+# TIMEOUT and UNKNOWN ARE accepted. They are budget exhaustion rather than
+# tooling breakage -- a real, recorded verdict about a check that did not
+# converge (ADR-0023's `reg` was exactly this before ADR-0024 changed the
+# engine) -- and a change that turned one into the other is a change this gate
+# should report, which is only possible if both are spellable.
+baselineable_status() {
+  case $1 in
+    FAIL | TIMEOUT | UNKNOWN) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Validate the baseline's FORMAT before anything expensive, and before any
+# comparison -- a rejected line must read as "this file is wrong", never as a
+# regression in the ladder. Exit 2 is this script's existing code for "the
+# inputs are broken", as distinct from exit 1, "the ladder disagrees with
+# them".
+#
+# A one-field line is the pre-ADR-0036 format. Accepting it silently would
+# make every legacy entry unmatchable in a way that reads exactly like a
+# regression, so it is named instead. An empty file has no lines and is
+# therefore fine -- which is the state the ladder is in today.
+baseline_errors=""
+while IFS= read -r line; do
+  [ -n "$line" ] || continue
+  # shellcheck disable=SC2086 # deliberate word split: the line is normalised.
+  set -- $line
+  case $# in
+    1)
+      baseline_errors+="  $line
+      -> no status field. The format is '<check>  <STATUS>'.
+"
+      ;;
+    2)
+      if ! known_status "$2"; then
+        baseline_errors+="  $line
+      -> '$2' is not a status sby can produce. Accepted: PASS FAIL ERROR
+         UNKNOWN TIMEOUT NO-STATUS.
+"
+      elif ! baselineable_status "$2"; then
+        baseline_errors+="  $line
+      -> '$2' must never be baselined. PASS cannot appear in a failure set at
+         all; ERROR and NO-STATUS are a broken harness rather than a known-red
+         property, and parking one here is what ADR-0036 exists to forbid.
+         Baselineable: FAIL TIMEOUT UNKNOWN.
+"
+      fi
+      ;;
+    *)
+      baseline_errors+="  $line
+      -> $# fields. The format is exactly two: '<check>  <STATUS>'. sby's
+         trailing engine numbers ('PASS 0 31') are not part of the status.
+"
+      ;;
+  esac
+done <<< "$expected_fail"
+
+if [ -n "$baseline_errors" ]; then
+  echo "error: $EXPECTED_FAIL is malformed (ADR-0036 format):" >&2
+  printf '%s' "$baseline_errors" >&2
+  echo "Read that file's header before editing it; the format is the gate." >&2
+  exit 2
+fi
 
 # The generated set: one line per checks/<name>.sby. `find` rather than a
 # glob, so a missing or empty directory yields nothing instead of the
@@ -97,29 +218,56 @@ all_checks=$(printf '%s\n%s\n' "$generated" "$expected_checks" | sort -u)
 
 total=0
 declare -a actual_fail=()
+declare -a unknown_statuses=()
 for name in $all_checks; do
   total=$((total + 1))
-  status=$(awk '{print $1; exit}' "$CHECKS_DIR/$name/status" 2>/dev/null)
+  # First word of the first NON-BLANK line. sby's status line is
+  # `<VERDICT> <engine> <depth>`; only the verdict is compared, because the
+  # numbers after it are bookkeeping that moves with the engine and would
+  # make the baseline pin something it is not asserting.
+  status=$(awk 'NF { print $1; exit }' "$CHECKS_DIR/$name/status" 2>/dev/null)
   if [ -z "$status" ]; then
     status="NO-STATUS"
   fi
+  if ! known_status "$status"; then
+    unknown_statuses+=("$name $status")
+  fi
   if [ "$status" != "PASS" ]; then
-    actual_fail+=("$name")
+    actual_fail+=("$name $status")
   fi
 done
 
 passed=$((total - ${#actual_fail[@]}))
 echo "$total checks: $passed pass, ${#actual_fail[@]} fail"
 
-actual_sorted=$(printf '%s\n' "${actual_fail[@]:-}" | sed '/^$/d' | sort)
+# A status sby has never written here before is reported on its own, not left
+# to be read out of a diff. It means the tool's output changed, which is a
+# different problem from the ladder disagreeing with its baseline, and the two
+# want different fixes. It still counts as non-PASS above, so it cannot pass
+# quietly either way.
+if [ ${#unknown_statuses[@]} -gt 0 ]; then
+  echo
+  echo "Unrecognised status(es) on disk -- not one of PASS FAIL ERROR UNKNOWN"
+  echo "TIMEOUT. sby's output has changed; do not baseline these, fix the"
+  echo "vocabulary in $0 after reading what the pin now emits:"
+  printf '  %s\n' "${unknown_statuses[@]}"
+  failed=1
+fi
+
+actual_sorted=$(printf '%s\n' "${actual_fail[@]:-}" | awk 'NF { $1 = $1; print }' | sort)
 
 if [ "$actual_sorted" = "$expected_fail" ]; then
-  echo "Failure list matches $EXPECTED_FAIL exactly."
+  echo "Failure list matches $EXPECTED_FAIL exactly (name and status)."
 else
   echo
   echo "Failure list does NOT match $EXPECTED_FAIL:"
   diff <(echo "$expected_fail") <(echo "$actual_sorted") \
     --label expected --label actual
+  echo
+  echo "A name on one side only is a check whose verdict moved. A name on BOTH"
+  echo "sides with different statuses is the ADR-0036 case: the check is still"
+  echo "red, but for a different reason than the one baselined -- ERROR and"
+  echo "NO-STATUS mean the harness broke, not that the property failed."
   failed=1
 fi
 


### PR DESCRIPTION
Executes ADR-0036's recorded-but-never-applied decision. `formal/check-baseline.sh` computed
each check's status and then threw it away, so `formal/EXPECTED_FAIL` matched on **names only**: a
baselined check that flipped `FAIL` → `ERROR`, `TIMEOUT`, `UNKNOWN` or `NO-STATUS` still matched
its entry and the gate stayed green. A missing `btorsim`, an sby crash, an unstartable solver and a
genuine property violation were the same result to it.

No new ADR — the decision is ADR-0036's. `rtl/` is untouched. The baseline stays **empty**, so the
ladder's current state does not move.

Closes JEF-658

## What changed

`formal/EXPECTED_FAIL` entries are now `<check>  <STATUS>` pairs, the same amendment ADR-0035 made
to `test/EXPECTED_FAIL`. The status is the **first word** of `formal/checks/<check>/status` — sby's
verdict without the engine/depth numbers it prints after it (`PASS 0 31`, `ERROR 16 37`), because a
baseline should not pin bookkeeping it is not asserting.

**The vocabulary is enumerated in both directions, and the two lists deliberately differ:**

| | |
|---|---|
| sby can write | `PASS` `FAIL` `ERROR` `UNKNOWN` `TIMEOUT` (+ this script's own `NO-STATUS`) |
| **may be baselined** | `FAIL` `TIMEOUT` `UNKNOWN` |

- `PASS` is rejected because it is **unreachable in a failure set** — a line carrying it could never
  match anything, which is a comparison with no reachable success branch, i.e. exactly the defect
  class this ticket closes. Not a thing to add on purpose.
- `ERROR` and `NO-STATUS` are rejected because they are a broken harness rather than a known-red
  property. ADR-0036's words: *"with `ERROR` never a legitimate baselined value."*
- `TIMEOUT` and `UNKNOWN` are **accepted**: budget exhaustion is a real recorded verdict (ADR-0023's
  `reg` was exactly this before ADR-0024 changed the engine), and a change from one to the other is
  worth reporting — which is only possible if both are spellable.

A one-field line is **rejected naming the format** (exit 2), not half-matched. A status found on
disk that is outside the vocabulary is reported on its own line rather than bucketed into "not
PASS". `formal/EXPECTED_FAIL`'s header states the format, both lists, and the reason, in the shape
of `test/EXPECTED_FAIL`'s header.

## Demonstrated reds — criteria 2 and 3

**No `rtl/` mutation, no throwaway branch, tracked tree clean throughout.** All three status files
below are **genuinely produced by sby**, not hand-written. The method:

1. `make -C formal check` produced the real 82-check results tree (82/82 PASS). A minimal mirror of
   it — `checks/*.sby` plus each `checks/<name>/status`, which is all this script reads — was copied
   to a scratch directory.
2. `rtl/*.v` was copied to the scratchpad and the **rs2 write-through bypass deleted in the copy** —
   this repo's own documented liveness probe for `reg_ch0` (ADR-0040, ADR-0046). `checks/reg_ch0.sby`
   was copied and its `read_verilog` lines repointed at the mutated copies. **`rtl/` in the worktree
   was never edited.**
3. Running that gave `bad state property 1 reachable at bound k = 20 SATISFIABLE`, exactly the
   counterexample ADR-0046 records for this probe — and then this:

```
SBY [reg_fail] engine_0.trace: bash: btorsim: command not found
SBY [reg_fail] DONE (ERROR, rc=16)
---- status file ----
ERROR 16 37
```

**That is ADR-0036's scenario reproducing itself live, unprompted.** This machine's toolchain
(boolector 3.2.4) ships `btormc` but not `btorsim`, so a check that genuinely finds a counterexample
reports `ERROR`, not `FAIL`. To obtain the `FAIL` a complete toolchain produces, a stub `btorsim`
was put on `PATH` for one re-run — it only renders the witness `btormc` had already found, it does
not decide the verdict — giving `FAIL 0 32`.

So `reg_ch0` has three real sby status files from the same source: `PASS 0 34` (real ladder),
`FAIL 0 32`, `ERROR 16 37`. Each was dropped into the mirrored results tree and both gates run
against it — this PR's script, and `git show d0ccf1e:formal/check-baseline.sh`.

### Control: the baselined FAIL matches

```
status on disk: FAIL 0 32 ;  baseline: reg_ch0  FAIL
82 checks: 81 pass, 1 fail
Failure list matches .../EF.new exactly (name and status).
Generated check set matches formal/EXPECTED_CHECKS exactly (82 checks).
exit=0
```

### Criterion 2 — FAIL → ERROR fails the gate

```
status on disk: ERROR 16 37 ;  baseline: reg_ch0  FAIL

NEW gate (this PR)
  82 checks: 81 pass, 1 fail

  Failure list does NOT match .../EF.new:
  1c1
  < reg_ch0 FAIL
  ---
  > reg_ch0 ERROR

  A name on one side only is a check whose verdict moved. A name on BOTH
  sides with different statuses is the ADR-0036 case: the check is still
  red, but for a different reason than the one baselined -- ERROR and
  NO-STATUS mean the harness broke, not that the property failed.
  exit=1

OLD gate (d0ccf1e), baseline 'reg_ch0'
  82 checks: 81 pass, 1 fail
  Failure list matches .../EF.old exactly.
  Generated check set matches formal/EXPECTED_CHECKS exactly (82 checks).
  exit=0            <-- the hole, on the same tree
```

### Criterion 3 — FAIL → PASS still fails the gate

```
status on disk: PASS 0 34 ;  baseline: reg_ch0  FAIL

NEW gate
  82 checks: 82 pass, 0 fail

  Failure list does NOT match .../EF.new:
  1c1
  < reg_ch0 FAIL
  ---
  >
  exit=1

OLD gate  exit=1   (the unexpected-pass direction is preserved, as required)
```

### Bonus — FAIL → NO-STATUS (the check was never scheduled)

```
status file deleted ;  baseline: reg_ch0  FAIL

NEW gate  reg_ch0 NO-STATUS  vs  reg_ch0 FAIL   exit=1
OLD gate  "Failure list matches ... exactly."   exit=0
```

The old gate reports a **clean match on a check that never produced a status file at all.**

### Criterion 1 — format rejection (synthetic three-check tree)

```
  gamma
      -> no status field. The format is '<check>  <STATUS>'.
exit=2

  gamma ERROR
      -> 'ERROR' must never be baselined. PASS cannot appear in a failure set at
         all; ERROR and NO-STATUS are a broken harness rather than a known-red
         property, and parking one here is what ADR-0036 exists to forbid.
         Baselineable: FAIL TIMEOUT UNKNOWN.
exit=2

  alpha PASS
      -> 'PASS' must never be baselined. ...
  beta WOBBLE
      -> 'WOBBLE' is not a status sby can produce. Accepted: PASS FAIL ERROR
         UNKNOWN TIMEOUT NO-STATUS.
  gamma FAIL 0 15
      -> 4 fields. The format is exactly two: '<check>  <STATUS>'. sby's
         trailing engine numbers ('PASS 0 31') are not part of the status.
exit=2
```

### Criterion 5 — the empty-baseline case still passes cleanly

Both entry points, against the real tree and the real (empty) `formal/EXPECTED_FAIL`:

```
$ make -C formal check          # 7m55s, always a fresh run (ADR-0040)
82 checks: 82 pass, 0 fail
Failure list matches EXPECTED_FAIL exactly (name and status).
Generated check set matches EXPECTED_CHECKS exactly (82 checks).
exit 0

$ make -C formal check-baseline
82 checks: 82 pass, 0 fail
Failure list matches EXPECTED_FAIL exactly (name and status).
Generated check set matches EXPECTED_CHECKS exactly (82 checks).
exit 0
```

## Gates

| Gate | Result |
|---|---|
| `make -C formal check` | **82 checks, 82 pass, 0 fail**, exit 0, 7m55s wall |
| `make -C formal check-baseline` | 82/82, both set equalities, exit 0 |
| `make test` | **52/52 passed**, `Failure list matches test/EXPECTED_FAIL exactly`, exit 0 |
| `make lint` | `svlint: clean in both passes` |

## Two false claims corrected where they are written

Neither is in scope; both would otherwise have been left saying something this PR makes untrue:

- **`.github/workflows/ci.yml`** — the `btorsim` guard's comment said this script *"compares check
  NAMES, not statuses"*. It no longer does. The guard **stays**, with a corrected reason: on an
  all-green ladder `btorsim` is never invoked, so its absence is invisible right up until the first
  check goes red, at which point the diagnostic would be "status changed" rather than "install
  btorsim". Asserting it up front makes the failure name its own cause.
- **`formal/EXPECTED_FAIL`'s header** — still described `formal/equiv.sh` as "still does not
  converge". ADR-0047 deleted that script; the paragraph now points at
  `make -C formal nonperturbation` and says it is strictly weaker than sequential equivalence.

## Scope, risks, and what this does not do

- **Files touched:** `formal/check-baseline.sh`, `formal/EXPECTED_FAIL`, `.github/workflows/ci.yml`.
  **`formal/EXPECTED_CHECKS` and `formal/checks.cfg` were not touched** (sibling-owned), nor were
  `test/run_tests.sh`, `test/run_cosim.sh` or the root `Makefile` (sibling-owned). CLAUDE.md
  untouched.
- **The empty baseline means the new rejection paths are exercised by nothing on `main` today.**
  That is why the demonstrations above are the deliverable rather than a footnote — and why every
  status string this script reacts to (`PASS`/`FAIL`/`ERROR`/`NO-STATUS`) was produced by sby or by
  the script itself and shown, rather than asserted. `TIMEOUT` and `UNKNOWN` are accepted on sby's
  documented vocabulary and are the two not exhibited here.
- **No self-test file was added.** No `formal/*.sh` has one and neither sibling mechanism
  (`genchecks-audit.py`, `check-genchecks.py`) is covered that way; the house pattern for this kind
  of gate change — ADR-0035's own `b585b17` — is demonstrated mutations carried in the PR. If the
  reviewer wants the demonstration mechanised, that is a follow-up and wants its own ticket, because
  the natural shape of it is one harness for all three `formal/` gate scripts, not one for this.
- **This does not make the mutation campaign's findings safe on its own.** It makes a red baseline
  entry able to say *why*. Whether a given finding belongs in `formal/EXPECTED_FAIL` at all is still
  the judgement ADR-0022 and that file's header describe.

No `DECISION NEEDED`.
