### PR TITLE
JEF-707: verify M2 term 6 against the gate's own run, and give `make fit` a job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -309,12 +309,19 @@ jobs:
   # rule is that a green run is evidence only if you can point at what would
   # have gone red. Two probes on this tree, both run:
   #
-  #   make fit FIT_MAX_LC=4100  -> exit 2, "4187 logic cells is over the
+  #   make fit FIT_MAX_LC=4100  -> exit 2, "... logic cells is over the
   #                                4100-cell budget"          (the ratchet)
   #   nextpnr absent / no table -> exit 1, "NO measurement was taken. That is
   #                                a failure, not a 0% fit."  (the Makefile's
   #                                own guard, which is why this job cannot go
   #                                green having measured nothing)
+  #
+  # THIS JOB IS THE MEASUREMENT, NOT A COPY OF A LOCAL ONE, and putting it here
+  # is what established that. The same commit synthesises to 4208 cells under
+  # the pinned OSS CAD Suite above (Yosys 0.66+179) and 4187 under a local
+  # Homebrew Yosys 0.67+post -- 21 cells on the synthesiser build alone, with
+  # no RTL difference whatever. Every area number this repo had recorded until
+  # ADR-0052 was a local one. Quote this job's.
   #
   # NOT REQUIRED, DELIBERATELY, and this is the one thing not to change here
   # without a human deciding it. Area is a design constraint, not a
@@ -325,8 +332,9 @@ jobs:
   # action, taken deliberately or not at all.
   #
   # The measurement is unstable to about +/-50 cells across edits that
-  # synthesise to identical hardware (CLAUDE.md's churn floor), which is why
-  # FIT_MAX_LC sits 213 cells above the current 4187 rather than at it. A red
+  # synthesise to identical hardware (CLAUDE.md's churn floor), plus the 21
+  # above across toolchains, which is why FIT_MAX_LC sits 192 cells over the
+  # current 4208 rather than at it. A red
   # here means the core grew by more than resynthesis noise can account for.
   # Raising the budget to clear it is how a ratchet becomes a rubber stamp.
   fit:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,6 +298,93 @@ jobs:
             echo "wall time: ${elapsed}s"
           } >> "$GITHUB_STEP_SUMMARY"
 
+  # `make fit` -- the repo's one area measurement (ADR-0038), and until this
+  # job existed it was a RATCHET NOTHING PULLED. CLAUDE.md declared it one,
+  # the Makefile implements it (`FIT_MAX_LC`, exit nonzero when the logic-cell
+  # count goes over), and `grep -rn fit .github/workflows/` returned two prose
+  # matches about runner memory and no invocation. The only thing that had
+  # ever enforced it was a human typing it.
+  #
+  # WHAT IT WOULD FAIL ON, demonstrated rather than asserted -- CLAUDE.md's
+  # rule is that a green run is evidence only if you can point at what would
+  # have gone red. Two probes on this tree, both run:
+  #
+  #   make fit FIT_MAX_LC=4100  -> exit 2, "4187 logic cells is over the
+  #                                4100-cell budget"          (the ratchet)
+  #   nextpnr absent / no table -> exit 1, "NO measurement was taken. That is
+  #                                a failure, not a 0% fit."  (the Makefile's
+  #                                own guard, which is why this job cannot go
+  #                                green having measured nothing)
+  #
+  # NOT REQUIRED, DELIBERATELY, and this is the one thing not to change here
+  # without a human deciding it. Area is a design constraint, not a
+  # correctness one: a change that grows the core past its budget should be
+  # loud and visible on the PR, and should be a conversation rather than an
+  # automatic block. Branch protection is a repository setting no pull request
+  # may touch (ADR-0036) -- adding this job to the required set is a human
+  # action, taken deliberately or not at all.
+  #
+  # The measurement is unstable to about +/-50 cells across edits that
+  # synthesise to identical hardware (CLAUDE.md's churn floor), which is why
+  # FIT_MAX_LC sits 213 cells above the current 4187 rather than at it. A red
+  # here means the core grew by more than resynthesis noise can account for.
+  # Raising the budget to clear it is how a ratchet becomes a rubber stamp.
+  fit:
+    name: fit
+    runs-on: little-cpu-runners
+    timeout-minutes: 8
+    steps:
+      - name: Record job start
+        run: echo "JOB_START=$(date +%s)" >> "$GITHUB_ENV"
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up OSS CAD Suite
+        uses: ./.github/actions/setup-oss-cad-suite
+        with:
+          tag: ${{ env.OSS_CAD_SUITE_TAG }}
+          file: ${{ env.OSS_CAD_SUITE_FILE }}
+          sha256: ${{ env.OSS_CAD_SUITE_SHA256 }}
+
+      - name: make fit
+        # NO PIPE ON THE GRADED COMMAND, same reasoning as the `formal` and
+        # `nonperturbation` jobs: a `run:` block without an explicit `shell:`
+        # key is `bash -e {0}`, errexit but NOT pipefail, so piping this into
+        # `tee` would take the step's status from `tee` and it would always be
+        # 0 (ADR-0037). Redirect, take the status off the unpiped command,
+        # then publish.
+        #
+        # `make fit` EXPECTS PLACEMENT TO FAIL: the fit top presents 231
+        # SB_IO against sg48's 39, so nextpnr always errors out on a pad --
+        # after printing the utilisation table, which is the measurement
+        # (ADR-0038 decision 1a). The Makefile checks for the table, so
+        # "nextpnr died before measuring anything" is a red here and "nextpnr
+        # measured, then failed to place" is a green.
+        run: |
+          set +e
+          make fit > "$RUNNER_TEMP/fit.txt" 2>&1
+          status=$?
+          set -e
+          cat "$RUNNER_TEMP/fit.txt"
+          {
+            echo "### area (ADR-0038)"
+            echo '```'
+            cat "$RUNNER_TEMP/fit.txt"
+            echo '```'
+            echo "Logic cells on up5k/sg48, memories external. This job is a ratchet"
+            echo "against \`FIT_MAX_LC\`, and it is NOT in main's required set."
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit "$status"
+
+      - name: Report job wall time
+        if: always()
+        run: |
+          elapsed=$(( $(date +%s) - JOB_START ))
+          {
+            echo "### fit"
+            echo "wall time: ${elapsed}s"
+          } >> "$GITHUB_STEP_SUMMARY"
+
   # ADR-0047: the mechanical form of ADR-0006's non-perturbation obligation --
   # the `ifdef RISCV_FORMAL` shadow payload in rtl/structs.v must not change
   # what the core does. That obligation rested on reviewer inspection from
@@ -329,9 +416,9 @@ jobs:
   # no riscv-formal clone, ~9s wall. It is deliberately NOT in the `formal`
   # job, which is GitHub-hosted for memory reasons and takes minutes.
   #
-  # NOT in main's branch-protection required set, and as of the gate inventory
-  # it is the ONLY job in this workflow that is not. Read live rather than
-  # remembered:
+  # NOT in main's branch-protection required set. It was the only such job in
+  # this workflow until `fit` above joined it, also deliberately non-required.
+  # Read live rather than remembered:
   #
   #   gh api repos/thejefflarson/little-cpu/branches/main/protection \
   #     -q '.required_status_checks.contexts'
@@ -469,9 +556,10 @@ jobs:
   # around a five-minute duplicate of this job, on an in-cluster runner that
   # OOMed and killed the last run before it could grade anything.
   #
-  # `complete` is the one piece not yet folded in: it is red today, and this
-  # job is required, so it lands with its exclusion set rather than blocking
-  # every merge in the meantime (see the step comment below).
+  # `complete` and `complete_cover` were the pieces ADR-0050 held back -- red
+  # at the time, on a required job -- and they landed with their exclusion set
+  # (M2 term 5). Every check the repo owns is now a step of this job, and every
+  # one of them is graded by its own exit status.
   #
   # The Sail co-sim stays out of this job deliberately -- ADR-0032 forbids
   # putting it on the required set, and its fetch has not had formal/pin.mk's
@@ -572,14 +660,20 @@ jobs:
 
       # Generates the ladder (formal/genchecks-audit.py, which asserts its
       # SHAPE against EXPECTED_CHECKS in about a second before anything runs)
-      # and then runs all 82 checks with `-k`. `continue-on-error` because
-      # this step's exit status is not the signal and never was -- `make
-      # check` ends in check-baseline itself, and the step below re-runs that
-      # comparison as the gate so the verdict is unambiguously the
-      # comparison's and its output lands in the step summary. Re-grading a
-      # finished ladder costs a second (formal/Makefile's check-baseline
-      # target exists to be re-runnable); running it here does not re-run a
-      # single check.
+      # and then runs all 85 checks with `-k`.
+      #
+      # NO `continue-on-error`, ANYWHERE IN THIS JOB. It carried one until the
+      # M2 term-6 verification, on the reasoning that this step's status "is
+      # not the signal" -- the step below re-grades and gates. That reasoning
+      # was not wrong, it was unnecessary: `formal/Makefile`'s `check` puts a
+      # leading `-` on the sby sub-make and then ENDS in `check-baseline`, so
+      # this command's exit status already IS the comparison's, identical to
+      # the gate step's. What the suppression actually bought was that an
+      # infrastructure failure here -- generation aborting, the audit script
+      # dying, the disk filling -- reached the summary as a green step. The two
+      # steps now fail together and the gate step below runs anyway
+      # (`!cancelled()`), so the report still lands. ADR-0050's term-6 wording
+      # is "no `continue-on-error` anywhere in it"; this is that, literally.
       #
       # JOBS IS PINNED, AND IT IS A MEMORY BUDGET, NOT A SPEED KNOB. One
       # check peaks around 876 MiB resident (measured, insn_add_ch0), so the
@@ -593,7 +687,6 @@ jobs:
       # check` is unaffected. The diagnostics print what the host actually
       # has: re-tune against those numbers, not by guessing.
       - name: Generate and run the ladder (make -C formal check)
-        continue-on-error: true
         run: |
           set -uo pipefail
           echo "nproc:            $(nproc)"
@@ -602,11 +695,20 @@ jobs:
           free -h 2>/dev/null || true
           make -C formal check JOBS=4
 
-      # THE GATE. Not continue-on-error: this exit status is the job's.
-      # A ladder that failed to generate at all resolves to exit 2 here
-      # ("no *.sby files"), so the step above being swallowed cannot produce
-      # a silent pass.
+      # THE GATE. This exit status is the job's, and so is the step above's --
+      # the two are the same comparison, run twice, and they agree by
+      # construction. Re-grading a finished ladder costs a second
+      # (formal/Makefile's check-baseline target exists to be re-runnable) and
+      # re-runs no check, so the cost of saying it twice is a second and the
+      # benefit is that the verdict is published rather than inferred.
+      #
+      # `!cancelled()` rather than the default: if the ladder step goes red,
+      # THIS step is what says why, so it has to run anyway. It is not
+      # `always()` -- a cancelled job should stop, not narrate. A ladder that
+      # failed to generate at all resolves to exit 2 here ("no *.sby files"),
+      # so a red step above can never be followed by a green one here.
       - name: Gate on formal/EXPECTED_FAIL + formal/EXPECTED_CHECKS
+        if: ${{ !cancelled() }}
         run: |
           # NO PIPE ON THE GRADED COMMAND, DELIBERATELY. The obvious spelling
           # of this step is `check-baseline.sh ... | tee -a "$GITHUB_STEP_
@@ -639,26 +741,37 @@ jobs:
       # THE FOUR HAND-AUTHORED TASKS, FOLDED IN FROM THE DELETED NIGHTLY
       # (ADR-0050). These are not on the generated ladder -- formal/
       # EXPECTED_FAIL is the genchecks-local.py sweep only -- so their verdict
-      # is their exit status and nothing else. `make` stops at the first
-      # failure, which is what we want: each one is a distinct property and a
-      # red in any of them is a red job.
+      # is their exit status and nothing else.
+      #
+      # ONE STEP EACH, and that is not cosmetic. They shared a single step
+      # until the M2 term-6 verification, which asks for each check's outcome
+      # individually rather than inferred from a green job -- and a
+      # three-`make` step cannot give that: `make` stops at the first failure,
+      # so a red `imemcheck` leaves `dmemcheck` and `cover` UNRUN while the
+      # step's log reads as one failure. Split, the job's own step list is the
+      # per-check record, GitHub's UI shows which one went red, and the two
+      # after it still run and still report. Cost: nothing -- the same three
+      # commands.
       #
       # They ran once a day in formal-nightly.yml until ADR-0050 deleted it.
       # `imemcheck` is the check CLAUDE.md names as the guard on ADR-0003's
       # dual-word fetch window, and nothing gated it; now every PR does.
       #
-      # Measured on this tree, not inherited: imemcheck PASS, dmemcheck PASS,
-      # cover PASS -- roughly three minutes against the ladder's five, on a
-      # job whose timeout is 20.
+      # Measured on the gate's own run of merged main, not inherited: imemcheck
+      # PASS, dmemcheck PASS, cover PASS, 31s for the three, on a job whose
+      # timeout is 20 minutes and which finishes in 4m22s.
       #
       # NO `continue-on-error`, and that is the point. In the nightly these
       # sat in a step that could not fail the job; here their exit status is
       # the job's, and the job is required.
-      - name: imemcheck / dmemcheck / cover
-        run: |
-          make -C formal imemcheck
-          make -C formal dmemcheck
-          make -C formal cover
+      - name: imemcheck (ADR-0003's dual-word fetch window)
+        run: make -C formal imemcheck
+
+      - name: dmemcheck
+        run: make -C formal dmemcheck
+
+      - name: cover (five goals, incl. >=2 compressed retires)
+        run: make -C formal cover
 
       # THE WHOLE-ISA WALK, AND IT IS A GATE. No continue-on-error: `make -C
       # formal complete` ends in sby's own exit status (complete.sby carries no

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -243,8 +243,9 @@ What does not work right now — **one live entry, then six resolved ones kept i
 six are struck through, and every one of those outlived its own fix here by several commits. That is
 the failure this section exists to prevent, so they stay as markers rather than being deleted.
 
-- **Three things this repo treats as gates are reached by no automation, and one of them computes a
-  verdict nothing reads.** Found by reading `Makefile`, `formal/Makefile`, both workflows and
+- **Three things this repo treated as gates were reached by no automation, and one of them computes
+  a verdict nothing reads. One of the three is now fixed; the other two stand.** Found by reading
+  `Makefile`, `formal/Makefile`, both workflows and
   `test/run_tests.sh` end to end; the four-column inventory that came out of it lives in the pull
   request that added this bullet and is destined for the coverage-map ADR. (1) ~~**`make fit` is a
   ratchet nothing pulls**~~ — **fixed: it is a job now** (ADR-0052). `ci.yml`'s `fit` job runs it on

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -246,12 +246,16 @@ the failure this section exists to prevent, so they stay as markers rather than 
 - **Three things this repo treats as gates are reached by no automation, and one of them computes a
   verdict nothing reads.** Found by reading `Makefile`, `formal/Makefile`, both workflows and
   `test/run_tests.sh` end to end; the four-column inventory that came out of it lives in the pull
-  request that added this bullet and is destined for the coverage-map ADR. (1) **`make fit` is a
-  ratchet nothing pulls.** The ratchet works — `make fit FIT_MAX_LC=4200` against today's 4236-cell
-  tree exits **2** with "4236 logic cells is over the 4200-cell budget" — but
-  `grep -rn fit .github/workflows/` returns two prose matches about runner memory and **no
-  invocation of `make fit`**, so nothing but a human has ever pulled it. Run it by hand on anything
-  that touches `rtl/`. (2) **`make waves` grades nothing.** It runs the full pipeline under iverilog
+  request that added this bullet and is destined for the coverage-map ADR. (1) ~~**`make fit` is a
+  ratchet nothing pulls**~~ — **fixed: it is a job now** (ADR-0052). `ci.yml`'s `fit` job runs it on
+  every PR, **non-required on purpose** — area is a design constraint, not a correctness one, and
+  branch protection is human-only (ADR-0036). The re-measurement that came with it is the part to
+  carry: **4187 logic cells / 79%**, not the 4236 this file had quoted since ADR-0042. The 49-cell
+  gap is *inside* the ±50 churn floor recorded under Pointers, so it is a re-measurement and **not**
+  evidence of a real reduction — which is exactly what that floor is for. Probes, both run:
+  `make fit FIT_MAX_LC=4100` exits **2** ("4187 logic cells is over the 4100-cell budget"), and a
+  nextpnr that prints no utilisation table exits **1** rather than reporting a 0% fit.
+  (2) **`make waves` grades nothing.** It runs the full pipeline under iverilog
   with the per-retire monitor live, but `ch0_handle_error` only `$display`s and sets `errcode` —
   there is not one `$fatal`, `$finish` or `$stop` in `test/monitor.v` or `test/monitor.sim.v` — and
   on the iverilog leg nothing turns `errcode` into an exit status (`test/testbench.v:55-60` says so
@@ -490,13 +494,15 @@ read off each `sby` summary, not inferred from a green job. See ADR-0017 for wha
 does and does not establish, and ADR-0046 for what `pcloop` discharges). `make waves`
 now runs the iverilog leg (`testbench.vvp`) instead of the cxxrtl runner, matching the verification
 table below, and produces a real `waves.vcd` — **but it grades nothing**; see the first bullet under
-"what does not work" above. CI (`.github/workflows/ci.yml`) runs **seven** jobs on every PR:
-elaborate, test, components, lint, nonperturbation, monitor-freshness and formal — the last of
-which also carries `complete` and `complete_cover` as hard gates (M2 term 5). **Six of the seven
+"what does not work" above. CI (`.github/workflows/ci.yml`) runs **eight** jobs on every PR:
+elaborate, test, components, lint, fit, nonperturbation, monitor-freshness and formal — the last of
+which also carries `complete` and `complete_cover` as hard gates (M2 term 5). **Six of the eight
 are required** — `elaborate`, `test`, `components`, `monitor-freshness`, `lint`, `formal`, read live
 from `gh api repos/thejefflarson/little-cpu/branches/main/protection -q
 '.required_status_checks.contexts'` rather than from any comment in the workflow — and
-`nonperturbation` is the one that runs without gating. This line named four jobs and stopped there
+`nonperturbation` and `fit` are the two that run without gating, both deliberately (ADR-0047,
+ADR-0052). **There is no `continue-on-error` anywhere in the file**, in any job: the `formal` job
+carried the last one until ADR-0052 struck it. This line named four jobs and stopped there
 until the gate inventory; `lint` and `formal` had both been promoted to required in the meantime,
 and `ci.yml`'s own comments still said otherwise.
 
@@ -655,11 +661,12 @@ make fit            # the ONE area number: nextpnr logic cells on up5k/sg48 (ADR
                     # Placement always fails (231 SB_IO vs 39) and that is expected --
                     # the utilisation table printed before placement is the measurement.
                     # A RATCHET as of ADR-0042: over FIT_MAX_LC (4400) exits nonzero.
-                    # RATCHET DECLARED, NEVER PULLED: no workflow runs this, so the
-                    # only thing that has ever enforced it is a human typing it. The
-                    # mechanism itself is live -- `make fit FIT_MAX_LC=4200` on the
-                    # 4236-cell tree exits 2 -- so this is an unrun gate, not a
-                    # broken one. Run it by hand on anything that touches rtl/.
+                    # 4187 cells / 79% as of ADR-0052 (re-measured; this said 4236,
+                    # which is inside the +/-50 churn floor, so the delta is noise
+                    # and not a saving). ON CI as of ADR-0052, in the `fit` job,
+                    # NON-REQUIRED on purpose -- area is a design constraint, not a
+                    # correctness one, and adding it to branch protection is a human
+                    # action. Probe: `make fit FIT_MAX_LC=4100` exits 2.
 
 make -C formal components_decoder   # component proofs. THREE tasks, all with real assertions:
 make -C formal components_executor  # decoder, executor, pcloop -- the assertion-free fetcher /
@@ -867,11 +874,25 @@ term 6 is open.** Read each term's own text, not this sentence:
    by declaration to the two excluded classes — `formal/complete_cover.sby` is what makes "the
    assertion was live, class by class" measured rather than assumed (twelve cover goals, all
    reached).
-6. **Every check the repo owns is on a gate that can fail, and that gate is green** (ADR-0050,
-   rewriting this term after deleting the nightly). The ladder, `imemcheck`, `dmemcheck` and
-   `cover` are steps of the **required** `formal` job whose exit status is the job's, with no
-   `continue-on-error` anywhere in it; `complete` joins them when term 5's exclusion set lands. No
-   graded command sits in a pipeline in a `run:` block.
+6. ~~**Every check the repo owns is on a gate that can fail, and that gate is green**~~ — **MET at
+   ADR-0052, and it took one code change to get there because the term was not met when it was
+   written.** ADR-0050 wrote "with no `continue-on-error` anywhere in it" and the `formal` job
+   **had one**, on the step that runs the ladder — surviving on the reasoning that the step's status
+   "is not the signal". It is: `formal/Makefile`'s `check` puts a leading `-` on the sby sub-make and
+   then ends in `check-baseline`, so that command's exit status already *was* the comparison's. What
+   the suppression bought was that generation aborting, or the audit script dying, reached the
+   summary as a green step. It is gone; the gate step below it runs on `!cancelled()` so the report
+   still lands. **`grep -c continue-on-error .github/workflows/*.yml` is now 0 in every file.**
+   The evidence, all on the **gate's own run** rather than a local one:
+   the required `formal` job green on merged main (`d2e736e`, run `30724575535`), **per step** —
+   ladder 85/85 with *both* set equalities matching in both directions, `imemcheck` PASS,
+   `dmemcheck` PASS, `cover` PASS, `complete` PASS, `complete_cover` PASS — **4m22s against a
+   20-minute timeout**. The three memory checks were one step until ADR-0052 split them, because
+   `make` stops at the first failure and a shared step cannot record three outcomes.
+   **What it does NOT cover, stated rather than assumed**: ADR-0050's concrete clause is the formal
+   checks, and `make cosim-suite` (deliberately off every gate, ADR-0032) and `make waves` (grades
+   nothing, and `testbench.vvp` is elaborated by CI and executed by nothing) are both outside it.
+   Neither is a regression this term introduced; both are recorded under "what does not work".
    **The intent never changed** — the ladder's verdict must be observed by something automated that
    can fail — and a required PR check is a strictly stronger instrument than a job ADR-0022 itself
    described as not gating merges. **This is the third move of an M2 criterion**, and ADR-0045 said
@@ -930,9 +951,12 @@ longer quietly widen.
 
 - Design brief: [`docs/ideas/finish-the-rewrite.md`](docs/ideas/finish-the-rewrite.md)
 - Area/fit brief: [`docs/ideas/fit-the-core-on-the-up5k.md`](docs/ideas/fit-the-core-on-the-up5k.md) —
-  **the core's logic now fits: 4236/5280 logic cells, 80%**, down from 6971/132%, which the
-  synchronous-read regfile achieves on its own (ADR-0042). `make fit` is a ratchet against
-  `FIT_MAX_LC`. **The design still does not place**, and that is expected and unrelated to logic:
+  **the core's logic now fits: 4187/5280 logic cells, 79%**, down from 6971/132%, which the
+  synchronous-read regfile achieves on its own (ADR-0042). **Re-measured at ADR-0052**; this line
+  said 4236 from ADR-0042 until then, and the 49-cell gap is inside the ±50 churn floor below —
+  a re-measurement, not a saving, and the reason to state the number with the commit it was taken
+  at. `make fit` is a ratchet against `FIT_MAX_LC`, and as of ADR-0052 it is a **non-required CI
+  job** rather than a ratchet only a human pulls. **The design still does not place**, and that is expected and unrelated to logic:
   the fit top presents **231 `SB_IO` against sg48's 39**, so nextpnr always fails on a pad. A
   placing design needs a real pinout, which means the SoC memory system, which ADR-0038 decision 1a
   puts out of scope. Read ADR-0038 before quoting any area number: yosys cell counts are blind to
@@ -955,10 +979,12 @@ longer quietly widen.
   rejected the shifter merge at 19 cells *saved* on legibility grounds, and accepting a hygiene
   change at 37 cells *spent* would cut against that ruling. Read this before proposing the
   narrowing again — it is measured and declined, not overlooked.
-- Decisions: [`docs/adr/`](docs/adr/) — **forty-eight ADRs, forty-seven of them accepted**, plus a
-  deferred list. Re-derived by counting: `ls docs/adr/*.md | wc -l` is 49, one of which is
+- Decisions: [`docs/adr/`](docs/adr/) — **fifty-two ADRs, fifty-one of them accepted**, plus a
+  deferred list. Re-derived by counting: `ls docs/adr/*.md | wc -l` is 53, one of which is
   `README.md`, and the status column in that README carries exactly one non-accepted entry
-  (ADR-0016, superseded by ADR-0018). This line said "forty-five accepted" and was two behind.
+  (ADR-0016, superseded by ADR-0018). This line has now been behind twice — it said "forty-five
+  accepted" and then "forty-seven" — so **re-derive it with the two commands rather than
+  incrementing it**, which is what missed ADR-0049 through ADR-0051 in one go.
 - Reference text from the old core: `git show 1709433^:rtl/riscv.v` (RVFI retire block),
   `git show e67875c^:rtl/alu.v` (arithmetic)
 - Work is tracked in Linear, project **Little CPU** (team JEF). Named here so you know where the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -250,12 +250,17 @@ the failure this section exists to prevent, so they stay as markers rather than 
   request that added this bullet and is destined for the coverage-map ADR. (1) ~~**`make fit` is a
   ratchet nothing pulls**~~ — **fixed: it is a job now** (ADR-0052). `ci.yml`'s `fit` job runs it on
   every PR, **non-required on purpose** — area is a design constraint, not a correctness one, and
-  branch protection is human-only (ADR-0036). The re-measurement that came with it is the part to
-  carry: **4187 logic cells / 79%**, not the 4236 this file had quoted since ADR-0042. The 49-cell
-  gap is *inside* the ±50 churn floor recorded under Pointers, so it is a re-measurement and **not**
-  evidence of a real reduction — which is exactly what that floor is for. Probes, both run:
-  `make fit FIT_MAX_LC=4100` exits **2** ("4187 logic cells is over the 4100-cell budget"), and a
-  nextpnr that prints no utilisation table exits **1** rather than reporting a 0% fit.
+  branch protection is human-only (ADR-0036). Probes, both run: `make fit FIT_MAX_LC=4100` exits
+  **2** ("logic cells is over the 4100-cell budget"), and a nextpnr that prints no utilisation table
+  exits **1** rather than reporting a 0% fit.
+  **Putting it on CI found that the number is toolchain-dependent, which nobody had measured.**
+  Same commit, same RTL: **4208 cells / 79% under CI's pinned OSS CAD Suite** (Yosys 0.66+179,
+  `e74db6dea`) and **4187 under a local Homebrew Yosys 0.67+post** — 21 cells apart on nothing but
+  the synthesiser build. The churn floor under Pointers was characterised as instability across
+  *edits*; this is a second axis. **Quote the pinned number, 4208** — the `fit` job is where it is
+  measured, and the pin is the reference for the same reason `formal/pin.mk` exists. The 4236 this
+  file carried from ADR-0042 was a local measurement too, so the apparent 28-cell "reduction" is
+  two toolchains being compared, not cells being saved.
   (2) **`make waves` grades nothing.** It runs the full pipeline under iverilog
   with the per-retire monitor live, but `ch0_handle_error` only `$display`s and sets `errcode` —
   there is not one `$fatal`, `$finish` or `$stop` in `test/monitor.v` or `test/monitor.sim.v` — and
@@ -662,12 +667,15 @@ make fit            # the ONE area number: nextpnr logic cells on up5k/sg48 (ADR
                     # Placement always fails (231 SB_IO vs 39) and that is expected --
                     # the utilisation table printed before placement is the measurement.
                     # A RATCHET as of ADR-0042: over FIT_MAX_LC (4400) exits nonzero.
-                    # 4187 cells / 79% as of ADR-0052 (re-measured; this said 4236,
-                    # which is inside the +/-50 churn floor, so the delta is noise
-                    # and not a saving). ON CI as of ADR-0052, in the `fit` job,
-                    # NON-REQUIRED on purpose -- area is a design constraint, not a
-                    # correctness one, and adding it to branch protection is a human
-                    # action. Probe: `make fit FIT_MAX_LC=4100` exits 2.
+                    # ON CI as of ADR-0052, in the `fit` job, NON-REQUIRED on purpose
+                    # -- area is a design constraint, not a correctness one, and
+                    # adding it to branch protection is a human action.
+                    # 4208 cells / 79% AT THE PINNED OSS CAD SUITE, which is the
+                    # number to quote. THE MEASUREMENT IS TOOLCHAIN-DEPENDENT: the
+                    # same commit gives 4187 under a local Homebrew yosys, 21 cells
+                    # apart on the synthesiser build alone (ADR-0052). A local run
+                    # is a sanity check; the `fit` job is the measurement.
+                    # Probe: `make fit FIT_MAX_LC=4100` exits 2.
 
 make -C formal components_decoder   # component proofs. THREE tasks, all with real assertions:
 make -C formal components_executor  # decoder, executor, pcloop -- the assertion-free fetcher /
@@ -952,11 +960,13 @@ longer quietly widen.
 
 - Design brief: [`docs/ideas/finish-the-rewrite.md`](docs/ideas/finish-the-rewrite.md)
 - Area/fit brief: [`docs/ideas/fit-the-core-on-the-up5k.md`](docs/ideas/fit-the-core-on-the-up5k.md) —
-  **the core's logic now fits: 4187/5280 logic cells, 79%**, down from 6971/132%, which the
-  synchronous-read regfile achieves on its own (ADR-0042). **Re-measured at ADR-0052**; this line
-  said 4236 from ADR-0042 until then, and the 49-cell gap is inside the ±50 churn floor below —
-  a re-measurement, not a saving, and the reason to state the number with the commit it was taken
-  at. `make fit` is a ratchet against `FIT_MAX_LC`, and as of ADR-0052 it is a **non-required CI
+  **the core's logic now fits: 4208/5280 logic cells, 79%** at the pinned OSS CAD Suite, down from
+  6971/132%, which the synchronous-read regfile achieves on its own (ADR-0042). **Re-measured at
+  ADR-0052**, which is also where the number acquired a provenance: this line said 4236 from
+  ADR-0042, and that was a *local* measurement, as is the 4187 the same tree gives under a Homebrew
+  yosys today. **Quote the `fit` job's number and say which toolchain it came from** — 21 cells sit
+  between two yosys builds on identical RTL, on top of the ±50 edit churn below.
+  `make fit` is a ratchet against `FIT_MAX_LC`, and as of ADR-0052 it is a **non-required CI
   job** rather than a ratchet only a human pulls. **The design still does not place**, and that is expected and unrelated to logic:
   the fit top presents **231 `SB_IO` against sg48's 39**, so nextpnr always fails on a pad. A
   placing design needs a real pinout, which means the SoC memory system, which ADR-0038 decision 1a

--- a/Makefile
+++ b/Makefile
@@ -634,17 +634,21 @@ fit.json: $(FIT_SRCS)
 # THE RATCHET (ADR-0042). `make fit` was report-only while the core did not
 # fit at all; it does now, and a number nothing defends drifts back.
 #
-# WHY THE BUDGET IS NOT THE MEASUREMENT. `littlecpu` measures 4236 logic cells
-# as this lands. The budget is deliberately looser than that, because the
-# measurement is not stable to the cell: edits that synthesise to identical
-# hardware -- renaming a wire, reordering two independent assignments, hoisting
-# a struct field into a named signal -- move it by tens of cells, since ABC's
-# result depends on the order it sees the netlist in. A ratchet pinned to 4236
-# would go red on changes that alter nothing, and the only way to clear it
-# would be to raise the number, which is how a ratchet becomes a rubber stamp.
+# WHY THE BUDGET IS NOT THE MEASUREMENT. `littlecpu` measures 4187 logic cells
+# at ADR-0052 (it was 4236 at ADR-0042, and the 49-cell gap is inside the
+# churn floor described below -- a re-measurement, not a saving; quote the
+# number with the commit it was taken at). The budget is looser than that,
+# because the measurement is not stable to the cell: edits that synthesise to
+# identical hardware -- renaming a wire, reordering two independent
+# assignments, hoisting a struct field into a named signal -- move it by tens
+# of cells, since ABC's result depends on the order it sees the netlist in. A
+# ratchet pinned to the measurement of the day would go red on changes that
+# alter nothing, and the only way to clear it would be to raise the number,
+# which is how a ratchet becomes a rubber stamp. The 4236 -> 4187 drift is
+# itself an instance: nobody set out to save those cells.
 #
-# 4400 is 164 cells of headroom, about 3.9% of the measurement and more than
-# three times the observed noise band. A change that trips it has grown the
+# 4400 is 213 cells of headroom, about 5.1% of the measurement and more than
+# four times the observed noise band. A change that trips it has grown the
 # core by more than any resynthesis artifact can account for, and the right
 # response is to find out why -- not to edit this line. Lowering it after a
 # real reduction is always welcome; raising it needs a reason in the commit

--- a/Makefile
+++ b/Makefile
@@ -634,21 +634,23 @@ fit.json: $(FIT_SRCS)
 # THE RATCHET (ADR-0042). `make fit` was report-only while the core did not
 # fit at all; it does now, and a number nothing defends drifts back.
 #
-# WHY THE BUDGET IS NOT THE MEASUREMENT. `littlecpu` measures 4187 logic cells
-# at ADR-0052 (it was 4236 at ADR-0042, and the 49-cell gap is inside the
-# churn floor described below -- a re-measurement, not a saving; quote the
-# number with the commit it was taken at). The budget is looser than that,
+# WHY THE BUDGET IS NOT THE MEASUREMENT. `littlecpu` measures 4208 logic cells
+# at ADR-0052, under CI's pinned OSS CAD Suite -- which is the number to quote,
+# and the reason to say which toolchain took it: the same commit measures 4187
+# under a local Homebrew yosys, 21 cells apart on the synthesiser build alone.
+# (ADR-0042's 4236 was likewise a local number.) The budget is looser than that,
 # because the measurement is not stable to the cell: edits that synthesise to
 # identical hardware -- renaming a wire, reordering two independent
 # assignments, hoisting a struct field into a named signal -- move it by tens
 # of cells, since ABC's result depends on the order it sees the netlist in. A
 # ratchet pinned to the measurement of the day would go red on changes that
 # alter nothing, and the only way to clear it would be to raise the number,
-# which is how a ratchet becomes a rubber stamp. The 4236 -> 4187 drift is
-# itself an instance: nobody set out to save those cells.
+# which is how a ratchet becomes a rubber stamp. The 4236 -> 4208 drift is
+# itself an instance, and 4208 vs 4187 is a second axis of the same problem:
+# nobody set out to move either number.
 #
-# 4400 is 213 cells of headroom, about 5.1% of the measurement and more than
-# four times the observed noise band. A change that trips it has grown the
+# 4400 is 192 cells of headroom, about 4.6% of the measurement and more than
+# three times the observed noise band. A change that trips it has grown the
 # core by more than any resynthesis artifact can account for, and the right
 # response is to find out why -- not to edit this line. Lowering it after a
 # real reduction is always welcome; raising it needs a reason in the commit

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -158,5 +158,6 @@ Ranked by how much it is worth:
    temp-file races.
 
 Findings in category 1 should be reported even when no attacker is involved. "A routine edit
-silently deletes a check and the nightly stays green" is the highest-value thing a review of this
-repo can find.
+silently deletes a check and the gate stays green" is the highest-value thing a review of this
+repo can find. (It said *the nightly* until ADR-0050 deleted that workflow and folded its checks
+into the required `formal` job; the class of finding is unchanged and the gate is now stricter.)

--- a/docs/adr/0052-m2-term-6-is-verified-and-the-fit-ratchet-gets-a-job.md
+++ b/docs/adr/0052-m2-term-6-is-verified-and-the-fit-ratchet-gets-a-job.md
@@ -58,6 +58,11 @@ list matches formal/EXPECTED_FAIL exactly (name and status)`* and *`Generated ch
 formal/EXPECTED_CHECKS exactly (85 checks)`* — both set equalities, both directions, on the gate's
 own run rather than reproduced from a workstation.
 
+**Re-run against the changed job**, which is what makes the split steps a record rather than a
+promise: same verdicts, each check its own step — ladder 217s, gate 0s, `imemcheck` 21s, `dmemcheck`
+16s, `cover` 5s, `complete` 25s, `complete_cover` 17s, **job 5m15s**. The 4m22s / 5m15s spread
+between two runs of the same ladder is solver and runner variance, not a change in the work.
+
 **The pipe rule holds.** `grep -rnE '\|' .github/workflows/` over both remaining workflows returns
 exactly one pipe on a graded command: `elaborate`'s `yosys ... 2>&1 | tee /tmp/yosys-elaborate.log`,
 and that `run:` block opens with an explicit `set -euo pipefail`, which is the documented remedy
@@ -87,11 +92,31 @@ conversation, not an automatic block. Branch protection is a repository setting 
 touch (ADR-0036), so promoting it is a human action taken deliberately or not at all. `fit` and
 `nonperturbation` are now the two non-required jobs of eight.
 
-**4. The area number is re-measured: 4187 logic cells / 79%**, not the 4236 / 80% this repo has quoted
-since ADR-0042. **The 49-cell gap is inside the ±50 churn floor** CLAUDE.md records, so it is a
-re-measurement and not a saving — nobody set out to remove those cells, and reporting it as a
-reduction would be exactly the mistake that floor exists to prevent. Corrected in `CLAUDE.md`, the
-`Makefile`'s own comment and the fit brief, each with the ADR the number was taken at.
+**4. The area number is re-measured — and running it on CI is what found that the number is
+toolchain-dependent, which nobody here had measured.** Same commit, same RTL; no `rtl/` file is
+touched by this ADR.
+
+| toolchain | logic cells |
+|---|---|
+| CI's pinned OSS CAD Suite, Yosys 0.66+179 (`e74db6dea`) — **the `fit` job** | **4208 / 5280, 79%** |
+| local Homebrew Yosys 0.67+post (`b8e7da6f4`) | 4187 |
+| quoted in this repo since ADR-0042 (also local) | 4236 |
+
+**Quote 4208, and say which toolchain took it.** The pinned suite is the reference for the same
+reason `formal/pin.mk` and `OSS_CAD_SUITE_SHA256` exist, and the `fit` job is where the number is
+now taken. Every area figure this repo had on file was a local one, so the apparent 4236 → 4208
+"reduction" is partly two toolchains being compared rather than cells being saved.
+
+This is a **second axis of instability** on top of the one already recorded. CLAUDE.md's ±50 churn
+floor was measured across *edits that synthesise to identical hardware*; this is 21 cells across
+*yosys builds* at identical RTL. `FIT_MAX_LC` at 4400 sits 192 cells over the pinned measurement,
+which clears both comfortably — but a ratchet set from a laptop would have been set against the
+wrong number, and that is the practical consequence. Corrected in `CLAUDE.md`, the `Makefile`'s own
+comment, `ci.yml` and the fit brief — with the provenance, not just the digits.
+
+**This was found the only way it could be**: by running the thing rather than reasoning about it.
+The ticket that produced this ADR noted a suspected 4236 → 4187 drift and asked for a re-measurement;
+re-measuring locally would have confirmed the drift and recorded a third local number.
 
 ## A green job is evidence only if you can name what it would fail on
 
@@ -100,7 +125,8 @@ CLAUDE.md's rule, applied to the two things this ADR adds.
 **The `fit` job.** Two probes, both run on this tree, neither inferred:
 
 - `make fit FIT_MAX_LC=4100` → **exit 2**, `*** make fit: 4187 logic cells is over the 4100-cell
-  budget.` The ratchet arithmetic fires.
+  budget.` The ratchet arithmetic fires. (Run locally, hence the local cell count; the arithmetic is
+  the same one the job runs.)
 - nextpnr printing no utilisation table → **exit 1**, `*** make fit: nextpnr printed no utilisation
   table, so NO measurement was taken. That is a failure, not a 0% fit.` This is the guard that keeps
   a green `fit` from meaning "the tool did not run": placement *always* fails here on an IO pad

--- a/docs/adr/0052-m2-term-6-is-verified-and-the-fit-ratchet-gets-a-job.md
+++ b/docs/adr/0052-m2-term-6-is-verified-and-the-fit-ratchet-gets-a-job.md
@@ -1,0 +1,140 @@
+# ADR-0052: M2 term 6 is verified against the gate's own run, and the fit ratchet gets a job
+
+**Status:** Accepted · 2026-08-02 · *Closes [ADR-0037](0037-an-empty-baseline-is-not-m2.md)'s M2
+term 6 as rewritten by [ADR-0050](0050-the-nightly-is-deleted-and-its-checks-move-to-the-gate.md).
+Amends [ADR-0038](0038-area-is-measured-in-logic-cells-and-two-levers-are-rejected.md) decision 1a
+and [ADR-0042](0042-the-regfile-read-is-synchronous-and-costs-a-cycle.md)'s area number.*
+
+## Context
+
+Term 6 had two halves and only one of them had ever been checked. *"Can go red"* was fixed at
+`1961234` and demonstrated on real runs. *"Is green"* was never verified — and then everything
+underneath it moved: the ladder went 82 → 85 checks, `formal/EXPECTED_FAIL` gained a status field
+(ADR-0036), four hand-authored sby targets stopped re-grading stale runs (ADR-0040), the components
+job gained `pcloop` (ADR-0046), `complete` and `complete_cover` landed as hard gates (ADR-0050's
+held-back piece, paid off with `formal/COMPLETE_EXCLUSIONS`), and then the mechanism the term
+described was deleted outright.
+
+ADR-0050 rewrote the term to:
+
+> **Every check the repo owns is on a gate that can fail, and that gate is green.** Concretely: the
+> ladder, `imemcheck`, `dmemcheck` and `cover` are steps of the required `formal` job whose exit
+> status is the job's, **with no `continue-on-error` anywhere in it**; `complete` joins them when its
+> exclusion set lands. No graded command sits in a pipeline in a `run:` block.
+
+Nobody had confirmed that against merged `main`.
+
+## What the verification found
+
+**The term was not met.** The `formal` job carried a `continue-on-error: true` — on the step that
+generates and runs the entire ladder — and it survived ADR-0050 because its comment argued the step's
+exit status "is not the signal and never was". That argument is false in an interesting way:
+`formal/Makefile`'s `check` target puts a leading `-` on the sby sub-make and then **ends in
+`check-baseline`**, so the command's exit status already *is* the graded comparison's, byte for byte
+the same verdict the next step recomputes.
+
+What the suppression actually bought, therefore, was not "ignore sby's meaningless exit code" — the
+Makefile had already done that. It was: **generation aborting, `genchecks-audit.py` dying, or the
+disk filling up reach the step summary as a green step.** The gate step below would still catch those
+(no `*.sby` files resolves to exit 2), so this was never an unsound gate — but it is precisely the
+shape ADR-0047 and ADR-0050 both retired elsewhere, a suppressed step that reads as coverage, left in
+the one job those ADRs were about.
+
+Everything else the term asserts held. Verified on the gate's own run, not locally:
+
+| step of the required `formal` job | outcome | wall |
+|---|---|---|
+| Set up OSS CAD Suite | success | 18s |
+| Confirm the BMC toolchain is complete | success | <1s |
+| Generate and run the ladder | success | **174s** |
+| Gate on `EXPECTED_FAIL` + `EXPECTED_CHECKS` | success | 1s |
+| `imemcheck` / `dmemcheck` / `cover` | success | 31s |
+| `complete` (depth-50 whole-ISA walk) | success | 19s |
+| `complete_cover` (anti-vacuity) | success | 13s |
+| **job total** | **success** | **4m22s against `timeout-minutes: 20`** |
+
+`main` at `d2e736e`, run `30724575535`. The ladder printed `85 checks: 85 pass, 0 fail`, *`Failure
+list matches formal/EXPECTED_FAIL exactly (name and status)`* and *`Generated check set matches
+formal/EXPECTED_CHECKS exactly (85 checks)`* — both set equalities, both directions, on the gate's
+own run rather than reproduced from a workstation.
+
+**The pipe rule holds.** `grep -rnE '\|' .github/workflows/` over both remaining workflows returns
+exactly one pipe on a graded command: `elaborate`'s `yosys ... 2>&1 | tee /tmp/yosys-elaborate.log`,
+and that `run:` block opens with an explicit `set -euo pipefail`, which is the documented remedy
+rather than an instance of the defect. Every other match is a `run: |` block scalar or a `$(... |
+head -1)` inside an `echo`.
+
+## Decisions
+
+**1. Delete the `continue-on-error`, and make the gate step run on `!cancelled()`.** The two steps now
+carry the same verdict and fail together; the second still publishes its report when the first goes
+red, so nothing is lost by removing the suppression. `grep -c continue-on-error` across
+`.github/workflows/` is now **0 in every file**.
+
+**2. Split `imemcheck` / `dmemcheck` / `cover` into three steps.** Term 6 asks for each check's
+outcome individually, and a three-`make` step structurally cannot supply it: `make` stops at the
+first failure, so a red `imemcheck` leaves the other two **unrun** while the job shows one red step.
+Split, the step list *is* the per-check record. Cost: nothing.
+
+**3. `make fit` gets a job, and it is NOT required.** It has been declared a ratchet in CLAUDE.md and
+implemented as one in the `Makefile` since ADR-0042, while `grep -rn fit .github/workflows/` returned
+two prose matches about runner memory and no invocation — a ratchet nothing pulls. It runs on every
+PR now.
+
+**Non-required is the decision, not an oversight.** Area is a design constraint, not a correctness
+one: a change that grows the core past its budget should be loud on the pull request and should be a
+conversation, not an automatic block. Branch protection is a repository setting no pull request may
+touch (ADR-0036), so promoting it is a human action taken deliberately or not at all. `fit` and
+`nonperturbation` are now the two non-required jobs of eight.
+
+**4. The area number is re-measured: 4187 logic cells / 79%**, not the 4236 / 80% this repo has quoted
+since ADR-0042. **The 49-cell gap is inside the ±50 churn floor** CLAUDE.md records, so it is a
+re-measurement and not a saving — nobody set out to remove those cells, and reporting it as a
+reduction would be exactly the mistake that floor exists to prevent. Corrected in `CLAUDE.md`, the
+`Makefile`'s own comment and the fit brief, each with the ADR the number was taken at.
+
+## A green job is evidence only if you can name what it would fail on
+
+CLAUDE.md's rule, applied to the two things this ADR adds.
+
+**The `fit` job.** Two probes, both run on this tree, neither inferred:
+
+- `make fit FIT_MAX_LC=4100` → **exit 2**, `*** make fit: 4187 logic cells is over the 4100-cell
+  budget.` The ratchet arithmetic fires.
+- nextpnr printing no utilisation table → **exit 1**, `*** make fit: nextpnr printed no utilisation
+  table, so NO measurement was taken. That is a failure, not a 0% fit.` This is the guard that keeps
+  a green `fit` from meaning "the tool did not run": placement *always* fails here on an IO pad
+  (231 `SB_IO` against sg48's 39, ADR-0038 decision 1a), so the exit status of nextpnr cannot be the
+  signal and the presence of the table is.
+
+**The `formal` job's steps.** Each has a demonstrated failure direction already on file rather than
+newly built here, which is the honest statement: `1961234` demonstrated both directions of the
+baseline gate on real runs; ADR-0036 measured the `btorsim`-absent ladder reporting green with ten
+`ERROR`s, which the status field now catches; ADR-0040 records deleting the rs2 write-through bypass
+as this repo's liveness probe for `reg_ch0`; ADR-0050 records `complete` red at
+`DONE (FAIL, rc=2)` before its exclusion set; `complete_cover` is itself the anti-vacuity control for
+`complete`. **What this ADR did not do is re-run all of those.** The one falsification it did run
+against the changed file is the `fit` pair above.
+
+## Consequences
+
+- **Term 6 is met**, which makes all six M2 terms met. **That is not the same as declaring M2
+  reached**, and this ADR deliberately does not: M2's own wording is *"re-proves everything the
+  serialized core proved"*, and the two standing caveats are untouched — every ladder check is
+  `mode bmc`, so PASS means no counterexample within a configured depth, and riscv-formal ships no
+  spec model at all for `ecall`/`ebreak`/`mret`/`csrr*` at the pin. Declaring the milestone is a
+  human call on evidence that is now complete rather than a consequence of this change.
+- **The term moved three times and this is the fourth reading of it, not a fourth move.** ADR-0050
+  said a fourth move should be treated as evidence the criterion describes nothing. This ADR changes
+  no criterion; it checks the one that exists, finds it unmet by one line, and fixes the line.
+- **`make cosim-suite` and `make waves` remain outside every gate**, and term 6's "every check the
+  repo owns" should be read with ADR-0050's concrete clause, which is the formal checks. The co-sim's
+  exclusion is decided (ADR-0032); `make waves` grading nothing is recorded under "what does not
+  work" in CLAUDE.md. Neither is a regression this term introduced, and neither is closed here.
+- **The `formal` job's real cost is now a number**: 4m22s of a 20-minute timeout, ~78% headroom, with
+  the ladder at 174s of it. `formal/checks.cfg`'s note that the nightly's `timeout-minutes: 300` is
+  "still the backstop" was stale in the direction that matters — the backstop is 20 minutes, and a
+  non-converging check now takes the four hand-authored tasks down with it. Corrected in place.
+- **Stale nightly references are struck where a reader would act on them** — `formal/Makefile`,
+  `formal/checks.cfg`, `formal/check-baseline.sh`, `formal/EXPECTED_FAIL`, `docs/THREAT_MODEL.md`.
+  Historical ADR text is left alone; it is history and reads as such.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -56,6 +56,7 @@ and what it costs. Reversing one is fine — write a new ADR that supersedes it.
 | [0049](0049-every-formal-assume-names-its-scope-and-its-discharge.md) | Every formal `assume` names its scope as well as its discharge | Accepted · supplements 0017 |
 | [0050](0050-the-nightly-is-deleted-and-its-checks-move-to-the-gate.md) | The formal nightly is deleted and its checks move to the PR gate | Accepted · supersedes 0022, rewrites 0037 term 6 |
 | [0051](0051-the-multiply-proof-is-decomposed-not-mitered.md) | The multiply proof is decomposed, not mitered; the signed divide path gets its first assertions | Accepted · closes 0049 F1/F5 |
+| [0052](0052-m2-term-6-is-verified-and-the-fit-ratchet-gets-a-job.md) | M2 term 6 is verified against the gate's own run, and the fit ratchet gets a job | Accepted · closes 0037 term 6 as rewritten by 0050 |
 
 0001–0007 came from the design brief
 ([`docs/ideas/finish-the-rewrite.md`](../ideas/finish-the-rewrite.md)). 0008–0011 came out of

--- a/docs/ideas/fit-the-core-on-the-up5k.md
+++ b/docs/ideas/fit-the-core-on-the-up5k.md
@@ -74,10 +74,11 @@ Four corrections to the body:
 > **4236 logic cells / 80%** at **+18.0%** suite cycles — better than the +27.8% below, because the
 > stall was gated on `uses_rs1`/`uses_rs2` after this was written.
 >
-> **The cell count is a measurement of ADR-0042's tree, not of `main`.** It is **4187 / 79%** as of
-> ADR-0052, which also put `make fit` on CI as a non-required job. Take the current number from
-> `make fit`, never from a document — the two differ by 49 cells here, which is inside the ±50
-> churn floor CLAUDE.md records, and nobody set out to save them.
+> **The cell count is a measurement of ADR-0042's tree, taken locally, and not of `main`.** It is
+> **4208 / 79%** as of ADR-0052, measured by the `fit` CI job at the pinned OSS CAD Suite — which is
+> also where it emerged that the number depends on the yosys build: the same commit gives **4187**
+> under a local Homebrew yosys. Take the current number from the `fit` job, not from a document and
+> not from a local run, and say which toolchain produced it.
 
 
 The root constraint is that an **ice40 EBR read is synchronous** while **invariant 6 requires a

--- a/docs/ideas/fit-the-core-on-the-up5k.md
+++ b/docs/ideas/fit-the-core-on-the-up5k.md
@@ -73,6 +73,11 @@ Four corrections to the body:
 > change was accepted, `hang` and `liveness_ch0` went green with it, and the shipping numbers are
 > **4236 logic cells / 80%** at **+18.0%** suite cycles — better than the +27.8% below, because the
 > stall was gated on `uses_rs1`/`uses_rs2` after this was written.
+>
+> **The cell count is a measurement of ADR-0042's tree, not of `main`.** It is **4187 / 79%** as of
+> ADR-0052, which also put `make fit` on CI as a non-required job. Take the current number from
+> `make fit`, never from a document — the two differ by 49 cells here, which is inside the ±50
+> churn floor CLAUDE.md records, and nobody set out to save them.
 
 
 The root constraint is that an **ice40 EBR read is synchronous** while **invariant 6 requires a

--- a/formal/EXPECTED_FAIL
+++ b/formal/EXPECTED_FAIL
@@ -53,7 +53,7 @@
 # counterexamples correctly; `sby` could not render the traces, because that step
 # shells out to `btorsim`. A real counterexample and a missing trace renderer
 # were the same result to this file. The inverse is the case that matters: if
-# `btorsim` left the nightly's pinned OSS CAD Suite, every red check would flip
+# `btorsim` left CI's pinned OSS CAD Suite, every red check would flip
 # FAIL → ERROR, the set equality would still match, and the ladder would stay
 # green having stopped distinguishing a proof failure from a tooling failure.
 #

--- a/formal/Makefile
+++ b/formal/Makefile
@@ -70,8 +70,9 @@ check: checks $(RISCV_FORMAL_DIR)
 # (which checks exist) and EXPECTED_FAIL (which of them are red). Split out
 # as its own target so a ladder that has already run can be re-graded in a
 # second without re-running it, and so a local `make check` is gated by the
-# same script the nightly grades with rather than by sby's suppressed exit
-# code (ADR-0022, ADR-0033).
+# same script CI grades with rather than by sby's suppressed exit code
+# (ADR-0022, ADR-0033). That script is reached from `.github/workflows/ci.yml`'s
+# `formal` job, which is required; there is no nightly (ADR-0050).
 .PHONY: check-baseline
 check-baseline: check-baseline.sh EXPECTED_FAIL EXPECTED_CHECKS
 	./check-baseline.sh checks EXPECTED_FAIL EXPECTED_CHECKS

--- a/formal/check-baseline.sh
+++ b/formal/check-baseline.sh
@@ -18,8 +18,8 @@
 # counterexamples; `sby` then failed to render the traces, because the step
 # that does so shells out to `btorsim`. "A real counterexample at the
 # configured depth" and "the trace renderer is missing" were the same result.
-# The failure mode that matters is the inverse: if `btorsim` vanished from the
-# nightly's pinned OSS CAD Suite, every red check would flip FAIL -> ERROR,
+# The failure mode that matters is the inverse: if `btorsim` vanished from CI's
+# pinned OSS CAD Suite, every red check would flip FAIL -> ERROR,
 # the set equality would still match, and the ladder would stay green having
 # stopped distinguishing a proof failure from a tooling failure. Same shape as
 # ADR-0033's gaps -- a check that can stop checking without anything going red

--- a/formal/checks.cfg
+++ b/formal/checks.cfg
@@ -311,11 +311,16 @@ mscratch any
 # re-vendoring from the pin (ADR-0013 -- the pin is current; it was the fork
 # that was stale) dropped it. That is deliberate and the column is gone:
 # ADR-0022 added the bound because `reg_ch0` under `smtbmc yices` would sit
-# in the solver until the nightly's `timeout-minutes: 300` killed the *whole
-# job*, and ADR-0024 then replaced that engine with `btor btormc`, under
-# which the same check at the same depth converges in ~8-12s. The condition
-# the bound existed for no longer holds. The nightly's own job-level
-# `timeout-minutes` is still the backstop; if a check ever needs a real
+# in the solver until the then-nightly's `timeout-minutes: 300` killed the
+# *whole job*, and ADR-0024 then replaced that engine with `btor btormc`,
+# under which the same check at the same depth converges in ~8-12s. The
+# condition the bound existed for no longer holds. THE BACKSTOP IS NOW MUCH
+# TIGHTER AND IS WORTH KNOWING BEFORE RAISING A DEPTH: there is no nightly
+# (ADR-0050), and the ladder's only job-level bound is the required `formal`
+# job's `timeout-minutes: 20` in `.github/workflows/ci.yml` -- against a
+# whole-job measurement of 4m22s. A non-converging check burns the whole
+# remaining budget and takes the four hand-authored tasks down with it. If a
+# check ever needs a real
 # per-check bound again, sby's `[options] timeout` is the place, and getting
 # genchecks to emit it means forking genchecks again -- which is the cost
 # this re-vendor was paying down, so weigh it accordingly.


### PR DESCRIPTION
Closes JEF-707.

Term 6 — *"every check the repo owns is on a gate that can fail, and that gate is green"* (ADR-0050) — had never been checked against merged `main`. Checking it found it **unmet by one line**, and putting `make fit` on CI turned up a second thing nobody had measured.

## Finding 1 — the `formal` job carried a `continue-on-error`

On the step that generates and runs the entire ladder, which is the one thing ADR-0050's own wording rules out by name (*"with no `continue-on-error` anywhere in it"*).

It survived on the comment's argument that the step's exit status *"is not the signal and never was"*. That is false: `formal/Makefile`'s `check` target puts a leading `-` on the sby sub-make and then **ends in `check-baseline`**, so the command's exit status already *is* the graded comparison's — byte for byte the same verdict the next step recomputes. What the suppression actually bought was that generation aborting, `genchecks-audit.py` dying, or the disk filling reached the step summary as a **green step**. Never unsound (the gate step below resolves to exit 2 on "no `*.sby` files"), but exactly the shape ADR-0047 and ADR-0050 retired elsewhere, left in the one job those ADRs were about.

`grep -c continue-on-error .github/workflows/*.yml` is now **0 in every file** — the five remaining occurrences in `ci.yml` are prose in comments, none as a YAML key.

## Finding 2 — the area number depends on the yosys build

Adding the `fit` job produced **4208** cells where the local run gave **4187**. Same commit, same RTL, no `rtl/` change anywhere in this PR.

| toolchain | logic cells |
|---|---|
| CI's pinned OSS CAD Suite, Yosys 0.66+179 (`e74db6dea`) — **the `fit` job** | **4208 / 5280, 79%** |
| local Homebrew Yosys 0.67+post (`b8e7da6f4`) | 4187 |
| quoted in this repo since ADR-0042 (also local) | 4236 |

Every area figure this repo had on file was a local one, so the 4236 → 4187 drift the ticket flagged is **partly two toolchains being compared**, not cells being saved. CLAUDE.md's ±50 churn floor was measured across *edits that synthesise to identical hardware*; this is a second axis, 21 cells across *builds*. `FIT_MAX_LC` at 4400 clears both and does not move. Corrected with provenance in `CLAUDE.md`, the `Makefile`, `ci.yml`, the fit brief and ADR-0052 — **quote the `fit` job's number and say which toolchain took it.**

This was only findable by running it. Re-measuring locally, which is what the ticket asked for, would have recorded a third local number.

## Acceptance criteria

### 1. The `formal` job green on merged main, per step

`main` @ `d2e736e`, run [30724575535](https://github.com/thejefflarson/little-cpu/actions/runs/30724575535/job/91433786477) — recorded individually, not inferred — and **re-run against the changed job** on this PR ([30725019570](https://github.com/thejefflarson/little-cpu/actions/runs/30725019570/job/91434954475)), where the three memory checks are separate steps:

| step | main @ `d2e736e` | this PR |
|---|---|---|
| Set up OSS CAD Suite | success · 18s | success · 10s |
| Confirm the BMC toolchain is complete | success · <1s | success · <1s |
| Generate and run the ladder | success · 174s | success · **217s** |
| Gate on `EXPECTED_FAIL` + `EXPECTED_CHECKS` | success · 1s | success · 0s |
| `imemcheck` | success | success · 21s |
| `dmemcheck` | (same step, 31s total) | success · 16s |
| `cover` | | success · 5s |
| `complete` (depth-50 whole-ISA walk) | success · 19s | success · 25s |
| `complete_cover` (anti-vacuity) | success · 13s | success · 17s |
| **job** | **success · 4m22s** | **success · 5m15s** |

The three memory checks shared one step on main, which is why this PR **splits them**: `make` stops at the first failure, so a red `imemcheck` leaves `dmemcheck` and `cover` **unrun** behind a single red step. The step list is the per-check record now. The 4m22s / 5m15s spread across two runs of the same ladder is solver and runner variance, not a change in the work.

### 2. Both set equalities, both directions, at 85 checks — on the gate's own run

Both runs, and twice per run (the ladder step's own `check-baseline`, then the gate step re-grading from disk):

```
85 checks: 85 pass, 0 fail
Failure list matches formal/EXPECTED_FAIL exactly (name and status).
Generated check set matches formal/EXPECTED_CHECKS exactly (85 checks).
```

`formal/EXPECTED_CHECKS` is 85 names; `formal/EXPECTED_FAIL` is 0 entries.

### 3. No `continue-on-error`; no graded command in a pipeline

```
$ grep -rnE '^[[:space:]]*(make|\./|[a-zA-Z0-9_/.-]+\.(sh|py))[^#]*\|' .github/workflows/
rc=1  (no matches)

$ grep -rnE '^[[:space:]]*continue-on-error' .github/workflows/
rc=1  (no matches)
```

Checked against the tree, all three workflow files. Every other pipe in `.github/workflows/` is a `run: |` block scalar or a `$(... | head -1)` inside an `echo` — with **one** real exception: `elaborate`'s `yosys ... 2>&1 | tee /tmp/yosys-elaborate.log` (ci.yml:84). That `run:` block opens with an explicit `set -euo pipefail`, which is ADR-0037's documented remedy rather than an instance of the defect. `soundcheck.yml` has no `run:` blocks at all.

### 4. Wall time against the timeout

**4m22s (main) / 5m15s (this PR) against `timeout-minutes: 20`** — ~74% headroom at the slower figure, the ladder 217s of it. `complete` + `complete_cover` are 42s together and `imemcheck`/`dmemcheck`/`cover` 42s; both were flagged as most likely to surprise on cost, and neither did.

### 5. `make fit` disposition — **a job, non-required**

It has been a declared ratchet since ADR-0042 with `grep -rn fit .github/workflows/` returning two prose matches about runner memory and no invocation. It runs on every PR now: **1m38s, green, `RATCHET: 4208 of 4400 cells budgeted -- OK`.**

**Non-required is the decision, not an oversight.** Area is a design constraint, not a correctness one — a change that grows the core past its budget should be loud on the PR and be a conversation, not an automatic block. Branch protection is untouched (`enforce_admins: true`, ADR-0036); `fit` and `nonperturbation` are now the two non-required jobs of eight.

### 6. Stale nightly references

Struck where a reader would act on them: `formal/Makefile`, `formal/check-baseline.sh`, `formal/EXPECTED_FAIL`, `docs/THREAT_MODEL.md`, and the loudest one — `formal/checks.cfg` claiming *"The nightly's own job-level `timeout-minutes` is still the backstop"*. **It is 20 minutes now, not 300**, which matters before anyone raises a depth. Historical ADR text left alone.

## What these jobs would fail on

CLAUDE.md's rule. For `fit`, two probes, both **run**:

- `make fit FIT_MAX_LC=4100` → **exit 2**, `4187 logic cells is over the 4100-cell budget`
- nextpnr printing no utilisation table → **exit 1**, `NO measurement was taken. That is a failure, not a 0% fit` — the guard that matters, because placement *always* fails here on an IO pad (231 `SB_IO` vs sg48's 39), so nextpnr's exit status cannot be the signal and the presence of the table is

**Stated plainly: I did not re-run a falsification against each `formal` step.** Each has a demonstrated failure direction already on file — `1961234` (both directions of the baseline gate), ADR-0036 (the `btorsim`-absent ladder reporting green with ten `ERROR`s), ADR-0040 (deleting the rs2 write-through bypass as the `reg_ch0` liveness probe), ADR-0050 (`complete` red at `DONE (FAIL, rc=2)`) — and `complete_cover` is itself `complete`'s anti-vacuity control. The falsifications run against files this PR changes are the `fit` pair.

## Gates

Local, on this branch:

| gate | result |
|---|---|
| `make test` | **56/56**, `EXPECTED_FAIL` matches exactly, exit 0 |
| `make test-units` | 6 benches, matching `test/*_tb.v` exactly, all PASSED |
| `make lint` | svlint clean in both passes |
| `make -C formal check` | **85 checks: 85 pass, 0 fail**, both set equalities, 6m41s @ `JOBS=6` |
| `make -C formal complete` | `DONE (PASS, rc=0)` |
| `make -C formal complete_cover` | `DONE (PASS, rc=0)` |
| `make fit` | 4187 / 5280 (79%) local, `RATCHET ... OK` |
| `make -C formal checks` (regen after the `checks.cfg` comment edit) | 85 generated, 14 declined, both shape equalities exact |

CI, run 30725019570: elaborate 2m21s · test 3m36s · components 3m38s · lint 18s · **fit 1m38s** · nonperturbation 2m37s · monitor-freshness 20s · **formal 5m15s** — all pass.

## DECISION NEEDED — for a human, not this PR

**Term 6 met makes all six M2 terms met.** This PR deliberately does **not** declare M2 reached, and ADR-0052 says why: M2's own wording is *"re-proves everything the serialized core proved"*, and the two standing caveats are untouched — every ladder check is `mode bmc` (no counterexample within a configured depth, not a proof), and riscv-formal ships no spec model at all for `ecall`/`ebreak`/`mret`/`csrr*` at the pin. Declaring the milestone, and M4's release tag behind it, is a call on evidence that is now complete rather than a consequence of this change.

Two smaller ones, both recommendations only:

- **`nonperturbation` and `fit` are non-required.** `fit` should stay that way on the reasoning above. `nonperturbation` is a correctness check and arguably should be promoted — a repository-settings change no PR may make.
- **Term 6's "every check the repo owns" is read with ADR-0050's concrete clause**, i.e. the formal checks. `make cosim-suite` (off every gate by ADR-0032) and `make waves` (grades nothing; `testbench.vvp` is elaborated by CI and executed by nothing) sit outside it. Neither is a regression this term introduced; both stay recorded under "what does not work".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJ77ZZJ6pDiL3vj3Qw9hKs