### PR TITLE
JEF-695: audit the grading scripts, and give every graded comparison a probe of its own red direction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,6 +182,23 @@ the same treatment: the six bench invocations were spelled out with nothing tyin
 compared against the tree in both directions **and drives the recipe**, so a declared bench with no
 `UNIT_BENCH_SRC_*` is red too rather than building with no design under test.
 
+**Every graded comparison in the grading layer now has a probe of its own red direction, and two of
+them had never been executed** (ADR-0053). Five of this repo's recorded defects were in that layer
+and every one was in a *script*; the class is the comparison whose failure path was never run, and
+reading the script is what missed all five. `test/probe_gates.sh` forces **108** of them to fail and
+requires each to fail *for the reason it was written for* — exit status **and** a fragment of the
+diagnostic, with a control per group that must exit 0, so a grader degenerated into `exit 1` cannot
+pass. It is hermetic (no toolchain, no Sail, no yosys, no sby — the failing `objcopy`, the
+unstartable runner and the diverging reference model are stubs) and hangs off `make test`, which
+puts it in CI's required `test` job with no workflow change. Two findings came out of it, both
+fixed with the red demonstrated: **`formal/check-baseline.sh` read an *unreadable* baseline as an
+empty one** — `chmod 000 formal/EXPECTED_FAIL` printed "Failure list matches ... exactly" and exited
+0, swallowing an unexpected pass as well (ADR-0035 item 4's fix, never carried to the formal side);
+and **`test/cxxrtl.cc`'s exit 5 was unreachable in its own scenario** — traps commit in decode while
+retires happen in writeback, so a fault in the first instructions of `_start` raised `trap_to_zero`
+with `RETIRES 0` and the silence gate turned it into `MONITOR-SILENT`, which is exactly the
+misattribution ADR-0029 added `TRAP-TO-ZERO` to prevent.
+
 **M3 opens: `rtl/csrs.v` lands the CSR file and the Zicsr access path.** ADR-0005's set, exactly —
 RW `mstatus` (MIE/MPIE, MPP WARL→`2'b11`), `mtvec` (direct mode, 4-byte-aligned base, resets to 0
 per ADR-0029), `mepc` (bit 0 only, because C makes 2-byte targets legal), `mcause`, `mscratch`,
@@ -658,7 +675,13 @@ make test           # assemble test/asm/*.S, run under cxxrtl, pass/fail table w
                     # test/EXPECTED_FAIL (set equality) and test/OBSERVED_FLOOR (>=).
                     # OBSERVED_FLOOR's NAME set is also the suite manifest, checked
                     # both ways before a single program is assembled -- so a suite
-                    # that SHRANK is red, not a smaller table that still "passes"
+                    # that SHRANK is red, not a smaller table that still "passes".
+                    # Also runs `make probe-gates` (ADR-0053).
+make probe-gates    # forces all 108 graded comparisons in the grading scripts to
+                    # FAIL and requires each to fail for its own reason. Hermetic
+                    # (stubs, no toolchain); a prerequisite of `test` on purpose,
+                    # so it is in CI's required job. All fork, no work: ~68-90s of
+                    # wall for ~4s of user time, and that ratio is the host's
 make waves          # iverilog + VCD (testbench.vvp's baked-in program) -> waves.vcd.
                     # GRADES NOTHING: the per-retire monitor is live but only
                     # $displays, so this exits 0 on a mismatch. Read the output.
@@ -990,8 +1013,8 @@ longer quietly widen.
   rejected the shifter merge at 19 cells *saved* on legibility grounds, and accepting a hygiene
   change at 37 cells *spent* would cut against that ruling. Read this before proposing the
   narrowing again — it is measured and declined, not overlooked.
-- Decisions: [`docs/adr/`](docs/adr/) — **fifty-two ADRs, fifty-one of them accepted**, plus a
-  deferred list. Re-derived by counting: `ls docs/adr/*.md | wc -l` is 53, one of which is
+- Decisions: [`docs/adr/`](docs/adr/) — **fifty-three ADRs, fifty-two of them accepted**, plus a
+  deferred list. Re-derived by counting: `ls docs/adr/*.md | wc -l` is 54, one of which is
   `README.md`, and the status column in that README carries exactly one non-accepted entry
   (ADR-0016, superseded by ADR-0018). This line has now been behind twice — it said "forty-five
   accepted" and then "forty-seven" — so **re-derive it with the two commands rather than

--- a/Makefile
+++ b/Makefile
@@ -565,13 +565,32 @@ test-units: check-unit-benches test/monitor.sim.v
 	  vvp $$tmp/$(b).vvp; ) \
 	true
 
+# THE GRADING LAYER'S OWN RED DIRECTION. Every graded comparison in the two
+# suite runners, the manifest check, the co-simulation comparison, the monitor
+# sanitizer and the two formal gates is forced to FAIL here, and required to
+# fail for the reason it was written for. Five of this repo's recorded defects
+# lived in that layer and every one was in a script (ADR-0037 §4, ADR-0040,
+# ADR-0033 gap 1, and the sanitizer's rule 3); the class is the comparison
+# whose failure path was never executed.
+#
+# It is a prerequisite of `test` rather than a target of its own on purpose.
+# A gate reached by no automation reads like coverage and is not — CLAUDE.md
+# records `make waves` and `make -C formal all` as exactly that — and hanging
+# it off `test` puts it in CI's required job with no workflow change and no
+# branch-protection change (ADR-0036 makes the latter a human action anyway).
+# It needs no RISC-V toolchain, no Sail, no yosys and no sby, so it cannot
+# narrow where `make test` runs.
+.PHONY: probe-gates
+probe-gates:
+	@./test/probe_gates.sh
+
 # Assembles every test/asm/*.S (rv32im_zicsr, -nostdlib, ADR-0008's memory
 # map), runs each under `sim`, and checks the pass/fail table against
 # test/EXPECTED_FAIL — the sprint-1 baseline. Exits 0 only when the actual
 # failure list matches that file exactly, so this is a working regression
 # gate today, against the current (still-broken, see CLAUDE.md) core.
 .PHONY: test
-test: sim test-units
+test: sim test-units probe-gates
 	@./test/run_tests.sh ./sim test/asm test/EXPECTED_FAIL test/OBSERVED_FLOOR
 
 # ---------------------------------------------------------------------------

--- a/docs/adr/0053-every-graded-comparison-carries-a-probe-of-its-red-direction.md
+++ b/docs/adr/0053-every-graded-comparison-carries-a-probe-of-its-red-direction.md
@@ -126,8 +126,11 @@ is worse than no guard:
 
 - **`test/cxxrtl.cc` exit 4** (a live RVFI monitor mismatch) needs the elaborated design.
   Demonstrated by hand instead: `test/testbench.v`'s monitor hookup mutated to
-  `.rvfi_rd_wdata(rvfi_rd_wdata ^ 32'd1)`, rebuilt, `add.S` reported `RVFI monitor error` and
-  exited 4. Reverted.
+  `.rvfi_rd_wdata(rvfi_rd_wdata ^ 32'd1)`, rebuilt, `add.S` reported
+  `RVFI monitor error 105 at cycle 5` — "mismatch in rd_wdata" — and exited 4. Reverted.
+  **Do not run two `make sim` builds concurrently while doing this**: the first attempt was
+  contradicted by a second, unmutated build racing it to the same output, and read as the mutation
+  not firing.
 - **`formal/genchecks-audit.py`'s two self-validation cross-checks** — the traced names against
   `genchecks`' own `consistency_checks`/`instruction_checks` sets, and the traced names against
   `checks/*.sby` on disk. Both would need `formal/genchecks-local.py` to behave differently from

--- a/docs/adr/0053-every-graded-comparison-carries-a-probe-of-its-red-direction.md
+++ b/docs/adr/0053-every-graded-comparison-carries-a-probe-of-its-red-direction.md
@@ -1,0 +1,165 @@
+# ADR-0053: Every graded comparison carries an executable probe of its own red direction
+
+**Status:** Accepted · 2026-08-01 · *Extends ADR-0035 (the merge gate's false-green audit) and
+ADR-0033 (a check that can stop checking without anything going red) to the whole grading layer.
+Applies ADR-0037 §4's rule about pipelines. Records one false green found in
+`formal/check-baseline.sh` and one unreachable failure path found in `test/cxxrtl.cc`.*
+
+## Context
+
+Five of this repository's recorded defects live in the layer that decides what "green" means, and
+**every one of them was in a script**:
+
+1. the graded comparison piped into `tee`, so a `run:` block's errexit — which is not pipefail —
+   took `tee`'s status and the gate could not go red. ADR-0022's central guarantee had therefore
+   never held (ADR-0037 §4);
+2. `make -C formal check` re-grading the previous run, because its `checks` target named a
+   directory whose mtime `sby` bumps (ADR-0040);
+3. `formal/check-baseline.sh` globbing the run directories `sby` creates only for checks it
+   started, so a never-scheduled check fell out of the results and out of the baseline at once and
+   set equality called that a match (ADR-0033 gap 1);
+4. `test/sanitize_monitor.py`'s rule 3, whose site count proved a rule *fired* but not what it
+   *swallowed* — mutation showed the pre-change script accepting every attack at exit 0;
+5. `formal/check-baseline.sh` computing a verdict and discarding it.
+
+The class is **the comparison whose failure path was never executed**. Each of the five was green,
+in CI, for weeks or months, while checking less than it claimed. In every case the reasoning
+written at the site was *correct*; what was missing was that nobody had ever made the comparison
+fail. Reading the script is what missed all five.
+
+Three questions were put to every graded comparison in `test/run_tests.sh`, `test/run_cosim.sh`,
+`test/cosim.py`, `test/cosim.cc`, `test/cxxrtl.cc`, `test/check_suite_shape.sh`,
+`formal/check-baseline.sh`, `formal/check-complete-exclusions.py` and
+`formal/genchecks-audit.py`:
+
+1. does every failure reach the process exit status?
+2. is any graded command inside a pipeline?
+3. **has the failure path ever been executed?**
+
+Questions 1 and 2 came back clean. Every pipeline in those scripts feeds a `$(...)` whose *value*
+is then compared; the comparison itself is never a pipeline. Both workflows keep the graded command
+off a pipe with the reasoning written at the site, and the one `| tee` in `.github/workflows/ci.yml`
+(the `elaborate` job's yosys invocation) sits under an explicit `set -euo pipefail` and is not the
+graded command — the `grep` on the next line is.
+
+Question 3 is where the work was, and it produced two findings.
+
+## Decision
+
+### 1. `test/probe_gates.sh` — 108 probes, and it runs
+
+Every graded comparison that can be driven without the elaborated design is **forced to fail**, and
+required to fail *for the reason it was written for*. A probe pins the exit **status** and a
+distinguishing fragment of the **diagnostic**. The second half is not decoration: a script that
+exited 1 because a fixture path was mistyped would satisfy every exit-status-only probe in the file
+while demonstrating nothing.
+
+**Every group carries a control** — the same fixtures, unmutated, required to exit 0. Without one, a
+grader that had degenerated into `exit 1` would pass every probe. That is this file's own
+anti-vacuity argument and it is the same one `formal/complete_cover.sby` makes for `complete`.
+
+The file is **hermetic**: no RISC-V toolchain, no `sim`, no Sail, no yosys, no `sby`. The failing
+`objcopy`, the `objcopy` that exits 0 having written nothing, the unstartable runner, the missing
+cross compiler, the reference model that diverges and the one that produces no trace are all stubs
+on a scratch `PATH`. That is what lets it hang off `make test` without narrowing where `make test`
+runs.
+
+**It is a prerequisite of `make test` rather than a target of its own.** A gate reached by no
+automation reads like coverage and is not — `CLAUDE.md` records `make waves` and
+`make -C formal all` as exactly that — and hanging it off `test` puts it inside CI's required
+`test` job with no workflow change and no branch-protection change, the latter being a human action
+(ADR-0036).
+
+The probe count is pinned as a literal, for the reason `test/exec_tb.v` pins its vector count: a
+deleted probe would otherwise shrink this file's coverage while it kept printing a green summary.
+
+### 2. `formal/check-baseline.sh` accepted an unreadable baseline as an empty one. Fixed.
+
+The script sets `set -u` and neither `-e` nor `pipefail`, and it checked its two baseline files for
+existence (`-f`) but not readability (`-r`). A `sed` that cannot open its input writes to stderr and
+yields the **empty string**, and an empty expected set against an all-passing ladder matches
+exactly. Measured before the fix:
+
+```
+$ chmod 000 EF && formal/check-baseline.sh $D/checks $D/EF $D/EC
+sed: .../EF: Permission denied
+1 checks: 1 pass, 0 fail
+Failure list matches .../EF exactly (name and status).
+exit=0
+```
+
+— with `alpha FAIL` in that baseline and `alpha` passing on disk, so it also swallowed an
+**unexpected pass**, which ADR-0014's contract exists to catch. After the fix the same command
+exits 2 naming the file. This is ADR-0035 item 4's fix, made on `test/run_tests.sh`'s baseline and
+never carried across to the formal side; `test/run_cosim.sh` and `test/check_suite_shape.sh` both
+already check `-r`.
+
+### 3. `test/cxxrtl.cc`'s exit 5 was unreachable in the scenario it was written for. Fixed.
+
+`finish()` routes the run's verdict through the observation counters, so a run with zero retires
+returns 6 (`MONITOR-SILENT`) whatever else happened. Exit 4 was already exempted, on the argument
+that a monitor errcode is *direct evidence the monitor fired* rather than a verdict the program
+reached. **The identical argument applies to exit 5** and was not made: `trap_to_zero` is a direct
+observation of the machine that owes nothing to the monitor.
+
+It is not hypothetical. Traps are detected and committed in **decode** (invariant 2) while a retire
+happens in writeback, so a fault in the first few instructions of `_start` raises `trap_to_zero`
+several cycles before anything has retired. Measured:
+
+| program | before | after |
+|---|---|---|
+| `ecall` as the second instruction of `_start` | exit **6**, `RETIRES 0` | exit **5** |
+| the same `ecall` after six retiring instructions | exit 5, `RETIRES 6` | exit 5 |
+
+`test/run_tests.sh` labels the first case `MONITOR-SILENT` — pointing at the monitor, for a program
+that faulted before installing `mtvec`, which is precisely the misattribution ADR-0029 added the
+`TRAP-TO-ZERO` label to prevent. A named failure path that is unreachable in its own scenario is
+this repo's grading-layer defect one level down.
+
+The silence gate is not weakened in any direction that matters: both outcomes are red either way,
+and the change only decides which of two red labels a reader gets.
+
+## What is NOT probed, and why
+
+Named rather than left to be discovered, per ADR-0033's rule that a guard which is named but absent
+is worse than no guard:
+
+- **`test/cxxrtl.cc` exit 4** (a live RVFI monitor mismatch) needs the elaborated design.
+  Demonstrated by hand instead: `test/testbench.v`'s monitor hookup mutated to
+  `.rvfi_rd_wdata(rvfi_rd_wdata ^ 32'd1)`, rebuilt, `add.S` reported `RVFI monitor error` and
+  exited 4. Reverted.
+- **`formal/genchecks-audit.py`'s two self-validation cross-checks** — the traced names against
+  `genchecks`' own `consistency_checks`/`instruction_checks` sets, and the traced names against
+  `checks/*.sby` on disk. Both would need `formal/genchecks-local.py` to behave differently from
+  the pin, and ADR-0031 holds that file byte-comparable with the clone. Placing a stray `.sby` in
+  `checks/` does not reach the disk cross-check either, because `genchecks` recreates the directory
+  on every run — measured. Its other two set equalities *were* demonstrated by hand (below).
+- **`test/cosim.cc`'s `regs_a` / `regs_b` divergence check** needs an `rtl/regfile.v` mutation.
+  Recorded as a finding rather than demonstrated here.
+- **`formal/genchecks-audit.py`'s "traced no `get_depth_cfg` calls" guard**, for the same
+  ADR-0031 reason.
+
+Demonstrated by hand, with the commands recorded in the pull request: `genchecks-audit.py`'s
+`EXPECTED_CHECKS` set equality (delete `insn_add_ch0` from the file → `in EXPECTED_CHECKS but not
+generated`), its `#omit` set equality and the lost-`[depth]`-line case together (delete
+`checks.cfg`'s `hang` line → both mismatches at once, 84 generated / 15 declined), and
+`test/cxxrtl.cc`'s exits 0, 1, 2, 3, 5 and 6 against the real runner.
+
+## Consequences
+
+- `make test` gains a step that can fail for a reason unrelated to the core, exactly as
+  `check-unit-benches` already can. It is **all fork and no work**, so its wall time is a property
+  of the host: ~1500 `exec()`s, about 4s of user time, and 90s of wall on the laptop it was written
+  on, which takes ~27ms to `exec` `/bin/echo`. Do not shrink it by deleting probes without first
+  measuring whether the host is the reason.
+- A grader's **diagnostic text is now part of its contract**. Rewording an error message breaks a
+  probe, deliberately: the message is how a probe knows which comparison went red, and this repo
+  has twice been bitten by a comparison that failed for the wrong reason.
+- `formal/EXPECTED_FAIL` and `formal/EXPECTED_CHECKS` must now be readable, not merely present.
+- One asymmetry is left in place on purpose: `test/run_tests.sh` iterates `"$ASM_DIR"/*.S` with no
+  `nullglob`, where `test/run_cosim.sh` has both `nullglob` and an emptiness guard. The unglobbed
+  literal fails `ASSEMBLE-ERROR`, so it fails **red** — and since ADR-0033's manifest check now runs
+  before the loop, an empty or missing `test/asm` is rejected before the glob is ever evaluated.
+  Both facts are probed; neither is worth a change.
+- This does not make any gate *correct*, only harder to fool. Every caveat in ADR-0023 and
+  ADR-0037 stands untouched, and nothing here changes `rtl/`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -57,6 +57,7 @@ and what it costs. Reversing one is fine — write a new ADR that supersedes it.
 | [0050](0050-the-nightly-is-deleted-and-its-checks-move-to-the-gate.md) | The formal nightly is deleted and its checks move to the PR gate | Accepted · supersedes 0022, rewrites 0037 term 6 |
 | [0051](0051-the-multiply-proof-is-decomposed-not-mitered.md) | The multiply proof is decomposed, not mitered; the signed divide path gets its first assertions | Accepted · closes 0049 F1/F5 |
 | [0052](0052-m2-term-6-is-verified-and-the-fit-ratchet-gets-a-job.md) | M2 term 6 is verified against the gate's own run, and the fit ratchet gets a job | Accepted · closes 0037 term 6 as rewritten by 0050 |
+| [0053](0053-every-graded-comparison-carries-a-probe-of-its-red-direction.md) | Every graded comparison carries an executable probe of its own red direction | Accepted · extends 0035, 0033 |
 
 0001–0007 came from the design brief
 ([`docs/ideas/finish-the-rewrite.md`](../ideas/finish-the-rewrite.md)). 0008–0011 came out of

--- a/formal/check-baseline.sh
+++ b/formal/check-baseline.sh
@@ -66,9 +66,23 @@ CHECKS_DIR=$1
 EXPECTED_FAIL=$2
 EXPECTED_CHECKS=${3:-$(dirname "$0")/EXPECTED_CHECKS}
 
+# READABLE, not merely present. This script sets `set -u` and neither `-e` nor
+# `pipefail`, so a `sed` that cannot open its input writes to stderr and yields
+# an EMPTY string, and an empty expected set against an all-passing ladder
+# prints "Failure list matches ... exactly" and exits 0 -- having compared
+# nothing, and having silently dropped whatever the baseline named. Measured
+# with `chmod 000 formal/EXPECTED_FAIL`; see the probe in test/probe_gates.sh.
+# ADR-0035 item 4 made exactly this fix on test/run_tests.sh's baseline and it
+# was never carried across to the formal side.
 for f in "$EXPECTED_FAIL" "$EXPECTED_CHECKS"; do
   if [ ! -f "$f" ]; then
     echo "error: no such file: $f" >&2
+    exit 2
+  fi
+  if [ ! -r "$f" ]; then
+    echo "error: $f exists but is not readable." >&2
+    echo "An unreadable baseline reads as an EMPTY one here, which matches an" >&2
+    echo "all-passing ladder exactly and exits 0. Refusing to grade." >&2
     exit 2
   fi
 done

--- a/test/cxxrtl.cc
+++ b/test/cxxrtl.cc
@@ -246,9 +246,24 @@ int main(int argc, char **argv) {
   // Silence outranks the run's own verdict. A run whose oracle never fired has
   // no verdict worth reporting: `tohost` saying PASS is exactly what a blind
   // monitor looks like, and a FAIL from such a run cannot be attributed either.
-  // Exit 4 is the one exception and does NOT come through here — an errcode is
-  // direct evidence that the monitor fired, which is stronger and more specific
-  // than any count.
+  //
+  // Exits 4 and 5 are the two exceptions and do NOT come through here. Neither
+  // is a verdict the PROGRAM reached: an errcode is direct evidence that the
+  // monitor fired, and trap-to-zero is a direct observation of the machine that
+  // owes nothing to the monitor. Routing either through the silence gate would
+  // replace a specific diagnosis with "the oracle was blind".
+  //
+  // For exit 5 that is not hypothetical, it is the ADR-0029 case itself. Traps
+  // are detected and committed in DECODE (invariant 2) while a retire happens
+  // in writeback, so a fault in the first few instructions of `_start` raises
+  // trap_to_zero several cycles before anything has retired. Measured: `ecall`
+  // as the second instruction gives `RETIRES 0` and used to return 6, which
+  // test/run_tests.sh labels MONITOR-SILENT — pointing at the monitor for a
+  // program that faulted before installing `mtvec`, which is precisely the
+  // misattribution ADR-0029 added the TRAP-TO-ZERO label to prevent. The same
+  // `ecall` after six retiring instructions returned 5. A named failure path
+  // that is unreachable in its own scenario is the defect this repo keeps
+  // finding in its grading layer, one level down.
   auto finish = [&](int code) {
     report_counts();
     uint32_t r = retires->curr[0];
@@ -307,7 +322,8 @@ int main(int argc, char **argv) {
                     "never installed and the program has restarted at _start "
                     "(ADR-0029)\n",
                     cycle);
-      return finish(5);
+      report_counts();
+      return 5;
     }
 
     uint32_t tohost = ram_data[tohost_index];

--- a/test/probe_gates.sh
+++ b/test/probe_gates.sh
@@ -1,0 +1,957 @@
+#!/bin/bash
+# Forces every graded comparison in this repo's grading scripts to FAIL, and
+# asserts that each one goes red for the reason it was written for.
+#
+# Usage: probe_gates.sh          # run every probe; exit 0 only if all pass
+#
+# WHY THIS EXISTS. Five of this repo's recorded defects live in the layer that
+# decides what "green" means, and every one of them was in a script:
+#
+#   * the graded comparison piped into `tee`, so a `run:` block's errexit
+#     (which is not pipefail) took `tee`'s status and the gate could not go red
+#     -- ADR-0022's central guarantee had never held (ADR-0037 §4);
+#   * `make -C formal check` re-grading the PREVIOUS run, because its `checks`
+#     target named a directory whose mtime sby bumps (ADR-0040);
+#   * `formal/check-baseline.sh` globbing run directories, so a check that was
+#     never scheduled fell out of the results and out of the baseline at once
+#     and set equality called that a match (ADR-0033 gap 1);
+#   * `test/sanitize_monitor.py`'s rule 3, whose site count proved a rule fired
+#     but not what it swallowed -- mutation showed the pre-change script
+#     accepting every attack at exit 0;
+#   * `check-baseline.sh` computing a verdict and discarding it.
+#
+# The class is THE COMPARISON WHOSE FAILURE PATH WAS NEVER EXECUTED. Each of
+# those five was green, in CI, for months, while checking less than it claimed
+# -- and in every case the reasoning at the site was sound. Reading the script
+# is what missed them. So this file does not read: it breaks the thing each
+# comparison guards and requires the red.
+#
+# WHAT A PROBE ASSERTS, and why the second half is not optional. A probe pins
+# the exit STATUS and a distinguishing fragment of the DIAGNOSTIC. Status alone
+# is nearly worthless here: a script that exited 1 because a fixture path was
+# mistyped would satisfy every exit-status probe in this file while
+# demonstrating nothing. The text is what ties the red to the comparison it is
+# supposed to be about.
+#
+# EVERY GROUP CARRIES A CONTROL -- the same fixtures, unmutated, required to
+# exit 0. Without one, a grader that had degenerated into `exit 1` would pass
+# every probe here. That is this file's own anti-vacuity check and it is the
+# same argument formal/complete_cover.sby makes for `complete`.
+#
+# HERMETIC ON PURPOSE. No RISC-V toolchain, no `sim`, no Sail, no yosys, no
+# sby: the failing objcopy, the crashing runner, the diverging reference model
+# and the compiler that is not installed are all stubs on a scratch PATH. That
+# is what lets this run inside `make test` on any machine, rather than being a
+# document nobody executes -- which is the failure mode CLAUDE.md records for
+# `make waves` and `make -C formal all`.
+#
+# IT IS ALL FORK, NO WORK, so its wall time is a property of the host and not
+# of this file. Measured on the machine it was written on: ~1500 exec()s for
+# about 4s of user time and 90s of wall, because that laptop takes ~27ms to
+# exec /bin/echo and ~62ms to exec a freshly written script. Do not "optimise"
+# it by deleting probes -- measure `time (for i in $(seq 1 100); do /bin/echo x
+# >/dev/null; done)` first and see whether the host is the reason.
+#
+# WHAT IS NOT HERE, and it is a short list. Four failure paths need something
+# this file deliberately does not have, and each was demonstrated by hand
+# instead, with the command recorded at its own site:
+#
+#   * test/cxxrtl.cc's exit 4 (a live RVFI monitor mismatch) and exit 5
+#     (trap-to-zero), which need the elaborated design;
+#   * formal/genchecks-audit.py's three set equalities, which need the pinned
+#     riscv-formal clone and a real generation run (only its working-directory
+#     guard is probed below);
+#   * test/cosim.cc's regs_a/regs_b divergence check, which needs the design.
+#
+set -euo pipefail
+
+HERE=$(cd "$(dirname "$0")" && pwd)
+REPO=$(cd "$HERE/.." && pwd)
+
+# The number of probes this file must run. Pinned as a literal for the same
+# reason test/exec_tb.v pins its vector count: a probe that is deleted, or that
+# stops being reached by an early `return`, would otherwise reduce the coverage
+# of this file while it kept printing a green summary.
+PROBES_EXPECTED=106
+
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/littlecpu-probe.XXXXXX") || {
+  echo "error: could not create a temporary directory under ${TMPDIR:-/tmp}." >&2
+  exit 1
+}
+if [ -z "$tmp" ] || [ ! -d "$tmp" ]; then
+  echo "error: mktemp -d produced no usable directory under ${TMPDIR:-/tmp}." >&2
+  exit 1
+fi
+trap 'rm -rf "$tmp"' EXIT
+
+probes=0
+failed=0
+group=""
+
+# Every fixture gets its own directory. `mktemp -d` rather than a counter
+# because these are built inside `$(...)`, which is a subshell: a counter would
+# never advance in the parent and every fixture would land on top of the last
+# one -- silently, and with the probes still reporting on something.
+new_case() {
+  mktemp -d "$tmp/case.XXXXXX"
+}
+
+group_started=0
+
+begin_group() {
+  if [ -n "$group" ]; then
+    printf '  (%ss)\n' "$((SECONDS - group_started))"
+  fi
+  group=$1
+  group_started=$SECONDS
+  echo
+  echo "== $group"
+}
+
+# probe <label> <expected-exit> <expected-text> <shell-snippet>
+probe() {
+  local label=$1 want_exit=$2 want_text=$3 snippet=$4
+  probes=$((probes + 1))
+  local out rc
+  set +e
+  out=$(eval "$snippet" 2>&1)
+  rc=$?
+  set -e
+  local why=""
+  # A here-string, not a pipe. `grep -q` exits at the first match and closes
+  # the pipe, and against a large output (the sanitized monitor is 11k lines)
+  # the writer then dies of SIGPIPE -- which under `set -o pipefail` becomes
+  # the pipeline's status, so a MATCHING probe reported no match. Found by
+  # this file failing its own control.
+  if [ "$rc" -ne "$want_exit" ]; then
+    why="exited $rc, expected $want_exit"
+  elif ! grep -qF -- "$want_text" <<< "$out"; then
+    why="output does not contain $want_text"
+  fi
+  if [ -z "$why" ]; then
+    printf '  ok   %s\n' "$label"
+  else
+    printf '  RED  %s\n     -> %s\n' "$label" "$why" >&2
+    printf '%s\n' "$out" | sed -e 's|^|        |' >&2
+    failed=1
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Stubs. Each stands in for one thing this file refuses to depend on, and each
+# is steered by environment variables so a probe reads as one line.
+#
+# They are written ONCE, up front, and shared by every fixture below -- as are
+# the scratch copies of the scripts under test. Per-fixture copies cost seconds:
+# macOS re-scans an executable the first time it is exec'd after being written,
+# so a probe that created its own stub tree measured 1.5-3.3s of wall against
+# 0.06s of user time. Fixtures create data files only; nothing a fixture writes
+# is ever executed.
+# ---------------------------------------------------------------------------
+
+make_toolchain_stubs() {  # $1 = bin dir
+  local bin=$1
+  mkdir -p "$bin"
+  cat > "$bin/riscv64-elf-gcc" <<'STUB'
+#!/bin/sh
+# Stands in for the cross compiler. Writes a non-empty file at -o and succeeds,
+# so run_tests.sh / cosim.py get past assembly without a toolchain installed.
+[ -n "${STUB_CC_WARN:-}" ] && echo "stub: assembler warning" >&2
+out=; prev=
+for a in "$@"; do
+  if [ "$prev" = "-o" ]; then out=$a; fi
+  prev=$a
+done
+[ -n "$out" ] && echo stub-elf > "$out"
+exit ${STUB_CC_EXIT:-0}
+STUB
+  cat > "$bin/riscv64-elf-objcopy" <<'STUB'
+#!/bin/sh
+# The last argument is the output image (run_tests.sh and cosim.py both call it
+# that way). STUB_OBJCOPY_FAIL is a full disk or a binutils without
+# --verilog-data-width; STUB_OBJCOPY_EMPTY is the quiet one ADR-0035 names --
+# exit 0 with no bytes, which parses fine and makes `tohost` read zero.
+for out; do :; done
+if [ -n "${STUB_OBJCOPY_FAIL:-}" ]; then
+  echo "stub objcopy: refusing" >&2
+  exit 1
+fi
+if [ -n "${STUB_OBJCOPY_EMPTY:-}" ]; then
+  : > "$out"
+  exit 0
+fi
+printf '@00000000\n13 00 00 00\n' > "$out"
+exit 0
+STUB
+  chmod +x "$bin/riscv64-elf-gcc" "$bin/riscv64-elf-objcopy"
+}
+
+make_sim_stub() {  # $1 = path
+  cat > "$1" <<'STUB'
+#!/bin/sh
+# Stands in for ./sim (test/cxxrtl.cc). Reproduces its output contract -- one
+# `RETIRES <n> SPEC-CHECKED <m>` line and one verdict line -- and its exit
+# ladder, so run_tests.sh's grading of that ladder can be probed without the
+# elaborated design.
+[ -z "${STUB_SIM_NOCOUNTS:-}" ] && \
+  echo "RETIRES ${STUB_SIM_RETIRES:-10} SPEC-CHECKED ${STUB_SIM_SPEC:-10}"
+case ${STUB_SIM_EXIT:-0} in
+  0) echo "PASS" ;;
+  1) echo "FAIL 7" ;;
+  4) echo "RVFI monitor error 101 at cycle 12" >&2 ;;
+esac
+exit ${STUB_SIM_EXIT:-0}
+STUB
+  chmod +x "$1"
+}
+
+make_cosim_py_stub() {  # $1 = path
+  cat > "$1" <<'STUB'
+#!/bin/sh
+# Stands in for test/cosim.py as run_cosim.sh drives it: a --check-setup probe
+# and a per-program run that prints the one machine-readable COSIM-STATUS line
+# the suite runner contracts on.
+case "$1" in
+  --check-setup) echo "stub setup"; exit ${STUB_SETUP_EXIT:-0} ;;
+esac
+[ -z "${STUB_COSIM_SILENT:-}" ] && echo "COSIM-STATUS ${STUB_COSIM_STATUS:-AGREE}"
+exit ${STUB_COSIM_EXIT:-0}
+STUB
+  chmod +x "$1"
+}
+
+make_sail_stub() {  # $1 = path
+  cat > "$1" <<'STUB'
+#!/bin/sh
+# Stands in for sail_riscv_sim. Copies a fixture trace to wherever cosim.py
+# asked for one and replays a fixture stdout, so cosim.py's whole comparison --
+# trace parsing, the distinct-state reduction, the divergence labels and the
+# HTIF verdict cross-check -- is exercised with no Sail installed.
+trace=; prev=
+for a in "$@"; do
+  if [ "$prev" = "--trace-output" ]; then trace=$a; fi
+  prev=$a
+done
+if [ -z "${STUB_SAIL_NOTRACE:-}" ] && [ -n "$trace" ]; then
+  cat "${STUB_SAIL_TRACE:-/dev/null}" > "$trace"
+fi
+[ -n "${STUB_SAIL_STDOUT:-}" ] && cat "$STUB_SAIL_STDOUT"
+exit 0
+STUB
+  chmod +x "$1"
+}
+
+make_cosim_bin_stub() {  # $1 = path
+  cat > "$1" <<'STUB'
+#!/bin/sh
+# Stands in for ./cosim (test/cosim.cc): replays a fixture's CS record stream.
+cat "${STUB_DUT_OUT:-/dev/null}"
+exit ${STUB_DUT_EXIT:-0}
+STUB
+  chmod +x "$1"
+}
+
+# The shared tree. `bin` is a complete stub toolchain; `bin-noobjcopy` is the
+# half-installed one; `bin-none` is a machine with no cross compiler at all.
+# `leg-rt` / `leg-rc` are scratch copies of the two suite runners, because each
+# resolves its helper scripts relative to its own path.
+mkdir -p "$tmp/bin-none" "$tmp/leg-rt" "$tmp/leg-rc" "$tmp/leg-rc-nopy"
+make_toolchain_stubs "$tmp/bin"
+make_toolchain_stubs "$tmp/bin-noobjcopy"
+rm "$tmp/bin-noobjcopy/riscv64-elf-objcopy"
+make_sim_stub "$tmp/sim"
+make_sail_stub "$tmp/sail"
+make_cosim_bin_stub "$tmp/dut"
+cp "$HERE/run_tests.sh" "$HERE/check_suite_shape.sh" "$tmp/leg-rt/"
+cp "$HERE/run_cosim.sh" "$HERE/check_suite_shape.sh" "$tmp/leg-rc/"
+make_cosim_py_stub "$tmp/leg-rc/cosim.py"
+cp "$HERE/run_cosim.sh" "$HERE/check_suite_shape.sh" "$tmp/leg-rc-nopy/"
+make_cosim_py_stub "$tmp/leg-rc-nopy/cosim.py"
+chmod -x "$tmp/leg-rc-nopy/cosim.py"
+
+# ===========================================================================
+# 1. test/check_suite_shape.sh -- the manifest check both sim legs run first.
+# ===========================================================================
+begin_group "test/check_suite_shape.sh"
+
+SHAPE="$HERE/check_suite_shape.sh"
+
+shape_fixture() {
+  local d; d=$(new_case)
+  mkdir -p "$d/asm"
+  : > "$d/asm/add.S"; : > "$d/asm/lw.S"
+  printf '# a comment\nadd.S 10 10\nlw.S 5 5\n' > "$d/MANIFEST"
+  printf '%s' "$d"
+}
+
+d=$(shape_fixture)
+probe "control: a suite matching its manifest is green" 0 "Suite shape matches" \
+  "$SHAPE '$d/asm' '$d/MANIFEST'"
+
+probe "wrong argument count is a usage error, not a silent pass" 1 "usage:" \
+  "$SHAPE '$d/asm'"
+
+probe "a missing asm directory is named" 1 "does not exist" \
+  "$SHAPE '$d/nope' '$d/MANIFEST'"
+
+probe "a mistyped manifest path cannot yield an empty expected set" 1 \
+  "does not exist or is not readable" "$SHAPE '$d/asm' '$d/NOPE'"
+
+d=$(shape_fixture); printf '# only comments\n' > "$d/MANIFEST"
+probe "an empty manifest matches an empty suite and is rejected" 1 \
+  "names no programs" "$SHAPE '$d/asm' '$d/MANIFEST'"
+
+d=$(shape_fixture); printf 'add.S 10 10\nnot-a-program 5 5\n' > "$d/MANIFEST"
+probe "a manifest entry that is not a .S name is a typo, not a phantom" 1 \
+  "is not a '<test>.S' name" "$SHAPE '$d/asm' '$d/MANIFEST'"
+
+d=$(shape_fixture); printf 'add.S 10 10\nadd.S 10 10\nlw.S 5 5\n' > "$d/MANIFEST"
+probe "a duplicated manifest line would make comm non-symmetric" 1 \
+  "names the same program more than once" "$SHAPE '$d/asm' '$d/MANIFEST'"
+
+d=$(shape_fixture); rm "$d/asm/add.S" "$d/asm/lw.S"
+probe "an empty asm directory is red rather than a suite of size zero" 1 \
+  "no .S programs found" "$SHAPE '$d/asm' '$d/MANIFEST'"
+
+d=$(shape_fixture); rm "$d/asm/lw.S"
+probe "a SHRUNK suite: the manifest names a program the tree does not have" 1 \
+  "The suite has SHRUNK" "$SHAPE '$d/asm' '$d/MANIFEST'"
+
+d=$(shape_fixture); : > "$d/asm/unlisted.S"
+probe "the other direction: a .S that landed without a manifest line" 1 \
+  "runs unmeasured" "$SHAPE '$d/asm' '$d/MANIFEST'"
+
+# ===========================================================================
+# 2. test/run_tests.sh -- the merge gate.
+# ===========================================================================
+begin_group "test/run_tests.sh"
+
+rt_fixture() {
+  local d; d=$(new_case)
+  mkdir -p "$d/asm"
+  : > "$d/asm/add.S"
+  : > "$d/asm/sections.lds"
+  printf 'add.S 10 10\n' > "$d/FLOOR"
+  : > "$d/BASELINE"
+  printf '%s' "$d"
+}
+
+# `sections.lds` is not a program and must not be counted as one; the manifest
+# check and this loop both key on `*.S`, which is why the fixture can carry it.
+RT="$tmp/leg-rt/run_tests.sh"
+rt() { printf "PATH='%s/bin:/usr/bin:/bin' %s %s/sim %s/asm %s/BASELINE %s/FLOOR" \
+  "$tmp" "$RT" "$tmp" "$1" "$1" "$1"; }
+
+d=$(rt_fixture)
+probe "control: a passing suite against an empty baseline is green" 0 \
+  "Failure list matches" "$(rt "$d")"
+
+probe "wrong argument count is a usage error" 1 "usage:" \
+  "PATH='$tmp/bin:/usr/bin:/bin' $RT $tmp/sim $d/asm"
+
+probe "a mistyped baseline path cannot compare nothing and pass" 1 \
+  "without it there is no gate" \
+  "PATH='$tmp/bin:/usr/bin:/bin' $RT $tmp/sim $d/asm $d/NOPE $d/FLOOR"
+
+probe "a mistyped floor path cannot make every floor lookup miss" 1 \
+  "there is nothing to compare this run's observation against" \
+  "PATH='$tmp/bin:/usr/bin:/bin' $RT $tmp/sim $d/asm $d/BASELINE $d/NOPE"
+
+d=$(rt_fixture); : > "$d/asm/unlisted.S"
+probe "the suite's shape is asserted before a single program is assembled" 1 \
+  "nothing was run" "$(rt "$d")"
+
+d=$(rt_fixture); printf 'add.S 10\n' > "$d/FLOOR"
+probe "a floor line this loop cannot parse is a floor that is not enforced" 1 \
+  "are not '<test>.S <retires> <spec-checked>'" "$(rt "$d")"
+
+d=$(rt_fixture); printf 'add.S ten 10\n' > "$d/FLOOR"
+probe "a non-numeric floor is named rather than compared arithmetically" 1 \
+  "are not '<test>.S <retires> <spec-checked>'" "$(rt "$d")"
+
+d=$(rt_fixture); printf 'add.S\n' > "$d/BASELINE"
+probe "a pre-ADR-0035 one-field baseline line is rejected, not half-matched" 1 \
+  "entries with no status" "$(rt "$d")"
+
+d=$(rt_fixture)
+probe "a half-installed toolchain says so once, up front" 1 \
+  "no RISC-V cross compiler found" \
+  "PATH='$tmp/bin-none:/usr/bin:/bin' $RT $tmp/sim $d/asm $d/BASELINE $d/FLOOR"
+
+d=$(rt_fixture)
+probe "objcopy is probed, not assumed to exist because gcc did" 1 \
+  "but not its matching" \
+  "PATH='$tmp/bin-noobjcopy:/usr/bin:/bin' $RT $tmp/sim $d/asm $d/BASELINE $d/FLOOR"
+
+d=$(rt_fixture)
+probe "a failing assembler is ASSEMBLE-ERROR" 1 "ASSEMBLE-ERROR" \
+  "STUB_CC_EXIT=1 $(rt "$d")"
+
+probe "assembler output on a successful build is still a defect" 1 \
+  "ASSEMBLE-WARNING" "STUB_CC_WARN=1 $(rt "$d")"
+
+probe "a failing objcopy names the region that failed" 1 "OBJCOPY-ERROR rom" \
+  "STUB_OBJCOPY_FAIL=1 $(rt "$d")"
+
+probe "the quiet one: objcopy exits 0 having written no bytes" 1 \
+  "OBJCOPY-EMPTY rom" "STUB_OBJCOPY_EMPTY=1 $(rt "$d")"
+
+probe "runner exit 1 is FAIL, carrying the test number" 1 "FAIL 7" \
+  "STUB_SIM_EXIT=1 $(rt "$d")"
+
+probe "runner exit 2 is TIMEOUT" 1 "TIMEOUT" "STUB_SIM_EXIT=2 $(rt "$d")"
+
+probe "runner exit 4 is MONITOR-ERROR, carrying the monitor's code" 1 \
+  "MONITOR-ERROR 101" "STUB_SIM_EXIT=4 $(rt "$d")"
+
+probe "runner exit 5 is TRAP-TO-ZERO, not a timeout with no cause" 1 \
+  "TRAP-TO-ZERO" "STUB_SIM_EXIT=5 $(rt "$d")"
+
+probe "runner exit 6 is MONITOR-SILENT: the oracle never looked" 1 \
+  "MONITOR-SILENT" "STUB_SIM_EXIT=6 $(rt "$d")"
+
+probe "an unexpected runner status is RUNNER-ERROR, carrying it" 1 \
+  "RUNNER-ERROR 3" "STUB_SIM_EXIT=3 $(rt "$d")"
+
+# ADR-0035's measured reason for `set +e` around the runner: bash 3.2 rewrites
+# a 127 to 1 under errexit, which would report an unstartable runner as a
+# verdict about the CPU.
+probe "an unstartable runner is RUNNER-ERROR 127, never FAIL" 1 \
+  "RUNNER-ERROR 127" \
+  "PATH='$tmp/bin:/usr/bin:/bin' $RT $tmp/no-such-sim $d/asm $d/BASELINE $d/FLOOR"
+
+probe "a PASS with no counts line is not a pass" 1 "NO-COUNTS" \
+  "STUB_SIM_NOCOUNTS=1 $(rt "$d")"
+
+probe "a program that went quiet is BELOW-FLOOR on retires" 1 \
+  "BELOW-FLOOR retires" "STUB_SIM_RETIRES=1 $(rt "$d")"
+
+probe "retires that stopped being spec-checked is its own status" 1 \
+  "BELOW-FLOOR spec-checked" "STUB_SIM_SPEC=1 $(rt "$d")"
+
+# ADR-0014's contract runs in BOTH directions, and ADR-0035 made the element a
+# name-and-status pair. Three probes, because the three are different claims.
+d=$(rt_fixture); printf 'add.S FAIL 7\n' > "$d/BASELINE"
+probe "control: a baselined failure that fails exactly that way is green" 0 \
+  "Failure list matches" "STUB_SIM_EXIT=1 $(rt "$d")"
+
+probe "a baselined test that starts failing a DIFFERENT way is red" 1 \
+  "does NOT match" "STUB_SIM_EXIT=2 $(rt "$d")"
+
+probe "an unexpected PASS is red too -- the baseline is not a ceiling" 1 \
+  "does NOT match" "$(rt "$d")"
+
+# ===========================================================================
+# 3. test/run_cosim.sh -- the co-simulation suite runner.
+# ===========================================================================
+begin_group "test/run_cosim.sh"
+
+rc_fixture() {
+  local d; d=$(new_case)
+  mkdir -p "$d/asm"
+  : > "$d/asm/add.S"
+  printf 'add.S 10 10\n' > "$d/MANIFEST"
+  : > "$d/BASELINE"
+  : > "$d/cosim-bin"
+  printf '%s' "$d"
+}
+
+RC="$tmp/leg-rc/run_cosim.sh"
+rcs() { printf "%s %s/cosim-bin %s/asm %s/BASELINE %s/MANIFEST" \
+  "$RC" "$1" "$1" "$1" "$1"; }
+
+d=$(rc_fixture)
+probe "control: a suite that agrees against an empty baseline is green" 0 \
+  "Divergence list matches" "$(rcs "$d")"
+
+probe "wrong argument count is a usage error" 1 "usage:" \
+  "$RC $d/cosim-bin"
+
+probe "a mistyped baseline path cannot compare nothing and pass" 1 \
+  "without it there is no gate" \
+  "$RC $d/cosim-bin $d/asm $d/NOPE $d/MANIFEST"
+
+d=$(rc_fixture)
+probe "a cosim.py that cannot be executed stops the run" 1 \
+  "is missing or not executable" \
+  "$tmp/leg-rc-nopy/run_cosim.sh $d/cosim-bin $d/asm $d/BASELINE $d/MANIFEST"
+
+d=$(rc_fixture); printf 'add.S\n' > "$d/BASELINE"
+probe "a one-field baseline line is rejected before the suite runs" 1 \
+  "entries with no status" "$(rcs "$d")"
+
+d=$(rc_fixture); : > "$d/asm/unlisted.S"
+probe "the manifest is checked here too, and before the setup probe" 1 \
+  "nothing was run" "$(rcs "$d")"
+
+d=$(rc_fixture)
+probe "a missing Sail install stops the run rather than scoring it" 1 \
+  "setup is incomplete" "STUB_SETUP_EXIT=1 $(rcs "$d")"
+
+probe "a run that printed no COSIM-STATUS is COSIM-ERROR, not a verdict" 1 \
+  "COSIM-ERROR 3" "STUB_COSIM_SILENT=1 STUB_COSIM_EXIT=3 $(rcs "$d")"
+
+probe "status AGREE with a nonzero exit is a broken harness, not agreement" 1 \
+  "COSIM-ERROR status/exit mismatch 1" "STUB_COSIM_EXIT=1 $(rcs "$d")"
+
+probe "and the reverse: a divergence reported with exit 0" 1 \
+  "COSIM-ERROR status/exit mismatch 0" \
+  "STUB_COSIM_STATUS='DISAGREE AT 4' $(rcs "$d")"
+
+d=$(rc_fixture); printf 'add.S DISAGREE AT 4\n' > "$d/BASELINE"
+probe "control: a baselined divergence at the baselined point is green" 0 \
+  "Divergence list matches" \
+  "STUB_COSIM_STATUS='DISAGREE AT 4' STUB_COSIM_EXIT=1 $(rcs "$d")"
+
+probe "a baselined program that diverges SOMEWHERE ELSE is red" 1 \
+  "does NOT match" \
+  "STUB_COSIM_STATUS='DISAGREE AT 9' STUB_COSIM_EXIT=1 $(rcs "$d")"
+
+probe "an unexpected agreement is red -- both directions, as everywhere" 1 \
+  "does NOT match" "$(rcs "$d")"
+
+# ===========================================================================
+# 4. test/cosim.py -- the comparison itself, driven end to end through stubs.
+# ===========================================================================
+begin_group "test/cosim.py"
+
+# Sail's trace format (test/cosim.py's INSN_RE / GPR_RE) and test/cosim.cc's
+# CS record stream, both replayed from fixtures. Everything between them --
+# the distinct-state reduction, the two cursors, the divergence labels, the
+# HTIF verdict cross-check -- is the real script.
+cp_fixture() {
+  local d; d=$(new_case)
+  cat > "$d/sail.trace" <<'TRACE'
+[1] [M]: 0x00000000 (0x00100093) addi x1, x0, 1
+x1 <- 0x00000001
+[2] [M]: 0x00000004 (0x00200113) addi x2, x0, 2
+x2 <- 0x00000002
+TRACE
+  printf 'SUCCESS\n' > "$d/sail.out"
+  cat > "$d/dut.out" <<'DUT'
+CS 0 10 x1=00000001 @pc=00000004
+CS 1 12 x2=00000002 @pc=00000008
+CS END PASS 12
+DUT
+  printf '%s' "$d"
+}
+
+cps() {
+  printf "PATH='%s/bin:/usr/bin:/bin' STUB_SAIL_TRACE=%s/sail.trace STUB_SAIL_STDOUT=%s/sail.out STUB_DUT_OUT=%s/dut.out %s/test/cosim.py --quiet --sail %s/sail --cosim-binary %s/dut add.S" \
+    "$tmp" "$1" "$1" "$1" "$REPO" "$tmp" "$tmp"
+}
+
+d=$(cp_fixture)
+probe "control: identical register traces and verdicts AGREE" 0 \
+  "COSIM-STATUS AGREE" "$(cps "$d")"
+
+d=$(cp_fixture)
+sed -i.bak 's/x2=00000002/x2=000000ff/' "$d/dut.out"
+probe "a differing value is a divergence, located by change index" 1 \
+  "COSIM-STATUS DISAGREE AT 1" "$(cps "$d")"
+
+d=$(cp_fixture)
+sed -i.bak 's/^CS 1 .*$//' "$d/dut.out"
+probe "a change the core never made is a length divergence" 1 \
+  "COSIM-STATUS DISAGREE LENGTH" "$(cps "$d")"
+
+d=$(cp_fixture)
+cat >> "$d/dut.out" <<'DUT'
+CS 2 14 x31=deadbeef @pc=0000000c
+DUT
+probe "an EXTRA architectural write the model never made is caught" 1 \
+  "COSIM-STATUS DISAGREE LENGTH" "$(cps "$d")"
+
+d=$(cp_fixture); printf '' > "$d/sail.out"
+probe "the reference model hitting its budget is INCONCLUSIVE, not a finding" 2 \
+  "COSIM-STATUS INCONCLUSIVE SAIL-LIMIT" "$(cps "$d")"
+
+d=$(cp_fixture); sed -i.bak 's/^CS END PASS 12$/CS END TIMEOUT/' "$d/dut.out"
+probe "the core hitting its cycle budget is INCONCLUSIVE too" 2 \
+  "COSIM-STATUS INCONCLUSIVE CORE-TIMEOUT" "$(cps "$d")"
+
+d=$(cp_fixture); printf 'FAILURE: 3\n' > "$d/sail.out"
+sed -i.bak 's/^CS END PASS 12$/CS END FAIL 3 12/' "$d/dut.out"
+probe "control: both sides failing the same test number still AGREE" 0 \
+  "COSIM-STATUS AGREE" "$(cps "$d")"
+
+d=$(cp_fixture); printf 'FAILURE: 3\n' > "$d/sail.out"
+probe "identical traces with different verdicts is DISAGREE VERDICT" 1 \
+  "COSIM-STATUS DISAGREE VERDICT" "$(cps "$d")"
+
+d=$(cp_fixture); sed -i.bak 's/^CS END PASS 12$//' "$d/dut.out"
+probe "a runner that printed no CS END terminator is a broken harness" 3 \
+  "produced no \`CS END\` line" "$(cps "$d")"
+
+d=$(cp_fixture); printf 'CS 9 nonsense\n' >> "$d/dut.out"
+probe "an unrecognised CS line is a hard error, never guessed at" 3 \
+  "unparseable cosim record line" "$(cps "$d")"
+
+d=$(cp_fixture)
+probe "a reference model that produced no trace is fatal" 3 \
+  "sail produced no trace" "STUB_SAIL_NOTRACE=1 $(cps "$d")"
+
+d=$(cp_fixture); : > "$d/sail.trace"
+probe "an empty trace is fatal rather than an empty comparison" 3 \
+  "sail traced no instructions" "$(cps "$d")"
+
+d=$(cp_fixture)
+probe "a failing assembler is fatal, not a divergence" 3 "failed" \
+  "STUB_CC_EXIT=1 $(cps "$d")"
+
+# The NONCOMPARABLE_CSRS relaxation. It is the one thing in this script that
+# makes the comparison weaker, so both halves are probed: that it is taken and
+# printed, and that it still requires a change to EXACTLY that register.
+d=$(cp_fixture)
+cat > "$d/sail.trace" <<'TRACE'
+[1] [M]: 0x00000000 (0xb00025f3) csrr x11, mcycle
+x11 <- 0x00000041
+TRACE
+printf 'CS 0 10 x11=00000099 @pc=00000004\nCS END PASS 10\n' > "$d/dut.out"
+probe "a non-comparable CSR value is exempted -- and every exemption printed" 0 \
+  "NOT COMPARED BY VALUE (1" "$(cps "$d")"
+
+d=$(cp_fixture)
+cat > "$d/sail.trace" <<'TRACE'
+[1] [M]: 0x00000000 (0xb00025f3) csrr x11, mcycle
+x11 <- 0x00000041
+TRACE
+printf 'CS 0 10 x12=00000099 @pc=00000004\nCS END PASS 10\n' > "$d/dut.out"
+probe "the exemption does not extend to a write of the WRONG register" 1 \
+  "COSIM-STATUS DISAGREE" "$(cps "$d")"
+
+# ===========================================================================
+# 5. formal/check-baseline.sh -- the ladder's gate.
+# ===========================================================================
+begin_group "formal/check-baseline.sh"
+
+CB="$REPO/formal/check-baseline.sh"
+
+cb_fixture() {
+  local d; d=$(new_case)
+  mkdir -p "$d/checks/alpha" "$d/checks/beta"
+  : > "$d/checks/alpha.sby"; : > "$d/checks/beta.sby"
+  printf 'PASS 0 31\n' > "$d/checks/alpha/status"
+  printf 'PASS 0 31\n' > "$d/checks/beta/status"
+  printf 'alpha\nbeta\n' > "$d/EXPECTED_CHECKS"
+  : > "$d/EXPECTED_FAIL"
+  printf '%s' "$d"
+}
+
+cbs() { printf "%s %s/checks %s/EXPECTED_FAIL %s/EXPECTED_CHECKS" "$CB" "$1" "$1" "$1"; }
+
+d=$(cb_fixture)
+probe "control: a full-pass ladder against an empty baseline is green" 0 \
+  "Failure list matches" "$(cbs "$d")"
+
+probe "wrong argument count is exit 2 -- the inputs are broken, not the ladder" 2 \
+  "usage:" "$CB $d/checks"
+
+probe "a missing baseline file is exit 2, not an empty expected set" 2 \
+  "no such file" "$CB $d/checks $d/NOPE $d/EXPECTED_CHECKS"
+
+d=$(cb_fixture); rm "$d/checks/alpha.sby" "$d/checks/beta.sby"
+probe "a ladder that was never generated is exit 2, not zero checks passing" 2 \
+  "the ladder was never" "$(cbs "$d")"
+
+d=$(cb_fixture); printf 'beta\n' > "$d/EXPECTED_FAIL"
+probe "a pre-ADR-0036 one-field baseline line is named, not half-matched" 2 \
+  "no status field" "$(cbs "$d")"
+
+d=$(cb_fixture); printf 'beta BANANA\n' > "$d/EXPECTED_FAIL"
+probe "a status sby cannot produce is rejected at format time" 2 \
+  "is not a status sby can produce" "$(cbs "$d")"
+
+d=$(cb_fixture); printf 'beta PASS\n' > "$d/EXPECTED_FAIL"
+probe "PASS in a failure set is a comparison whose only branch is failure" 2 \
+  "must never be baselined" "$(cbs "$d")"
+
+d=$(cb_fixture); printf 'beta ERROR\n' > "$d/EXPECTED_FAIL"
+probe "baselining ERROR would re-create the btorsim hole with this gate's blessing" 2 \
+  "must never be baselined" "$(cbs "$d")"
+
+d=$(cb_fixture); printf 'beta NO-STATUS\n' > "$d/EXPECTED_FAIL"
+probe "NO-STATUS is a broken harness and is not baselineable either" 2 \
+  "must never be baselined" "$(cbs "$d")"
+
+d=$(cb_fixture); printf 'beta PASS 0 31\n' > "$d/EXPECTED_FAIL"
+probe "sby's trailing engine numbers are not part of the status" 2 \
+  "The format is exactly two" "$(cbs "$d")"
+
+d=$(cb_fixture); printf 'FAIL 0 20\n' > "$d/checks/beta/status"
+probe "a check that went red is red here" 1 "beta FAIL" "$(cbs "$d")"
+
+d=$(cb_fixture); printf 'FAIL 0 20\n' > "$d/checks/beta/status"
+printf 'beta FAIL\n' > "$d/EXPECTED_FAIL"
+probe "control: a baselined red check at the baselined status is green" 0 \
+  "Failure list matches" "$(cbs "$d")"
+
+# ADR-0036's measured hole, and the newest comparison in this script: on a
+# machine without btorsim every red check flipped FAIL -> ERROR and the
+# name-only set equality still matched.
+printf 'ERROR 16 2\n' > "$d/checks/beta/status"
+probe "still red, but for a DIFFERENT reason: FAIL baselined, ERROR on disk" 1 \
+  "beta ERROR" "$(cbs "$d")"
+
+d=$(cb_fixture); printf 'TIMEOUT 0 20\n' > "$d/checks/beta/status"
+printf 'beta TIMEOUT\n' > "$d/EXPECTED_FAIL"
+probe "control: TIMEOUT is a real verdict and IS baselineable" 0 \
+  "Failure list matches" "$(cbs "$d")"
+
+d=$(cb_fixture); rm -r "$d/checks/beta"
+probe "a generated check that was never scheduled resolves to NO-STATUS" 1 \
+  "beta NO-STATUS" "$(cbs "$d")"
+
+d=$(cb_fixture); : > "$d/checks/gamma.sby"; mkdir "$d/checks/gamma"
+printf 'PASS 0 31\n' > "$d/checks/gamma/status"
+probe "a check that APPEARED needs a line -- the shape check runs both ways" 1 \
+  "Generated check set does NOT match" "$(cbs "$d")"
+
+d=$(cb_fixture); rm "$d/checks/beta.sby"
+probe "a lost [depth] line trips the shape check AND the verdict check" 1 \
+  "Generated check set does NOT match" "$(cbs "$d")"
+
+d=$(cb_fixture); printf 'WOBBLE 1 2\n' > "$d/checks/beta/status"
+probe "a status sby has never written here is reported on its own" 1 \
+  "Unrecognised status" "$(cbs "$d")"
+
+# ===========================================================================
+# 6. formal/check-complete-exclusions.py -- the exclusion set's gate.
+# ===========================================================================
+begin_group "formal/check-complete-exclusions.py"
+
+CE="$REPO/formal/check-complete-exclusions.py"
+
+# The riscv-formal stand-in carries only what clause 5 reads: an insns/
+# directory and its isa list. Naming `add` and `lw` there is what makes the
+# control probe meaningful -- the file is non-empty and simply does not name
+# any excluded mnemonic.
+ce_fixture() {
+  local d; d=$(new_case)
+  mkdir -p "$d/rf/insns"
+  printf 'add\nlw\n' > "$d/rf/insns/isa_rv32imc.txt"
+  cp "$REPO/formal/complete.sv" "$d/complete.sv"
+  cp "$REPO/formal/COMPLETE_EXCLUSIONS" "$d/BASELINE"
+  printf '%s' "$d"
+}
+
+ces() { printf "%s %s/complete.sv %s/BASELINE %s/rf" "$CE" "$1" "$1" "$1"; }
+
+d=$(ce_fixture)
+probe "control: the shipping exclusion set matches its baseline both ways" 0 \
+  "COMPLETE EXCLUSION SET: PASS" "$(ces "$d")"
+
+probe "wrong argument count is exit 2" 2 "check-complete-exclusions.py" \
+  "$CE $d/complete.sv"
+
+d=$(ce_fixture)
+sed -i.bak "s|wire \[6:0\]  insn_opcode       = rvfi_insn\[6:0\];|wire [6:0]  insn_opcode       = decoded_opcode;|" "$d/complete.sv"
+probe "the two definitions the predicates are built from are pinned literally" 1 \
+  "expected the exact line defining" "$(ces "$d")"
+
+d=$(ce_fixture)
+sed -i.bak "s|wire exclude_misc_mem = insn_uncompressed && insn_opcode == 7'b0001111;|wire exclude_misc_mem = decoder_is_fence;|" "$d/complete.sv"
+probe "a predicate keyed on a decoder flag is rejected, not parsed" 1 \
+  "must not be able to excuse" "$(ces "$d")"
+
+d=$(ce_fixture)
+sed -i.bak "s|wire exclude_misc_mem = insn_uncompressed && insn_opcode == 7'b0001111;|wire exclude_fences = insn_uncompressed \&\& insn_opcode == 7'b0001111;|" "$d/complete.sv"
+probe "a wire that does not carry its class's name is named" 1 \
+  "must name its wire" "$(ces "$d")"
+
+d=$(ce_fixture)
+sed -i.bak "s|wire exclude_misc_mem = insn_uncompressed && insn_opcode == 7'b0001111;|wire exclude_misc_mem = insn_uncompressed \&\& insn_opcode == 7'b0000011;|" "$d/complete.sv"
+probe "a predicate matching an opcode its declaration does not is named" 1 \
+  "but its wire matches" "$(ces "$d")"
+
+# `@` as the sed delimiter throughout this block: the text being replaced
+# contains `||`, which closes an `s|...|...|` early.
+d=$(ce_fixture)
+sed -i.bak "s@wire insn_excluded = .*@wire insn_excluded = exclude_system;@" "$d/complete.sv"
+probe "a declared-but-unwired exclusion over-reports the restriction" 1 \
+  "must be wired in and nothing else may be" "$(ces "$d")"
+
+d=$(ce_fixture)
+sed -i.bak "s@wire insn_excluded = .*@wire insn_excluded = exclude_misc_mem || (exclude_system \&\& !rvfi_trap);@" "$d/complete.sv"
+probe "insn_excluded must be a plain disjunction, not an expression" 1 \
+  "must be a plain" "$(ces "$d")"
+
+d=$(ce_fixture)
+sed -i.bak "s|^  // EXCLUDE MISC-MEM 0001111 fence fence.i$|  // EXCLUDE MISC-MEM 0001111 fence fence.i lw|" "$d/complete.sv"
+probe "widening a declared mnemonic list without the baseline is red" 1 \
+  "declares an exclusion that" "$(ces "$d")"
+
+d=$(ce_fixture)
+printf 'STORE 0100011 sw\n' >> "$d/BASELINE"
+probe "a baseline line with no predicate behind it is red too" 1 \
+  "names an exclusion" "$(ces "$d")"
+
+d=$(ce_fixture)
+sed -i.bak 's|^MISC-MEM  0001111  fence fence.i$|MISC-MEM  00011 fence fence.i|' "$d/BASELINE"
+probe "a baseline opcode that is not seven binary digits is named" 1 \
+  "seven binary digits" "$(ces "$d")"
+
+# Clause 5, the one a baseline alone cannot give you: a stale exclusion covers
+# less and less of the ISA while staying green.
+d=$(ce_fixture); : > "$d/rf/insns/insn_fence.v"
+probe "a pin that ADDS a spec model makes the exclusion stale, and red" 1 \
+  "EXISTS at the pin" "$(ces "$d")"
+
+d=$(ce_fixture); printf 'add\nlw\nfence\n' > "$d/rf/insns/isa_rv32imc.txt"
+probe "the isa list is read too, not just the insns/ directory" 1 \
+  "so rvfi_isa_rv32imc drives a spec model" "$(ces "$d")"
+
+d=$(ce_fixture); rm "$d/rf/insns/isa_rv32imc.txt"
+probe "an unreadable clone makes 'no spec model' unmeasurable, and fatal" 1 \
+  "cannot read" "$(ces "$d")"
+
+# Clause 2 -- a recorded restriction with nothing recorded. The reason lives on
+# the comment lines under the header, so deleting them is the mutation.
+d=$(ce_fixture)
+python3 - "$d/complete.sv" <<'PY'
+import sys
+path = sys.argv[1]
+lines = open(path).read().splitlines(True)
+out, strip = [], False
+for line in lines:
+    if line.strip().startswith('// EXCLUDE MISC-MEM'):
+        out.append(line)
+        strip = True
+        continue
+    if strip:
+        if line.lstrip().startswith('//'):
+            continue
+        strip = False
+    out.append(line)
+open(path, 'w').write(''.join(out))
+PY
+probe "an exclusion with no reason written under it is rejected" 1 \
+  "has no reason written under it" "$(ces "$d")"
+
+# ===========================================================================
+# 7. test/sanitize_monitor.py -- the oracle both sim legs read.
+#
+# These assertions were mutation-confirmed once, when rule 3's three content
+# layers landed. They are RE-RUN here, not re-derived: re-deriving
+# TRAP_GATE_ENCLOSED_CODES from whatever the generator currently emits is
+# exactly how a change gets laundered into the expectation, which that list's
+# own comment forbids. Nothing below edits the script's constants; each probe
+# mutates a COPY of the tracked test/monitor.v and requires the sanitizer to
+# refuse it.
+# ===========================================================================
+begin_group "test/sanitize_monitor.py"
+
+# Not executable in the tree (the Makefile invokes it through python3), so this
+# does too -- a probe that failed on the mode bit would look like a rule fault.
+SM="python3 $REPO/test/sanitize_monitor.py"
+
+sm_fixture() {
+  local d; d=$(new_case)
+  cp "$REPO/test/monitor.v" "$d/monitor.v"
+  printf '%s' "$d"
+}
+
+sm_mutate() {  # $1 = file, stdin = python that rewrites `text`
+  python3 - "$1"
+}
+
+d=$(sm_fixture)
+probe "control: the tracked monitor sanitizes, and rule 3 fires" 0 \
+  "if (!ch0_spec_trap) begin" "$SM $d/monitor.v"
+
+probe "usage: a missing argument is exit 2" 2 "usage:" "$SM"
+
+d=$(sm_fixture)
+sm_mutate "$d/monitor.v" <<'PY'
+import sys
+p = sys.argv[1]
+t = open(p).read().replace(', $time)', ')', 1)
+open(p, 'w').write(t)
+PY
+probe "rule 1 declares a site count, so a generator change cannot ship unapplied" 1 \
+  "matched 3 site(s), expected 4" "$SM $d/monitor.v"
+
+d=$(sm_fixture)
+sm_mutate "$d/monitor.v" <<'PY'
+import sys
+p = sys.argv[1]
+t = open(p).read().replace(
+    '$signed(rvfi_rs1_rdata) / $signed(rvfi_rs2_rdata);',
+    '(rvfi_rs1_rdata / rvfi_rs2_rdata);', 1)
+open(p, 'w').write(t)
+PY
+probe "rule 2 likewise -- ADR-0019's DIV/REM repair cannot silently stop applying" 1 \
+  "matched 1 site(s), expected 2" "$SM $d/monitor.v"
+
+# Layer 1: the generator relocates the trap comparison between the anchors.
+d=$(sm_fixture)
+sm_mutate "$d/monitor.v" <<'PY'
+import sys
+p = sys.argv[1]
+t = open(p).read().replace(
+    '          ch0_handle_error(102, "mismatch in rs1_addr");',
+    '          ch0_handle_error(102, "mismatch in rs1_addr");\n'
+    '          if (ch0_rvfi_trap != ch0_spec_trap)\n'
+    '            ch0_handle_error(101, "mismatch in trap");', 1)
+open(p, 'w').write(t)
+PY
+probe "layer 1: the trap comparison moved INTO the span is refused, not gated" 1 \
+  "the generator now emits the" "$SM $d/monitor.v"
+
+# Layer 2: any other check moving into or out of the span.
+d=$(sm_fixture)
+sm_mutate "$d/monitor.v" <<'PY'
+import sys
+p = sys.argv[1]
+t = open(p).read().replace('ch0_handle_error(107, "mismatch in mem_addr")',
+                           'ch0_handle_error(109, "mismatch in mem_addr")', 1)
+open(p, 'w').write(t)
+PY
+probe "layer 2: the enclosed handle_error multiset is pinned, not merely counted" 1 \
+  "the span encloses" "$SM $d/monitor.v"
+
+# Layer 3: the generator dropping the trap comparison altogether -- which
+# layers 1 and 2 both accept, because neither looks outside the span.
+d=$(sm_fixture)
+sm_mutate "$d/monitor.v" <<'PY'
+import sys
+p = sys.argv[1]
+t = open(p).read().replace('ch0_handle_error(101, "mismatch in trap");', ';', 1)
+open(p, 'w').write(t)
+PY
+probe "layer 3: error 101 vanishing from the OUTPUT is caught after every rule" 1 \
+  "the trap comparison survives" "$SM $d/monitor.v"
+
+# ===========================================================================
+# 8. formal/genchecks-audit.py -- only the guard that needs no clone.
+# ===========================================================================
+begin_group "formal/genchecks-audit.py"
+
+# The three set equalities this script makes need the pinned riscv-formal clone
+# and a real generation run, so they are demonstrated by hand rather than here;
+# the commands and their output are recorded in the pull request that added this
+# file. What IS hermetic is the working-directory guard, and it is not
+# decoration: genchecks takes `corename` from the last path component and writes
+# `checks/` relative to the cwd, so running it from anywhere else silently
+# produces a ladder somewhere else.
+probe "running the generator from the wrong directory is refused, not done" 1 \
+  "error: run from" "cd '$tmp' && python3 '$REPO/formal/genchecks-audit.py'"
+
+# ===========================================================================
+echo
+if [ "$probes" -ne "$PROBES_EXPECTED" ]; then
+  echo "error: ran $probes probes, expected $PROBES_EXPECTED." >&2
+  echo "A probe was added or removed. Update PROBES_EXPECTED in the same commit;" >&2
+  echo "the literal is what stops this file quietly covering less than it did." >&2
+  exit 1
+fi
+
+if [ "$failed" -ne 0 ]; then
+  echo "error: a graded comparison did not go red where it was supposed to." >&2
+  echo "Read the probe above: either the grader stopped checking something, or" >&2
+  echo "its diagnostic changed and this file has to be updated to match." >&2
+  exit 1
+fi
+
+printf "  (%ss)\n" "$((SECONDS - group_started))"
+echo "$probes graded comparisons, every failure path executed."

--- a/test/probe_gates.sh
+++ b/test/probe_gates.sh
@@ -47,10 +47,11 @@
 #
 # IT IS ALL FORK, NO WORK, so its wall time is a property of the host and not
 # of this file. Measured on the machine it was written on: ~1500 exec()s for
-# about 4s of user time and 90s of wall, because that laptop takes ~27ms to
+# about 4s of user time and 68-90s of wall, because that laptop takes ~27ms to
 # exec /bin/echo and ~62ms to exec a freshly written script. Do not "optimise"
 # it by deleting probes -- measure `time (for i in $(seq 1 100); do /bin/echo x
-# >/dev/null; done)` first and see whether the host is the reason.
+# >/dev/null; done)` first and see whether the host is the reason. The
+# per-group seconds printed below are there so that stays visible.
 #
 # WHAT IS NOT HERE, and it is a short list. Four failure paths need something
 # this file deliberately does not have, and each was demonstrated by hand
@@ -72,7 +73,7 @@ REPO=$(cd "$HERE/.." && pwd)
 # reason test/exec_tb.v pins its vector count: a probe that is deleted, or that
 # stops being reached by an early `return`, would otherwise reduce the coverage
 # of this file while it kept printing a green summary.
-PROBES_EXPECTED=106
+PROBES_EXPECTED=108
 
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/littlecpu-probe.XXXXXX") || {
   echo "error: could not create a temporary directory under ${TMPDIR:-/tmp}." >&2
@@ -649,6 +650,21 @@ probe "wrong argument count is exit 2 -- the inputs are broken, not the ladder" 
 
 probe "a missing baseline file is exit 2, not an empty expected set" 2 \
   "no such file" "$CB $d/checks $d/NOPE $d/EXPECTED_CHECKS"
+
+# The false green this ticket found. `set -u` with no `-e` and no `pipefail`
+# means an unreadable baseline yields an EMPTY expected set, and an empty
+# expected set matches an all-passing ladder exactly. Before the `-r` check
+# this printed "Failure list matches ... exactly" and exited 0, having also
+# silently dropped the entry the baseline named.
+d=$(cb_fixture); printf 'beta FAIL\n' > "$d/EXPECTED_FAIL"; chmod 000 "$d/EXPECTED_FAIL"
+probe "an UNREADABLE baseline is refused, not read as an empty one" 2 \
+  "exists but is not readable" "$(cbs "$d")"
+chmod 644 "$d/EXPECTED_FAIL"
+
+d=$(cb_fixture); chmod 000 "$d/EXPECTED_CHECKS"
+probe "and the same for the check-set baseline" 2 \
+  "exists but is not readable" "$(cbs "$d")"
+chmod 644 "$d/EXPECTED_CHECKS"
 
 d=$(cb_fixture); rm "$d/checks/alpha.sby" "$d/checks/beta.sby"
 probe "a ladder that was never generated is exit 2, not zero checks passing" 2 \

--- a/test/probe_gates.sh
+++ b/test/probe_gates.sh
@@ -257,6 +257,28 @@ STUB
 # `leg-rt` / `leg-rc` are scratch copies of the two suite runners, because each
 # resolves its helper scripts relative to its own path.
 mkdir -p "$tmp/bin-none" "$tmp/leg-rt" "$tmp/leg-rc" "$tmp/leg-rc-nopy"
+
+# `bin-none` is "this machine has no cross compiler", and for the one probe that
+# claims that it has to be the WHOLE path: with /usr/bin behind it, run_tests.sh
+# finds a real riscv64-unknown-elf-gcc on any host that has one installed there,
+# which is every CI runner -- and that is exactly how that probe went green here
+# and red on CI. So it carries symlinks to the utilities the scripts need before
+# their compiler probe, resolved from this shell's own PATH rather than assumed
+# to live in /usr/bin. Every OTHER probe keeps /usr/bin on the end (the stub
+# directory is in front, so the stubs still win) because test/cosim.py runs
+# under `#!/usr/bin/env python3` and a python3 that is a version-manager shim
+# needs an interpreter of its own.
+# No python3 and no env here on purpose: nothing runs before a compiler probe
+# needs them, and a python3 that is a version-manager shim would shadow the real
+# interpreter for every OTHER probe's PATH, which has this directory on it too.
+for util in sed awk sort uniq comm basename dirname wc tr cat rm mktemp diff \
+             grep find head; do
+  path=$(command -v "$util") || {
+    echo "error: $util is not on PATH; the probes cannot build a minimal one." >&2
+    exit 1
+  }
+  ln -s "$path" "$tmp/bin-none/$util"
+done
 make_toolchain_stubs "$tmp/bin"
 make_toolchain_stubs "$tmp/bin-noobjcopy"
 rm "$tmp/bin-noobjcopy/riscv64-elf-objcopy"
@@ -340,23 +362,23 @@ rt_fixture() {
 # `sections.lds` is not a program and must not be counted as one; the manifest
 # check and this loop both key on `*.S`, which is why the fixture can carry it.
 RT="$tmp/leg-rt/run_tests.sh"
-rt() { printf "PATH='%s/bin:/usr/bin:/bin' %s %s/sim %s/asm %s/BASELINE %s/FLOOR" \
-  "$tmp" "$RT" "$tmp" "$1" "$1" "$1"; }
+rt() { printf "PATH='%s/bin:%s/bin-none:/usr/bin:/bin' %s %s/sim %s/asm %s/BASELINE %s/FLOOR" \
+  "$tmp" "$tmp" "$RT" "$tmp" "$1" "$1" "$1"; }
 
 d=$(rt_fixture)
 probe "control: a passing suite against an empty baseline is green" 0 \
   "Failure list matches" "$(rt "$d")"
 
 probe "wrong argument count is a usage error" 1 "usage:" \
-  "PATH='$tmp/bin:/usr/bin:/bin' $RT $tmp/sim $d/asm"
+  "PATH='$tmp/bin:$tmp/bin-none:/usr/bin:/bin' $RT $tmp/sim $d/asm"
 
 probe "a mistyped baseline path cannot compare nothing and pass" 1 \
   "without it there is no gate" \
-  "PATH='$tmp/bin:/usr/bin:/bin' $RT $tmp/sim $d/asm $d/NOPE $d/FLOOR"
+  "PATH='$tmp/bin:$tmp/bin-none:/usr/bin:/bin' $RT $tmp/sim $d/asm $d/NOPE $d/FLOOR"
 
 probe "a mistyped floor path cannot make every floor lookup miss" 1 \
   "there is nothing to compare this run's observation against" \
-  "PATH='$tmp/bin:/usr/bin:/bin' $RT $tmp/sim $d/asm $d/BASELINE $d/NOPE"
+  "PATH='$tmp/bin:$tmp/bin-none:/usr/bin:/bin' $RT $tmp/sim $d/asm $d/BASELINE $d/NOPE"
 
 d=$(rt_fixture); : > "$d/asm/unlisted.S"
 probe "the suite's shape is asserted before a single program is assembled" 1 \
@@ -377,12 +399,12 @@ probe "a pre-ADR-0035 one-field baseline line is rejected, not half-matched" 1 \
 d=$(rt_fixture)
 probe "a half-installed toolchain says so once, up front" 1 \
   "no RISC-V cross compiler found" \
-  "PATH='$tmp/bin-none:/usr/bin:/bin' $RT $tmp/sim $d/asm $d/BASELINE $d/FLOOR"
+  "PATH='$tmp/bin-none' $RT $tmp/sim $d/asm $d/BASELINE $d/FLOOR"
 
 d=$(rt_fixture)
 probe "objcopy is probed, not assumed to exist because gcc did" 1 \
   "but not its matching" \
-  "PATH='$tmp/bin-noobjcopy:/usr/bin:/bin' $RT $tmp/sim $d/asm $d/BASELINE $d/FLOOR"
+  "PATH='$tmp/bin-noobjcopy:$tmp/bin-none' $RT $tmp/sim $d/asm $d/BASELINE $d/FLOOR"
 
 d=$(rt_fixture)
 probe "a failing assembler is ASSEMBLE-ERROR" 1 "ASSEMBLE-ERROR" \
@@ -419,7 +441,7 @@ probe "an unexpected runner status is RUNNER-ERROR, carrying it" 1 \
 # verdict about the CPU.
 probe "an unstartable runner is RUNNER-ERROR 127, never FAIL" 1 \
   "RUNNER-ERROR 127" \
-  "PATH='$tmp/bin:/usr/bin:/bin' $RT $tmp/no-such-sim $d/asm $d/BASELINE $d/FLOOR"
+  "PATH='$tmp/bin:$tmp/bin-none:/usr/bin:/bin' $RT $tmp/no-such-sim $d/asm $d/BASELINE $d/FLOOR"
 
 probe "a PASS with no counts line is not a pass" 1 "NO-COUNTS" \
   "STUB_SIM_NOCOUNTS=1 $(rt "$d")"
@@ -538,8 +560,8 @@ DUT
 }
 
 cps() {
-  printf "PATH='%s/bin:/usr/bin:/bin' STUB_SAIL_TRACE=%s/sail.trace STUB_SAIL_STDOUT=%s/sail.out STUB_DUT_OUT=%s/dut.out %s/test/cosim.py --quiet --sail %s/sail --cosim-binary %s/dut add.S" \
-    "$tmp" "$1" "$1" "$1" "$REPO" "$tmp" "$tmp"
+  printf "PATH='%s/bin:%s/bin-none:/usr/bin:/bin' STUB_SAIL_TRACE=%s/sail.trace STUB_SAIL_STDOUT=%s/sail.out STUB_DUT_OUT=%s/dut.out %s/test/cosim.py --quiet --sail %s/sail --cosim-binary %s/dut add.S" \
+    "$tmp" "$tmp" "$1" "$1" "$1" "$REPO" "$tmp" "$tmp"
 }
 
 d=$(cp_fixture)


### PR DESCRIPTION
Five of this repo's recorded defects live in the layer that decides what "green" means, and every
one was in a script. The class is **the comparison whose failure path was never executed** — and in
every case the reasoning written at the site was correct, which is why reading the scripts missed
all of them.

So this PR does not read. It breaks the thing each graded comparison guards and requires the red.

## What it lands

**`test/probe_gates.sh` — 108 probes, and it runs.** Each one forces a graded comparison to fail
and pins both the **exit status** and a distinguishing fragment of the **diagnostic**. The second
half is load-bearing: a script that exited 1 because a fixture path was mistyped would satisfy every
exit-status-only probe in the file while demonstrating nothing. **Every group carries a control** —
the same fixtures, unmutated, required to exit 0 — so a grader degenerated into `exit 1` cannot
pass. It is hermetic (no RISC-V toolchain, no `sim`, no Sail, no yosys, no `sby`; the failing
`objcopy`, the unstartable runner and the diverging reference model are stubs), and it is a
prerequisite of `make test`, which puts it inside CI's required `test` job with **no workflow change
and no branch-protection change**.

**Two fixes**, each with its red demonstrated:

1. **`formal/check-baseline.sh` read an *unreadable* baseline as an empty one.** It sets `set -u`
   with neither `-e` nor `pipefail` and checked `-f` but not `-r`, so a `sed` that cannot open its
   input yields the empty string — and an empty expected set matches an all-passing ladder exactly.
   This is ADR-0035 item 4's fix, made on `test/run_tests.sh`'s baseline and never carried across.
2. **`test/cxxrtl.cc`'s exit 5 was unreachable in the scenario it exists for.** Traps commit in
   decode (invariant 2) while a retire happens in writeback, so a fault in the first instructions of
   `_start` raises `trap_to_zero` before anything has retired and `finish()`'s silence gate turned
   exit 5 into exit 6 — which `run_tests.sh` labels `MONITOR-SILENT`, pointing at the monitor for a
   program that faulted before installing `mtvec`. That is exactly the misattribution ADR-0029 added
   `TRAP-TO-ZERO` to prevent. Exit 4 was already exempted from that gate on the argument that an
   errcode is direct evidence rather than a verdict the program reached; `trap_to_zero` is a direct
   observation of the machine and the same argument applies.

**ADR-0053** records the audit, both findings, and what is deliberately not probed.

## The three questions

1. **Does every failure reach the process exit status?** Yes, everywhere.
2. **Is any graded command inside a pipeline?** No. Every pipeline in these scripts feeds a
   `$(...)` whose *value* is then compared; the comparison itself is never a pipeline. Both
   workflows were re-checked rather than assumed: the only `| tee` in `.github/workflows/ci.yml` is
   the `elaborate` job's yosys invocation, which sits under an explicit `set -euo pipefail` and is
   not the graded command (the `grep` on the next line is). `grep -c continue-on-error
   .github/workflows/*.yml` is 0 in every file.
3. **Has the failure path ever been executed?** This is where the work was, and where the two
   findings came from.

## Every graded comparison, and its demonstrated red

Probed ones live in `test/probe_gates.sh` and re-run on every `make test`; hand demonstrations carry
the command.

### `test/check_suite_shape.sh` — 10 probes

| comparison | forced red |
|---|---|
| control (matching suite) | exit 0, `Suite shape matches` |
| argument count | exit 1, `usage:` |
| asm dir missing | exit 1, `does not exist` |
| manifest missing / unreadable | exit 1, `does not exist or is not readable` |
| manifest names no programs | exit 1, `names no programs` |
| entry that is not a `.S` name | exit 1, `is not a '<test>.S' name` |
| duplicate manifest line | exit 1, `names the same program more than once` |
| no `.S` in the tree | exit 1, `no .S programs found` |
| **suite SHRANK** (manifest names a missing program) | exit 1, `The suite has SHRUNK` |
| **unlisted `.S`** (the other direction) | exit 1, `runs unmeasured` |

### `test/run_tests.sh` — 28 probes

| comparison | forced red |
|---|---|
| control (passing suite, empty baseline) | exit 0, `Failure list matches` |
| argument count | exit 1, `usage:` |
| baseline path unreadable | exit 1, `without it there is no gate` |
| floor path unreadable | exit 1, `nothing to compare this run's observation against` |
| suite shape, called before anything is assembled | exit 1, `nothing was run` |
| floor line malformed (2 fields; non-numeric) | exit 1 ×2, `are not '<test>.S <retires> <spec-checked>'` |
| one-field baseline line (pre-ADR-0035) | exit 1, `entries with no status` |
| no cross compiler | exit 1, `no RISC-V cross compiler found` |
| gcc present, objcopy absent | exit 1, `but not its matching` |
| `ASSEMBLE-ERROR` / `ASSEMBLE-WARNING` | exit 1, each label |
| `OBJCOPY-ERROR rom` / **`OBJCOPY-EMPTY rom`** | exit 1, each label |
| runner exit 1 / 2 / 4 / 5 / 6 / 3 | exit 1: `FAIL 7`, `TIMEOUT`, `MONITOR-ERROR 101`, `TRAP-TO-ZERO`, `MONITOR-SILENT`, `RUNNER-ERROR 3` |
| unstartable runner (ADR-0035's bash-3.2 case) | exit 1, `RUNNER-ERROR 127`, never `FAIL` |
| `NO-COUNTS` | exit 1, `NO-COUNTS` |
| **`BELOW-FLOOR retires` / `BELOW-FLOOR spec-checked`** | exit 1, each label |
| control: baselined failure at the baselined status | exit 0, `Failure list matches` |
| baselined test failing a **different** way | exit 1, `does NOT match` |
| unexpected **pass** | exit 1, `does NOT match` |

`NO-FLOOR` is **not probed and is unreachable** — `check_suite_shape.sh` has already required every
program in `$ASM_DIR` to have a manifest line before the loop runs, and the script says so at the
site. The `nullglob` asymmetry the ticket asked to leave alone is left alone, and is now doubly
guarded: the unglobbed literal fails `ASSEMBLE-ERROR` (red), and the manifest check rejects an empty
or missing `test/asm` before the glob is ever evaluated.

### `test/run_cosim.sh` — 13 probes

| comparison | forced red |
|---|---|
| control | exit 0, `Divergence list matches` |
| argument count; unreadable baseline; unexecutable `cosim.py` | exit 1 each |
| one-field baseline line | exit 1, `entries with no status` |
| suite shape, before the setup probe | exit 1, `nothing was run` |
| setup probe fails (no Sail) | exit 1, `setup is incomplete` |
| no `COSIM-STATUS` line at all | exit 1, `COSIM-ERROR 3` |
| status/exit disagreement, **both directions** | exit 1, `COSIM-ERROR status/exit mismatch 1` / `... 0` |
| control: baselined divergence at the baselined point | exit 0 |
| baselined program diverging **elsewhere**; unexpected agreement | exit 1 each |

### `test/cosim.py` — 16 probes

Driven end to end through a stub `sail_riscv_sim` (replaying a fixture trace in Sail's own format)
and a stub `cosim` binary (replaying a `CS` record stream). Everything between them — the
distinct-state reduction, the two cursors, the divergence labels, the HTIF verdict cross-check — is
the real script.

| comparison | forced red |
|---|---|
| control | exit 0, `COSIM-STATUS AGREE` |
| a differing register value | exit 1, `DISAGREE AT 1` |
| a change the core never made | exit 1, `DISAGREE LENGTH` |
| an **extra** architectural write | exit 1, `DISAGREE LENGTH` |
| sail hits `--inst-limit`; core hits its cycle budget | exit 2, `INCONCLUSIVE SAIL-LIMIT` / `INCONCLUSIVE CORE-TIMEOUT` |
| control: both sides `FAIL 3` | exit 0, `AGREE` |
| identical traces, different verdicts | exit 1, `DISAGREE VERDICT` |
| no `CS END` terminator; unparseable `CS` line | exit 3 each |
| sail produced no trace; empty trace; failing assembler | exit 3 each |
| `NONCOMPARABLE_CSRS` exemption is taken **and printed** | exit 0, `NOT COMPARED BY VALUE (1` |
| the exemption does **not** extend to the wrong register | exit 1, `DISAGREE` |

### `formal/check-baseline.sh` — 21 probes

| comparison | forced red |
|---|---|
| control (all pass, empty baseline) | exit 0, `Failure list matches` |
| argument count; missing baseline file | exit 2 each |
| **unreadable baseline / unreadable check set** | exit 2, `exists but is not readable` — **the finding**; before the fix, exit **0** and `Failure list matches ... exactly` |
| ladder never generated (no `*.sby`) | exit 2, `the ladder was never` |
| baseline format: one field; unknown status; `PASS`; `ERROR`; `NO-STATUS`; `PASS 0 31` | exit 2 ×6, each with its own message |
| a check goes red | exit 1, `beta FAIL` |
| control: baselined red at the baselined status | exit 0 |
| **still red, different reason** — `FAIL` baselined, `ERROR` on disk (ADR-0036's btorsim hole) | exit 1, `beta ERROR` |
| control: `TIMEOUT` is baselineable | exit 0 |
| generated-but-never-scheduled check | exit 1, `beta NO-STATUS` |
| a check **appeared**; a `[depth]` line was **lost** | exit 1, `Generated check set does NOT match` |
| an unrecognised status on disk | exit 1, `Unrecognised status` |

The finding, before the fix:

```
$ chmod 000 $D/EF && formal/check-baseline.sh $D/checks $D/EF $D/EC
sed: .../EF: Permission denied
1 checks: 1 pass, 0 fail
Failure list matches .../EF exactly (name and status).
Generated check set matches .../EC exactly (1 checks).
exit=0
```

`$D/EF` contained `alpha FAIL` and `alpha` was PASSing on disk, so it also swallowed an unexpected
pass. After the fix the same command exits 2 naming the file.

### `formal/check-complete-exclusions.py` — 15 probes

| comparison | forced red |
|---|---|
| control (shipping set vs its baseline, both ways) | exit 0, `COMPLETE EXCLUSION SET: PASS` |
| argument count | exit 2 |
| `insn_opcode` redefined off something other than `rvfi_insn` | exit 1, `expected the exact line defining` |
| predicate keyed on a decoder flag | exit 1, `must not be able to excuse` |
| wire name / opcode disagreeing with the declaration | exit 1 each |
| declared but unwired; `insn_excluded` not a plain disjunction | exit 1 each |
| declared mnemonic list widened without the baseline | exit 1, `declares an exclusion that` |
| baseline line with no predicate; malformed opcode | exit 1 each |
| **clause 5**: a pin that *adds* `insns/insn_fence.v` | exit 1, `EXISTS at the pin` |
| clause 5 via `isa_rv32imc.txt`; unreadable clone | exit 1 each |
| **clause 2**: an exclusion with no reason written under it | exit 1, `has no reason written under it` |

### `test/sanitize_monitor.py` — 7 probes (AC5: **re-run, not re-derived**)

The rule-3 content assertions were mutation-confirmed once when they landed. They are re-run here
against mutated **copies** of `test/monitor.v`; **no constant in the script was touched**, because
re-deriving `TRAP_GATE_ENCLOSED_CODES` from whatever the generator currently emits is exactly how a
change gets laundered into the expectation, which that list's own comment forbids.

- riscv-formal pin: `c992aa61fdfe0846c5ed90324c596202a1c69b76` (`formal/pin.mk`, unchanged)
- `test/monitor.v` blob: `git rev-parse HEAD:test/monitor.v` → `b839cdbda92f8a14553bb9e38203848cd2a9b99b`

| comparison | forced red |
|---|---|
| control (tracked monitor sanitizes, rule 3 fires) | exit 0, `if (!ch0_spec_trap) begin` present |
| usage | exit 2 |
| rule 1 site count | exit 1, `matched 3 site(s), expected 4` |
| rule 2 site count (ADR-0019's DIV/REM repair) | exit 1, `matched 1 site(s), expected 2` |
| **layer 1**: trap comparison relocated *into* the span | exit 1, `the generator now emits the` |
| **layer 2**: enclosed `handle_error` multiset changed | exit 1, `the span encloses` |
| **layer 3**: error 101 gone from the *output* | exit 1, `the trap comparison survives` |

### `formal/genchecks-audit.py` — 1 probe + 2 hand demonstrations

Probed: the working-directory guard (exit 1, `error: run from`), which is not decoration —
`genchecks` takes `corename` from the last path component and writes `checks/` relative to the cwd.

Hand-demonstrated (needs the pinned clone and a real generation run):

```
$ cd formal && grep -v '^insn_add_ch0$' EXPECTED_CHECKS > /tmp/ec && cp /tmp/ec EXPECTED_CHECKS
$ python3 genchecks-audit.py
generated ladder vs formal/EXPECTED_CHECKS: MISMATCH
  in EXPECTED_CHECKS but not generated: insn_add_ch0
exit=1                                                     # reverted
```

```
$ cd formal && sed -i.bak '526d' checks.cfg      # deletes `hang     1     30`
$ python3 genchecks-audit.py
generated ladder vs formal/EXPECTED_CHECKS: MISMATCH
  in EXPECTED_CHECKS but not generated: hang
dropped checks vs checks.cfg #omit declarations: MISMATCH
  in dropped but not #omit: hang
Ladder shape: 84 generated, 15 declined for want of a [depth] line.
exit=1                                                     # reverted
```

Control: `python3 genchecks-audit.py` → exit 0, `Ladder shape: 85 generated, 14 declined`, both set
equalities exact.

### `test/cxxrtl.cc` — hand demonstrations (needs the elaborated design)

```
$ ./sim                                                     -> 3   usage
$ ./sim --rom nope.hex --ram nope.hex --cycles 10           -> 3   error: cannot open nope.hex
$ ./sim --rom add.rom.hex  --ram add.ram.hex  --cycles 1    -> 6   "observed nothing this run: 0 retires"
$ ./sim --rom add.rom.hex  --ram add.ram.hex  --cycles 100  -> 2   TIMEOUT, RETIRES 53
$ ./sim --rom fail.rom.hex --ram fail.ram.hex --cycles 5000 -> 1   FAIL 7
$ ./sim --rom add.rom.hex  --ram add.ram.hex  --cycles 5000 -> 0   PASS, RETIRES 429
```

Exit 5, before and after the fix, on a scratch program whose second instruction is `ecall`:

```
before:   trapzero  exit=6   RETIRES 0 SPEC-CHECKED 0   -> run_tests.sh: MONITOR-SILENT
after:    trapzero  exit=5   RETIRES 0 SPEC-CHECKED 0   -> run_tests.sh: TRAP-TO-ZERO
control:  trapzero2 exit=5   RETIRES 6 SPEC-CHECKED 6   (ecall after six retiring instructions,
                                                         unchanged by the fix in either direction)
```

Exit 4, by mutating `test/testbench.v`'s monitor hookup to
`.rvfi_rd_wdata(rvfi_rd_wdata ^ 32'd1)`, rebuilding and running `add.S`:

```
MUTATED add.S exit=4
RVFI monitor error 105 at cycle 5          # "mismatch in rd_wdata"
```

Reverted; `git status` clean, and the mutation is not in any commit on this branch. **A warning
worth carrying**: the first attempt at this read as *not firing*, because a second, unmutated
`make sim` was racing it to the same output file. Do not run two builds concurrently while
mutating.

### The harness's own red direction

Reverting the `-r` fix and re-running gives exactly the two probes that guard it, and nothing else:

```
$ ./test/probe_gates.sh
  RED  an UNREADABLE baseline is refused, not read as an empty one
  RED  and the same for the check-set baseline
error: a graded comparison did not go red where it was supposed to.
EXIT=1
```

## Not demonstrable, and why (AC3)

| comparison | reason |
|---|---|
| `genchecks-audit.py`: traced names vs `genchecks`' own `consistency_checks`/`instruction_checks` | would need `formal/genchecks-local.py` to behave differently from the pin, and ADR-0031 holds that file byte-comparable with the clone |
| `genchecks-audit.py`: traced names vs `checks/*.sby` on disk | same, and measured: placing a stray `.sby` in `checks/` does not reach it, because `genchecks` recreates the directory on every run (attempted; exit 0) |
| `genchecks-audit.py`: "traced no `get_depth_cfg` calls" | same ADR-0031 reason |
| `test/cosim.cc`: `regs_a` vs `regs_b` divergence | needs an `rtl/regfile.v` mutation; out of this ticket's lane (a sibling owns the mutation campaign) |
| `test/cosim.cc`: the `uut regfile regs_a` lookup and shape guards | need the elaborated design; the lookup pointing at the array the core commits to is established by mutation in ADR-0042 |

## One observation, not changed

`formal/check-baseline.sh` runs under `set -u` alone — no `-e`, no `pipefail`. Every remaining path
fails closed (a missing status file resolves to `NO-STATUS`; an empty `find` is caught explicitly),
and adding `-e` to a script that deliberately reads nonzero statuses is the shape of change ADR-0035
measured a real cost for. The one path that did **not** fail closed is the `-r` finding above, fixed
at the source rather than by turning on `-e`.

## One probe was itself a false green, and CI found it

The "a half-installed toolchain says so once, up front" probe put its empty stub directory in
**front** of `/usr/bin`. On this laptop that is a machine with no cross compiler; on any host with
`riscv64-unknown-elf-gcc` installed there — every CI runner — `run_tests.sh` found one and the red
never happened. **Green locally, red on CI**, which is this file demonstrating its own thesis about
itself on its first run through a gate. It now runs with that directory as the whole `PATH`,
carrying symlinks to the utilities the scripts need before their compiler probe; `python3` and `env`
are deliberately excluded, because the same directory sits on every other probe's `PATH` and a
`python3` that is a version-manager shim would shadow the real interpreter for `test/cosim.py`.

## Gates

| gate | result |
|---|---|
| `make test` | **56/56 passed**, `Failure list matches test/EXPECTED_FAIL exactly (name and status)`, exit 0 — including `108 graded comparisons, every failure path executed` |
| `make test-units` | exit 0, `6 unit benches, matching test/*_tb.v exactly`; `exec_tb` / `mem_tb` / `decoder_tb` / `regfile_tb` / `csr_tb` / `monitor_tb` all PASSED |
| `make lint` | exit 0, `svlint: clean in both passes` |
| `make -C formal check` | exit 0, **85 checks: 85 pass, 0 fail**, both set equalities matching in both directions, 4m56s |
| `make -C formal check-baseline` | exit 0, same numbers re-graded off the finished run |
| `./test/probe_gates.sh` alone | exit 0, 108/108, 68-90s wall on this host |

The ladder was re-run **clean** for that number. A first attempt reported 75 pass / 10 `NO-STATUS`
and it was my own fault, not the core's: the `genchecks-audit.py` demonstrations above regenerate
`formal/checks/`, which ADR-0040 made delete the run directories first, and I ran them while the
ladder was in flight. Recorded because the failure mode is exactly the one this PR is about — a
grading result that was about the harness and looked like a result about the design. `check-baseline`
called it correctly: ten `NO-STATUS`, which its own header says means "the check was generated and
never scheduled", not "the property failed."


Closes JEF-695

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJ77ZZJ6pDiL3vj3Qw9hKs
