### PR TITLE
JEF-701: Record that a faulting bus reopens `fault_ch0` and the `bus_*` family, and puts invariant 2 under pressure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -587,8 +587,9 @@ These are the design. Violating one is a bug even if tests pass.
 2. **All traps are detected and committed in decode.** Nothing faults after decode. This is what
    makes CSR commit precise without a reorder buffer. **The memory system is what will test this**:
    an access fault is raised by memory refusing a transaction, i.e. after decode, so a bus that can
-   refuse forces a ruling on this invariant — which is why eleven ladder checks are declined today
-   and why ADR-0044 records the three options without picking one.
+   refuse forces a ruling on this invariant — which is why five of the fourteen checks
+   `formal/checks.cfg` declines are declined against it, and why ADR-0044 records the three options
+   without picking one.
 3. **Every inter-stage struct carries a `valid` bit.** A bubble is `valid = 0`; retire is `valid`
    reaching writeback, which gates `wen` and drives `rvfi_valid`.
 4. **Hazards are handled by stall-only interlock in decode.** No forwarding network. Adding one is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -585,7 +585,10 @@ These are the design. Violating one is a bug even if tests pass.
    **No flush logic may be introduced, ever.** If a change appears to need one, something upstream
    has gone wrong — stop and reconsider rather than adding a kill signal.
 2. **All traps are detected and committed in decode.** Nothing faults after decode. This is what
-   makes CSR commit precise without a reorder buffer.
+   makes CSR commit precise without a reorder buffer. **The memory system is what will test this**:
+   an access fault is raised by memory refusing a transaction, i.e. after decode, so a bus that can
+   refuse forces a ruling on this invariant — which is why eleven ladder checks are declined today
+   and why ADR-0044 records the three options without picking one.
 3. **Every inter-stage struct carries a `valid` bit.** A bubble is `valid = 0`; retire is `valid`
    reaching writeback, which gates `wen` and drives `rvfi_valid`.
 4. **Hazards are handled by stall-only interlock in decode.** No forwarding network. Adding one is

--- a/docs/adr/0044-what-the-memory-system-has-to-be.md
+++ b/docs/adr/0044-what-the-memory-system-has-to-be.md
@@ -143,3 +143,106 @@ system self-contained; the first costs a bootloader and a flash controller.
   target part. Reaching for the negedge because the remaining options are uncomfortable would be
   buying hardware that works with a core nobody can check, which is the trade this repo has spent
   the whole rewrite refusing.
+
+## Consequences for the formal ladder — eleven declined checks reopen, and invariant 2 comes under pressure
+
+Everything above is about hardware. This section is about the ladder, and it is the part that will
+be hardest to reconstruct later, because the thing it depends on is an *absence*: **this core's bus
+cannot refuse a transaction.** `imem_data`/`imem_data2`/`mem_rdata` are free every cycle, with no
+fault line and no handshake — invariant 1, ADR-0015, and `formal/wrapper.v`, which speaks that bus
+directly. A memory system that can say *no* is a different bus, and eleven of the checks
+`formal/checks.cfg` declines are declined against the bus we have.
+
+**The count is derived, not remembered.** `formal/genchecks-audit.py` reports, on this tree,
+`85 generated, 14 declined for want of a [depth] line`, and set-equalities that 14 against
+`checks.cfg`'s `#omit` lines in both directions. Of those fourteen:
+
+**Eleven are conditional on a memory system that does not exist. Named, so the burn-down is
+mechanical:**
+
+| check | what it needs that today's bus cannot give |
+|---|---|
+| `fault_ch0` | `rvfi_mem_fault{,_rmask,_wmask}` — a transaction the memory refused |
+| `bus_imem_ch0` | `RISCV_FORMAL_BUS` |
+| `bus_imem_fault_ch0` | `RISCV_FORMAL_BUS` + a faulting bus |
+| `bus_dmem_ch0` | `RISCV_FORMAL_BUS` |
+| `bus_dmem_fault_ch0` | `RISCV_FORMAL_BUS` + a faulting bus |
+| `bus_dmem_io_read_ch0` | `RISCV_FORMAL_BUS` + a distinguished MMIO region (`rvformal_addr_io`) |
+| `bus_dmem_io_read_fault_ch0` | the same, plus a faulting bus |
+| `bus_dmem_io_write_ch0` | `RISCV_FORMAL_BUS` + `rvformal_addr_io` |
+| `bus_dmem_io_write_fault_ch0` | the same, plus a faulting bus |
+| `bus_dmem_io_order_ch0` | `RISCV_FORMAL_BUS` + `rvformal_addr_io` + more than one outstanding access |
+| `causal_io_ch0` | `rvformal_addr_io` |
+
+**Two of those eleven carry a standing second argument that no memory design touches**:
+`bus_imem_ch0` and `bus_dmem_ch0` would re-derive a property `formal/imemcheck.sv` and
+`formal/dmemcheck.sv` already hold against the real split `imem_addr`/`imem_addr2` interface, and
+adopting them means driving nine more RVFI outputs — which ADR-0047's non-perturbation check has an
+interest in. Expect those two to be re-tagged as declined-on-the-merits rather than adopted. They
+are listed here anyway, because a ruling made once and written down beats a check that quietly
+never gets reconsidered.
+
+**Three are not conditional at all, and no memory design reopens them**: `csrc_inc_mcycle_ch0` and
+`csrc_inc_minstret_ch0` (red on a *correct* core — a defect in `rvfi_csrc_inc_check.sv`'s shadow
+model, measured and swept in `checks.cfg`'s `[csrs]` block), and `cover` (relocated to
+`formal/cover.sby` with this repo's own five goals). That eleven/three split is why `checks.cfg`'s
+`#omit` lines now carry a `[BLOCKED]`/`[DESIGN]` tag: both classes read identically as prose, and a
+future reader cannot otherwise tell a burn-down item from a settled decision.
+
+### `fault_ch0` is where the ladder and invariant 2 meet
+
+`checks.cfg`'s omit line for it said the check *"models a post-decode trap invariant 2 forbids"* —
+true, and stated as though the matter were settled. It is not settled; it is *unreached*. The two
+propositions only coexist because nothing on this core can raise an access fault:
+
+- **Invariant 2** says every trap is detected **and committed** in decode, and that this is what
+  makes CSR commit precise with no reorder buffer.
+- **An access fault is raised by the memory**, which answers after decode has already committed.
+
+So the memory system does not merely unblock eleven checks. **It forces a ruling on one of the nine
+invariants** — the ones `CLAUDE.md` opens by saying are a bug to violate even if the tests pass.
+
+Read from `checks/rvfi_fault_check.sv` at the pin (`c992aa61`) rather than from memory, because the
+check's shape narrows the question usefully. It splits into three cases by fault mask, and they are
+not equally hard:
+
+- `wfault` → asserts `mcause == 7` (store access fault) — **after decode**
+- `rfault` → asserts `mcause == 5` (load access fault) — **after decode**
+- `ifault` (neither mask set, `insn == 0`) → asserts `mcause == 1`, instruction access fault —
+  which arrives **with the fetched instruction**, in the cycle decode is looking at it, and is
+  therefore the one case that could be committed in decode with invariant 2 untouched.
+
+One more thing that makes the burn-down concrete: the whole `mcause` half of that check sits under
+`` `ifdef RISCV_FORMAL_CSR_MCAUSE ``, and `genchecks` emits that define only for CSRs named in
+`[csrs]` — where `mcause` is deliberately absent for the WARL reason written out there. **Reopening
+`fault_ch0` is therefore three things, not one**: a bus that can refuse, `rvfi_mem_fault*` driven
+from `rtl/`, and `mcause` on the RVFI CSR set (which is blocked on its own, unrelated grounds).
+
+### The options — recorded, not chosen
+
+Three, and they are visible now in a way they will not be once a design is half-built:
+
+1. **No faulting bus at all.** An address-decoded system where every access in range is answered
+   and nothing out of range is reachable. Invariant 2 survives untouched; the eleven checks stay
+   declined permanently, and their `#omit` lines become `[DESIGN]`.
+2. **Faults resolved in decode by construction.** The memory map is a static address-range decode
+   that decode itself can evaluate from the address it already computes — the same
+   `$signed(immediate) + $signed(reg_rs1)` the misalignment check reads. There is no *dynamic*
+   refusal, so a fault is a decode-time property of the address and invariant 2 holds as written.
+   `fault_ch0` becomes reachable at least for `ifault`; `rfault`/`wfault` follow only if the range
+   decode is exact.
+3. **Invariant 2 changes**, with its own ADR, its own precision argument, and a rewrite of the
+   ladder's post-decode trap story.
+
+**This ADR picks none of them**, deliberately and for the same reason it declines to pre-decide the
+memory design at all: the choice belongs to the eventual ADR, taken with measurements this repo
+does not have. ADR-0038 set that precedent by refusing to decide the regfile before the spike data
+existed, and ADR-0042 then decided it *with* the data — including a cycle cost nobody would have
+guessed at (+18.0%) and a verifiability argument that reversed the area-only recommendation.
+Guessing here would produce a decision of the quality of the one ADR-0038 refused to make.
+
+**What the eventual memory ADR owes this one**: a ruling on each of the eleven checks *by name*,
+with each `#omit` line either deleted (the check joins the ladder), re-tagged `[DESIGN]` (it is
+declined permanently, on the merits), or left `[BLOCKED]` with what it is still blocked on. That is
+the same burn-down shape as `formal/EXPECTED_FAIL`, and it is why the eleven are tabulated above
+instead of described.

--- a/docs/adr/0044-what-the-memory-system-has-to-be.md
+++ b/docs/adr/0044-what-the-memory-system-has-to-be.md
@@ -223,8 +223,10 @@ from `rtl/`, and `mcause` on the RVFI CSR set (which is blocked on its own, unre
 Three, and they are visible now in a way they will not be once a design is half-built:
 
 1. **No faulting bus at all.** An address-decoded system where every access in range is answered
-   and nothing out of range is reachable. Invariant 2 survives untouched; the eleven checks stay
-   declined permanently, and their `#omit` lines become `[DESIGN]`.
+   and nothing out of range is reachable. Invariant 2 survives untouched, and every `*_fault` check
+   plus `fault_ch0` is declined permanently — those five `#omit` lines become `[DESIGN]`. The
+   remaining five `bus_*` and `causal_io_ch0` are decided separately: by whether the map ends up
+   with a distinguished IO region, and by the `imemcheck`/`dmemcheck` argument above.
 2. **Faults resolved in decode by construction.** The memory map is a static address-range decode
    that decode itself can evaluate from the address it already computes — the same
    `$signed(immediate) + $signed(reg_rs1)` the misalignment check reads. There is no *dynamic*

--- a/docs/adr/0044-what-the-memory-system-has-to-be.md
+++ b/docs/adr/0044-what-the-memory-system-has-to-be.md
@@ -157,7 +157,7 @@ directly. A memory system that can say *no* is a different bus, and eleven of th
 `85 generated, 14 declined for want of a [depth] line`, and set-equalities that 14 against
 `checks.cfg`'s `#omit` lines in both directions. Of those fourteen:
 
-**Eleven are conditional on a memory system that does not exist. Named, so the burn-down is
+**Eleven are conditional on hardware that does not exist yet. Named, so the burn-down is
 mechanical:**
 
 | check | what it needs that today's bus cannot give |
@@ -174,7 +174,30 @@ mechanical:**
 | `bus_dmem_io_order_ch0` | `RISCV_FORMAL_BUS` + `rvformal_addr_io` + more than one outstanding access |
 | `causal_io_ch0` | `rvformal_addr_io` |
 
-**Two of those eleven carry a standing second argument that no memory design touches**:
+**They do not all turn on the same decision, and that is worth more than the grouping.** The
+one-line story — "eleven checks are declined because the bus cannot refuse a transaction" — is the
+right story for **five** of them and is wrong about the other six. Sorted by what actually unblocks
+each:
+
+- **A faulting bus (5)** — `fault_ch0`, `bus_imem_fault_ch0`, `bus_dmem_fault_ch0`,
+  `bus_dmem_io_read_fault_ch0`, `bus_dmem_io_write_fault_ch0`. **These five, and only these five,
+  are the ones that put invariant 2 in question.** Everything in the rest of this section about
+  post-decode traps is about them.
+- **A distinguished IO region in the map (4)** — `bus_dmem_io_read_ch0`, `bus_dmem_io_write_ch0`,
+  `bus_dmem_io_order_ch0`, `causal_io_ch0`. A memory-*map* question with no invariant-2 content at
+  all: ADR-0008's map has a `tohost` doubleword, not a region the RTL treats differently. A design
+  could add a faulting bus and leave all four exactly where they are, or add an IO region and leave
+  the five above exactly where they are. (The two `io_*_fault` checks need both this and a faulting
+  bus, which is why they are counted in the first group.)
+- **`RISCV_FORMAL_BUS` plumbing and nothing else (2)** — `bus_imem_ch0`, `bus_dmem_ch0`.
+
+And one of them is not blocked on the memory system at all: **`bus_dmem_io_order_ch0` is blocked on
+the core.** There is nothing to order because the accessor has one access outstanding at a time
+(ADR-0015), and no memory design changes that — a second outstanding access is a pipeline change,
+with everything invariant 8's stall protocol would have to say about it. It sits in the eleven
+because it is declined against today's system, not because this work reopens it.
+
+**Two of the eleven carry a standing second argument that no memory design touches**:
 `bus_imem_ch0` and `bus_dmem_ch0` would re-derive a property `formal/imemcheck.sv` and
 `formal/dmemcheck.sv` already hold against the real split `imem_addr`/`imem_addr2` interface, and
 adopting them means driving nine more RVFI outputs — which ADR-0047's non-perturbation check has an
@@ -245,6 +268,8 @@ Guessing here would produce a decision of the quality of the one ADR-0038 refuse
 
 **What the eventual memory ADR owes this one**: a ruling on each of the eleven checks *by name*,
 with each `#omit` line either deleted (the check joins the ladder), re-tagged `[DESIGN]` (it is
-declined permanently, on the merits), or left `[BLOCKED]` with what it is still blocked on. That is
-the same burn-down shape as `formal/EXPECTED_FAIL`, and it is why the eleven are tabulated above
-instead of described.
+declined permanently, on the merits), or left `[BLOCKED]` with what it is still blocked on — which
+is the honest outcome for at least `bus_dmem_io_order_ch0`, whose blocker is the core's single
+outstanding access and not the memory at all. That is the same burn-down shape as
+`formal/EXPECTED_FAIL`, and it is why the eleven are tabulated above and sorted by blocker instead
+of described as a group.

--- a/formal/checks.cfg
+++ b/formal/checks.cfg
@@ -209,15 +209,53 @@ mscratch any
 # genchecks' cfg parser drops every line starting with `#`, so these
 # declarations are invisible to it and cannot perturb generation.
 #
+# EVERY `#omit` LINE CARRIES A CLASS TAG, and the distinction is the one a
+# future reader most needs and could least recover:
+#
+#   [BLOCKED]  Declined for want of HARDWARE THAT DOES NOT EXIST YET. The
+#              property is wanted; there is nothing here to state it about.
+#              These are a BURN-DOWN, owned by the memory-system ADR
+#              (ADR-0044 has the eleven tabulated by name), and each one is
+#              either deleted, re-tagged [DESIGN], or re-stated with what it
+#              is still blocked on when that work lands.
+#
+#   [DESIGN]   Declined ON THE MERITS. No hardware change reopens it. Either
+#              the upstream model is wrong for this core, or the property is
+#              held better somewhere else in this tree.
+#
+# The tag is prose like the rest of the line -- formal/genchecks-audit.py's
+# OMIT_RE captures the check NAME and treats everything after it as a free-
+# form reason, so tagging cannot perturb the set equality or generation.
+#
 # The reasons, grouped. Nothing here is a depth problem:
 #
 # 1. `fault` and every `*_fault` variant model a bus that can refuse a
 #    transaction. This core's bus cannot: imem_data/imem_data2/mem_rdata
 #    are free every cycle with no fault line and no handshake (invariant 1,
-#    ADR-0015, formal/wrapper.v). More decisively, a bus fault is by
-#    construction detected *after* decode, and invariant 2 says nothing
-#    faults after decode. These check a trap model this design has ruled
-#    out; they need an ADR before they need a depth.
+#    ADR-0015, formal/wrapper.v). There is nothing here to refuse anything,
+#    so there is no property to state -- which is why these are [BLOCKED]
+#    and not [DESIGN].
+#
+#    THE SECOND HALF OF THIS ENTRY USED TO READ AS SETTLED AND IS NOT.
+#    A bus fault is raised by the memory, i.e. AFTER decode, and invariant 2
+#    says every trap is detected and committed IN decode. Those two coexist
+#    today only because no access fault is reachable on this core. A memory
+#    system that can refuse a transaction therefore forces a ruling on
+#    invariant 2 -- and the honest options (no faulting bus at all; faults
+#    resolved in decode by construction from a static address-range decode;
+#    or invariant 2 changes) are recorded in ADR-0044, DELIBERATELY UNDECIDED.
+#    Do not read "invariant 2 forbids it" here as the decision having been
+#    taken. It needs that ADR before it needs a depth.
+#
+#    Worth knowing before reopening fault_ch0, read off checks/
+#    rvfi_fault_check.sv at the pin: it splits three ways. wfault asserts
+#    mcause == 7 and rfault mcause == 5 -- both post-decode. ifault asserts
+#    mcause == 1, an INSTRUCTION access fault, which arrives with the fetched
+#    instruction in the cycle decode reads it and so sits inside invariant 2
+#    unchanged. And its whole mcause half is under `RISCV_FORMAL_CSR_MCAUSE`,
+#    which genchecks emits only for a CSR named in [csrs] -- where mcause is
+#    absent for the WARL reason above. So that check needs three things, not
+#    one.
 #
 # 2. All nine bus_* need `RISCV_FORMAL_BUS` -- a second RVFI interface:
 #    bus_valid, bus_insn, bus_data, bus_fault, bus_addr, bus_rmask,
@@ -233,6 +271,14 @@ mscratch any
 #    re-derive a result already held, and would put an `ifdef RISCV_FORMAL`
 #    value on a path the core reads -- exactly what ADR-0020's
 #    non-perturbation argument depends on nothing doing.
+#
+#    All nine are tagged [BLOCKED], because a memory system with a real bus
+#    is what makes any of them statable and the eventual ADR has to rule on
+#    each by name. TWO OF THE NINE CARRY A STANDING [DESIGN] ARGUMENT AS
+#    WELL: bus_imem_ch0 and bus_dmem_ch0 would re-derive a property
+#    formal/imemcheck.sv and formal/dmemcheck.sv already hold, and that stays
+#    true whatever the memory turns out to be. Expect those two to be
+#    re-tagged [DESIGN] rather than adopted.
 #
 # 3. The two csrc_inc_* are declined because rvfi_csrc_inc_check.sv is RED
 #    ON A CORRECT CORE here. The counterexample, the depth sweep that shows
@@ -258,7 +304,16 @@ mscratch any
 #    generated ladder as well.
 #
 # 5. `causal_io` needs the same `rvformal_addr_io` region as the three bus
-#    io checks, for the same reason: there isn't one.
+#    io checks, for the same reason: there isn't one. [BLOCKED], with them.
+#
+# COUNTING THE TWO CLASSES, so the split is not left to be inferred: of the
+# fourteen lines below, ELEVEN are [BLOCKED] -- fault_ch0, all nine bus_*,
+# and causal_io_ch0 -- and every one of them traces to the same absence, a
+# bus that cannot refuse a transaction and a map with no distinguished IO
+# region. THREE are [DESIGN] and no hardware reopens them: the two
+# csrc_inc_* (reason 3) and `cover` (reason 4). The fourteen is derived --
+# formal/genchecks-audit.py prints it and set-equalities it both ways -- so
+# re-derive it after a pin bump rather than trusting this paragraph.
 #
 # THREE checks that used to sit in this list are now ON the ladder, and
 # their absence was the hole ADR-0033 found.
@@ -288,20 +343,20 @@ mscratch any
 #                   omitting it evaporated on inspection, and the check went
 #                   on the ladder instead. PASSes in ~3s.
 #
-#omit fault_ch0                   needs rvfi_mem_fault{,_rmask,_wmask} and mcause; models a post-decode trap invariant 2 forbids
-#omit bus_imem_ch0                needs RISCV_FORMAL_BUS; property already held by formal/imemcheck.sv
-#omit bus_imem_fault_ch0          needs RISCV_FORMAL_BUS; and a bus that can refuse a transaction
-#omit bus_dmem_ch0                needs RISCV_FORMAL_BUS; property already held by formal/dmemcheck.sv
-#omit bus_dmem_fault_ch0          needs RISCV_FORMAL_BUS; and a bus that can refuse a transaction
-#omit bus_dmem_io_read_ch0        needs RISCV_FORMAL_BUS and rvformal_addr_io; no MMIO region exists
-#omit bus_dmem_io_read_fault_ch0  needs RISCV_FORMAL_BUS, rvformal_addr_io, and a faulting bus
-#omit bus_dmem_io_write_ch0       needs RISCV_FORMAL_BUS and rvformal_addr_io; no MMIO region exists
-#omit bus_dmem_io_write_fault_ch0 needs RISCV_FORMAL_BUS, rvformal_addr_io, and a faulting bus
-#omit bus_dmem_io_order_ch0       needs RISCV_FORMAL_BUS and rvformal_addr_io; one outstanding access, no ordering to check
-#omit causal_io_ch0               needs rvformal_addr_io; no MMIO region exists
-#omit csrc_inc_mcycle_ch0         rvfi_csrc_inc_check.sv is red on a CORRECT core here; measured, see [csrs]
-#omit csrc_inc_minstret_ch0       rvfi_csrc_inc_check.sv is red on a CORRECT core here; measured, see [csrs]
-#omit cover                       run standalone by formal/cover.sby with this repo's own five goals
+#omit fault_ch0                   [BLOCKED] needs a bus that can refuse, rvfi_mem_fault{,_rmask,_wmask}, and mcause in [csrs]; and it puts invariant 2 in question -- ADR-0044
+#omit bus_imem_ch0                [BLOCKED] needs RISCV_FORMAL_BUS; property already held by formal/imemcheck.sv, so expect [DESIGN] on review
+#omit bus_imem_fault_ch0          [BLOCKED] needs RISCV_FORMAL_BUS and a bus that can refuse a transaction
+#omit bus_dmem_ch0                [BLOCKED] needs RISCV_FORMAL_BUS; property already held by formal/dmemcheck.sv, so expect [DESIGN] on review
+#omit bus_dmem_fault_ch0          [BLOCKED] needs RISCV_FORMAL_BUS and a bus that can refuse a transaction
+#omit bus_dmem_io_read_ch0        [BLOCKED] needs RISCV_FORMAL_BUS and rvformal_addr_io; no MMIO region exists
+#omit bus_dmem_io_read_fault_ch0  [BLOCKED] needs RISCV_FORMAL_BUS, rvformal_addr_io, and a faulting bus
+#omit bus_dmem_io_write_ch0       [BLOCKED] needs RISCV_FORMAL_BUS and rvformal_addr_io; no MMIO region exists
+#omit bus_dmem_io_write_fault_ch0 [BLOCKED] needs RISCV_FORMAL_BUS, rvformal_addr_io, and a faulting bus
+#omit bus_dmem_io_order_ch0       [BLOCKED] needs RISCV_FORMAL_BUS and rvformal_addr_io; one outstanding access, no ordering to check
+#omit causal_io_ch0               [BLOCKED] needs rvformal_addr_io; no MMIO region exists
+#omit csrc_inc_mcycle_ch0         [DESIGN] rvfi_csrc_inc_check.sv is red on a CORRECT core here; measured, see [csrs]
+#omit csrc_inc_minstret_ch0       [DESIGN] rvfi_csrc_inc_check.sv is red on a CORRECT core here; measured, see [csrs]
+#omit cover                       [DESIGN] run standalone by formal/cover.sby with this repo's own five goals
 # ------------------------------------------------------------------------
 
 [depth]

--- a/formal/checks.cfg
+++ b/formal/checks.cfg
@@ -308,12 +308,29 @@ mscratch any
 #
 # COUNTING THE TWO CLASSES, so the split is not left to be inferred: of the
 # fourteen lines below, ELEVEN are [BLOCKED] -- fault_ch0, all nine bus_*,
-# and causal_io_ch0 -- and every one of them traces to the same absence, a
-# bus that cannot refuse a transaction and a map with no distinguished IO
-# region. THREE are [DESIGN] and no hardware reopens them: the two
-# csrc_inc_* (reason 3) and `cover` (reason 4). The fourteen is derived --
-# formal/genchecks-audit.py prints it and set-equalities it both ways -- so
-# re-derive it after a pin bump rather than trusting this paragraph.
+# and causal_io_ch0. THREE are [DESIGN] and no hardware reopens them: the
+# two csrc_inc_* (reason 3) and `cover` (reason 4). The fourteen is derived
+# -- formal/genchecks-audit.py prints it and set-equalities it both ways --
+# so re-derive it after a pin bump rather than trusting this paragraph.
+#
+# THE ELEVEN DO NOT ALL TURN ON THE SAME DECISION, and reading them as one
+# group is the mistake this paragraph exists to prevent. Sorted by blocker:
+#
+#   a faulting bus (5)      fault_ch0 and the four *_fault. THESE FIVE, AND
+#                           ONLY THESE FIVE, are the ones that put invariant
+#                           2 in question.
+#   an IO region (4)        the three bus_dmem_io_* non-fault forms and
+#                           causal_io_ch0. A memory-MAP question with no
+#                           invariant 2 content whatever. (The two io_*_fault
+#                           checks need this AND a faulting bus, and are
+#                           counted above.)
+#   BUS plumbing only (2)   bus_imem_ch0, bus_dmem_ch0 -- which also carry
+#                           the standing [DESIGN] argument in reason 2.
+#
+# And bus_dmem_io_order_ch0 is NOT blocked on the memory system at all: it
+# is blocked on THIS CORE, which has one access outstanding at a time
+# (ADR-0015). A second one is a pipeline change with everything invariant 8
+# would have to say about it, so no memory design reopens that check either.
 #
 # THREE checks that used to sit in this list are now ON the ladder, and
 # their absence was the hole ADR-0033 found.


### PR DESCRIPTION
Closes JEF-701

Docs only. No RTL, no change to which checks the ladder declines, no invariant changed.

## The headline is a correction, not the amendment that was asked for

The ticket's framing — *eleven declined checks turn on one thing, this core's bus cannot refuse a
transaction* — **is right for five of them and wrong about the other six.** Reading the eleven as
one group is what hides the useful structure, so the ADR now sorts them by what actually unblocks
each:

| blocker | count | checks | bears on invariant 2? |
|---|---|---|---|
| **a faulting bus** | 5 | `fault_ch0`, `bus_imem_fault_ch0`, `bus_dmem_fault_ch0`, `bus_dmem_io_read_fault_ch0`, `bus_dmem_io_write_fault_ch0` | **yes — only these** |
| **a distinguished IO region in the map** | 4 | `bus_dmem_io_read_ch0`, `bus_dmem_io_write_ch0`, `bus_dmem_io_order_ch0`, `causal_io_ch0` | no — a memory-*map* question with no invariant-2 content |
| **`RISCV_FORMAL_BUS` plumbing alone** | 2 | `bus_imem_ch0`, `bus_dmem_ch0` | no |

A design could add a faulting bus and leave the middle four exactly where they are, or add an IO
region and leave the top five exactly where they are. The two `io_*_fault` checks need both, which
is why they are counted in the first row.

**And one of the eleven is not blocked on the memory system at all.** `bus_dmem_io_order_ch0` is
blocked on *this core*: there is nothing to order because the accessor has one access outstanding
at a time (ADR-0015), and a second one is a pipeline change with everything invariant 8 would have
to say about it. The eventual memory ADR should expect to leave that line `[BLOCKED]` rather than
rule on it.

Two more that will not move on memory grounds: `bus_imem_ch0` and `bus_dmem_ch0` re-derive a
property `formal/imemcheck.sv` and `formal/dmemcheck.sv` already hold against the real split
`imem_addr`/`imem_addr2` interface, and adopting them means driving nine more RVFI outputs — which
ADR-0047's non-perturbation check has an interest in. Expect those two to be re-tagged
declined-on-the-merits. They stay listed anyway: a ruling made once and written down beats a check
that quietly never gets reconsidered.

## The tension this exists to record

`fault_ch0`'s omit line read *"models a post-decode trap invariant 2 forbids"* — the tension stated
as though it were settled. It is **unreached, not settled**:

- **invariant 2** says every trap is detected *and committed* in decode, and that this is what makes
  CSR commit precise with no reorder buffer;
- an **access fault** is raised by the memory, which answers *after* decode.

Those two coexist today only because nothing on this core can raise an access fault. So the memory
design does not merely unblock checks — **it forces a ruling on one of the nine invariants.**
ADR-0044 records the three options — no faulting bus at all; faults resolved in decode by
construction from a static address-range decode; invariant 2 changes with its own ADR — and **picks
none of them.** Pre-deciding the memory design is what ADR-0044 declines to do, on ADR-0038's
precedent of not deciding the regfile before the spike data existed (ADR-0042 then decided it *with*
data that reversed the area-only recommendation).

`checks.cfg`'s `#omit` lines now carry a **`[BLOCKED]` / `[DESIGN]`** class tag, because "blocked on
hardware that does not exist yet" and "declined on the merits" read identically as prose and a future
reader could not otherwise tell a burn-down item from a settled decision. Eleven `[BLOCKED]`, three
`[DESIGN]` (`csrc_inc_mcycle_ch0`, `csrc_inc_minstret_ch0`, `cover`).

## How each claim was verified

| claim | how |
|---|---|
| fourteen declined, eleven memory-conditional | `python3 formal/genchecks-audit.py` → `85 generated, 14 declined`, both set equalities exact. Counted from the generator's output, not by hand |
| nine `bus_*`, not ten | the audit's dropped set; ADR-0031 says nine independently |
| `fault_ch0` asserts `mcause` 5 / 7 | read off `checks/rvfi_fault_check.sv` in the clone at the pin |
| `fault_ch0` has a **third** case | same file: `ifault` (neither fault mask set) asserts `mcause == 1`, an *instruction* access fault — which arrives with the fetched instruction, in the cycle decode reads it, and so sits inside invariant 2 unchanged. Recorded because it narrows the eventual decision |
| reopening `fault_ch0` is three things, not one | its whole `mcause` block is under `` `ifdef RISCV_FORMAL_CSR_MCAUSE ``, and `formal/genchecks-local.py:494` emits that define only for a CSR named in `[csrs]` — where `mcause` is absent for the WARL reason already written there |
| `bus_dmem_io_order_ch0` is blocked on the core | ADR-0015 and `checks.cfg`'s own reason 2: one outstanding access at a time |
| the `csrc` "has never existed upstream" phrasing | **already correct — a sibling landed it**, in both `[csrs]` and omit-reason 3, with the evidence. Re-verified anyway in the clone: `git rev-parse origin/main` equals the pin `c992aa61`, `git rev-list --count HEAD..origin/main` is 0, `git log --all --diff-filter=AD -- checks/rvfi_csrc_check.sv` is empty, `git grep -l rvfi_csrc_check $(git rev-list --all)` is empty, and `git tag` lists nothing. No edit needed; none made |
| tagging cannot perturb generation | `genchecks-audit.py`'s `OMIT_RE` captures the check name and treats the rest of the line as free-form reason; audit re-run after every prose edit gives an identical verdict |

## Gates

| gate | result |
|---|---|
| `make -C formal check` | `85 generated, 14 declined`, `#omit: 14 names, exact match`; **`85 checks: 85 pass, 0 fail`**, `Failure list matches EXPECTED_FAIL exactly (name and status)`, `Generated check set matches EXPECTED_CHECKS exactly (85 checks)`, exit 0 |
| `make test` | **56/56 passed**, `Failure list matches test/EXPECTED_FAIL exactly (name and status)`, exit 0 |
| `make lint` | `svlint: clean in both passes` |

**Ladder note, because the run needed two passes to get there.** The ladder is slow on this
machine — ~46 minutes, against the 310s CLAUDE.md records — and the first full run was killed with
`csrw_minstret_ch0`, `csrw_mscratch_ch0` and `insn_sw_ch0` still solving. All three came back
`NO-STATUS`, which `formal/EXPECTED_FAIL`'s header is explicit is *the harness not finishing*, not a
property failing, and which it forbids baselining for exactly that reason. Re-running those three
alone (`sby -f`, full machine) gave `PASS 0 104`, `PASS 0 186` and `PASS 0 30`, and
`make -C formal check-baseline` then graded the complete run — the tally above. No `rtl/` file is
touched by this branch, so no check's verdict can move on its account.

*Process note, since it cost a ladder run:* running `formal/genchecks-audit.py` while
`make -C formal check` is in flight destroys the run — `genchecks-local.py:280` is
`shutil.rmtree(cfgname)`, which deletes `checks/` out from under the live `sby` processes and turns
the rest of the ladder into `FileNotFoundError: ... .sby`. The first run was killed that way by my
own audit; the number above is from a clean re-run with `checks/` removed first.

## Files

- `docs/adr/0044-what-the-memory-system-has-to-be.md` — new consequences section
- `formal/checks.cfg` — `#omit` prose and the reason block above it. `[depth]` and `[csrs]` untouched
- `CLAUDE.md` — one sentence on invariant 2 recording the pressure; the invariant itself is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJ77ZZJ6pDiL3vj3Qw9hKs
