### PR TITLE
JEF-716: exec_tb runs 10,000 vectors per op and never exercises plain ADD

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -497,8 +497,9 @@ signal and is the single entry on the `elaborate` gate's allowlist; everything e
 note). It is not zero, and this line said zero until ADR-0037. The
 cxxrtl binary builds and runs, the whole `.S` suite passes under it with `test/EXPECTED_FAIL`
 empty, `make test-units` passes (six benches: `exec_tb` — 10,000 randomized differential vectors
-per op across `mul`/`mulh`/`mulhu`/`mulhsu`/`div`/`divu`/`rem`/`remu` **and**
-`sll`/`srl`/`sra`, plus 384 directed shift vectors per shift op sweeping every amount 0-31 with a
+per op across `mul`/`mulh`/`mulhu`/`mulhsu`/`div`/`divu`/`rem`/`remu`/`sll`/`srl`/`sra` **and**
+`add`/`sub` — the latter pair closing the bench's own blind spot on the simplest ALU op — plus 384
+directed shift vectors per shift op sweeping every amount 0-31 with a
 clean and a dirty rs2 so the `rs2[4:0]` mask is checked rather than coincided with, and — because
 ADR-0045 names it M2's mul/div oracle and ADR-0033's rule is that a named gate must be unable to
 stop checking quietly — it now asserts **its own shape** first: every mul and div reference is

--- a/test/exec_tb.v
+++ b/test/exec_tb.v
@@ -16,6 +16,20 @@
 // from you; read the comment above the shift reference model below before
 // touching it.
 //
+// ADD and SUB are covered the same way, added for a narrower reason: this is
+// the bench that exists specifically to grind the executor's arithmetic, and
+// it drove zero vectors through the simplest, most-used ALU operation in the
+// ISA. ADR-0010's *primary-guarantee* language is scoped to the ops
+// RISCV_FORMAL_ALTOPS hides from the riscv-formal ladder, which ADD/SUB are
+// not -- `insn_add_ch0`/`insn_sub_ch0` exercise real arithmetic on every PR.
+// But that ladder is `mode bmc`, not `mode prove` (see CLAUDE.md's milestone
+// caveats), and the randomized loop here is the fast, targeted leg for
+// exactly this datapath -- the same reasoning that put shifts here despite
+// `insn_sll_ch0`/`insn_srl_ch0`/`insn_sra_ch0` existing too. An ADD off-by-one
+// was measured reaching `tohost` via the `.S` suite and co-simulation while
+// every unit bench stayed silent; this closes that gap the cheap way, on the
+// same footing as everything else here.
+//
 // ---- THIS BENCH ASSERTS ITS OWN SHAPE BEFORE IT ASSERTS ANYTHING ABOUT THE
 //      CORE, AND THAT IS DELIBERATE ------------------------------------------
 //
@@ -88,7 +102,9 @@ module exec_tb;
   localparam int OP_SLL    = 8;
   localparam int OP_SRL    = 9;
   localparam int OP_SRA    = 10;
-  localparam int NUM_OPS   = 11;
+  localparam int OP_ADD    = 11;
+  localparam int OP_SUB    = 12;
+  localparam int NUM_OPS   = 13;
 
   string op_names  [0:NUM_OPS-1];
   int    vec_count [0:NUM_OPS-1];
@@ -159,6 +175,8 @@ module exec_tb;
       op_names[OP_SLL]    = "sll";
       op_names[OP_SRL]    = "srl";
       op_names[OP_SRA]    = "sra";
+      op_names[OP_ADD]    = "add";
+      op_names[OP_SUB]    = "sub";
       for (k = 0; k < NUM_OPS; k++) vec_count[k] = 0;
       dir_pending = DIRECTED_N;
 
@@ -256,6 +274,21 @@ module exec_tb;
     begin
       ref_remu = (b == 0) ? a : (a % b);
     end
+  endfunction
+
+  // ---- reference model: add / sub --------------------------------------
+  //
+  // Neither of these touches `$signed` or a conditional expression at all --
+  // two's-complement add/sub is signedness-independent bit for bit -- so the
+  // sign-context hazard above the shift references does not apply here.
+  // Direct one-line assignments, same as ref_divu/ref_remu above for the same
+  // reason: nothing here is a `?:` arm evaluating a signed operand.
+  function automatic logic [31:0] ref_add(input logic [31:0] a, input logic [31:0] b);
+    ref_add = a + b;
+  endfunction
+
+  function automatic logic [31:0] ref_sub(input logic [31:0] a, input logic [31:0] b);
+    ref_sub = a - b;
   endfunction
 
   // ---- reference model: shifts ----------------------------------------
@@ -434,6 +467,8 @@ module exec_tb;
         OP_SLL:    in.is_sll    = 1'b1;
         OP_SRL:    in.is_srl    = 1'b1;
         OP_SRA:    in.is_sra    = 1'b1;
+        OP_ADD:    in.is_add    = 1'b1;
+        OP_SUB:    in.is_sub    = 1'b1;
       endcase
 
       // Everything this bench claims about its own coverage is measured here,
@@ -556,6 +591,13 @@ module exec_tb;
     // ...including the reference's own rs2[4:0] masking, on both sides of 32.
     ref_selftest("sra(80000000,36)", ref_sra(32'h80000000, 32'd36), 32'hf8000000);
     ref_selftest("sll(00000001,32)", ref_sll(32'h00000001, 32'd32), 32'h00000001);
+    // ---- add / sub references ------------------------------------------
+    // Two's complement wraps: -1 + 1 = 0; INT_MAX + 1 overflows into the sign
+    // bit; 0 - 1 wraps to all-ones; INT_MIN - 1 wraps to INT_MAX.
+    ref_selftest("add(ffffffff,00000001)", ref_add(32'hffffffff, 32'h00000001), 32'h00000000);
+    ref_selftest("add(7fffffff,00000001)", ref_add(32'h7fffffff, 32'h00000001), 32'h80000000);
+    ref_selftest("sub(00000000,00000001)", ref_sub(32'h00000000, 32'h00000001), 32'hffffffff);
+    ref_selftest("sub(80000000,00000001)", ref_sub(32'h80000000, 32'h00000001), 32'h7fffffff);
     if (errors != 0) begin
       $display("FAILED: the reference model is broken; no core result below means anything");
       $fatal(1);
@@ -618,6 +660,8 @@ module exec_tb;
       run_op("sll",    a, b, ref_sll(a, b));
       run_op("srl",    a, b, ref_srl(a, b));
       run_op("sra",    a, b, ref_sra(a, b));
+      run_op("add",    a, b, ref_add(a, b));
+      run_op("sub",    a, b, ref_sub(a, b));
     end
 
     // The bench grades its own shape LAST and reports it FIRST: everything


### PR DESCRIPTION
## Summary

`test/exec_tb.v` is the randomized differential bench for the executor's
arithmetic — 10,000 vectors per op across `mul`/`mulh`/`mulhu`/`mulhsu`/
`div`/`divu`/`rem`/`remu` and `sll`/`srl`/`sra` — but it drove zero vectors
through ADD, the simplest and most-used ALU op in the ISA. An off-by-one in
ADD is caught by the `.S` suite and by co-simulation but was missed by every
unit bench, per this ticket's measurement.

**Decision: add ADD/SUB to the randomized loop**, rather than document the
omission as deliberate. ADR-0010's *primary-guarantee* language is scoped to
the ops `RISCV_FORMAL_ALTOPS` hides from the riscv-formal ladder, and ADD/SUB
are not among them — `insn_add_ch0`/`insn_sub_ch0` already run real
arithmetic on every PR. But that ladder is `mode bmc`, not `mode prove`, and
this bench already extended past ADR-0010's literal op list once before for
exactly this reasoning: the three shift ops were added despite having their
own real ladder checks too (`insn_sll_ch0`/`insn_srl_ch0`/`insn_sra_ch0`),
because the fast, targeted per-PR leg is worth having on top of the BMC
ladder. ADD/SUB follow that same precedent.

## Changes

- `test/exec_tb.v`: adds `OP_ADD`/`OP_SUB` to the existing op table,
  `ref_add`/`ref_sub` reference functions (direct one-line self-determined
  assignments — add/sub have no `$signed`/sign-context hazard at all, so
  they follow the same shape as `ref_divu`/`ref_remu` rather than the
  shift references' extra local), `ref_selftest` cases pinning
  two's-complement wrap behavior against hand-computed literals, and
  entries in the randomized 10,000-vector loop. They participate in the
  existing `check_vector_counts` machinery automatically (no manifest
  change needed — no directed corner vectors are required for add/sub,
  unlike the swapped-sign-enable cases ADR-0010 names for mul/div).
- `CLAUDE.md`: updates the one line describing `exec_tb`'s op coverage.

## Test plan

- [x] `make test-units` — all six benches pass, including `exec_tb` with
      `add`/`sub` each reporting 10000 vectors driven and 0 mismatches
- [x] Runtime delta measured directly: `vvp` on `exec_tb.vvp` alone went
      4.37s → 4.70s user (+0.33s, ~7.5%) for the two new ops — each add/sub
      vector settles in one cycle (no multi-cycle divider), so the increase
      is well under proportional to 2/11 more ops
- [x] `ref_selftest` block pins the new references before any RTL vector
      runs (criterion 2)
- [x] `soundcheck:pr-review` — clean, no security-relevant surface in a
      testbench-only diff
- [x] `/simplify` pass — trimmed an unnecessary local variable in
      `ref_add`/`ref_sub` to match the file's existing precedent for
      signedness-safe single-line references (`ref_divu`/`ref_remu`)

Closes JEF-716.