### PR TITLE
Grade the iverilog leg in CI, on its baked-in program

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,14 +112,14 @@ jobs:
         # engineering rules call this out by name, with the same count, as a
         # known separately-tracked class this gate must not block on. This
         # comment said "~30" until the gate inventory counted them.
-        #
-        # THIS STEP BUILDS testbench.vvp AND NEVER RUNS IT, and nothing else
-        # in this workflow runs it either. The full-pipeline iverilog leg --
-        # CLAUDE.md's "microscope" -- is elaborated on every PR and executed
-        # by no gate; `make waves` is the only thing that runs it and is in
-        # no workflow. The iverilog SIMULATION that CI does run is the six
-        # unit benches under `make test-units`, in the `test` job.
         run: make rvfi_macros.vh testbench.vvp
+
+      - name: iverilog full-pipeline simulation (one fixed program, graded)
+        # Runs testbench.vvp's baked-in 200-cycle program; test/testbench.v
+        # fatals on a nonzero monitor errcode or on a write/retire floor
+        # (ADR-0055). Not the `.S` suite -- there is still no image loader
+        # for this file, so a graded multi-program runner stays deferred.
+        run: vvp testbench.vvp
 
       - name: Report job wall time
         if: always()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -305,7 +305,7 @@ six are struck through, and every one of those outlived its own fix here by seve
 the failure this section exists to prevent, so they stay as markers rather than being deleted.
 
 - **Three things this repo treated as gates were reached by no automation, and one of them computes
-  a verdict nothing reads. One of the three is now fixed; the other two stand.** Found by reading
+  a verdict nothing reads. Two of the three are now fixed; the other one stands.** Found by reading
   `Makefile`, `formal/Makefile`, both workflows and
   `test/run_tests.sh` end to end; the four-column inventory that came out of it lives in the pull
   request that added this bullet and is destined for the coverage-map ADR. (1) ~~**`make fit` is a
@@ -322,15 +322,24 @@ the failure this section exists to prevent, so they stay as markers rather than 
   measured, and the pin is the reference for the same reason `formal/pin.mk` exists. The 4236 this
   file carried from ADR-0042 was a local measurement too, so the apparent 28-cell "reduction" is
   two toolchains being compared, not cells being saved.
-  (2) **`make waves` grades nothing.** It runs the full pipeline under iverilog
-  with the per-retire monitor live, but `ch0_handle_error` only `$display`s and sets `errcode` —
-  there is not one `$fatal`, `$finish` or `$stop` in `test/monitor.v` or `test/monitor.sim.v` — and
-  on the iverilog leg nothing turns `errcode` into an exit status (`test/testbench.v:55-60` says so
-  in its own comment; `test/cxxrtl.cc` is what reads it, and that is the other leg). So `make waves`
-  exits 0 on a monitor mismatch, and it is in no workflow either. The consequence is the part worth
-  keeping: **`testbench.vvp` is elaborated on every PR and executed by no gate anywhere.** The
-  iverilog *simulation* CI actually runs is the six `make test-units` benches, which do `$fatal(1)`
-  and are gated. (3) **`make -C formal all` is dead** — no workflow names it. That one is
+  (2) ~~**`make waves` grades nothing.**~~ — **fixed, on the artifact rather than the target**
+  (ADR-0055). `ch0_handle_error` still only `$display`s — there is still no `$fatal`, `$finish` or
+  `$stop` anywhere in `test/monitor.v` or `test/monitor.sim.v` — but `test/testbench.v` now checks
+  `rvfi_monitor_errcode` itself, every cycle (it is a one-cycle pulse, so a once-at-the-end read
+  would miss it), and adds an end-of-run floor on memory writes and RVFI retires: fewer than 15
+  writes or 60 retires over the baked-in 200-cycle program is `$fatal(1)`, matching
+  `test/cxxrtl.cc`'s exit 4. **`ci.yml`'s `elaborate` job now runs `vvp testbench.vvp` and grades
+  its exit status** — the same step that used to build it and stop. `make waves`'s recipe
+  (`vvp $< && mv testbench.vcd $@`) inherits the same three failure paths as a side effect of
+  sharing the binary, not because it was made to grade anything on purpose.
+  **This is one fixed program, not the deferred multi-program `.S` runner** — `test/testbench.v`
+  still has no image loader, so the coverage gap the design brief defers stays open; only the
+  baked-in loop is graded. All three red directions were demonstrated on real runs and are tabled in
+  ADR-0055: reverting the hazard scoreboard's two continuous assigns to ADR-0037's
+  `function automatic live_producer(r)` form gives 0 writes / 1 retire against the 15/60 floor; a
+  `+1` offset on the accessor's `rvfi_mem_wdata` shadow (real memory unaffected) trips the errcode
+  check; and a broken ADD trips the pre-existing `trap_to_zero` `$fatal`.
+  (3) **`make -C formal all` is dead** — no workflow names it. That one is
   redundancy rather than a hole: every target it lists (`complete`, `check`, `dmemcheck`,
   `imemcheck`, the three `components_*`) is invoked separately by `ci.yml` (ADR-0050 deleted the
   nightly and folded its checks into the `formal` job).
@@ -564,8 +573,10 @@ component proofs — decoder, executor and `pcloop` — pass by k-induction (`mo
 read off each `sby` summary, not inferred from a green job. See ADR-0017 for what the decoder proof
 does and does not establish, and ADR-0046 for what `pcloop` discharges). `make waves`
 now runs the iverilog leg (`testbench.vvp`) instead of the cxxrtl runner, matching the verification
-table below, and produces a real `waves.vcd` — **but it grades nothing**; see the first bullet under
-"what does not work" above. CI (`.github/workflows/ci.yml`) runs **eight** jobs on every PR:
+table below, and produces a real `waves.vcd` — and, as of ADR-0055, grades the run it produces one
+too: `ci.yml`'s `elaborate` job runs and checks this same `testbench.vvp` directly, on one fixed
+baked-in program, not the `.S` suite (see the second bullet under "what does not work" above for
+what stays open). CI (`.github/workflows/ci.yml`) runs **eight** jobs on every PR:
 elaborate, test, components, lint, fit, nonperturbation, monitor-freshness and formal — the last of
 which also carries `complete` and `complete_cover` as hard gates (M2 term 5). **Six of the eight
 are required** — `elaborate`, `test`, `components`, `monitor-freshness`, `lint`, `formal`, read live
@@ -743,8 +754,13 @@ make probe-gates    # forces all 108 graded comparisons in the grading scripts t
                     # so it is in CI's required job. All fork, no work: ~68-90s of
                     # wall for ~4s of user time, and that ratio is the host's
 make waves          # iverilog + VCD (testbench.vvp's baked-in program) -> waves.vcd.
-                    # GRADES NOTHING: the per-retire monitor is live but only
-                    # $displays, so this exits 0 on a mismatch. Read the output.
+                    # testbench.vvp now checks the monitor's errcode every cycle and a
+                    # 15-write/60-retire floor itself (ADR-0055), so `vvp` -- and this
+                    # recipe, which aborts before the `mv` on vvp's nonzero exit -- fails
+                    # on those too. ONE FIXED PROGRAM, NOT THE `.S` SUITE: there is still
+                    # no image loader for test/testbench.v, so this is not the deferred
+                    # multi-program runner. `.github/workflows/ci.yml`'s `elaborate` job
+                    # runs and grades this same testbench.vvp directly, on every PR.
 make monitor-check  # regenerate test/monitor.v at the pin and diff
 make fit            # the ONE area number: nextpnr logic cells on up5k/sg48 (ADR-0038).
                     # Placement always fails (231 SB_IO vs 39) and that is expected --
@@ -1011,9 +1027,12 @@ term 6 is open.** Read each term's own text, not this sentence:
    20-minute timeout**. The three memory checks were one step until ADR-0052 split them, because
    `make` stops at the first failure and a shared step cannot record three outcomes.
    **What it does NOT cover, stated rather than assumed**: ADR-0050's concrete clause is the formal
-   checks, and `make cosim-suite` (deliberately off every gate, ADR-0032) and `make waves` (grades
-   nothing, and `testbench.vvp` is elaborated by CI and executed by nothing) are both outside it.
-   Neither is a regression this term introduced; both are recorded under "what does not work".
+   checks, and `make cosim-suite` (deliberately off every gate, ADR-0032) is outside it — term 6 is
+   about the formal ladder, not about every gate in the repo. That is not a regression this term
+   introduced and is recorded under "what does not work". `make waves` (`testbench.vvp` and its
+   baked-in program, elaborated by CI's `elaborate` job) was recorded there too at the time, but is
+   now graded, as its own step unrelated to this term — it was never one of term 6's checks either
+   way (ADR-0055).
    **The intent never changed** — the ladder's verdict must be observed by something automated that
    can fail — and a required PR check is a strictly stronger instrument than a job ADR-0022 itself
    described as not gating merges. **This is the third move of an M2 criterion**, and ADR-0045 said
@@ -1117,8 +1136,8 @@ longer quietly widen.
   rejected the shifter merge at 19 cells *saved* on legibility grounds, and accepting a hygiene
   change at 37 cells *spent* would cut against that ruling. Read this before proposing the
   narrowing again — it is measured and declined, not overlooked.
-- Decisions: [`docs/adr/`](docs/adr/) — **fifty-four ADRs, fifty-three of them accepted**, plus a
-  deferred list. Re-derived by counting: `ls docs/adr/*.md | wc -l` is 55, one of which is
+- Decisions: [`docs/adr/`](docs/adr/) — **fifty-five ADRs, fifty-four of them accepted**, plus a
+  deferred list. Re-derived by counting: `ls docs/adr/*.md | wc -l` is 56, one of which is
   `README.md`, and the status column in that README carries exactly one non-accepted entry
   (ADR-0016, superseded by ADR-0018). This line has now been behind twice — it said "forty-five
   accepted" and then "forty-seven" — so **re-derive it with the two commands rather than

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -882,6 +882,18 @@ the oracle (ADR-0019).
   **Do not add new ones outside `rtl/writeback.v`**, and prefer a continuous
   assign for any new struct-field read in an `always_comb` — that is what holds the count at 20
   (ADR-0034; this bullet named `rtl/executor.v` until then, which was measurably wrong).
+- **Every comment must earn its place, and the default is delete.** A comment earns it only by
+  telling the reader something the code does not already say, in one or two plain sentences,
+  understandable without leaving the file. Otherwise it goes — not shortened, gone. Delete
+  restatement of the next line, history (git has it), "this is deliberate" with no *why*, section
+  banners, and emphasis furniture: ALL-CAPS, "which is the whole point", rhetorical setup that
+  announces a lesson before stating it, arguing with a hypothetical reader. **A shorter essay is
+  still an essay.** An ADR citation is an optional trailing pointer, never the explanation.
+  **One exception: tripwires.** A warning that stops someone silently reintroducing a defect earns
+  its place by preventing a bug — keep it, in two sentences. The test is whether deleting it would
+  let the defect back in; if the bug is fixed and guarded, the story about it is history and goes.
+  This applies to code, tests, config and workflows. It does **not** apply to this file, which is
+  deliberately a running log, or to `docs/adr/`.
 - **Every non-trivial change adds or updates tests and runs the full suite** before being declared
   done. Elaboration succeeding is not a substitute for tests passing.
 - **Never commit build artifacts.** `test/rtl.cc`, `sim`, `*.vvp`, `*.vcd`, `rvfi_macros.vh`, and

--- a/docs/adr/0055-the-iverilog-leg-is-graded-in-ci-without-the-multi-program-runner.md
+++ b/docs/adr/0055-the-iverilog-leg-is-graded-in-ci-without-the-multi-program-runner.md
@@ -1,0 +1,110 @@
+# ADR-0055: The iverilog leg is graded in CI, without building the multi-program runner
+
+**Status:** Accepted · 2026-08-02 · *Closes one clause of the "what does not work" bullet in
+CLAUDE.md that named `make waves` — the iverilog leg still has no image loader, and that stays
+deferred.*
+
+## Context
+
+`test/testbench.v` builds under iverilog on every PR (`.github/workflows/ci.yml`'s `elaborate`
+job) and is executed by nothing. `make waves` is the only thing that ran `testbench.vvp`, and it
+was not in any workflow; even run by hand, the per-retire monitor only `$display`s on a mismatch —
+`ch0_handle_error` sets `errcode` and there is no `$fatal`, `$finish` or `$stop` anywhere in
+`test/monitor.v` or `test/monitor.sim.v` — so a mismatch exited 0.
+
+ADR-0037 already measured what this leaves uncaught: with the hazard scoreboard's two continuous
+assigns written as a `function automatic live_producer(r)` (iverilog under-sensitizes the call,
+CLAUDE.md's engineering rules), the leg froze at the first RAW hazard for the whole of M1 and
+nothing noticed, because nothing ran it. "A leg that cannot fail is not a leg."
+
+The design brief defers a graded multi-program iverilog runner (an image loader for
+`test/testbench.v`, mirroring `test/cxxrtl.cc`'s `--rom`/`--ram`). That stays deferred here. The
+only artifact this ADR grades is the one that already exists: `testbench.vvp`'s baked-in 200-cycle
+program (the six-instruction increment loop `test/testbench.v` writes into `rtl/imemory.v`'s two
+banks under `ifdef ICARUS`).
+
+## Decision
+
+### 1. Two failure paths, both under `ifdef ICARUS`
+
+`rvfi_monitor_errcode` is a one-cycle **pulse** — `test/monitor.sim.v`'s outer `always` block
+resets it to 0 every cycle before conditionally setting it — so it has to be checked every cycle,
+the same way `test/cxxrtl.cc`'s runner loop already does. A continuous `always @(posedge clk)`
+block right after the monitor instantiation does that and `$fatal(1)`s on a nonzero value,
+matching `test/cxxrtl.cc`'s exit 4.
+
+A second block adds an end-of-run floor: fewer than 15 memory writes or fewer than 60 RVFI retires
+over the 200-cycle run is also `$fatal(1)`. Both counters are new (`mem_write_count`) or already
+present for `test/cxxrtl.cc`'s debug-item reads (`rvfi_retires`, declared in the existing
+`ifdef RISCV_FORMAL` block for the observation counters — ADR-0053's sibling change to
+`test/testbench.v`).
+
+**Measured on this exact program at `238a066`: 20 writes, 79 retires, all 79 spec-checked.** The
+floors (15, 60) sit 25% and 24% under those, enough margin for a legitimate change that costs a few
+extra stall cycles, and nowhere near what the named regression produces: reverting `live_rs1`/
+`live_rs2` to the `function automatic live_producer(r)` form gives **0 writes, 1 retire** on the
+same program, confirmed by building and running it.
+
+### 2. Why the grading code moved, not just grew
+
+The existing `ifdef ICARUS` `initial` block that waits 200 cycles and calls `$finish` sits right
+after the clock/reset declarations, near the top of the file — *before* `rvfi_monitor_errcode`/
+`rvfi_retires`/`mem_write_count` are declared (all three live inside or need the
+`ifdef RISCV_FORMAL` block that follows). iverilog does not bind a forward reference to a `logic`
+declared later in the same module — confirmed with a two-line repro (`$display` of a variable
+declared after the referencing `initial` block fails to elaborate: `error: Unable to bind
+wire/reg/memory`). `clk`/`reset` themselves stay declared where they were, since the memory/CPU
+instantiations that follow reference them by name; the whole `$dumpfile`/`$dumpvars`/reset/wait/
+grade/`$finish` sequence moved, as one `initial` block, to sit after those three declarations
+instead of splitting into two blocks that would need to agree on a cycle count (`repeat(1)` here,
+`repeat(200)` there) without either saying so.
+`testbench.vvp` always compiles with both `ICARUS` and the `RISCV_FORMAL_MACROS` list together (one
+Makefile recipe, `RISCV_FORMAL_MACROS` unconditional), so nothing here changes what the build
+requires.
+
+### 3. `ci.yml`'s `elaborate` job runs and grades it
+
+The step that builds `testbench.vvp` gains `vvp testbench.vvp`, checked directly (no pipe — the
+existing `run:` block already avoids one, per ADR-0037 §4's rule). `vvp`'s exit status is `$fatal`
+→ 1, `$finish` → 0, so the step is graded with no new tooling and no new dependency.
+
+**`elaborate` was already a required status check.** This strengthens a required job in place; it
+does not add anything to branch protection, which stays a human action (ADR-0036). A side effect,
+not a target of this change: `make waves`'s recipe (`vvp $< && mv testbench.vcd $@`) now also fails
+on the same three conditions, because `make` aborts a recipe on the first nonzero line. `make waves`
+was not made to grade anything on purpose here — the multi-program runner it would need to mean
+something beyond this one baked-in program is still the deferred work — but it no longer silently
+swallows a mismatch either.
+
+### 4. What stays out of scope
+
+No image loader for `test/testbench.v`, so this is **one fixed program, not the `.S` suite** — the
+gap CLAUDE.md's "what does not work" bullet already names stays open for that half. Record the
+outcome as *single-program graded, multi-program still absent*, not as the coverage gap closed.
+
+## Evidence
+
+Three red directions demonstrated on real `vvp` runs of `testbench.vvp`, each reverted after:
+
+| Mutation | Result |
+|---|---|
+| `rtl/decoder.v`'s `live_rs1`/`live_rs2` reverted to `function automatic live_producer(r)` (ADR-0037's defect) | `FLOOR VIOLATION: writes=0 (need >= 15) retires=1 (need >= 60)`, exit 1 |
+| `rtl/accessor.v`'s `out.rvfi_mem_wdata` shadow offset by `+1` on stores (real memory unaffected) | `RVFI Monitor error 120` every store, `RVFI MONITOR ERROR 120`, exit 1 |
+| `rtl/executor.v`'s `is_add` arm computes `rs1 + rs2 + 1` | existing `TRAP TO ZERO` `$fatal` fires (mtvec == 0, no handler installed), exit 1 |
+
+The unmutated tree exits 0 and prints `RETIRES 79 SPEC-CHECKED 79 WRITES 20`.
+
+## Consequences
+
+- CI's `elaborate` job now actually exercises the iverilog leg instead of only proving it
+  compiles — CLAUDE.md's verification table calls this leg "the microscope"; it now has something
+  to look through.
+- The floor is a fixed pair of numbers pinned to one fixed program, in the ADR-0038/ADR-0040
+  measurement idiom: cite the commit it was measured at, not "current"; re-measure and restate
+  (with margin) if the baked-in program or the pipeline's stall behaviour changes enough to move it.
+- `test/testbench.v` gains two `ifdef ICARUS` regions: the per-cycle errcode check, placed right
+  after the monitor instantiation it reads, and the floor check folded into the existing
+  wait/`$finish` block, placed after the counters it reads. `test/rtl.cc` (the cxxrtl leg's
+  elaboration of this same file, `make sim`'s dependency) and `make elaborate-strict` both build
+  `test/testbench.v` through yosys with `ICARUS` never defined, so neither region exists in either
+  of those builds — only iverilog defines `ICARUS`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -59,6 +59,7 @@ and what it costs. Reversing one is fine — write a new ADR that supersedes it.
 | [0052](0052-m2-term-6-is-verified-and-the-fit-ratchet-gets-a-job.md) | M2 term 6 is verified against the gate's own run, and the fit ratchet gets a job | Accepted · closes 0037 term 6 as rewritten by 0050 |
 | [0053](0053-every-graded-comparison-carries-a-probe-of-its-red-direction.md) | Every graded comparison carries an executable probe of its own red direction | Accepted · extends 0035, 0033 |
 | [0054](0054-the-memory-system-and-the-first-real-timing-number.md) | The memory system, and the first real timing number | Accepted · the design 0044 called for; answers 0038 decision 2 |
+| [0055](0055-the-iverilog-leg-is-graded-in-ci-without-the-multi-program-runner.md) | The iverilog leg is graded in CI, without the multi-program runner | Accepted · closes part of the `make waves` bullet in CLAUDE.md's "what does not work" |
 
 0001–0007 came from the design brief
 ([`docs/ideas/finish-the-rewrite.md`](../ideas/finish-the-rewrite.md)). 0008–0011 came out of

--- a/docs/ideas/one-address-space-over-two-memories.md
+++ b/docs/ideas/one-address-space-over-two-memories.md
@@ -100,9 +100,12 @@ Each future text access costs 2 cycles: one steal bubble, and one `operand_stall
 because the garbage window perturbs `prev_rs1`/`prev_rs2`. That is per trap handled or per
 word loaded. Invisible in aggregate.
 
-For reference, measured cycles per instruction on the current design:
+For reference, the measured issue rate on the current design. Every instruction passes
+through all four registered stages — decode, execute, access, writeback — so the *latency*
+of any one instruction is about 4 cycles. The stages overlap, so what sets runtime is how
+often decode can start a new instruction, and that is what this table measures.
 
-| instruction | cycles |
+| instruction | cycles between issues |
 |---|---|
 | `lui`, `auipc`, `jal` | 1 |
 | ALU, branches, `jalr`, stores | 2 |
@@ -110,6 +113,11 @@ For reference, measured cycles per instruction on the current design:
 | loads | 3 |
 | `div`, `rem` family | ~34 |
 | `csr*`, `mret` | 2 + drain |
+
+The limiter is decode, not the stage count. `operand_stall` makes it present the register
+addresses one cycle and issue the next, so it emits at most one instruction every two
+cycles. `lui`/`auipc`/`jal` use no registers, skip the present cycle, and issue back to
+back — which is why whole-program CPI comes in under 2.
 
 Whole-program CPI runs 1.78 (`beq.S`) to 4.57 (`div.S`), baseline around 1.8. Almost all
 of that baseline is `operand_stall` — the synchronous regfile from ADR-0042. This proposal

--- a/docs/ideas/one-address-space-over-two-memories.md
+++ b/docs/ideas/one-address-space-over-two-memories.md
@@ -1,0 +1,212 @@
+# One address space over two memories
+
+**Status:** brief, ready to plan · 2026-08-02 · follows ADR-0054
+
+Make instruction memory writable and put it in the same address space as data, so a
+kernel can load and run programs — and so a trap handler can read the instruction that
+faulted.
+
+## Why
+
+Three problems, all the same absence: there is no path from a store to something the
+fetcher can later see.
+
+1. Program text lives in a ROM built into the bitstream. Nothing can be loaded at runtime.
+2. The trap handler cannot read the faulting instruction. That is why every trapping
+   instruction in a test has to be wrapped in `.option norvc`, and that rule is what hid
+   the `c.ebreak` bug in ADR-0048 — a blind spot exactly one instruction wide.
+3. ADR-0054 records that the SoC cannot run a program that reads its own `.data`. The
+   SPRAM is not initialised by the bitstream and nothing copies an image into it.
+
+ADR-0008 picked separate address spaces because the RTL already had separate buses. Its
+own rationale says so. It was inherited, not chosen.
+
+## The idea
+
+**Do not merge the memories. Merge the address space.**
+
+Every benefit above needs one address space. None of them needs one memory. The two
+physical memories stay exactly where ADR-0054 put them.
+
+The enabling fact: an ice40 EBR has **one read port and one write port**, and the ROM
+banks only use the read side. The write port needed to make text writable is already
+there, unused.
+
+```
+0x0000_0000  ┌──────────────────────────┐
+             │ BRAM  8 KB               │  text: readable, writable, executable
+             │ 2 word-interleaved banks │  initialised from the bitstream
+0x0000_2000  ├──────────────────────────┤
+             │ SPRAM  64 KB             │  data only
+             │ read/write, not executable│
+0x0001_0000  └──────────────────────────┘
+```
+
+Fetch reaches only the BRAM region. A PC in SPRAM fetches zero, which decodes as an
+illegal instruction — the out-of-range behaviour that already exists.
+
+## Arbitration
+
+A data access that lands in the text region uses the BRAM banks. Fetch is using them too.
+Something has to give.
+
+**Data always wins.** It belongs to an instruction that already issued, and the accessor
+issues a store exactly once. A fetch is repeatable — the PC holds and asks again next
+cycle. This is a ruling, not a tuning knob.
+
+Two pieces of hardware:
+
+- **`mem_ren`**, a new core output: `!reset && in_valid && is_load`. Needed because the
+  idle bus presents `mem_addr = 0`, which is inside the text region. Without a read
+  enable, every idle cycle would steal a fetch and the core would never run.
+- **`fetch_stall`**, a new core input, registered from
+  `(mem_ren || |mem_wstrb) && text_range(mem_addr)`.
+
+A store steals the fetch edge as well as taking the write port, on purpose: a fetch read
+and a store write of the same word should never meet on one edge.
+
+`fetch_stall` is the **sixth stall reason** on the existing two mechanisms. It bubbles,
+like `operand_stall` — `pc` holds, `out <= '0`. **No flush.** Nothing was issued, because
+`issuing = !reset && !stall` already gates trap commit, CSR writes and `minstret`, so a
+stolen window cannot issue or trap.
+
+SPRAM accesses steal nothing. Different memory, different ports. That is most of why this
+is nearly free.
+
+## `fence.i` has to change
+
+This is the one semantic change, and it is a real bug rather than a tidy-up.
+
+The fetch address is published one cycle early (ADR-0054). So a store to text at cycle D
+writes the array at edge D+2, but the instruction after a `fence.i` at D+1 was fetched at
+edge D+1 — before the write. It would execute stale text after `fence.i` retired. That
+breaks Zifencei.
+
+Today's NOP is only correct because separate buses make the store impossible. ADR-0002's
+"correct and for free" was a property of the split, not of the core.
+
+Fix: `fence.i` joins the serialization drain that CSR instructions already use. One OR
+term on the existing predicate. Costs 3-4 cycles when executed, which is nothing.
+
+Instructions *between* a text store and `fence.i` may see old or new text. That is legal.
+They cannot see a torn value, because the steal forbids a same-edge read and write.
+
+## Cost
+
+**Zero on the current suite.** No program does a text-region data access today — separate
+buses make it impossible, which is the whole point.
+
+Each future text access costs 2 cycles: one steal bubble, and one `operand_stall` refetch
+because the garbage window perturbs `prev_rs1`/`prev_rs2`. That is per trap handled or per
+word loaded. Invisible in aggregate.
+
+For reference, measured cycles per instruction on the current design:
+
+| instruction | cycles |
+|---|---|
+| `lui`, `auipc`, `jal` | 1 |
+| ALU, branches, `jalr`, stores | 2 |
+| `mul` family | 2 |
+| loads | 3 |
+| `div`, `rem` family | ~34 |
+| `csr*`, `mret` | 2 + drain |
+
+Whole-program CPI runs 1.78 (`beq.S`) to 4.57 (`div.S`), baseline around 1.8. Almost all
+of that baseline is `operand_stall` — the synchronous regfile from ADR-0042. This proposal
+does not move any of it.
+
+The rejected alternative — one physically merged BRAM pool — costs +2.0% measured on the
+suite and 8-15% on compiled code, and throws away 64 KB of SPRAM to get there.
+
+## The `.data` gap closes for free
+
+Link `.data`'s load address into the BRAM image and have crt0 copy it to SPRAM through the
+new text-read path. No new hardware. This is the ADR-0054 gap that would otherwise need a
+flash controller.
+
+## Invariant 2 and the formal ladder
+
+**The bus stays non-faulting, permanently.** Every in-range access is answered. Out-of-range
+loads read zero, out-of-range writes are dropped, out-of-range fetch reads zero and traps
+as an illegal instruction in decode. No access fault exists, so nothing faults after
+decode. This adopts ADR-0044 option 1 as a commitment. A kernel that wants access faults
+needs its own ADR.
+
+That settles the eleven declined checks ADR-0054 owed ADR-0044:
+
+- Five fault checks (`fault_ch0`, `bus_imem_fault_ch0`, `bus_dmem_fault_ch0`,
+  `bus_dmem_io_read_fault_ch0`, `bus_dmem_io_write_fault_ch0`) become `[DESIGN]`.
+- `bus_imem_ch0` and `bus_dmem_ch0` become `[DESIGN]`, on ADR-0044's existing argument
+  that `imemcheck`/`dmemcheck` already hold the property.
+- Four io/ordering checks stay `[BLOCKED]` — still no MMIO region, and `io_order`'s real
+  blocker is that only one access is ever outstanding.
+
+**Unification unblocks none of them.** That is the right answer, not a disappointment.
+
+What does change:
+
+- `formal/wrapper.v`'s assumption that imem is a function of its address gains an
+  exception for the cycle after a text store. `fetch_stall` must be constrained to the
+  arbiter's real equation, never left free — a free stall input starves `hang` and
+  `liveness`, which is what ADR-0042 found.
+- `formal/imemcheck.sv` needs the write path, so it observes `mem_addr`/`mem_wstrb`/
+  `mem_wdata`. Assuming store-free traces instead would be a weakening; don't.
+- `dmemcheck` should be unaffected. Verify rather than assume.
+- **F and G must be re-measured before anything lands.** A sixth stall reason moves the
+  worst-case first retire and retire gap that every ladder depth was derived from
+  (ADR-0046), and `insn 15` and `reg 15 20` clear their floors by one cycle. M2 term 1
+  says re-measure. This is step 1, not a follow-up.
+
+## Tests
+
+- `sections.lds`: regions unchanged. For the hardware flow only, `.data` gains a load
+  address in the text region and `riscv_test.h` gains a crt0 copy loop.
+- Both sim runners keep loading two images, so the 56 programs and `OBSERVED_FLOOR` do not
+  move. Its floors are retire counts; CPI does not touch them.
+- `test/sail/rv32imc_zicsr.json`: the text region must be readable and writable to the
+  data bus in the reference model, or Sail faults where the core does not — a false
+  divergence of the ADR-0043 kind.
+- New programs, each with an `OBSERVED_FLOOR` line: `selfmod.S` (store, `fence.i`,
+  execute, including the D+2 case above), `textload.S` (handler reads the encoding at
+  `mepc`, works out 2 vs 4 bytes, resumes past a **compressed** trapping instruction), and
+  a contention test.
+- `test/imem_tb.v` extends for the write port; the arbiter gets a bench. `UNIT_BENCHES`
+  goes 7 → 8.
+
+## Risks
+
+**Timing is the real one.** The steal mux sits on the bank address input, at the tail of
+the 88.51 ns fetch → decode → `next_pc` loop, where each logic level costs about 2-2.5 ns
+of local interconnect. Estimate one added level, 2-3%. `SOC_MIN_MHZ = 10.5` should hold,
+but ADR-0054 measured a 3.6% churn band on `make soc-timing`, so only a run on the branch
+settles it. If it does not hold, the fallback is decoding the steal from the accessor's
+registered inputs a cycle early — more state, and its own ADR.
+
+**Ladder depth** may grow with the steal cycles reachable inside each check's window.
+Unknown until F and G are re-run.
+
+**8 KB is a tight ceiling** for a kernel plus a loaded program. Widening text to 12 KB
+costs 24 EBRs and 203 LUT4s (ADR-0054 measured it). Recorded, not taken.
+
+## Sequence
+
+1. Re-measure F and G with a modelled `fetch_stall`; confirm the depth budget. Gating.
+2. `rtl/imemory.v` gains the write port, the data-read path and the steal output. SoC and
+   testbench gain the range decode and `mem_rdata` mux. `imem_tb` extends; arbiter bench.
+3. Core: `mem_ren` out, `fetch_stall` in, `fence.i` serialization. `pcloop` and the
+   decoder's `FORMAL` block updated in the same change.
+4. Formal: wrapper assumption, `imemcheck` write path, the eleven `#omit` rulings,
+   re-derived depths, full ladder.
+5. Tests: the three new programs, Sail config, crt0 and the load address for hardware.
+   `make soc-timing` re-measured, quoted with its toolchain.
+
+## Not in scope
+
+- SPI flash boot and a bigger text region in SPRAM. The hard IP SPI core makes this
+  cheaper than ADR-0044 assumed, and up5k_riscv is a working reference, but it is new
+  unverified surface and M2 is still open. Every arbitration rule here carries over
+  unchanged, so this is the rehearsal.
+- Any MMIO region, and with it the four blocked io checks.
+- Protection of any kind.
+- Recovering the second stall cycle with shadow fetch-hold registers. That is the first
+  half of a fetch buffer and it saves a cycle nobody will notice.

--- a/test/testbench.v
+++ b/test/testbench.v
@@ -83,15 +83,6 @@ module testbench(
   logic clk = 0;
   logic reset = 1;
   always #5 clk = ~clk;
-
-  initial begin
-    $dumpfile("testbench.vcd");
-    $dumpvars(0, testbench);
-    repeat (1) @(posedge clk);
-    reset <= 0;
-    repeat (200) @(posedge clk);
-    $finish;
-  end
  `endif
   memory #(.BASE(RAM_BASE), .RAM_WORDS(RAM_WORDS)) dmem (
     .clk(clk),
@@ -194,6 +185,18 @@ module testbench(
     .rvfi_mem_wdata(rvfi_mem_wdata),
     .errcode(rvfi_monitor_errcode)
   );
+
+ `ifdef ICARUS
+  // Matches test/cxxrtl.cc's exit 4. errcode is a one-cycle pulse
+  // (test/monitor.sim.v resets it every cycle), so this checks every
+  // cycle rather than once at the end of the run.
+  always @(posedge clk) begin
+    if (rvfi_monitor_errcode != 16'b0) begin
+      $display("RVFI MONITOR ERROR %0d -- see the diagnostic above", rvfi_monitor_errcode);
+      $fatal(1);
+    end
+  end
+ `endif
 
   // ---------------------------------------------------------------------------
   // DID THE ORACLE EVER LOOK?
@@ -305,6 +308,46 @@ module testbench(
       end
     end
   end
+
+ `ifdef ICARUS
+  // A counter independent of the retire count below: a stalled pipeline
+  // can keep retiring instructions with no stores at all, which a
+  // retire-only floor would miss.
+  (* keep *) logic [31:0] mem_write_count;
+  initial mem_write_count = 32'b0;
+  always @(posedge clk) begin
+    if (!reset && mem_wstrb != 4'b0000) begin
+      mem_write_count <= mem_write_count + 32'd1;
+    end
+  end
+
+  // Measured on this program at 238a066: 20 writes, 79 retires. These
+  // floors sit a margin under both so a few extra stall cycles still
+  // pass; reverting `live_rs1`/`live_rs2` to ADR-0037's
+  // `live_producer(r)` function form gives 0 writes, 1 retire here.
+  localparam int unsigned WRITE_FLOOR  = 15;
+  localparam int unsigned RETIRE_FLOOR = 60;
+
+  // Owns dumpfile setup, reset and the whole run: the floor check below
+  // needs `rvfi_retires`/`mem_write_count`, declared earlier in this
+  // `ifdef RISCV_FORMAL` region, and iverilog will not bind a forward
+  // reference to a `logic` declared later in the same module.
+  initial begin
+    $dumpfile("testbench.vcd");
+    $dumpvars(0, testbench);
+    repeat (1) @(posedge clk);
+    reset <= 0;
+    repeat (200) @(posedge clk);
+    #1;
+    if (mem_write_count < WRITE_FLOOR || rvfi_retires < RETIRE_FLOOR) begin
+      $display("FLOOR VIOLATION: writes=%0d (need >= %0d) retires=%0d (need >= %0d) spec-checked=%0d",
+                mem_write_count, WRITE_FLOOR, rvfi_retires, RETIRE_FLOOR, rvfi_spec_retires);
+      $fatal(1);
+    end
+    $display("RETIRES %0d SPEC-CHECKED %0d WRITES %0d", rvfi_retires, rvfi_spec_retires, mem_write_count);
+    $finish;
+  end
+ `endif
  `endif
 `ifdef ICARUS
   // `make waves`' program: the six-instruction increment loop this file used to


### PR DESCRIPTION
## Summary

CI built `testbench.vvp` on every PR and ran it nowhere; `make waves` was the only thing that ran it, and even that grades nothing (`test/monitor.v`/`test/monitor.sim.v` only `$display` on a mismatch, no `$fatal`/`$finish`/`$stop`). This closes that gap for the one program already baked into `test/testbench.v` — not by building the deferred multi-program `.S` runner, which stays out of scope.

- `test/testbench.v` gains, under `ifdef ICARUS`: a `$fatal(1)` on a nonzero `rvfi_monitor_errcode`, checked **every cycle** (it's a one-cycle pulse — `test/monitor.sim.v` resets it every cycle before conditionally setting it, so a once-at-the-end read would miss a transient error), matching `test/cxxrtl.cc`'s exit 4; and an end-of-run floor on memory writes and RVFI retires over the baked-in 200-cycle program.
- Floor is committed at **15 writes / 60 retires**, measured on this exact program **at `238a066`: 20 writes, 79 retires** (see `docs/adr/0055-...md` for the full measurement, in the ADR-0038/ADR-0040 idiom).
- `.github/workflows/ci.yml`'s `elaborate` job (already a **required** status check — no branch-protection change here, that stays a human action per ADR-0036) adds `vvp testbench.vvp` as a graded step right after the build step. `vvp`'s exit status is the grade: `$fatal(1)` → 1, `$finish` → 0.
- `docs/adr/0055-...md` records the decision, including why the grading code sits where it does (iverilog will not bind a forward reference to a `logic` declared later in the same module — the retire/errcode counters live inside the `ifdef RISCV_FORMAL` block, textually after the original wait-and-`$finish` block, so that block moved down as a whole rather than the check being added where it used to sit).
- `CLAUDE.md` updated in the two places this change makes stale: the "what does not work" bullet about `make waves` grading nothing (struck through, fixed), and the `make waves` command comment.

## What stays out of scope

Single program graded, not the `.S` suite — `test/testbench.v` still has no image loader, so a graded multi-program iverilog runner is still deferred, exactly as the design brief has it.

## Test plan

All demonstrated on real `vvp` runs, then reverted:

- [x] Healthy tree: `vvp testbench.vvp` exits 0, prints `RETIRES 79 SPEC-CHECKED 79 WRITES 20`.
- [x] **Named liveness probe** (acceptance criterion 3): reverting `rtl/decoder.v`'s `live_rs1`/`live_rs2` to ADR-0037's `function automatic live_producer(r)` form → `FLOOR VIOLATION: writes=0 (need >= 15) retires=1 (need >= 60)`, exit 1.
- [x] Nonzero monitor errcode, independent of the floor: `+1` offset on `rtl/accessor.v`'s `rvfi_mem_wdata` shadow (real memory unaffected) → `RVFI MONITOR ERROR 120`, exit 1.
- [x] Existing `$fatal` (trap-to-zero): a broken ADD (`rs1 + rs2 + 1`) derails control flow into an untrapped `mtvec == 0` state → existing `TRAP TO ZERO` fatal fires, exit 1.
- [x] `make elaborate-strict` (yosys leg, never defines `ICARUS`) still exits 0 with zero promoted warnings — the new code is invisible to that build.
- [x] `make waves` still builds a real `waves.vcd` end to end (its recipe now also fails on the same three conditions as a side effect of sharing `testbench.vvp`, not because it was made to grade anything on purpose).
- [x] `make test-units` — 0 exit, all seven benches pass.
- [x] `make test` — 56/56 pass, `test/EXPECTED_FAIL` matches exactly.

Closes JEF-690.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>