### PR TITLE
Probe the Makefile-embedded ratchets, and put soc-timing on CI

### DIFF
--- a/.github/actions/verify-toolchain/action.yml
+++ b/.github/actions/verify-toolchain/action.yml
@@ -1,0 +1,29 @@
+name: Verify toolchain
+description: >-
+  Assert that specific command-line tools are on PATH, baked into the runner
+  image, rather than installing them (thejefflarson/runner#35). One copy so
+  the tool list and the failure message cannot drift between the jobs that
+  need it -- the ci.yml `elaborate` job diverged from its own file-list
+  comment this way once already.
+inputs:
+  tools:
+    description: space-separated list of tools to check for on PATH
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Verify the toolchain is present in the runner image
+      shell: bash
+      run: |
+        set -euo pipefail
+        missing=""
+        for tool in ${{ inputs.tools }}; do
+          command -v "$tool" >/dev/null 2>&1 || missing="$missing $tool"
+        done
+        if [ -n "$missing" ]; then
+          echo "::error::runner image is missing:$missing — expected them baked in (thejefflarson/runner#35)"
+          exit 1
+        fi
+        for tool in ${{ inputs.tools }}; do
+          echo "$tool: $("$tool" --version | head -1)"
+        done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,26 +155,15 @@ jobs:
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      # The cross compiler and clang++ are baked into the runner image
-      # (thejefflarson/runner#35) instead of apt-installed here: these runners are
-      # runAsNonRoot with allowPrivilegeEscalation:false, so `sudo apt-get install`
-      # fails with "the 'no new privileges' flag is set".
-      #
-      # This is an ASSERTION, not an install. If the image is ever rebuilt without
-      # the toolchain, fail here with a message that names the cause rather than
-      # letting run_tests.sh die on a missing compiler or `sim` on a missing clang++.
+      # The cross compiler and clang++ are baked into the runner image instead
+      # of apt-installed here: these runners are runAsNonRoot with
+      # allowPrivilegeEscalation:false, so `sudo apt-get install` fails with
+      # "the 'no new privileges' flag is set". This is an ASSERTION, not an
+      # install -- see the composite action for why it is one copy.
       - name: Verify the toolchain is present in the runner image
-        run: |
-          set -euo pipefail
-          missing=""
-          for tool in riscv64-unknown-elf-gcc clang++; do
-            command -v "$tool" >/dev/null 2>&1 || missing="$missing $tool"
-          done
-          if [ -n "$missing" ]; then
-            echo "::error::runner image is missing:$missing — expected them baked in (thejefflarson/runner#35)"
-            exit 1
-          fi
-          echo "toolchain present: $(riscv64-unknown-elf-gcc --version | head -1); $(clang++ --version | head -1)"
+        uses: ./.github/actions/verify-toolchain
+        with:
+          tools: riscv64-unknown-elf-gcc clang++
 
       - name: Set up OSS CAD Suite
         uses: ./.github/actions/setup-oss-cad-suite
@@ -398,6 +387,84 @@ jobs:
           elapsed=$(( $(date +%s) - JOB_START ))
           {
             echo "### fit"
+            echo "wall time: ${elapsed}s"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # `make soc-timing` -- the SoC place-and-route flow and the only timing
+  # figure this project has (ADR-0054). Mirrors the `fit` job immediately
+  # above: same non-piped graded-command pattern, same NON-REQUIRED status.
+  # Area and timing are design constraints, not correctness ones (ADR-0036),
+  # and adding either to branch protection is a human action taken
+  # deliberately or not at all.
+  #
+  # UNLIKE `fit`, this needs the RISC-V cross compiler as well as the OSS CAD
+  # Suite: `make soc-timing` builds a real ROM image from test/asm/*.S before
+  # synthesising. No other job needs both, so the toolchain assertion is the
+  # shared composite action rather than a second copy of the `test` job's
+  # step -- a workflow re-stating something the Makefile or another job
+  # already owns is the exact shape that broke `elaborate` once (see the
+  # `elaborate` job's own file-list comment).
+  #
+  # `make soc-timing` itself EXPECTS placement to succeed, unlike `fit`: the
+  # SoC's two memories are internal, so it presents 4 SB_IO against sg48's 39
+  # and places cleanly. What is graded is soc/fit_report.py's sibling scripts
+  # -- soc/cell_census.py's SPRAM/EBR census and soc/timing_split.py's
+  # SOC_MIN_MHZ ratchet -- both probed hermetically in test/probe_gates.sh.
+  soc-timing:
+    name: soc-timing
+    runs-on: little-cpu-runners
+    timeout-minutes: 10
+    steps:
+      - name: Record job start
+        run: echo "JOB_START=$(date +%s)" >> "$GITHUB_ENV"
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Verify the toolchain is present in the runner image
+        uses: ./.github/actions/verify-toolchain
+        with:
+          tools: riscv64-unknown-elf-gcc
+
+      - name: Set up OSS CAD Suite
+        uses: ./.github/actions/setup-oss-cad-suite
+        with:
+          tag: ${{ env.OSS_CAD_SUITE_TAG }}
+          file: ${{ env.OSS_CAD_SUITE_FILE }}
+          sha256: ${{ env.OSS_CAD_SUITE_SHA256 }}
+
+      - name: make soc-timing
+        # NO PIPE ON THE GRADED COMMAND, same reasoning as `fit` and
+        # `nonperturbation`: a `run:` block without an explicit `shell:` key
+        # is `bash -e {0}`, errexit but NOT pipefail, so piping this into
+        # `tee` would take the step's status from `tee` and it would always
+        # be 0 (ADR-0037). Redirect, take the status off the unpiped
+        # command, then publish -- the census and the logic/routing split
+        # land in the step summary whether this passes or fails, because the
+        # summary write happens before the exit.
+        run: |
+          set +e
+          make soc-timing > "$RUNNER_TEMP/soc-timing.txt" 2>&1
+          status=$?
+          set -e
+          cat "$RUNNER_TEMP/soc-timing.txt"
+          {
+            echo "### timing (ADR-0054)"
+            echo '```'
+            cat "$RUNNER_TEMP/soc-timing.txt"
+            echo '```'
+            echo "Critical path over the whole SoC (core + ROM + RAM), with the"
+            echo "logic/routing split. This job ratchets against \`SOC_MIN_MHZ\`,"
+            echo "a floor set below the measurement rather than at ADR-0038's"
+            echo "declared 12 MHz, and it is NOT in main's required set."
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit "$status"
+
+      - name: Report job wall time
+        if: always()
+        run: |
+          elapsed=$(( $(date +%s) - JOB_START ))
+          {
+            echo "### soc-timing"
             echo "wall time: ${elapsed}s"
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -243,6 +243,24 @@ retires happen in writeback, so a fault in the first instructions of `_start` ra
 with `RETIRES 0` and the silence gate turned it into `MONITOR-SILENT`, which is exactly the
 misattribution ADR-0029 added `TRAP-TO-ZERO` to prevent.
 
+**ADR-0053 reached every script; four graded ratchets living in the Makefile itself were still
+untouched, and one of them had never been run on CI at all.** `make fit`'s `FIT_MAX_LC` ratchet,
+`make soc-timing`'s `SOC_MIN_MHZ` ratchet, the SPRAM/EBR census `soc.json`'s recipe runs, and
+`check-unit-benches`' list equality are each a graded comparison in the same sense ADR-0053's
+audit covers, and none had its red direction exercised. Two of the four were `awk`/`grep` embedded
+in a recipe rather than a script, so probing them meant extracting them first: `soc/fit_report.py`
+now carries `make fit`'s table-presence check and ratchet, and `soc/cell_census.py` replaces the
+`soc_expect_cells` `define` — both callable against a fixture log, both wired back into the
+Makefile so there is one copy of the logic. `check-unit-benches` needed no extraction: its three
+branches are probed by invoking the real target against the real `test/*_tb.v` tree with
+`UNIT_BENCHES`/`UNIT_BENCH_SRC_*` overridden on the command line, which is what its own comment
+already commits to being possible. `test/probe_gates.sh` is **122** probes now, up from 108.
+**`make soc-timing` joins CI in the `soc-timing` job**, mirroring `fit`: non-required, for the same
+reason (ADR-0036) — it publishes the census and the logic/routing split to the step summary whether
+it passes or fails. It is the first job needing both the RISC-V cross compiler and the OSS CAD
+Suite, so the toolchain assertion moved into `.github/actions/verify-toolchain` rather than being
+copied from the `test` job — the duplication shape that broke `elaborate` once already.
+
 **M3 opens: `rtl/csrs.v` lands the CSR file and the Zicsr access path.** ADR-0005's set, exactly —
 RW `mstatus` (MIE/MPIE, MPP WARL→`2'b11`), `mtvec` (direct mode, 4-byte-aligned base, resets to 0
 per ADR-0029), `mepc` (bit 0 only, because C makes 2-byte targets legal), `mcause`, `mscratch`,
@@ -576,16 +594,18 @@ now runs the iverilog leg (`testbench.vvp`) instead of the cxxrtl runner, matchi
 table below, and produces a real `waves.vcd` — and, as of ADR-0055, grades the run it produces one
 too: `ci.yml`'s `elaborate` job runs and checks this same `testbench.vvp` directly, on one fixed
 baked-in program, not the `.S` suite (see the second bullet under "what does not work" above for
-what stays open). CI (`.github/workflows/ci.yml`) runs **eight** jobs on every PR:
-elaborate, test, components, lint, fit, nonperturbation, monitor-freshness and formal — the last of
-which also carries `complete` and `complete_cover` as hard gates (M2 term 5). **Six of the eight
-are required** — `elaborate`, `test`, `components`, `monitor-freshness`, `lint`, `formal`, read live
-from `gh api repos/thejefflarson/little-cpu/branches/main/protection -q
+what stays open). CI (`.github/workflows/ci.yml`) runs **nine** jobs on every PR:
+elaborate, test, components, lint, fit, soc-timing, nonperturbation, monitor-freshness and formal —
+the last of which also carries `complete` and `complete_cover` as hard gates (M2 term 5). **Six of
+the nine are required** — `elaborate`, `test`, `components`, `monitor-freshness`, `lint`, `formal`,
+read live from `gh api repos/thejefflarson/little-cpu/branches/main/protection -q
 '.required_status_checks.contexts'` rather than from any comment in the workflow — and
-`nonperturbation` and `fit` are the two that run without gating, both deliberately (ADR-0047,
-ADR-0052). **There is no `continue-on-error` anywhere in the file**, in any job: the `formal` job
-carried the last one until ADR-0052 struck it. This line named four jobs and stopped there
-until the gate inventory; `lint` and `formal` had both been promoted to required in the meantime,
+`nonperturbation`, `fit` and `soc-timing` are the three that run without gating, each deliberately
+(ADR-0047, ADR-0052; `soc-timing` for the same reason as `fit` — area and timing are design
+constraints, not correctness ones, ADR-0036). **There is no `continue-on-error` anywhere in the
+file**, in any job: the `formal` job carried the last one until ADR-0052 struck it. This line named
+four jobs and stopped there until the gate inventory; `lint` and `formal` had both been promoted to
+required in the meantime,
 and `ci.yml`'s own comments still said otherwise.
 
 **A Sail co-simulation spike measured what the existing oracles structurally cannot see**
@@ -748,7 +768,7 @@ make test           # assemble test/asm/*.S, run under cxxrtl, pass/fail table w
                     # both ways before a single program is assembled -- so a suite
                     # that SHRANK is red, not a smaller table that still "passes".
                     # Also runs `make probe-gates` (ADR-0053).
-make probe-gates    # forces all 108 graded comparisons in the grading scripts to
+make probe-gates    # forces all 122 graded comparisons in the grading scripts to
                     # FAIL and requires each to fail for its own reason. Hermetic
                     # (stubs, no toolchain); a prerequisite of `test` on purpose,
                     # so it is in CI's required job. All fork, no work: ~68-90s of
@@ -789,9 +809,14 @@ make soc-timing     # THE SoC PLACE-AND-TIME FLOW (ADR-0054), and NOT `make fit`
                     # DOES NOT MEET ADR-0038's DECLARED 12 MHz, and that intent
                     # is unchanged. Ratchets on SOC_MIN_MHZ (10.5), a regression
                     # floor set below the measurement rather than at the intent.
-                    # Needs the RISC-V toolchain (it builds a real ROM image),
-                    # so it is hand-run and not on CI. `SOC_PROG=lw.S` picks the
-                    # program. Probe: `make soc-timing SOC_MIN_MHZ=99` exits 1.
+                    # Needs the RISC-V toolchain (it builds a real ROM image).
+                    # ON CI as of the `soc-timing` job (non-required, same
+                    # reasoning as `fit`: area and timing are design
+                    # constraints, not correctness ones, ADR-0036). The
+                    # census (soc/cell_census.py) and the ratchet
+                    # (soc/timing_split.py) are both probed hermetically in
+                    # test/probe_gates.sh. `SOC_PROG=lw.S` picks the program.
+                    # Probe: `make soc-timing SOC_MIN_MHZ=99` exits 1.
 
 make -C formal components_decoder   # component proofs. THREE tasks, all with real assertions:
 make -C formal components_executor  # decoder, executor, pcloop -- the assertion-free fetcher /

--- a/Makefile
+++ b/Makefile
@@ -737,41 +737,15 @@ fit.json: $(FIT_SRCS)
 # proportion 4400 kept over 4208 and still well clear of both noise axes.
 FIT_MAX_LC := 4100
 
+# The table-presence check and the ratchet both live in soc/fit_report.py, not
+# here, so test/probe_gates.sh can drive them against a fixture log instead of
+# a second copy of this parsing (ADR-0053; the pattern soc/timing_split.py
+# already uses for `make soc-timing`'s ratchet).
 .PHONY: fit
 fit: fit.json
 	@nextpnr-ice40 --up5k --package sg48 --json $< --pcf-allow-unconstrained \
 	  > fit.log 2>&1 || true
-	@grep -q 'ICESTORM_LC:' fit.log || { \
-	  echo '*** make fit: nextpnr printed no utilisation table, so NO measurement'; \
-	  echo '*** was taken. That is a failure, not a 0% fit. Tail of fit.log:'; \
-	  tail -20 fit.log; \
-	  exit 1; \
-	}
-	@sed -n '/^Info: Device utilisation:/,/^$$/s/^Info: //p' fit.log
-	@awk '/ICESTORM_LC:/ { split($$3, u, "/"); printf "\nLOGIC CELLS: %s of %s (%s)  --  up5k / sg48 / littlecpu, memories external\n", u[1], $$4, $$5 }' fit.log
-	@# Both spellings, because nextpnr uses different wording depending on which
-	@# phase gives up: 'Unable to place cell ... no BELs remaining' when a BEL
-	@# class is exhausted, 'Unable to find a placement location for cell' when
-	@# it cannot site a constrained IO. The 132% configuration produced the
-	@# first; the 80% one produces the second, on an `mem_rdata` pad. Matching
-	@# only the first made a normal run print the "read fit.log before quoting
-	@# this" warning (ADR-0042).
-	@if grep -qE '^ERROR: Unable to (place cell|find a placement location for cell)' fit.log; then \
-	  echo 'Placement failed on IO, which is the expected state (ADR-0038 decision 1a);'; \
-	  echo 'the utilisation above is the measurement. Full log: fit.log'; \
-	else \
-	  echo 'Placement did not report an IO error -- read fit.log before quoting this.'; \
-	fi
-	@awk -v budget=$(FIT_MAX_LC) '/ICESTORM_LC:/ { \
-	    split($$3, u, "/"); \
-	    if (u[1] + 0 > budget + 0) { \
-	      printf "\n*** make fit: %s logic cells is over the %s-cell budget.\n", u[1], budget; \
-	      printf "*** This is a ratchet (ADR-0042), not a suggestion. Find what grew;\n"; \
-	      printf "*** raising FIT_MAX_LC in the Makefile needs a reason in the commit.\n"; \
-	      exit 1; \
-	    } \
-	    printf "\nRATCHET: %s of %s cells budgeted -- OK\n", u[1], budget; \
-	  }' fit.log
+	@python3 soc/fit_report.py fit.log --max-lc $(FIT_MAX_LC)
 
 # ---------------------------------------------------------------------------
 # `make soc-timing` -- the SoC place-and-route and the FIRST REAL TIMING NUMBER
@@ -813,22 +787,6 @@ SOC_ROM_WORDS := 2048
 SOC_EXPECT_SPRAM := 2
 SOC_EXPECT_EBR   := 20
 
-# $(call soc_expect_cells,<cell type>,<expected count>,<what it means>)
-# Reads the count out of yosys's own statistics block -- the LAST one, which is
-# the whole-design total -- and fails if it is not exactly the declared number.
-define soc_expect_cells
-set -e; \
-got=$$(grep -E '^ +[0-9]+ +$(1)$$' soc.synth.log | tail -1 | awk '{print $$1}'); \
-got=$${got:-0}; \
-if [ "$$got" != "$(2)" ]; then \
-  echo "*** make soc-timing: $$got $(1) cells, expected $(2)."; \
-  echo "*** $(3)."; \
-  echo "*** Read soc.synth.log. If the change was deliberate, update"; \
-  echo "*** SOC_EXPECT_SPRAM / SOC_EXPECT_EBR in the Makefile in the same commit."; \
-  exit 1; \
-fi; \
-echo "$(1): $$got, as declared"
-endef
 SOC_SRCS      := rtl/structs.v rtl/accessor.v rtl/csrs.v rtl/decoder.v \
                  rtl/executor.v rtl/fetcher.v rtl/imemory.v rtl/memory.v \
                  rtl/regfile.v rtl/writeback.v rtl/littlecpu.v rtl/littlesoc.v
@@ -866,23 +824,17 @@ soc.json: $(SOC_SRCS) soc-rom
 	@echo 'yosys: synthesising littlesoc for ice40 (log: soc.synth.log)'
 	@yosys -p 'read_verilog -sv $(SOC_SRCS); synth_ice40 -dsp -spram -top littlesoc -json $@' \
 	  > soc.synth.log 2>&1 || { tail -40 soc.synth.log; exit 1; }
-	@# THE INFERENCE IS CHECKED AGAINST A COUNT, NOT ASSUMED AND NOT GREPPED FOR
-	@# BY NAME. rtl/memory.v maps to SPRAM only because its read port is
-	@# no-change on a write; the read-first spelling maps the same array to 148
-	@# `SB_RAM40_4K` -- five times the part's entire block RAM -- and yosys
-	@# reports that as a normal run, failing later in nextpnr with a message
-	@# about BELs. rtl/imemory.v maps to block RAM only while it stays a plain
-	@# synchronous array; an inferred-as-logic ROM would blow the LUT budget.
-	@#
-	@# The counts are exact because they are properties of the design, not of
-	@# placement: 2 SPRAM for a 64 KB data RAM, 16 EBR for an 8 KB banked ROM
-	@# plus 4 for rtl/regfile.v. `grep -q SB_SPRAM256KA` was the first version of
-	@# this check and it PASSED on the mutated build -- yosys logs the cell's
-	@# library definition whether or not it instantiates one. Measured.
-	@$(call soc_expect_cells,SB_SPRAM256KA,$(SOC_EXPECT_SPRAM),rtl/memory.v has stopped \
-	  matching the SPRAM shape -- read its header comment about the no-change read port)
-	@$(call soc_expect_cells,SB_RAM40_4K,$(SOC_EXPECT_EBR),rtl/imemory.v or rtl/regfile.v \
-	  has stopped inferring block RAM, or the ROM size changed)
+	@# rtl/memory.v maps to SPRAM only because its read port is no-change on a
+	@# write; the read-first spelling maps the same array to 148 `SB_RAM40_4K`
+	@# -- five times the part's entire block RAM -- and yosys reports that as a
+	@# normal run, failing later in nextpnr with a message about BELs.
+	@# rtl/imemory.v maps to block RAM only while it stays a plain synchronous
+	@# array. The census below is what catches either regression; soc/cell_census.py
+	@# carries the reasoning for matching by exact count rather than by name.
+	@python3 soc/cell_census.py soc.synth.log SB_SPRAM256KA $(SOC_EXPECT_SPRAM) \
+	  "rtl/memory.v has stopped matching the SPRAM shape -- read its header comment about the no-change read port"
+	@python3 soc/cell_census.py soc.synth.log SB_RAM40_4K $(SOC_EXPECT_EBR) \
+	  "rtl/imemory.v or rtl/regfile.v has stopped inferring block RAM, or the ROM size changed"
 
 # nextpnr's exit status is NOT the signal here, and tolerating it is a decision
 # rather than a convenience. It defaults to a 12 MHz target on ice40 and EXITS

--- a/docs/adr/0055-the-makefile-embedded-ratchets-get-probes-and-soc-timing-gets-a-job.md
+++ b/docs/adr/0055-the-makefile-embedded-ratchets-get-probes-and-soc-timing-gets-a-job.md
@@ -1,0 +1,82 @@
+# ADR-0055: The Makefile-embedded ratchets get probes, and `soc-timing` gets a job
+
+**Status:** Accepted · 2026-08-02 · *Extends [ADR-0053](0053-every-graded-comparison-carries-a-probe-of-its-red-direction.md)
+to the four graded comparisons that live in the Makefile itself. Follows [ADR-0052](0052-m2-term-6-is-verified-and-the-fit-ratchet-gets-a-job.md)'s
+job for `make soc-timing`.*
+
+## Context
+
+ADR-0053's audit reached `test/*.sh`, `test/*.py`, `formal/*.sh` and `formal/*.py`. It did not reach
+the Makefile, and four graded, red-capable comparisons live there: `make fit`'s `FIT_MAX_LC` ratchet,
+`make soc-timing`'s `SOC_MIN_MHZ` ratchet (inside `soc/timing_split.py`, which the Makefile calls but
+`test/probe_gates.sh` never drove), the SPRAM/EBR census `soc.json`'s recipe runs, and
+`check-unit-benches`' list equality. None had its red direction executed by anything. This is the
+same defect class ADR-0053 named, one level up from where the audit looked.
+
+Separately, `make soc-timing` was hand-run only. ADR-0054 built the SoC and took the first real
+timing number; nothing kept a regression from landing unnoticed the way `make fit` did before
+ADR-0052.
+
+## Decision
+
+**1. `soc_expect_cells` and `make fit`'s table/ratchet check are extracted into scripts.** Neither
+was a target — one is a `define`, the other is inline `grep`/`sed`/`awk` in the `fit` recipe — so
+neither could be driven against a fixture without either a real synthesis run or a second parser of
+the same log. `soc/cell_census.py` replaces `soc_expect_cells`; `soc/fit_report.py` replaces the
+`fit` recipe's table-presence check, utilisation dump and ratchet. Both are called from the Makefile
+exactly where the inline logic used to sit, so there is one copy of each check — the same reason
+`soc/timing_split.py` already carries `make soc-timing`'s ratchet instead of a `python3 -c` in the
+recipe. Verified byte-for-byte against real `make fit` output before and after the extraction, and
+against real `soc.synth.log` cell-table formatting.
+
+**2. `check-unit-benches` needed no extraction.** It is already a `.PHONY` target with no side
+effects, comparing `$(UNIT_BENCHES)`/`$(UNIT_BENCH_SRC_*)` against the real `test/*_tb.v` tree. Its
+own comment says the declaration drives the recipe; the probes take that literally and invoke
+`make -C $REPO check-unit-benches` with those variables overridden on the command line, against the
+real tree, hermetically (no compiler, no simulator — the target itself uses only `mktemp`, `ls`,
+`sort`, `comm`, `cmp`).
+
+**3. `test/probe_gates.sh` gains four groups, fourteen probes, 108 → 122.** One control plus its red
+directions per group, matching ADR-0053's discipline exactly:
+
+- `soc/timing_split.py --min-mhz`: a report that clears the floor (control), one that misses it, one
+  with no critical path (`reported_total is None`), one whose hop sum does not reconcile with the
+  reported total.
+- `soc/cell_census.py`: a matching count (control), a wrong count, and a cell type the log never
+  mentions (`got=${got:-0}`).
+- `check-unit-benches`: a bench present in `test/` but missing from `UNIT_BENCHES`, a declared bench
+  with no file, and a declared bench with no `UNIT_BENCH_SRC_*` — the three branches the recipe
+  already has.
+- `soc/fit_report.py`: a measurement within budget (control), over budget, and no utilisation table.
+
+`PROBES_EXPECTED` is bumped to the literal count, per the same rule that pins it in the first place.
+
+**4. `make soc-timing` gets a CI job, mirroring `make fit`.** Same non-piped graded-command pattern
+(a `run:` block is `bash -e {0}`, not pipefail — ADR-0037 §4), same non-required status: area and
+timing are design constraints, not correctness ones (ADR-0036), and adding either to branch
+protection is a human action taken deliberately or not at all. It publishes the census and the
+logic/routing split to the step summary whether the step passes or fails, by writing the summary
+before checking the captured exit status — the same shape `fit` and `nonperturbation` already use.
+
+**5. The toolchain assertion is a composite action, not a second copy.** `soc-timing` is the first
+job needing both the RISC-V cross compiler (to build a real ROM image) and the OSS CAD Suite.
+Hand-copying the `test` job's inline assertion step would be the exact duplication shape that broke
+the `elaborate` job once already: a workflow re-stating something another job (or the Makefile)
+already owns, under a comment claiming it could not diverge. `.github/actions/verify-toolchain`
+takes a `tools` input and is used by both `test` and `soc-timing`, so the tool list and the failure
+message live once.
+
+## Consequences
+
+- `grep -c continue-on-error .github/workflows/*.yml` is unchanged by this ADR: no directive is
+  added. A plain substring `grep` over `ci.yml` returns non-zero because of prose in the `formal`
+  job's own comments describing continue-on-error's removal (ADR-0050, ADR-0052) — pre-existing,
+  and not the YAML key.
+- Nine CI jobs run on every PR now, not eight; the required set is unchanged (`elaborate`, `test`,
+  `components`, `monitor-freshness`, `lint`, `formal`) and `soc-timing` joins `fit` and
+  `nonperturbation` as non-required.
+- `soc/fit_report.py` and `soc/cell_census.py` are load-bearing for correctness now, not just for
+  `test/probe_gates.sh`'s coverage: `make fit` and `make soc-timing` both read them, so a change to
+  either script changes the ratchet.
+- This does not make `make fit` or `make soc-timing` grade anything they did not grade before —
+  same checks, same thresholds, extracted rather than rewritten.

--- a/docs/adr/0056-the-makefile-embedded-ratchets-get-probes-and-soc-timing-gets-a-job.md
+++ b/docs/adr/0056-the-makefile-embedded-ratchets-get-probes-and-soc-timing-gets-a-job.md
@@ -1,4 +1,4 @@
-# ADR-0055: The Makefile-embedded ratchets get probes, and `soc-timing` gets a job
+# ADR-0056: The Makefile-embedded ratchets get probes, and `soc-timing` gets a job
 
 **Status:** Accepted · 2026-08-02 · *Extends [ADR-0053](0053-every-graded-comparison-carries-a-probe-of-its-red-direction.md)
 to the four graded comparisons that live in the Makefile itself. Follows [ADR-0052](0052-m2-term-6-is-verified-and-the-fit-ratchet-gets-a-job.md)'s

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -60,6 +60,7 @@ and what it costs. Reversing one is fine — write a new ADR that supersedes it.
 | [0053](0053-every-graded-comparison-carries-a-probe-of-its-red-direction.md) | Every graded comparison carries an executable probe of its own red direction | Accepted · extends 0035, 0033 |
 | [0054](0054-the-memory-system-and-the-first-real-timing-number.md) | The memory system, and the first real timing number | Accepted · the design 0044 called for; answers 0038 decision 2 |
 | [0055](0055-the-iverilog-leg-is-graded-in-ci-without-the-multi-program-runner.md) | The iverilog leg is graded in CI, without the multi-program runner | Accepted · closes part of the `make waves` bullet in CLAUDE.md's "what does not work" |
+| [0056](0056-the-makefile-embedded-ratchets-get-probes-and-soc-timing-gets-a-job.md) | The Makefile-embedded ratchets get probes, and `soc-timing` gets a job | Accepted · extends 0053, follows 0052 |
 
 0001–0007 came from the design brief
 ([`docs/ideas/finish-the-rewrite.md`](../ideas/finish-the-rewrite.md)). 0008–0011 came out of

--- a/soc/cell_census.py
+++ b/soc/cell_census.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Check yosys's own cell census in a synth log against a declared count.
+
+Replaces the Makefile's `soc_expect_cells` define so `test/probe_gates.sh`
+can drive `make soc-timing`'s SPRAM/EBR census against a fixture log without a
+real yosys run (ADR-0053) -- the same reason `soc/timing_split.py` carries
+`make soc-timing`'s frequency ratchet instead of a second parser in the
+recipe.
+
+Matched by cell NAME, not by presence: yosys logs a cell's library definition
+in the same "Number of cells" table whether or not it actually instantiates
+one, so `grep -q SB_SPRAM256KA` passed on a build that inferred zero of them
+(ADR-0054).
+"""
+
+import argparse
+import re
+import sys
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("log", help="yosys synth_ice40 log, e.g. soc.synth.log")
+    parser.add_argument("cell", help="cell type, e.g. SB_SPRAM256KA")
+    parser.add_argument("expected", type=int, help="the declared, exact count")
+    parser.add_argument("reason", help="what a mismatch means, printed on failure")
+    args = parser.parse_args()
+
+    try:
+        with open(args.log) as handle:
+            lines = handle.read().splitlines()
+    except FileNotFoundError:
+        sys.exit(f"{args.log}: no such file")
+
+    # The LAST match, matching the Makefile's `tail -1`: yosys prints this
+    # table after more than one pass, and the final one is the whole-design
+    # total.
+    pattern = re.compile(r"^\s+(\d+)\s+" + re.escape(args.cell) + r"\s*$")
+    got = 0
+    for line in lines:
+        m = pattern.match(line)
+        if m:
+            got = int(m.group(1))
+
+    if got != args.expected:
+        sys.exit(
+            f"*** make soc-timing: {got} {args.cell} cells, expected {args.expected}.\n"
+            f"*** {args.reason}.\n"
+            f"*** Read {args.log}. If the change was deliberate, update\n"
+            "*** SOC_EXPECT_SPRAM / SOC_EXPECT_EBR in the Makefile in the same commit."
+        )
+    print(f"{args.cell}: {got}, as declared")
+
+
+if __name__ == "__main__":
+    main()

--- a/soc/fit_report.py
+++ b/soc/fit_report.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Read nextpnr's fit.log, print the utilisation table, and apply the
+FIT_MAX_LC ratchet (ADR-0042).
+
+Replaces the Makefile's inline grep/sed/awk chain so `test/probe_gates.sh`
+can drive both checks against a fixture log without running nextpnr --
+the same reason `soc/timing_split.py` carries `make soc-timing`'s ratchet
+instead of a second parser in the recipe.
+
+`make fit` EXPECTS placement to fail: `littlecpu` with its memories external
+presents 231 SB_IO against sg48's 39, so nextpnr always errors out on a pad,
+after printing the utilisation table -- which is the measurement (ADR-0038
+decision 1a). nextpnr's exit status carries no signal either way; the
+presence of the table is what says a measurement was taken at all.
+"""
+
+import argparse
+import re
+import sys
+
+UTIL_START = "Info: Device utilisation:"
+LC_LINE = re.compile(r"ICESTORM_LC:\s+(\d+)/\s*(\d+)\s+(\S+)")
+
+# Both spellings, because nextpnr words this differently depending on which
+# phase gives up: "Unable to place cell ... no BELs remaining" when a BEL
+# class is exhausted, "Unable to find a placement location for cell" when it
+# cannot site a constrained IO. Matching only the first made a normal 80%-full
+# run print the "read fit.log before quoting this" warning (ADR-0042).
+PLACEMENT_ERROR = re.compile(r"^ERROR: Unable to (place cell|find a placement location for cell)")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("log", help="nextpnr's fit.log")
+    parser.add_argument("--max-lc", type=int, required=True, help="FIT_MAX_LC budget")
+    args = parser.parse_args()
+
+    try:
+        with open(args.log) as handle:
+            lines = handle.read().splitlines()
+    except FileNotFoundError:
+        sys.exit(f"{args.log}: no such file")
+
+    if not any("ICESTORM_LC:" in line for line in lines):
+        tail = "\n".join(lines[-20:])
+        sys.exit(
+            "*** make fit: nextpnr printed no utilisation table, so NO measurement\n"
+            f"*** was taken. That is a failure, not a 0% fit. Tail of {args.log}:\n{tail}"
+        )
+
+    in_table = False
+    for line in lines:
+        if line.startswith(UTIL_START):
+            in_table = True
+        if not in_table:
+            continue
+        if line.strip() == "":
+            break
+        if line.startswith("Info: "):
+            print(line[len("Info: "):])
+
+    # The last match, matching the Makefile's `tail -1`: yosys/nextpnr can
+    # print more than one utilisation block, and the final one is the
+    # whole-design total.
+    lc = total = pct = None
+    for line in lines:
+        m = LC_LINE.search(line)
+        if m:
+            lc, total, pct = m.group(1), m.group(2), m.group(3)
+
+    print(f"\nLOGIC CELLS: {lc} of {total} ({pct})  --  up5k / sg48 / littlecpu, memories external")
+
+    if any(PLACEMENT_ERROR.match(line) for line in lines):
+        print("Placement failed on IO, which is the expected state (ADR-0038 decision 1a);")
+        print("the utilisation above is the measurement. Full log: fit.log")
+    else:
+        print("Placement did not report an IO error -- read fit.log before quoting this.")
+
+    got = int(lc)
+    if got > args.max_lc:
+        sys.exit(
+            f"\n*** make fit: {got} logic cells is over the {args.max_lc}-cell budget.\n"
+            "*** This is a ratchet (ADR-0042), not a suggestion. Find what grew;\n"
+            "*** raising FIT_MAX_LC in the Makefile needs a reason in the commit."
+        )
+    print(f"\nRATCHET: {got} of {args.max_lc} cells budgeted -- OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/probe_gates.sh
+++ b/test/probe_gates.sh
@@ -73,7 +73,7 @@ REPO=$(cd "$HERE/.." && pwd)
 # reason test/exec_tb.v pins its vector count: a probe that is deleted, or that
 # stops being reached by an early `return`, would otherwise reduce the coverage
 # of this file while it kept printing a green summary.
-PROBES_EXPECTED=108
+PROBES_EXPECTED=122
 
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/littlecpu-probe.XXXXXX") || {
   echo "error: could not create a temporary directory under ${TMPDIR:-/tmp}." >&2
@@ -974,6 +974,140 @@ begin_group "formal/genchecks-audit.py"
 # produces a ladder somewhere else.
 probe "running the generator from the wrong directory is refused, not done" 1 \
   "error: run from" "cd '$tmp' && python3 '$REPO/formal/genchecks-audit.py'"
+
+# ===========================================================================
+# 9. soc/timing_split.py -- make soc-timing's SOC_MIN_MHZ ratchet.
+# ===========================================================================
+begin_group "soc/timing_split.py"
+
+TS="python3 $REPO/soc/timing_split.py"
+
+# One LogicCell40 hop, one routing hop, and the two summary lines the script
+# derives everything else from. 1.50 ns total is 666.67 MHz, clear of every
+# floor these probes use.
+ts_fixture() {
+  local d; d=$(new_case)
+  cat > "$d/report.rpt" <<'RPT'
+ lut1 (LogicCell40) LC: 1.00 ns
+   1.00 ns netA (start_point)
+ mux1 (LocalMux) MX: 0.50 ns
+   1.50 ns netB (mid_point)
+              lcout -> end_point
+Total path delay: 1.50 ns
+Total number of logic levels: 1
+RPT
+  printf '%s' "$d"
+}
+
+d=$(ts_fixture)
+probe "control: a report clearing the floor is green" 0 "RATCHET:" \
+  "$TS $d/report.rpt --min-mhz 10.0"
+
+d=$(ts_fixture)
+probe "a report missing the floor is a ratchet, not a suggestion" 1 \
+  "is under the" "$TS $d/report.rpt --min-mhz 9999"
+
+d=$(ts_fixture); sed -i.bak '/^Total path delay:/d' "$d/report.rpt"
+probe "no critical path in the report is a failed measurement, not a fast design" 1 \
+  "does not look like an" "$TS $d/report.rpt --min-mhz 10.0"
+
+d=$(ts_fixture)
+sed -i.bak 's/^Total path delay: 1.50 ns/Total path delay: 5.00 ns/' "$d/report.rpt"
+probe "a hop sum that does not reconcile blames the script, not the design" 1 \
+  "summed hops come to" "$TS $d/report.rpt --min-mhz 10.0"
+
+# ===========================================================================
+# 10. soc/cell_census.py -- make soc-timing's SPRAM/EBR census.
+# ===========================================================================
+begin_group "soc/cell_census.py"
+
+CC="python3 $REPO/soc/cell_census.py"
+
+cc_fixture() {
+  local d; d=$(new_case)
+  cat > "$d/soc.synth.log" <<'LOG'
+     4   SB_MAC16
+     2   SB_SPRAM256KA
+    20   SB_RAM40_4K
+LOG
+  printf '%s' "$d"
+}
+
+d=$(cc_fixture)
+probe "control: a count matching the declaration is green" 0 "as declared" \
+  "$CC $d/soc.synth.log SB_SPRAM256KA 2 reason"
+
+d=$(cc_fixture)
+probe "the wrong count is named against the log's real one" 1 \
+  "20 SB_RAM40_4K cells, expected 16" "$CC $d/soc.synth.log SB_RAM40_4K 16 reason"
+
+d=$(cc_fixture)
+probe "a cell type the log never mentions reads as zero, not a crash" 1 \
+  "0 SB_RGBA_DRV cells, expected 1" "$CC $d/soc.synth.log SB_RGBA_DRV 1 reason"
+
+# ===========================================================================
+# 11. check-unit-benches -- the UNIT_BENCHES / test/*_tb.v list equality.
+# ===========================================================================
+begin_group "check-unit-benches"
+
+# Driven against the REAL Makefile and the REAL test/*_tb.v tree, with the
+# declaration overridden on the command line: UNIT_BENCHES lives in the
+# tracked Makefile, and duplicating its comparison here would be the
+# second-parser risk this file exists to avoid elsewhere.
+MB="make -C $REPO check-unit-benches"
+
+probe "control: the declared list matches the tree exactly" 0 \
+  "unit benches, matching test/*_tb.v exactly" "$MB"
+
+probe "a bench in test/ that make does not run is named" 2 \
+  "in test/ but not in UNIT_BENCHES: monitor_tb" \
+  "$MB UNIT_BENCHES='exec_tb mem_tb imem_tb decoder_tb regfile_tb csr_tb'"
+
+probe "a declared bench with no file is named the other way" 2 \
+  "in UNIT_BENCHES but not in test/: nope_tb" \
+  "$MB UNIT_BENCHES='exec_tb mem_tb imem_tb decoder_tb regfile_tb csr_tb monitor_tb nope_tb'"
+
+probe "a declared bench with no UNIT_BENCH_SRC_* would build with no design under test" 2 \
+  "monitor_tb is in UNIT_BENCHES with no UNIT_BENCH_SRC_monitor_tb" \
+  "$MB UNIT_BENCH_SRC_monitor_tb="
+
+# ===========================================================================
+# 12. soc/fit_report.py -- make fit's FIT_MAX_LC ratchet.
+# ===========================================================================
+begin_group "soc/fit_report.py"
+
+FR="python3 $REPO/soc/fit_report.py"
+
+fr_fixture() {
+  local d; d=$(new_case)
+  cat > "$d/fit.log" <<'LOG'
+Warning: No PCF file specified; IO pins will be placed automatically
+
+Info: Packing constants..
+Info: Device utilisation:
+Info: 	         ICESTORM_LC:    3875/   5280    73%
+Info: 	        ICESTORM_RAM:       4/     30    13%
+Info: 	               SB_IO:     263/     39   674%
+Info: 	               SB_GB:       8/      8   100%
+
+Info: Placed 0 cells based on constraints.
+ERROR: Unable to find a placement location for cell 'imem_addr[20]$sb_io'
+1 warning, 1 error
+LOG
+  printf '%s' "$d"
+}
+
+d=$(fr_fixture)
+probe "control: a measurement within budget is green" 0 "RATCHET:" \
+  "$FR $d/fit.log --max-lc 4100"
+
+d=$(fr_fixture)
+probe "over budget names the count and the budget" 1 \
+  "is over the 3800-cell budget" "$FR $d/fit.log --max-lc 3800"
+
+d=$(fr_fixture); sed -i.bak '/ICESTORM_LC:/d' "$d/fit.log"
+probe "no utilisation table is a failure, not a 0% fit" 1 \
+  "printed no utilisation table" "$FR $d/fit.log --max-lc 4100"
 
 # ===========================================================================
 echo


### PR DESCRIPTION
## Summary

ADR-0053's audit of the grading layer reached `test/*.sh`, `test/*.py`, `formal/*.sh` and `formal/*.py` — and nothing in the Makefile itself. Four graded, red-capable comparisons lived there with no probe ever executing their red direction:

- `make fit`'s `FIT_MAX_LC` ratchet
- `make soc-timing`'s `SOC_MIN_MHZ` ratchet (`soc/timing_split.py --min-mhz`)
- the `soc_expect_cells` SPRAM/EBR census
- `check-unit-benches`' list equality

Separately, `make soc-timing` was hand-run only, so nothing but memory would catch a timing regression the way `make fit` got caught by ADR-0052.

## What changed

- **`soc/cell_census.py`** and **`soc/fit_report.py`** replace the `soc_expect_cells` `define` and `make fit`'s inline grep/sed/awk chain, respectively — the same extraction pattern `soc/timing_split.py` already established for `make soc-timing`'s ratchet, so there is one copy of each check and it's drivable against a fixture log without a real synthesis run. Verified byte-for-byte against real `make fit` output before and after.
- **`check-unit-benches`** needed no extraction — it's already a real `.PHONY` target with no side effects, so its three branches are probed by overriding `UNIT_BENCHES`/`UNIT_BENCH_SRC_*` on the command line against the real Makefile and the real `test/*_tb.v` tree.
- **`test/probe_gates.sh`** gains four groups / 14 probes (108 → 122), each with a control plus its red directions, per ADR-0053's discipline.
- **`.github/workflows/ci.yml`** gains a `soc-timing` job mirroring `fit`: same non-piped graded-command pattern, non-required (area/timing are design constraints, not correctness ones — ADR-0036), publishes the census and logic/routing split to the step summary whether the step passes or fails.
- **`.github/actions/verify-toolchain`** is a new composite action factoring out the runner-image toolchain assertion, used by both `test` and the new `soc-timing` job (the first job needing both the RISC-V cross compiler and the OSS CAD Suite) — avoiding the hand-copy-and-drift shape that broke `elaborate` once already.
- `docs/adr/0055` records the decisions; `CLAUDE.md` and the ADR index are updated to match (probe count, CI job count, `make soc-timing`'s CI status).

## Test plan

- [x] `make test` — 56/56 programs, `test/EXPECTED_FAIL` empty, `test/probe_gates.sh` 122/122 probes green
- [x] `make lint` — clean in both passes (no `rtl/` touched)
- [x] `make fit` — run before and after the extraction; identical output both times, including the over-budget (`FIT_MAX_LC=3800`, exit 2) and no-utilisation-table red paths
- [x] `make soc-timing` — run once (machine load ~7–9 on 10 cores at the time): 4041/5280 LC, 20/30 EBR, 2/4 SPRAM, 88.51 ns = 11.30 MHz, matching ADR-0054's recorded figures exactly; both `soc/cell_census.py` calls and the `soc/timing_split.py` ratchet all passed for real
- [x] `grep -c continue-on-error .github/workflows/*.yml` — no new directive added (pre-existing prose-only matches in the `formal` job's comments are unchanged)
- [x] `/soundcheck:pr-review` — no Critical/High findings (internal build/CI tooling only, no untrusted input, no new network calls or secrets)
- [x] `/simplify` — single-pass (no Agent tool fan-out available in this context); found and fixed one real issue, both new scripts using bare `open()` instead of the `with open(...) as handle:` convention `soc/rom_banks.py` already established

Closes JEF-721.