### PR TITLE
Bump riscv-formal pin to c992aa61fdfe

### DIFF
--- a/formal/bump-riscv-formal-pin.sh
+++ b/formal/bump-riscv-formal-pin.sh
@@ -1,0 +1,143 @@
+#!/bin/bash
+# Opens a PR bumping formal/pin.mk's riscv-formal SHA when upstream's `main`
+# has moved past it, regenerating test/monitor.v so monitor-freshness is a
+# real verdict on the bump rather than a guaranteed failure. Does nothing --
+# no branch, no commit, no PR -- if the pin is already current, or if a PR
+# already proposes the SHA upstream is at.
+#
+# The existing gates (monitor-freshness, formal/check-genchecks.py,
+# formal/check-complete-exclusions.py, the ladder itself) decide whether the
+# bump is safe; this script only notices and proposes.
+#
+# Usage: formal/bump-riscv-formal-pin.sh
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+UPSTREAM_URL="https://github.com/YosysHQ/riscv-formal.git"
+
+PIN_SHA=$(python3 -c "
+import re, pathlib
+text = pathlib.Path('formal/pin.mk').read_text()
+m = re.search(r'override RISCV_FORMAL_SHA := ([0-9a-f]{40})', text)
+assert m, 'could not find RISCV_FORMAL_SHA in formal/pin.mk'
+print(m.group(1))
+")
+
+UPSTREAM_SHA=$(git ls-remote "$UPSTREAM_URL" HEAD | cut -f1)
+# Validated before use anywhere else in this script: it is about to be
+# written into formal/pin.mk, a branch name, and a shell-evaluated Python
+# argument, and an upstream server is who supplies it.
+if ! printf '%s' "$UPSTREAM_SHA" | grep -qE '^[0-9a-f]{40}$'; then
+  echo "upstream HEAD for $UPSTREAM_URL is not a 40-hex SHA: '$UPSTREAM_SHA'" >&2
+  exit 1
+fi
+
+echo "pinned:   $PIN_SHA"
+echo "upstream: $UPSTREAM_SHA"
+
+if [ "$PIN_SHA" = "$UPSTREAM_SHA" ]; then
+  echo "pin is current; nothing to do"
+  exit 0
+fi
+
+BRANCH="riscv-formal-pin/bump-${UPSTREAM_SHA:0:12}"
+
+OPEN_COUNT=$(gh pr list --state open --head "$BRANCH" --json number --jq 'length')
+if [ "$OPEN_COUNT" -gt 0 ]; then
+  echo "a PR already proposes $UPSTREAM_SHA (branch $BRANCH); nothing to do"
+  exit 0
+fi
+
+CLONE_DIR=$(mktemp -d)
+trap 'rm -rf "$CLONE_DIR"' EXIT
+git clone --quiet --filter=blob:none "$UPSTREAM_URL" "$CLONE_DIR"
+
+DIFFSTAT=$(git -C "$CLONE_DIR" diff --stat "$PIN_SHA..$UPSTREAM_SHA" -- checks/ insns/ monitor/)
+FULLDIFF=$(git -C "$CLONE_DIR" diff "$PIN_SHA..$UPSTREAM_SHA" -- checks/ insns/ monitor/)
+DIFF_LINES=$(printf '%s\n' "$FULLDIFF" | wc -l | tr -d ' ')
+
+git checkout -b "$BRANCH"
+
+python3 - "$UPSTREAM_SHA" <<'EOF'
+import pathlib, re, sys
+new_sha = sys.argv[1]
+p = pathlib.Path('formal/pin.mk')
+text = p.read_text()
+new_text, n = re.subn(
+    r'(override RISCV_FORMAL_SHA := )[0-9a-f]{40}',
+    lambda m: m.group(1) + new_sha,
+    text,
+)
+if n != 1:
+    sys.exit(f'expected exactly one RISCV_FORMAL_SHA line, replaced {n}')
+p.write_text(new_text)
+EOF
+
+# A clone left on disk at the old pin trips pin.mk's own fail-closed guard
+# (ADR-0013) the moment the SHA above changes underneath it.
+rm -rf formal/riscv-formal
+make test/monitor.v
+
+if git diff --quiet -- formal/pin.mk test/monitor.v; then
+  echo "bumping the pin produced no diff in formal/pin.mk or test/monitor.v" >&2
+  exit 1
+fi
+
+git config user.name "github-actions[bot]"
+git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+git add formal/pin.mk test/monitor.v
+git commit --quiet -m "Bump riscv-formal pin to ${UPSTREAM_SHA:0:12}
+
+$DIFFSTAT"
+
+git push --quiet origin "$BRANCH"
+
+COMPARE_URL="https://github.com/YosysHQ/riscv-formal/compare/${PIN_SHA}...${UPSTREAM_SHA}"
+BODY_FILE="$CLONE_DIR/pr-body.md"
+{
+  echo "Upstream riscv-formal moved."
+  echo
+  echo "- pinned:   \`$PIN_SHA\`"
+  echo "- upstream: \`$UPSTREAM_SHA\`"
+  echo "- compare:  $COMPARE_URL"
+  echo
+  echo "\`test/monitor.v\` is regenerated against the new pin in this commit."
+  echo "The existing gates decide whether the bump is safe: monitor-freshness,"
+  echo "\`formal/check-genchecks.py\`, \`formal/check-complete-exclusions.py\`,"
+  echo "and the riscv-formal ladder itself."
+  echo
+  echo "### Diff under checks/, insns/, monitor/"
+  echo
+  if [ -z "$DIFFSTAT" ]; then
+    echo "None -- this bump only touches other directories (e.g. cores/)."
+  else
+    echo '```'
+    printf '%s\n' "$DIFFSTAT"
+    echo '```'
+    if [ "$DIFF_LINES" -le 300 ]; then
+      echo
+      echo "<details><summary>Full diff (${DIFF_LINES} lines)</summary>"
+      echo
+      echo '```diff'
+      printf '%s\n' "$FULLDIFF"
+      echo '```'
+      echo "</details>"
+    else
+      echo
+      echo "Full diff is ${DIFF_LINES} lines; see the compare link above."
+    fi
+  fi
+} > "$BODY_FILE"
+
+PR_URL=$(gh pr create --title "Bump riscv-formal pin to ${UPSTREAM_SHA:0:12}" \
+  --body-file "$BODY_FILE" --head "$BRANCH" --base main)
+echo "opened $PR_URL"
+
+# A PR opened with the Actions default GITHUB_TOKEN does not trigger
+# pull_request-triggered workflows -- GitHub suppresses events caused by that
+# token to prevent recursive runs -- so without this, ci.yml's required checks
+# would never run on this PR. workflow_dispatch is exempt, and GitHub attaches
+# check runs to a PR by commit SHA regardless of which event asked for them.
+if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
+  gh workflow run ci.yml --ref "$BRANCH"
+fi

--- a/formal/pin.mk
+++ b/formal/pin.mk
@@ -9,7 +9,7 @@
 # from a script or CI job: this is a supply-chain control, not a knob. The
 # repo executes Python straight out of this clone (checks/rvfi_macros.py,
 # monitor/generate.py) and commits its stdout as tracked, compiled source.
-override RISCV_FORMAL_SHA := 12e87bb2dcc438178f3b23a7ab0cf294e2a08147
+override RISCV_FORMAL_SHA := c992aa61fdfe0846c5ed90324c596202a1c69b76
 override RISCV_FORMAL_URL := https://github.com/YosysHQ/riscv-formal.git
 
 ifeq ($(shell printf '%s' '$(RISCV_FORMAL_SHA)' | grep -cE '^[0-9a-f]{40}$$'),0)

--- a/formal/pin.mk
+++ b/formal/pin.mk
@@ -9,7 +9,7 @@
 # from a script or CI job: this is a supply-chain control, not a knob. The
 # repo executes Python straight out of this clone (checks/rvfi_macros.py,
 # monitor/generate.py) and commits its stdout as tracked, compiled source.
-override RISCV_FORMAL_SHA := c992aa61fdfe0846c5ed90324c596202a1c69b76
+override RISCV_FORMAL_SHA := 12e87bb2dcc438178f3b23a7ab0cf294e2a08147
 override RISCV_FORMAL_URL := https://github.com/YosysHQ/riscv-formal.git
 
 ifeq ($(shell printf '%s' '$(RISCV_FORMAL_SHA)' | grep -cE '^[0-9a-f]{40}$$'),0)


### PR DESCRIPTION
Upstream riscv-formal moved.

- pinned:   `12e87bb2dcc438178f3b23a7ab0cf294e2a08147`
- upstream: `c992aa61fdfe0846c5ed90324c596202a1c69b76`
- compare:  https://github.com/YosysHQ/riscv-formal/compare/12e87bb2dcc438178f3b23a7ab0cf294e2a08147...c992aa61fdfe0846c5ed90324c596202a1c69b76

`test/monitor.v` is regenerated against the new pin in this commit.
The existing gates decide whether the bump is safe: monitor-freshness,
`formal/check-genchecks.py`, `formal/check-complete-exclusions.py`,
and the riscv-formal ladder itself.

### Diff under checks/, insns/, monitor/

```
 checks/rvfi_bus_imem_fault_check.sv | 18 +++++++++++++-----
 1 file changed, 13 insertions(+), 5 deletions(-)
```

<details><summary>Full diff (43 lines)</summary>

```diff
diff --git a/checks/rvfi_bus_imem_fault_check.sv b/checks/rvfi_bus_imem_fault_check.sv
index f6a9858..fe865ac 100644
--- a/checks/rvfi_bus_imem_fault_check.sv
+++ b/checks/rvfi_bus_imem_fault_check.sv
@@ -20,6 +20,7 @@ module rvfi_bus_imem_fault_check (
 	`RVFI_BUS_INPUTS
 );
 	`rvformal_rand_const_reg [`RISCV_FORMAL_XLEN-1:0] imem_addr;
+	`rvformal_rand_const_reg                          imem_prev_32bit;
 
 	reg [`RISCV_FORMAL_XLEN-1:0] pc;
 	reg [`RISCV_FORMAL_ILEN-1:0] insn;
@@ -38,10 +39,17 @@ module rvfi_bus_imem_fault_check (
 					bus_addr = rvfi_bus_addr[channel_idx*`RISCV_FORMAL_XLEN +: `RISCV_FORMAL_XLEN];
 					bus_rmask = rvfi_bus_rmask[channel_idx*`RISCV_FORMAL_BUSLEN/8 +: `RISCV_FORMAL_BUSLEN/8];
 					bus_rdata = rvfi_bus_rdata[channel_idx*`RISCV_FORMAL_BUSLEN +: `RISCV_FORMAL_BUSLEN];
-					for (i = 0; i < `RISCV_FORMAL_BUSLEN/8; i=i+1)
-					for (j = 0; j < 2; j=j+1) begin
-						if (bus_rmask[i] && bus_addr + i == imem_addr + j) begin
-							assume (rvfi_bus_fault[channel_idx]);
+					for (i = 0; i < `RISCV_FORMAL_BUSLEN/8; i=i+1) begin
+						for (j = 0; j < 2; j=j+1) begin
+							if (bus_rmask[i] && bus_addr + i == imem_addr + j) begin
+								assume (rvfi_bus_fault[channel_idx]);
+							end
+						end
+						// Checks on fault of second half of instruction are enabled only when the
+						// immediately previous halfword is constrained to be the start of a 32-bit
+						// encoding. See https://github.com/YosysHQ/riscv-formal/issues/44
+						if (bus_rmask[i] && bus_addr + i + 2 == imem_addr && imem_prev_32bit) begin
+							assume(bus_rdata[i * 8 +: 2] == 2'b11);
 						end
 					end
 					cover (rvfi_bus_fault[channel_idx]);
@@ -62,7 +70,7 @@ module rvfi_bus_imem_fault_check (
 `endif
 					end;
 
-					if (`rvformal_addr_valid(pc+2) && pc+2 == imem_addr) begin
+					if (`rvformal_addr_valid(pc+2) && pc+2 == imem_addr && imem_prev_32bit) begin
 						cover (1);
 						assert (rvfi_trap[`RISCV_FORMAL_CHANNEL_IDX]);
 						assert (insn == 0);
```
</details>
