### PR TITLE
Notice when the riscv-formal pin drifts, and open the bump as a PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
   push:
     branches: [main]
+  # Lets .github/workflows/riscv-formal-pin-bump.yml force a run on a PR it
+  # opened with the default GITHUB_TOKEN: GitHub does not fire pull_request
+  # for events caused by that token (recursion prevention), but does attach
+  # workflow_dispatch check runs to the PR by commit SHA.
+  workflow_dispatch:
 
 # Least privilege: nothing in this workflow pushes, comments, or writes
 # back anywhere. Set once at workflow level so no job needs a wider

--- a/.github/workflows/riscv-formal-pin-bump.yml
+++ b/.github/workflows/riscv-formal-pin-bump.yml
@@ -1,0 +1,34 @@
+name: riscv-formal pin bump
+
+# Notices when upstream YosysHQ/riscv-formal's `main` has moved past
+# formal/pin.mk's SHA and opens a PR bumping it, with test/monitor.v
+# regenerated against the new pin (ADR-0013). The existing gates --
+# monitor-freshness, formal/check-genchecks.py,
+# formal/check-complete-exclusions.py, the ladder itself -- grade the bump;
+# this workflow only notices and proposes. No auto-merge: ADR-0018's
+# dependabot-automerge.yml is scoped to `dependabot[bot]` and does not apply
+# here, and this workflow does not enable auto-merge on the PRs it opens.
+on:
+  schedule:
+    - cron: "17 6 * * 1" # weekly, Monday
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: write # gh workflow run, needed only under the default GITHUB_TOKEN -- see the script
+
+jobs:
+  check-and-bump:
+    name: check-and-bump
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: formal/bump-riscv-formal-pin.sh
+        run: formal/bump-riscv-formal-pin.sh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/formal/bump-riscv-formal-pin.sh
+++ b/formal/bump-riscv-formal-pin.sh
@@ -1,0 +1,143 @@
+#!/bin/bash
+# Opens a PR bumping formal/pin.mk's riscv-formal SHA when upstream's `main`
+# has moved past it, regenerating test/monitor.v so monitor-freshness is a
+# real verdict on the bump rather than a guaranteed failure. Does nothing --
+# no branch, no commit, no PR -- if the pin is already current, or if a PR
+# already proposes the SHA upstream is at.
+#
+# The existing gates (monitor-freshness, formal/check-genchecks.py,
+# formal/check-complete-exclusions.py, the ladder itself) decide whether the
+# bump is safe; this script only notices and proposes.
+#
+# Usage: formal/bump-riscv-formal-pin.sh
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+UPSTREAM_URL="https://github.com/YosysHQ/riscv-formal.git"
+
+PIN_SHA=$(python3 -c "
+import re, pathlib
+text = pathlib.Path('formal/pin.mk').read_text()
+m = re.search(r'override RISCV_FORMAL_SHA := ([0-9a-f]{40})', text)
+assert m, 'could not find RISCV_FORMAL_SHA in formal/pin.mk'
+print(m.group(1))
+")
+
+UPSTREAM_SHA=$(git ls-remote "$UPSTREAM_URL" HEAD | cut -f1)
+# Validated before use anywhere else in this script: it is about to be
+# written into formal/pin.mk, a branch name, and a shell-evaluated Python
+# argument, and an upstream server is who supplies it.
+if ! printf '%s' "$UPSTREAM_SHA" | grep -qE '^[0-9a-f]{40}$'; then
+  echo "upstream HEAD for $UPSTREAM_URL is not a 40-hex SHA: '$UPSTREAM_SHA'" >&2
+  exit 1
+fi
+
+echo "pinned:   $PIN_SHA"
+echo "upstream: $UPSTREAM_SHA"
+
+if [ "$PIN_SHA" = "$UPSTREAM_SHA" ]; then
+  echo "pin is current; nothing to do"
+  exit 0
+fi
+
+BRANCH="riscv-formal-pin/bump-${UPSTREAM_SHA:0:12}"
+
+OPEN_COUNT=$(gh pr list --state open --head "$BRANCH" --json number --jq 'length')
+if [ "$OPEN_COUNT" -gt 0 ]; then
+  echo "a PR already proposes $UPSTREAM_SHA (branch $BRANCH); nothing to do"
+  exit 0
+fi
+
+CLONE_DIR=$(mktemp -d)
+trap 'rm -rf "$CLONE_DIR"' EXIT
+git clone --quiet --filter=blob:none "$UPSTREAM_URL" "$CLONE_DIR"
+
+DIFFSTAT=$(git -C "$CLONE_DIR" diff --stat "$PIN_SHA..$UPSTREAM_SHA" -- checks/ insns/ monitor/)
+FULLDIFF=$(git -C "$CLONE_DIR" diff "$PIN_SHA..$UPSTREAM_SHA" -- checks/ insns/ monitor/)
+DIFF_LINES=$(printf '%s\n' "$FULLDIFF" | wc -l | tr -d ' ')
+
+git checkout -b "$BRANCH"
+
+python3 - "$UPSTREAM_SHA" <<'EOF'
+import pathlib, re, sys
+new_sha = sys.argv[1]
+p = pathlib.Path('formal/pin.mk')
+text = p.read_text()
+new_text, n = re.subn(
+    r'(override RISCV_FORMAL_SHA := )[0-9a-f]{40}',
+    lambda m: m.group(1) + new_sha,
+    text,
+)
+if n != 1:
+    sys.exit(f'expected exactly one RISCV_FORMAL_SHA line, replaced {n}')
+p.write_text(new_text)
+EOF
+
+# A clone left on disk at the old pin trips pin.mk's own fail-closed guard
+# (ADR-0013) the moment the SHA above changes underneath it.
+rm -rf formal/riscv-formal
+make test/monitor.v
+
+if git diff --quiet -- formal/pin.mk test/monitor.v; then
+  echo "bumping the pin produced no diff in formal/pin.mk or test/monitor.v" >&2
+  exit 1
+fi
+
+git config user.name "github-actions[bot]"
+git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+git add formal/pin.mk test/monitor.v
+git commit --quiet -m "Bump riscv-formal pin to ${UPSTREAM_SHA:0:12}
+
+$DIFFSTAT"
+
+git push --quiet origin "$BRANCH"
+
+COMPARE_URL="https://github.com/YosysHQ/riscv-formal/compare/${PIN_SHA}...${UPSTREAM_SHA}"
+BODY_FILE="$CLONE_DIR/pr-body.md"
+{
+  echo "Upstream riscv-formal moved."
+  echo
+  echo "- pinned:   \`$PIN_SHA\`"
+  echo "- upstream: \`$UPSTREAM_SHA\`"
+  echo "- compare:  $COMPARE_URL"
+  echo
+  echo "\`test/monitor.v\` is regenerated against the new pin in this commit."
+  echo "The existing gates decide whether the bump is safe: monitor-freshness,"
+  echo "\`formal/check-genchecks.py\`, \`formal/check-complete-exclusions.py\`,"
+  echo "and the riscv-formal ladder itself."
+  echo
+  echo "### Diff under checks/, insns/, monitor/"
+  echo
+  if [ -z "$DIFFSTAT" ]; then
+    echo "None -- this bump only touches other directories (e.g. cores/)."
+  else
+    echo '```'
+    printf '%s\n' "$DIFFSTAT"
+    echo '```'
+    if [ "$DIFF_LINES" -le 300 ]; then
+      echo
+      echo "<details><summary>Full diff (${DIFF_LINES} lines)</summary>"
+      echo
+      echo '```diff'
+      printf '%s\n' "$FULLDIFF"
+      echo '```'
+      echo "</details>"
+    else
+      echo
+      echo "Full diff is ${DIFF_LINES} lines; see the compare link above."
+    fi
+  fi
+} > "$BODY_FILE"
+
+PR_URL=$(gh pr create --title "Bump riscv-formal pin to ${UPSTREAM_SHA:0:12}" \
+  --body-file "$BODY_FILE" --head "$BRANCH" --base main)
+echo "opened $PR_URL"
+
+# A PR opened with the Actions default GITHUB_TOKEN does not trigger
+# pull_request-triggered workflows -- GitHub suppresses events caused by that
+# token to prevent recursive runs -- so without this, ci.yml's required checks
+# would never run on this PR. workflow_dispatch is exempt, and GitHub attaches
+# check runs to a PR by commit SHA regardless of which event asked for them.
+if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
+  gh workflow run ci.yml --ref "$BRANCH"
+fi


### PR DESCRIPTION
## Summary

`formal/pin.mk` pins riscv-formal to a 40-hex SHA, but nothing checked whether upstream had moved past it. Measured before this change: the pin was exactly upstream `main`'s HEAD, which is luck, not a control.

- `.github/workflows/riscv-formal-pin-bump.yml` runs weekly (plus `workflow_dispatch`), resolves upstream's `main` HEAD via `git ls-remote`, and calls `formal/bump-riscv-formal-pin.sh`.
- `formal/bump-riscv-formal-pin.sh` compares the resolved SHA to the pin. If they match, or a PR already proposes the resolved SHA, it does nothing and exits 0. Otherwise it opens a branch that bumps `formal/pin.mk` and regenerates `test/monitor.v` (so `monitor-freshness` is a real verdict on the bump, not a guaranteed failure), and opens a PR whose body carries both SHAs, the upstream compare link, and the diff under `checks/`, `insns/` and `monitor/` (the three directories that change what this repo sees — a bump touching only `cores/` says so).
- No new grading and no auto-merge: the existing gates (`monitor-freshness`, `formal/check-genchecks.py`, `formal/check-complete-exclusions.py`, the ladder itself) decide whether a bump is safe, exactly as the ticket asked. `dependabot-automerge.yml` is scoped to `dependabot[bot]` (ADR-0018) and does not fire on this workflow's PRs.
- `ci.yml` gains a `workflow_dispatch` trigger. Reason: GitHub does not fire `pull_request` for events caused by the default `GITHUB_TOKEN` (recursion prevention), so a PR opened by the scheduled workflow would never get graded without this — `workflow_dispatch` is exempt, and GitHub attaches those check runs to the PR by commit SHA regardless of which event asked for them.
- `formal/pin.mk` itself is unchanged — the `override`, the 40-hex validation, the fail-closed clone check, and the atomic clone-then-verify all stay exactly as they are.

## Test plan

- [x] `shellcheck formal/bump-riscv-formal-pin.sh` — clean.
- [x] Ran the script against the real, current pin (which matches upstream exactly): prints both SHAs, "pin is current; nothing to do", exits 0 (satisfies "re-running with the pin already current opens nothing and exits 0").
- [x] **Red direction, demonstrated live, not just reasoned about**: in a separate scratch clone of this repo, set `formal/pin.mk` to an older real riscv-formal commit (`12e87bb2`, ~45 commits behind), then ran the script for real. It detected the drift, cloned upstream, computed the `checks/`/`insns/`/`monitor/` diff, regenerated `test/monitor.v`, pushed a branch and opened a real PR (`thejefflarson/little-cpu#93`, later `#94`/`#95` after two follow-up fixes) with the correct SHAs, compare link, and diff summary. `gh pr checks` confirmed CI attached and started grading it (`lint` passed before the demo was torn down). Closed each demo PR without merging and deleted the branches; no residue.
- [x] A `pr-review` self-check on the diff found one real issue — `$UPSTREAM_SHA` (upstream-controlled) was spliced directly into an inline `python3 -c "..."` script body, which is code injection if a compromised upstream ever answered `git ls-remote` with something other than a clean SHA. Fixed by validating the SHA against `^[0-9a-f]{40}$` before it's used anywhere, and passing it to Python as `sys.argv[1]` instead of interpolating it into source. Re-ran the live demo after the fix to confirm it still works.
- [x] A single-pass `/simplify` review found one cleanup: a second `mktemp` for the PR body file was never cleaned up; it now lives inside the already-trap-cleaned clone-diff temp directory.

Closes JEF-736.