### PR TITLE
JEF-719: rewrite the comments in four files to plain English

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,33 +5,23 @@ on:
   push:
     branches: [main]
 
-# Least privilege: nothing in this workflow pushes, comments, or writes
-# back anywhere. Set once at workflow level so no job needs a wider
-# permissions: block of its own.
 permissions:
   contents: read
 
-# oss-cad-suite-linux-x64-20260629.tgz is 719 MB (measured), so
-# every job that needs yosys/iverilog/sby restores it from actions/cache
-# instead of re-downloading. The tag and the filename below must name the
-# same release (https://github.com/YosysHQ/oss-cad-suite-build/releases);
-# bump them together.
+# The tag and the filename must name the same oss-cad-suite release
+# (https://github.com/YosysHQ/oss-cad-suite-build/releases); bump them together.
 env:
   OSS_CAD_SUITE_TAG: "2026-06-29"
   OSS_CAD_SUITE_FILE: "oss-cad-suite-linux-x64-20260629.tgz"
-  # Upstream does not publish a checksum asset for this release, so this is
-  # this repo's own pin: computed locally from the tarball fetched at the
-  # URL below, the same "don't trust the dependency, pin what you got"
-  # posture as formal/pin.mk (ADR-0013). Verified below before the archive
-  # is ever extracted.
+  # Upstream publishes no checksum asset for this release, so this digest is
+  # this repo's own pin, computed locally from the tarball it fetched -- the
+  # same posture as formal/pin.mk. The composite action verifies it before
+  # extracting anything.
   OSS_CAD_SUITE_SHA256: "dfb5df3c28599081d2baca13884c069c025b1990c86e90f4a4d84aadcd255cc5"
 
 jobs:
-  # yosys write_cxxrtl plus the iverilog leg
-  # (test/testbench.v + rtl + test/monitor.v under iverilog -- the "second
-  # elaboration frontend" in CLAUDE.md's verification table, unblocked by
-  # eb18320). Neither leg runs a single test vector; both just prove the
-  # design elaborates.
+  # Both elaboration frontends: yosys write_cxxrtl, then iverilog over
+  # test/testbench.v + rtl/ + test/monitor.v.
   elaborate:
     name: elaborate
     runs-on: little-cpu-runners
@@ -50,40 +40,28 @@ jobs:
           sha256: ${{ env.OSS_CAD_SUITE_SHA256 }}
 
       - name: yosys write_cxxrtl, warnings promoted
-        # The elaboration itself is `make elaborate-strict` -- the Makefile's
-        # test/rtl.cc sources plus `proc; opt_clean; check` ahead of
-        # write_cxxrtl, which is what actually reports "is used but has no
-        # driver" (the bare recipe elaborates an undriven wire with zero
-        # diagnostic output and exit 0).
+        # `make elaborate-strict` runs `proc; opt_clean; check` ahead of
+        # write_cxxrtl, which is what reports "is used but has no driver"; the
+        # bare recipe elaborates an undriven wire silently and exits 0.
         #
-        # THIS STEP USED TO SPELL THE FILE LIST OUT ITSELF, under a comment
-        # claiming it "reads the same sources, so the two cannot diverge on
-        # what they elaborate". It diverged: ADR-0054 put rtl/imemory.v and
-        # rtl/memory.v on the simulator's graph, this copy was not updated,
-        # and the gate spent a run elaborating a testbench whose memory
-        # instances resolved to nothing -- reporting all 32 bits of
-        # `imem_data2` as undriven. The list now lives once, in the Makefile
-        # variable both sim legs already build from, so a fourth copy cannot
-        # go stale here. What stays in the workflow is the promotion POLICY
-        # below, which is a gate decision and belongs at the gate.
+        # Do not spell the source list out here. This step used to, under a
+        # comment claiming it could not diverge from the Makefile's, and it
+        # diverged -- the gate spent a run elaborating a testbench whose memory
+        # instances resolved to nothing. The list lives once, in the Makefile
+        # variable both sim legs build from.
         #
-        # The promotion below is a curated list, not `yosys -e '.*'`: this
-        # design legitimately emits "Warning: Deep recursion in AST
-        # simplifier" on some inputs (see CLAUDE.md's technical notes),
-        # which is a recursion-depth notice, not a correctness signal, and
-        # must not fail the build. Everything else yosys prefixes
-        # "Warning:" is promoted. Implicit declarations and
-        # multiple/conflicting drivers were confirmed locally to already
-        # abort elaboration with a hard ERROR (nonzero exit) before
-        # write_cxxrtl runs, so in practice this line promotes the two
-        # classes that would otherwise elaborate silently: undriven wires
-        # and width mismatches.
+        # The grep is an allowlist rather than `yosys -e '.*'` because this
+        # design legitimately emits "Warning: Deep recursion in AST simplifier",
+        # a recursion-depth notice with no correctness content. Everything else
+        # yosys prefixes "Warning:" fails the build. Implicit declarations and
+        # conflicting drivers already abort with a hard ERROR before
+        # write_cxxrtl, so what this actually promotes is undriven wires and
+        # width mismatches.
         run: |
           set -euo pipefail
-          # Redirect, never a pipeline: a `run:` block is `bash -e`, and
-          # `-o pipefail` is set above, but the repo has shipped a graded
-          # command whose status was `tee`'s exactly once already (ADR-0037)
-          # and the cheapest defence is not to build the pipeline.
+          # Redirect rather than pipe: this repo has shipped a graded command
+          # whose status was `tee`'s once already (ADR-0037), and pipefail being
+          # set here is one edit away from not being.
           if ! make elaborate-strict > /tmp/yosys-elaborate.log 2>&1; then
             echo "::error::elaboration failed before warnings were even graded"
             cat /tmp/yosys-elaborate.log
@@ -98,27 +76,19 @@ jobs:
           echo "yosys write_cxxrtl: zero promoted warnings"
 
       - name: iverilog full-pipeline elaboration (second frontend)
-        # testbench.vvp needs rvfi_macros.vh, an existing Makefile target
-        # that clones the pinned riscv-formal (formal/pin.mk) -- harmless
-        # here, and exercises the same from-scratch-clone pin guard
-        # ADR-0013 asks CI to run.
+        # rvfi_macros.vh clones the pinned riscv-formal (formal/pin.mk), so this
+        # step also exercises the from-scratch-clone pin guard.
         #
-        # iverilog emits exactly 20 "sorry: constant selects in always_*
-        # processes" notes on this design (counted with `make -B
-        # testbench.vvp | grep -c`, all 20 identical and all against
-        # `in[952:0]`, which is rtl/writeback.v's accessor_output -- a real
-        # iverilog limitation, not a bug in this RTL) and still exits 0. Do
-        # not grep for them: they are notes, not warnings, and CLAUDE.md's
-        # engineering rules call this out by name, with the same count, as a
-        # known separately-tracked class this gate must not block on. This
-        # comment said "~30" until the gate inventory counted them.
+        # iverilog emits 20 "sorry: constant selects in always_* processes"
+        # notes here, all against rtl/writeback.v's accessor_output, and still
+        # exits 0. They are notes rather than warnings and CLAUDE.md tracks the
+        # count separately; do not grep for them.
         run: make rvfi_macros.vh testbench.vvp
 
       - name: iverilog full-pipeline simulation (one fixed program, graded)
-        # Runs testbench.vvp's baked-in 200-cycle program; test/testbench.v
-        # fatals on a nonzero monitor errcode or on a write/retire floor
-        # (ADR-0055). Not the `.S` suite -- there is still no image loader
-        # for this file, so a graded multi-program runner stays deferred.
+        # testbench.vvp's baked-in 200-cycle program. test/testbench.v fatals on
+        # a nonzero monitor errcode or a write/retire floor (ADR-0055). Not the
+        # `.S` suite -- this file has no image loader.
         run: vvp testbench.vvp
 
       - name: Report job wall time
@@ -130,21 +100,17 @@ jobs:
             echo "wall time: ${elapsed}s"
           } >> "$GITHUB_STEP_SUMMARY"
 
-  # The ADR-0007/ADR-0008 cxxrtl regression gate: builds `sim`, runs
-  # test-units (the iverilog RTL-level benches), then every test/asm/*.S
-  # under `sim` and checks the pass/fail table against test/EXPECTED_FAIL
-  # (ADR-0014's baseline). That baseline is EMPTY again -- the three M3 tests
-  # written ahead of their RTL (csr.S, minstret.S, trap.S) have all been paid
-  # off -- so the gate is a plain 52 pass / 0 expected-fail today. This
-  # comment described the 49/3 state until the gate inventory re-ran it.
-  # ADR-0014's set-equality check runs in both directions regardless, so a
-  # baselined test starting to pass fails the gate just as loudly as a passing
-  # test starting to fail, until its line moves in the same commit.
+  # The cxxrtl regression gate. `make test` pulls in three things besides the
+  # `.S` suite: `test-units` (the seven iverilog benches, each of which
+  # $fatal(1)s on a mismatch), `probe-gates` (ADR-0053, which forces every
+  # graded comparison in the grading scripts to fail for its own reason), and
+  # the suite-shape check that grades test/OBSERVED_FLOOR's name set both ways
+  # before a program is assembled.
   #
-  # `make test` depends on `test-units`, so this one step is also the only
-  # place any iverilog simulation runs on this workflow (six benches:
-  # exec_tb, mem_tb, decoder_tb, regfile_tb, csr_tb, monitor_tb). Each
-  # $fatal(1)s on a mismatch, so vvp's exit code is the verdict.
+  # The pass/fail table is graded against test/EXPECTED_FAIL by set equality in
+  # both directions, so a baselined test that starts passing fails this gate as
+  # loudly as a passing test that starts failing, until its line moves in the
+  # same commit (ADR-0014).
   test:
     name: test
     runs-on: little-cpu-runners
@@ -155,11 +121,10 @@ jobs:
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      # The cross compiler and clang++ are baked into the runner image instead
-      # of apt-installed here: these runners are runAsNonRoot with
+      # An assertion, not an install: these runners are runAsNonRoot with
       # allowPrivilegeEscalation:false, so `sudo apt-get install` fails with
-      # "the 'no new privileges' flag is set". This is an ASSERTION, not an
-      # install -- see the composite action for why it is one copy.
+      # "the 'no new privileges' flag is set" and the cross compiler has to be
+      # baked into the runner image.
       - name: Verify the toolchain is present in the runner image
         uses: ./.github/actions/verify-toolchain
         with:
@@ -184,36 +149,15 @@ jobs:
             echo "wall time: ${elapsed}s"
           } >> "$GITHUB_STEP_SUMMARY"
 
-  # formal/components.sby carries exactly THREE tasks -- decoder, executor and
-  # pcloop -- and this job runs all three; all three pass by k-induction
-  # (`mode prove`, verified by running each target and reading its sby summary,
-  # not by inference from a green job). ADR-0006 scoped the set to decoder and
-  # executor; ADR-0046 added pcloop. This comment named only the first two
-  # until the gate inventory read the .sby file.
+  # formal/components.sby carries three tasks -- decoder, executor, pcloop --
+  # and this job runs all three, so a task added there needs a step here or it
+  # runs nowhere. They pass by k-induction (`mode prove`), and unlike the
+  # ladder they are not bounded checks.
   #
-  # The executor proof is under
-  # a 4-bit operand restriction (ADR-0010). The decoder proof used to FAIL on
-  # the `past_pc + 4 == pc` assertion, which was a broken property rather
-  # than a decode hole -- `fetcher_pc` was a free input, so nothing tied the
-  # decoder's own pc output back to what it was fed. `a4662a2` fixed the
-  # harness (see rtl/decoder.v's `assume(in.pc == pc)`, which models
-  # littlecpu.v's actual fetcher wiring) and it now passes; gating on it here
-  # is what keeps it from silently regressing.
-  #
-  # The fetcher, accessor and writeback tasks used to sit alongside these
-  # carrying no assertions at all -- a vacuous green, worse than no proof.
-  # They were deleted rather than left unrun, so formal/components.sby now
-  # holds exactly three tasks and this job runs all three.
-  #
-  # components_pcloop is the third, and it is here because ADR-0017 put the
-  # fetcher-decoder pc loop in M2's scope and then nothing ran it. It is the
-  # task that DISCHARGES the standalone decoder proof's `assume(in.pc == pc)`,
-  # which is where that proof's content went -- so leaving it off this list
-  # left an M2-scope obligation guarded by prose. It had in fact been FAILING
-  # since `e4f5250` (ADR-0046): its stall over-approximation predated ADR-0042's
-  # operand-fetch cycle, so its sequential-advance assertion covered a cycle on
-  # which the decoder legitimately holds the pc. Adding the step is what found
-  # that; keeping it is what stops the next one.
+  # The executor proof caps the divide family's operand magnitudes with the sign
+  # left free (ADR-0051). The standalone decoder proof assumes its pc input is
+  # what it last produced, and components_pcloop is what discharges that
+  # assumption -- so the decoder task's result is worth only what pcloop's is.
   components:
     name: components
     runs-on: little-cpu-runners
@@ -249,24 +193,15 @@ jobs:
             echo "wall time: ${elapsed}s"
           } >> "$GITHUB_STEP_SUMMARY"
 
-  # The structural lint gate: svlint over rtl/ with the tracked .svlint.toml.
+  # svlint over rtl/ with the tracked .svlint.toml. It parses with sv-parser, a
+  # third SystemVerilog frontend after yosys's and iverilog's. `make lint` runs
+  # it twice, with and without the RVFI macros, because roughly a fifth of rtl/
+  # sits behind `ifdef RISCV_FORMAL` and svlint's preprocessor drops it
+  # otherwise.
   #
-  # svlint parses with sv-parser -- a THIRD SystemVerilog frontend, neither
-  # yosys's nor iverilog's. It has already earned that: it cannot resolve
-  # rtl/structs.v without an explicit `-i rtl`, a parse-configuration fact
-  # neither of the other two surfaces. `make lint` runs it twice, with and
-  # without the RVFI macros, because roughly a fifth of rtl/ sits behind
-  # `ifdef RISCV_FORMAL` and svlint's preprocessor drops it otherwise.
-  #
-  # Read .svlint.toml before changing anything here: every disabled rule
-  # carries its reason and its measured finding count, and the enabled set is
-  # deliberately small so a finding means something.
-  #
-  # Needs neither oss-cad-suite nor the RISC-V cross compiler -- just the
-  # pinned svlint archive, which `make lint-setup` fetches, SHA-256-verifies
-  # and unpacks (the Makefile owns that pin, so the workflow and the local
-  # path cannot drift on which svlint they run). That makes this by far the
-  # cheapest job here and the first to report.
+  # Needs no oss-cad-suite and no cross compiler -- `make lint-setup` fetches
+  # and verifies the pinned svlint archive, and the Makefile owns that pin so
+  # the workflow cannot run a different svlint than a local build does.
   lint:
     name: lint
     runs-on: little-cpu-runners
@@ -281,9 +216,9 @@ jobs:
         run: make lint-setup
 
       - name: make lint
-        # Exit code is the gate. GITHUB_ACTIONS is set on every runner, so
-        # `make lint` passes --github-actions and any finding also lands as an
-        # ::error annotation on the PR diff.
+        # GITHUB_ACTIONS is set on every runner, so `make lint` passes
+        # --github-actions and each finding also lands as an ::error annotation
+        # on the PR diff.
         run: make lint
 
       - name: Report job wall time
@@ -295,45 +230,16 @@ jobs:
             echo "wall time: ${elapsed}s"
           } >> "$GITHUB_STEP_SUMMARY"
 
-  # `make fit` -- the repo's one area measurement (ADR-0038), and until this
-  # job existed it was a RATCHET NOTHING PULLED. CLAUDE.md declared it one,
-  # the Makefile implements it (`FIT_MAX_LC`, exit nonzero when the logic-cell
-  # count goes over), and `grep -rn fit .github/workflows/` returned two prose
-  # matches about runner memory and no invocation. The only thing that had
-  # ever enforced it was a human typing it.
+  # `make fit` -- the repo's area ratchet against FIT_MAX_LC (ADR-0038). Quote
+  # this job's number and name the toolchain with it: the same commit
+  # synthesises ~21 cells apart under the pinned OSS CAD Suite and a local
+  # Homebrew yosys. The ratchet's own failure directions are probed
+  # hermetically in test/probe_gates.sh.
   #
-  # WHAT IT WOULD FAIL ON, demonstrated rather than asserted -- CLAUDE.md's
-  # rule is that a green run is evidence only if you can point at what would
-  # have gone red. Two probes on this tree, both run:
-  #
-  #   make fit FIT_MAX_LC=4100  -> exit 2, "... logic cells is over the
-  #                                4100-cell budget"          (the ratchet)
-  #   nextpnr absent / no table -> exit 1, "NO measurement was taken. That is
-  #                                a failure, not a 0% fit."  (the Makefile's
-  #                                own guard, which is why this job cannot go
-  #                                green having measured nothing)
-  #
-  # THIS JOB IS THE MEASUREMENT, NOT A COPY OF A LOCAL ONE, and putting it here
-  # is what established that. The same commit synthesises to 4208 cells under
-  # the pinned OSS CAD Suite above (Yosys 0.66+179) and 4187 under a local
-  # Homebrew Yosys 0.67+post -- 21 cells on the synthesiser build alone, with
-  # no RTL difference whatever. Every area number this repo had recorded until
-  # ADR-0052 was a local one. Quote this job's.
-  #
-  # NOT REQUIRED, DELIBERATELY, and this is the one thing not to change here
-  # without a human deciding it. Area is a design constraint, not a
-  # correctness one: a change that grows the core past its budget should be
-  # loud and visible on the PR, and should be a conversation rather than an
-  # automatic block. Branch protection is a repository setting no pull request
-  # may touch (ADR-0036) -- adding this job to the required set is a human
-  # action, taken deliberately or not at all.
-  #
-  # The measurement is unstable to about +/-50 cells across edits that
-  # synthesise to identical hardware (CLAUDE.md's churn floor), plus the 21
-  # above across toolchains, which is why FIT_MAX_LC sits 192 cells over the
-  # current 4208 rather than at it. A red
-  # here means the core grew by more than resynthesis noise can account for.
-  # Raising the budget to clear it is how a ratchet becomes a rubber stamp.
+  # Not in main's required set, deliberately: area is a design constraint, not
+  # a correctness one, so growing past the budget should be visible and
+  # discussed rather than blocking. Branch protection is a repository setting no
+  # pull request may touch (ADR-0036).
   fit:
     name: fit
     runs-on: little-cpu-runners
@@ -352,19 +258,19 @@ jobs:
           sha256: ${{ env.OSS_CAD_SUITE_SHA256 }}
 
       - name: make fit
-        # NO PIPE ON THE GRADED COMMAND, same reasoning as the `formal` and
-        # `nonperturbation` jobs: a `run:` block without an explicit `shell:`
-        # key is `bash -e {0}`, errexit but NOT pipefail, so piping this into
-        # `tee` would take the step's status from `tee` and it would always be
-        # 0 (ADR-0037). Redirect, take the status off the unpiped command,
-        # then publish.
+        # Never pipe a graded command in a `run:` block. Without an explicit
+        # `shell:` key the step is `bash -e {0}` -- errexit but not pipefail --
+        # so `cmd | tee` takes its status from `tee` and always succeeds. This
+        # repo shipped exactly that once (ADR-0037). Redirect, take the status
+        # off the unpiped command, then publish. The same pattern below in
+        # `soc-timing`, `nonperturbation` and the `formal` gate is this rule.
         #
-        # `make fit` EXPECTS PLACEMENT TO FAIL: the fit top presents 231
-        # SB_IO against sg48's 39, so nextpnr always errors out on a pad --
-        # after printing the utilisation table, which is the measurement
-        # (ADR-0038 decision 1a). The Makefile checks for the table, so
-        # "nextpnr died before measuring anything" is a red here and "nextpnr
-        # measured, then failed to place" is a green.
+        # `make fit` expects placement to FAIL: the fit top presents 231 SB_IO
+        # against sg48's 39, so nextpnr always errors on a pad -- after printing
+        # the utilisation table, which is the measurement (ADR-0038 decision
+        # 1a). The Makefile checks for that table, so "nextpnr died before
+        # measuring anything" is red and "measured, then failed to place" is
+        # green.
         run: |
           set +e
           make fit > "$RUNNER_TEMP/fit.txt" 2>&1
@@ -390,26 +296,16 @@ jobs:
             echo "wall time: ${elapsed}s"
           } >> "$GITHUB_STEP_SUMMARY"
 
-  # `make soc-timing` -- the SoC place-and-route flow and the only timing
-  # figure this project has (ADR-0054). Mirrors the `fit` job immediately
-  # above: same non-piped graded-command pattern, same NON-REQUIRED status.
-  # Area and timing are design constraints, not correctness ones (ADR-0036),
-  # and adding either to branch protection is a human action taken
-  # deliberately or not at all.
+  # `make soc-timing` -- the SoC place-and-route and the only timing figure this
+  # project has (ADR-0054). Non-required for the same reason as `fit`.
   #
-  # UNLIKE `fit`, this needs the RISC-V cross compiler as well as the OSS CAD
-  # Suite: `make soc-timing` builds a real ROM image from test/asm/*.S before
-  # synthesising. No other job needs both, so the toolchain assertion is the
-  # shared composite action rather than a second copy of the `test` job's
-  # step -- a workflow re-stating something the Makefile or another job
-  # already owns is the exact shape that broke `elaborate` once (see the
-  # `elaborate` job's own file-list comment).
-  #
-  # `make soc-timing` itself EXPECTS placement to succeed, unlike `fit`: the
-  # SoC's two memories are internal, so it presents 4 SB_IO against sg48's 39
-  # and places cleanly. What is graded is soc/fit_report.py's sibling scripts
-  # -- soc/cell_census.py's SPRAM/EBR census and soc/timing_split.py's
-  # SOC_MIN_MHZ ratchet -- both probed hermetically in test/probe_gates.sh.
+  # Unlike `fit` it needs the cross compiler as well as the OSS CAD Suite,
+  # because it assembles a real ROM image before synthesising, and it expects
+  # placement to SUCCEED: the SoC's memories are internal, so it presents 4
+  # SB_IO against sg48's 39. There is no `.asc` for icetime to read without a
+  # completed placement. What is graded is soc/cell_census.py's SPRAM/EBR census
+  # and soc/timing_split.py's SOC_MIN_MHZ ratchet, both probed hermetically in
+  # test/probe_gates.sh.
   soc-timing:
     name: soc-timing
     runs-on: little-cpu-runners
@@ -433,14 +329,9 @@ jobs:
           sha256: ${{ env.OSS_CAD_SUITE_SHA256 }}
 
       - name: make soc-timing
-        # NO PIPE ON THE GRADED COMMAND, same reasoning as `fit` and
-        # `nonperturbation`: a `run:` block without an explicit `shell:` key
-        # is `bash -e {0}`, errexit but NOT pipefail, so piping this into
-        # `tee` would take the step's status from `tee` and it would always
-        # be 0 (ADR-0037). Redirect, take the status off the unpiped
-        # command, then publish -- the census and the logic/routing split
-        # land in the step summary whether this passes or fails, because the
-        # summary write happens before the exit.
+        # Redirected rather than piped -- see the `fit` job's step for why. The
+        # summary is written before the exit, so the census and the
+        # logic/routing split land whether this passes or fails.
         run: |
           set +e
           make soc-timing > "$RUNNER_TEMP/soc-timing.txt" 2>&1
@@ -468,49 +359,23 @@ jobs:
             echo "wall time: ${elapsed}s"
           } >> "$GITHUB_STEP_SUMMARY"
 
-  # ADR-0047: the mechanical form of ADR-0006's non-perturbation obligation --
-  # the `ifdef RISCV_FORMAL` shadow payload in rtl/structs.v must not change
-  # what the core does. That obligation rested on reviewer inspection from
-  # `b2dafcc` onward (ADR-0020's consequences: "verify by reading that no
-  # `ifdef`'d value reaches a non-`ifdef`'d signal"), and the script that was
-  # supposed to mechanise it, formal/equiv.sh, never converged and never will:
-  # equiv_make's name-based matching left 459 of 495 $equiv cells unproven
-  # because the two builds optimise to differently-named netlists. It is
-  # deleted, along with its nightly step, in the same change as this job.
+  # ADR-0047: the `-D RISCV_FORMAL` build, with its rvfi_* ports deleted and
+  # every gate that only fed them swept away, must be structurally identical to
+  # the plain build -- same cell histogram, same name-independent connectivity
+  # fingerprint. That is the mechanical form of the obligation that the RVFI
+  # shadow payload not change what the core does.
   #
-  # WHAT IS GATED HERE is that the `-D RISCV_FORMAL` build, with its rvfi_*
-  # ports deleted and every gate that only fed them swept away, is
-  # structurally identical to the plain build -- same cell histogram, same
-  # name-independent connectivity fingerprint. It is STRICTLY WEAKER than
-  # sequential equivalence and must not be quoted as if it were: it proves the
-  # instrumentation is unread, not that two designs behave alike. It is also
-  # STRONGER than the bounded miter it replaces for this one purpose, because
-  # it fails the moment an `ifdef`'d value reaches a real signal rather than
-  # only when that value changes an output within some depth.
+  # It is strictly weaker than sequential equivalence and must not be quoted as
+  # if it were: it proves the instrumentation is unread, not that two designs
+  # behave alike. Both failure directions were demonstrated on real mutations,
+  # the smaller being an `ifdef`'d value gating rtl/accessor.v's `out.valid` at
+  # +11 cells.
   #
-  # BOTH DIRECTIONS WERE DEMONSTRATED on real runs before this job landed, on
-  # the two shapes ADR-0020 names: an `ifdef`'d shadow value ORed into
-  # rtl/decoder.v's global `stall` term (+193 cells) and one gating
-  # rtl/accessor.v's `out.valid` (+11 cells). The 11-cell case is the one
-  # worth remembering -- a gate that only catches large perturbations is not
-  # much of a gate.
-  #
-  # Cheap enough to be a PR gate at all: yosys and python3, no sby, no solver,
-  # no riscv-formal clone, ~9s wall. It is deliberately NOT in the `formal`
-  # job, which is GitHub-hosted for memory reasons and takes minutes.
-  #
-  # NOT in main's branch-protection required set. It was the only such job in
-  # this workflow until `fit` above joined it, also deliberately non-required.
-  # Read live rather than remembered:
+  # Not in main's required set. Which jobs are is a repository setting, so read
+  # it live rather than from any comment here:
   #
   #   gh api repos/thejefflarson/little-cpu/branches/main/protection \
   #     -q '.required_status_checks.contexts'
-  #   ["elaborate","test","components","monitor-freshness","lint","formal"]
-  #
-  # `lint` and `formal` have since been promoted; this comment cited both as
-  # fellow non-required jobs, which stopped being true without anything here
-  # noticing. Promoting `nonperturbation` too is a repository-settings change
-  # for a human to make deliberately (ADR-0036) -- never attempted from a PR.
   nonperturbation:
     name: nonperturbation
     runs-on: little-cpu-runners
@@ -529,13 +394,7 @@ jobs:
           sha256: ${{ env.OSS_CAD_SUITE_SHA256 }}
 
       - name: make -C formal nonperturbation
-        # NO PIPE ON THE GRADED COMMAND, DELIBERATELY -- same reasoning as the
-        # `formal` job's gate step below. A `run:` block without an explicit
-        # `shell:` key is `bash -e {0}`: errexit but NOT pipefail, so piping
-        # this into `tee` would make the step's status tee's and always 0.
-        # This repo has shipped that exact bug once already (ADR-0037).
-        # Redirect to a file, take the status off the unpiped command, then
-        # publish.
+        # Redirected rather than piped -- see the `fit` job's step for why.
         run: |
           set +e
           make -C formal nonperturbation > "$RUNNER_TEMP/nonperturbation.txt" 2>&1
@@ -561,14 +420,10 @@ jobs:
             echo "wall time: ${elapsed}s"
           } >> "$GITHUB_STEP_SUMMARY"
 
-  # Regenerates test/monitor.v from a from-scratch riscv-formal clone at
-  # the pin (formal/pin.mk) and diffs it against the tracked copy
-  # (CLAUDE.md invariant 7: generated but tracked, never hand-edited).
-  # ADR-0013 asks CI to run this from a from-scratch clone, which is what a
-  # fresh runner gives for free -- no oss-cad-suite needed here, just
-  # python3 and git, both preinstalled. The job then reuses that same clone to
-  # check the repo's other vendored-from-the-pin file, formal/genchecks-local.py
-  # (ADR-0031); see the second step.
+  # Regenerates test/monitor.v from a from-scratch riscv-formal clone at the pin
+  # and diffs it against the tracked copy (CLAUDE.md invariant 7: generated but
+  # tracked, never hand-edited). A fresh runner gives the from-scratch clone for
+  # free, and this needs only python3 and git.
   monitor-freshness:
     name: monitor-freshness
     runs-on: little-cpu-runners
@@ -582,14 +437,10 @@ jobs:
       - name: make monitor-check
         run: make monitor-check
 
-      # The same control for the repo's OTHER vendored generated artifact.
-      # formal/genchecks-local.py is a copy of the pinned riscv-formal's
-      # checks/genchecks.py and may differ from it only by this repo's header
-      # and `basedir` (ADR-0031) -- a rule that until now lived only in a
-      # hand-run recipe in the script's own header, which nothing enforced.
-      # Runs here rather than in its own job because the step above has already
-      # paid for the from-scratch clone at the pin that this needs too, and
-      # like monitor-check it wants nothing but python3 and git.
+      # The same control for the repo's other vendored generated file:
+      # formal/genchecks-local.py may differ from the pin's checks/genchecks.py
+      # only by this repo's header and `basedir` (ADR-0031). It shares this job
+      # because the step above has already paid for the clone.
       - name: make -C formal genchecks-check
         run: make -C formal genchecks-check
 
@@ -602,96 +453,39 @@ jobs:
             echo "wall time: ${elapsed}s"
           } >> "$GITHUB_STEP_SUMMARY"
 
-  # The riscv-formal ladder, on the PR gate.
+  # The riscv-formal ladder, plus every hand-authored formal task the repo owns.
   #
-  # Until this job existed the ladder ran only in formal-nightly.yml, so an
-  # edit to formal/EXPECTED_FAIL -- the burn-down file ADR-0022 designed for
-  # exactly that edit -- merged green and was contradicted hours later, by
-  # which time the change was on main and the nightly failure read as
-  # somebody else's problem. The check that a baseline edit is honest now
-  # runs on the change that makes it.
+  # What is gated is formal/check-baseline.sh's exit status, not sby's: every
+  # generated .sby carries `expect pass,fail`, so sby exits 0 whether a check
+  # passed or failed and its exit code has never carried a verdict. The verdict
+  # is the two set equalities check-baseline.sh performs, each in both
+  # directions (ADR-0014) -- formal/EXPECTED_CHECKS for which checks genchecks
+  # generated, formal/EXPECTED_FAIL for which of them are red. Deleting a
+  # baseline line without fixing the check fails here, and so does fixing a
+  # check without deleting its line.
   #
-  # WHAT IS GATED HERE IS formal/check-baseline.sh's EXIT STATUS, NOT sby's.
-  # Every generated .sby carries `expect pass,fail`, so `sby` exits 0 whether
-  # a check passed or failed -- its exit code has never carried a verdict.
-  # The verdict exists only as the two set equalities check-baseline.sh
-  # performs, both in both directions per ADR-0014: formal/EXPECTED_CHECKS
-  # (which checks genchecks generated) and formal/EXPECTED_FAIL (which of
-  # them are red). Deleting a baseline line without fixing the check fails
-  # here; fixing a check without deleting its line fails here too.
+  # A green run means the ladder still matches its baseline and nothing more.
+  # Every check is `mode bmc` -- no counterexample within a configured depth,
+  # not a proof -- and the whole ladder runs under RISCV_FORMAL_ALTOPS, so a
+  # passing insn_mul or insn_div says nothing about the real multiplier or
+  # divider (ADR-0010).
   #
-  # WHAT A GREEN RUN HERE DOES NOT MEAN. Every check on this ladder is
-  # `mode bmc`: PASS means no counterexample was found within that check's
-  # configured depth, not that the property holds. The whole ladder runs
-  # under RISCV_FORMAL_ALTOPS, so a passing insn_mul/insn_div says nothing
-  # whatever about the real multiplier or divider (ADR-0010). Green here
-  # means "the ladder still matches its baseline" and nothing more. It is not
-  # a proof of correctness, and it is not M2 -- M2's signal is
-  # formal/EXPECTED_FAIL reaching empty, read together with
-  # formal/EXPECTED_CHECKS (ADR-0023, ADR-0033).
-  #
-  # THERE IS NO NIGHTLY. ADR-0050 deleted `formal-nightly.yml` and folded its
-  # unique content -- `imemcheck`, `dmemcheck`, `cover` -- into the steps at
-  # the end of this job. Both of that workflow's reasons for existing had
-  # expired: `equiv.sh`'s hour-long timeout was most of its runtime until
-  # ADR-0047 deleted it, and the ladder stopped being nightly-only at
-  # `1961234`. What was left was three minutes of unique checks wrapped
-  # around a five-minute duplicate of this job, on an in-cluster runner that
-  # OOMed and killed the last run before it could grade anything.
-  #
-  # `complete` and `complete_cover` were the pieces ADR-0050 held back -- red
-  # at the time, on a required job -- and they landed with their exclusion set
-  # (M2 term 5). Every check the repo owns is now a step of this job, and every
-  # one of them is graded by its own exit status.
-  #
-  # The Sail co-sim stays out of this job deliberately -- ADR-0032 forbids
-  # putting it on the required set, and its fetch has not had formal/pin.mk's
-  # treatment.
-  #
-  # THIS JOB IS REQUIRED. main's branch-protection required set is
-  # elaborate/test/components/monitor-freshness/lint/formal, read live with
-  #
-  #   gh api repos/thejefflarson/little-cpu/branches/main/protection \
-  #     -q '.required_status_checks.contexts'
-  #
-  # `lint` and `formal` were both promoted after they landed. This comment
-  # still said `formal` was advisory and that the required set ended at
-  # `lint`, which is the drift the gate inventory went looking for: adding a
-  # job to this file does not make it required, and neither does removing one
-  # make it not, so the only trustworthy source is the API above.
+  # The Sail co-sim stays off this job deliberately: ADR-0032 forbids putting it
+  # on the required set, and its fetch has not had formal/pin.mk's treatment.
   formal:
     name: formal
-    # Stays GitHub-hosted, and unlike `test` and `lint` above the reason is
-    # memory rather than packaging. Measured, because two runs of this job
-    # died on little-cpu-runners with "The self-hosted runner lost
-    # communication with the server ... starves it for CPU/Memory" before
-    # they could even upload a log:
-    #
-    #   in-cluster pod   cpu.max 300000 100000 (a 3-CPU quota), memory.max
-    #                    1610612736 (1.5 GiB), of which memory.current was
-    #                    already 876480000 (836 MiB) at job start
-    #   one ladder check peak RSS 918781952 (876 MiB) for insn_add_ch0
-    #
-    # So a single check does not fit in what the pod has left, at any
-    # parallelism -- `-j1` would not have saved it. Note also that `nproc`
-    # reports 12 in that pod, because it reads the CPU affinity mask and a
-    # CFS quota does not narrow it; that is why formal/Makefile's `nproc`
-    # default is wrong in a container and JOBS is pinned below. None of the
-    # other little-cpu-runners jobs surfaced any of this because none of them
-    # runs a wide parallel make of memory-hungry solvers.
-    #
-    # Moving this back in-cluster needs the runner pod's memory limit raised
-    # (cluster repo: charts/actions/runners/values.yaml) to at least
-    # JOBS x 1 GiB plus the ~1 GiB the runner and toolchain already hold.
+    # GitHub-hosted for memory, not packaging. One ladder check peaks around
+    # 876 MiB resident (insn_add_ch0, measured), and the in-cluster pod has a
+    # 1.5 GiB limit with ~836 MiB already held at job start -- so a single check
+    # does not fit there at any parallelism, and two runs died with the runner
+    # losing contact before they could upload a log. Moving back in-cluster
+    # needs that pod's memory limit raised to at least JOBS x 1 GiB plus the
+    # ~1 GiB the runner and toolchain hold.
     runs-on: ubuntu-latest
-    # ADR-0025 measures the sweep at 4m05s wall with -j6 at the depths
-    # checks.cfg configures; add the clone, the cache restore and the
-    # generation pass and this lands in single-digit minutes. The ceiling is
-    # loose because there is no per-check wall bound -- ADR-0031 retired
-    # checks.cfg's `timeout=` and ADR-0033 records the replacement as not
-    # implemented -- so one non-converging check starves everything scheduled
-    # after it and `-k` does not help, because the job dies rather than the
-    # check. Raising any depth in checks.cfg re-opens this number.
+    # Loose because there is no per-check wall bound: one non-converging check
+    # starves everything scheduled after it, and `-k` does not help because the
+    # job dies rather than the check. Raising a depth in checks.cfg re-opens
+    # this number.
     timeout-minutes: 20
     steps:
       - name: Record job start
@@ -706,22 +500,13 @@ jobs:
           file: ${{ env.OSS_CAD_SUITE_FILE }}
           sha256: ${{ env.OSS_CAD_SUITE_SHA256 }}
 
-      # Not a formality, and it is NOT made redundant by ADR-0036's status
-      # field. sby's btor engine solves with btormc and then replays the
-      # witness with btorsim, and btorsim is reached ONLY on a check that
-      # found a counterexample -- so on a box without it every red check
-      # reports ERROR instead of FAIL. (Confirmed: btorsim is absent from a
-      # stock macOS brew install of yosys+sby.)
-      #
-      # check-baseline.sh now compares NAME AND STATUS, so that flip turns
-      # this job RED rather than green: `ERROR` cannot be baselined at all,
-      # and a baselined `FAIL` no longer matches an `ERROR` on disk. What it
-      # cannot do is notice the missing tool on an ALL-GREEN ladder, which is
-      # the state this repo is in -- no counterexample means btorsim is never
-      # invoked, so its absence is invisible right up until the first check
-      # goes red, at which point the diagnostic is "status changed" rather
-      # than "install btorsim". Assert it up front so the failure names its
-      # own cause.
+      # sby's btor engine replays a counterexample with btorsim, so btorsim is
+      # reached only by a check that found one -- on a box without it, every red
+      # check reports ERROR instead of FAIL. On an all-green ladder, which is
+      # the state this repo is in, its absence is therefore invisible until the
+      # first check goes red, and the diagnostic then reads "status changed"
+      # rather than "install btorsim". Asserting up front is what makes the
+      # failure name its own cause.
       - name: Confirm the BMC toolchain is complete
         run: |
           set -euo pipefail
@@ -741,34 +526,16 @@ jobs:
             exit 1
           fi
 
-      # Generates the ladder (formal/genchecks-audit.py, which asserts its
-      # SHAPE against EXPECTED_CHECKS in about a second before anything runs)
-      # and then runs all 85 checks with `-k`.
+      # Generation runs formal/genchecks-audit.py, which asserts the ladder's
+      # shape against EXPECTED_CHECKS in about a second before any check runs.
       #
-      # NO `continue-on-error`, ANYWHERE IN THIS JOB. It carried one until the
-      # M2 term-6 verification, on the reasoning that this step's status "is
-      # not the signal" -- the step below re-grades and gates. That reasoning
-      # was not wrong, it was unnecessary: `formal/Makefile`'s `check` puts a
-      # leading `-` on the sby sub-make and then ENDS in `check-baseline`, so
-      # this command's exit status already IS the comparison's, identical to
-      # the gate step's. What the suppression actually bought was that an
-      # infrastructure failure here -- generation aborting, the audit script
-      # dying, the disk filling -- reached the summary as a green step. The two
-      # steps now fail together and the gate step below runs anyway
-      # (`!cancelled()`), so the report still lands. ADR-0050's term-6 wording
-      # is "no `continue-on-error` anywhere in it"; this is that, literally.
-      #
-      # JOBS IS PINNED, AND IT IS A MEMORY BUDGET, NOT A SPEED KNOB. One
-      # check peaks around 876 MiB resident (measured, insn_add_ch0), so the
-      # ladder's peak footprint is roughly JOBS GiB and 4 is what fits a
-      # 16 GiB GitHub-hosted runner with room to spare. formal/Makefile
-      # defaults JOBS to `nproc`, which is right on a workstation and wrong
-      # anywhere the core count is not the binding constraint -- see the
-      # runs-on comment above for how that killed two runs outright. `JOBS=`
-      # on the command line overrides the Makefile's `:=` default and still
-      # passes its own numeric sanity guard, so a local `make -C formal
-      # check` is unaffected. The diagnostics print what the host actually
-      # has: re-tune against those numbers, not by guessing.
+      # JOBS is a memory budget, not a speed knob: one check peaks around
+      # 876 MiB resident, so the ladder's footprint is roughly JOBS GiB and 4
+      # fits a 16 GiB hosted runner. formal/Makefile defaults it to `nproc`,
+      # which is right on a workstation and wrong in a container, where the
+      # affinity mask is not narrowed by a CPU quota. The diagnostics below
+      # print what the host actually has; re-tune against those, not by
+      # guessing.
       - name: Generate and run the ladder (make -C formal check)
         run: |
           set -uo pipefail
@@ -778,31 +545,23 @@ jobs:
           free -h 2>/dev/null || true
           make -C formal check JOBS=4
 
-      # THE GATE. This exit status is the job's, and so is the step above's --
-      # the two are the same comparison, run twice, and they agree by
-      # construction. Re-grading a finished ladder costs a second
-      # (formal/Makefile's check-baseline target exists to be re-runnable) and
-      # re-runs no check, so the cost of saying it twice is a second and the
-      # benefit is that the verdict is published rather than inferred.
+      # The step above already ends in this same comparison (formal/Makefile's
+      # `check` puts a leading `-` on the sby sub-make and then runs
+      # check-baseline), so the two agree by construction. Re-grading a finished
+      # ladder re-runs no check and costs a second, and it publishes the verdict
+      # instead of leaving it inferred.
       #
-      # `!cancelled()` rather than the default: if the ladder step goes red,
-      # THIS step is what says why, so it has to run anyway. It is not
-      # `always()` -- a cancelled job should stop, not narrate. A ladder that
-      # failed to generate at all resolves to exit 2 here ("no *.sby files"),
-      # so a red step above can never be followed by a green one here.
+      # `!cancelled()` rather than the default, because if the ladder step goes
+      # red this step is what says why. A ladder that failed to generate at all
+      # exits 2 here ("no *.sby files"), so a red step above cannot be followed
+      # by a green one here.
       - name: Gate on formal/EXPECTED_FAIL + formal/EXPECTED_CHECKS
         if: ${{ !cancelled() }}
         run: |
-          # NO PIPE ON THE GRADED COMMAND, DELIBERATELY. The obvious spelling
-          # of this step is `check-baseline.sh ... | tee -a "$GITHUB_STEP_
-          # SUMMARY"` and it silently cannot fail: without an explicit
-          # `shell:` key a `run:` step is `bash -e {0}`, which sets errexit
-          # but NOT pipefail -- only an explicit `shell: bash` gets
-          # `-eo pipefail` -- so `$?` after that pipeline is tee's status,
-          # which is always 0. Demonstrated: with the pipe in place, a
-          # deliberately wrong formal/EXPECTED_FAIL printed "Failure list
-          # does NOT match" and the job still reported success. Redirect to a
-          # file, capture the status off the unpiped command, then publish.
+          # Redirected rather than piped -- see the `fit` job's step for why.
+          # Demonstrated here specifically: with `| tee` in place, a
+          # deliberately wrong formal/EXPECTED_FAIL printed "Failure list does
+          # NOT match" and the job still reported success.
           set +e
           formal/check-baseline.sh formal/checks formal/EXPECTED_FAIL > "$RUNNER_TEMP/baseline-report.txt" 2>&1
           status=$?
@@ -821,32 +580,14 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
           exit "$status"
 
-      # THE FOUR HAND-AUTHORED TASKS, FOLDED IN FROM THE DELETED NIGHTLY
-      # (ADR-0050). These are not on the generated ladder -- formal/
-      # EXPECTED_FAIL is the genchecks-local.py sweep only -- so their verdict
-      # is their exit status and nothing else.
+      # The hand-authored tasks. These are not on the generated ladder --
+      # formal/EXPECTED_FAIL covers the genchecks sweep only -- so each one's
+      # verdict is its own exit status and nothing else.
       #
-      # ONE STEP EACH, and that is not cosmetic. They shared a single step
-      # until the M2 term-6 verification, which asks for each check's outcome
-      # individually rather than inferred from a green job -- and a
-      # three-`make` step cannot give that: `make` stops at the first failure,
-      # so a red `imemcheck` leaves `dmemcheck` and `cover` UNRUN while the
-      # step's log reads as one failure. Split, the job's own step list is the
-      # per-check record, GitHub's UI shows which one went red, and the two
-      # after it still run and still report. Cost: nothing -- the same three
-      # commands.
-      #
-      # They ran once a day in formal-nightly.yml until ADR-0050 deleted it.
-      # `imemcheck` is the check CLAUDE.md names as the guard on ADR-0003's
-      # dual-word fetch window, and nothing gated it; now every PR does.
-      #
-      # Measured on the gate's own run of merged main, not inherited: imemcheck
-      # PASS, dmemcheck PASS, cover PASS, 31s for the three, on a job whose
-      # timeout is 20 minutes and which finishes in 4m22s.
-      #
-      # NO `continue-on-error`, and that is the point. In the nightly these
-      # sat in a step that could not fail the job; here their exit status is
-      # the job's, and the job is required.
+      # One step each rather than one step running three `make`s, because make
+      # stops at the first failure: a red imemcheck would leave dmemcheck and
+      # cover unrun while the log read as a single failure. Split, the step list
+      # is the per-check record.
       - name: imemcheck (ADR-0003's dual-word fetch window)
         run: make -C formal imemcheck
 
@@ -856,61 +597,35 @@ jobs:
       - name: cover (five goals, incl. >=2 compressed retires)
         run: make -C formal cover
 
-      # THE WHOLE-ISA WALK, AND IT IS A GATE. No continue-on-error: `make -C
-      # formal complete` ends in sby's own exit status (complete.sby carries no
-      # `expect` line, unlike every generated ladder check), so this step's
-      # status is the job's.
+      # complete.sby carries no `expect` line, unlike every generated ladder
+      # check, so this step's status is sby's own.
       #
-      # It ran behind `continue-on-error` in formal-nightly.yml until this
-      # change, which is the resting place ADR-0047 named: a check that has
-      # never produced a verdict, suppressed, reads as coverage. It is the same
-      # reasoning that retired equiv.sh, and `complete` is the second instance.
-      # It is here rather than on the nightly because it costs 12-16s -- the
-      # "this gate cannot afford complete's depth-50 walk" line above was
-      # written when it FAILED in seconds and nobody had measured a passing
-      # run. complete_cover below is another 14-17s.
+      # What a green `complete` means: on every trace of at most 50 cycles from
+      # reset, every non-trapping retire the core reports carries an encoding
+      # riscv-formal's whole-ISA model recognises and agrees is non-trapping.
+      # Each of the 70 insn_* ladder checks constrains rvfi_insn to its own
+      # encoding, so an encoding none of them names is invisible to all of them,
+      # and this is what sees it.
       #
-      # WHAT A GREEN `complete` DOES AND DOES NOT MEAN.
+      # What it does not mean: it is `mode bmc` at depth 50, it says nothing
+      # about spec values, and it is silent on the opcode classes declared in
+      # formal/COMPLETE_EXCLUSIONS -- which `make -C formal complete` refuses to
+      # run until they match complete.sv in both directions. Whole-ISA coverage
+      # minus a declared, baselined hole is not whole-ISA coverage.
       #
-      #   DOES: on every trace of at most 50 cycles from reset, every
-      #   non-trapping retire this core reports carries an encoding
-      #   riscv-formal's whole-ISA model recognises and agrees is
-      #   non-trapping. That is the one check in the tree that walks the ISA as
-      #   a whole -- each of the 70 insn_* ladder checks constrains rvfi_insn
-      #   to its own encoding, so an encoding none of them names is invisible
-      #   to all of them, and this is what sees it.
-      #
-      #   DOES NOT: it is `mode bmc` at depth 50. PASS means no counterexample
-      #   within 50 cycles, not that the property holds -- same caveat as the
-      #   ladder above, and there is no `mode prove` anywhere in formal/. It is
-      #   also silent on two whole opcode classes by declaration: MISC-MEM and
-      #   SYSTEM are excluded, because riscv-formal ships no spec model for
-      #   `fence`/`fence.i`/`ecall`/`ebreak`/`mret`/`wfi`/`csrr*` at
-      #   formal/pin.mk's SHA. formal/COMPLETE_EXCLUSIONS is that set, and
-      #   `make -C formal complete` will not run until it matches complete.sv
-      #   in both directions. So: NOT whole-ISA coverage, and it must not be
-      #   quoted as such -- it is whole-ISA coverage minus a declared,
-      #   baselined, mechanically re-derived hole.
-      #
-      #   AND: it says nothing about spec VALUES. `spec_rd_wdata` and friends
-      #   are what the insn_* checks compare; this asks only that the
-      #   instruction is modelled and non-trapping.
-      #
-      # THIRD ENGINE. complete.sby runs `abc bmc3` -- neither the ladder's
-      # `btor btormc` (ADR-0024) nor components.sby's `smtbmc boolector`. It
-      # therefore does not depend on btorsim, so the toolchain assertion above
-      # is not what covers it.
+      # complete.sby runs `abc bmc3`, a third engine after the ladder's
+      # `btor btormc` and components.sby's `smtbmc boolector`, so the btorsim
+      # assertion above does not cover it.
       - name: complete (whole-ISA BMC walk, depth 50)
         run: make -C formal complete
 
-      # THE ANTI-VACUITY CONTROL, and it is a gate for the same reason the
-      # check is. `complete`'s assertion is guarded by `rvfi_valid` and
-      # `!rvfi_trap`, both core-supplied, and by `!insn_excluded`. A core that
-      # never retired, or claimed a trap on everything, or an exclusion set
-      # that had grown to swallow the ISA, would all pass it having been asked
-      # nothing. This runs the same complete.sv under `mode cover` (sby strips
-      # the assertions and keeps the assumes) and requires a real non-trapping,
-      # non-excluded retire of each of the twelve opcode classes the exclusion
+      # The anti-vacuity control for the step above, and a gate for the same
+      # reason it is. `complete`'s assertion is guarded by `rvfi_valid`,
+      # `!rvfi_trap` and `!insn_excluded`, so a core that never retired, or
+      # claimed a trap on everything, or an exclusion set that had grown to
+      # swallow the ISA would each pass it having been asked nothing. This runs
+      # the same complete.sv under `mode cover` and requires a real
+      # non-trapping, non-excluded retire of every opcode class the exclusion
       # set does not name. Green above without green here is not a result.
       - name: complete_cover (anti-vacuity — every non-excluded class retires)
         run: make -C formal complete_cover

--- a/formal/checks.cfg
+++ b/formal/checks.cfg
@@ -1,365 +1,86 @@
 [options]
-# rv32imc, matching what test/asm/*.S now assembles (-march=rv32imc_zicsr).
-# This line predates that: it used to be the *only* place the C extension was
-# exercised, back when the ladder ran ahead of the dual-word fetch window and
-# the suite was still rv32im_zicsr. That gap is closed (ADR-0003), so the two
-# legs now agree -- but they still check different things, and both are worth
-# having. riscv-formal's insn_c_* checks never constrain how imem_data
-# arrives (unlike formal/imemcheck.sv); it is a free value every cycle
-# regardless of alignment, per formal/wrapper.v. So an insn_c_* check
-# exercises rtl/decoder.v's compressed decode in isolation, while the .S
-# suite exercises decode and the fetch window together.
+# The insn_c_* checks this generates exercise rtl/decoder.v's compressed decode
+# on its own: imem_data is a free value every cycle here (formal/wrapper.v), so
+# no fetch window is involved. The .S suite is what covers the two together.
 isa rv32imc
-# `solver` is genchecks' engine selector, not merely an SMT solver name: the
-# three spellings it special-cases are `bmc3` -> `abc bmc3`, `btormc` ->
-# `btor btormc`, and anything else -> `smtbmc <that>`. So `btormc` here puts
-# `btor btormc` in every generated .sby's [engines] section.
-#
-# btormc is the measured choice, not the default one (genchecks defaults to
-# `boolector`, which OSS CAD Suite ships but a bare `brew install yosys` /
-# apt toolchain does not). `reg_ch0` is why: a single depth-21 BMC query that
-# did not converge under `smtbmc yices` in >20 minutes, independently
-# reproduced twice, and passes under `btor btormc` in ~8-12s -- same check,
-# same depth, only the engine differs. Verified against the full 78-check
-# ladder on both engines; see ADR-0024 for the side-by-side tally and wall
-# time, including a caveat on how machine-dependent that gap turned out to be.
-#
-# ADR-0024 reached that conclusion through a local `engine` option added to
-# this repo's vendored genchecks copy, which had drifted far enough from
-# upstream to be missing the `solver` handling above. The measurement stands;
-# the mechanism was redundant and is gone. To pin one check to a different
-# engine, sby's own [engines] section is the lever -- there is no per-check
-# override here, and adding one back means forking genchecks again.
+# `solver` selects genchecks' engine, not just an SMT solver name: `bmc3` means
+# `abc bmc3`, `btormc` means `btor btormc`, anything else means `smtbmc <that>`.
+# Keep btormc -- reg_ch0 is one depth-21 query that did not converge under
+# `smtbmc yices` in over 20 minutes and returns in 8-12s here (ADR-0024).
 solver btormc
 
 [csrs]
-# This list does two jobs. A name generates that CSR's csrw_* check. A name
-# followed by a TEST LIST -- `minstret upcnt`, `mscratch any` -- additionally
-# generates one csrc_* counter check per spelling, `csrc_<test>_<name>`. The
-# six counter models upstream ships (rvfi_csrc_{any,const,hpm,inc,upcnt,
-# zero}_check.sv) are reachable ONLY this way. Arguments are accepted inside
-# a spelling and passed through as defines: `const="32'h dead_beef"` becomes
-# RISCV_FORMAL_CSRC_CONSTVAL, `<test>_mask="32'h fffffffc"` becomes
-# RISCV_FORMAL_CSRC_MASK, `hpm=<n>` picks an hpmevent. None is used here.
+# A name here generates that CSR's csrw_* check. A name followed by a test list
+# also generates one csrc_<test>_<name> check per spelling, which is the only
+# way upstream's rvfi_csrc_{any,const,hpm,inc,upcnt,zero}_check.sv models are
+# reachable at all.
 #
-# THE BARE `csrc` SPELLING IS A DEAD CODE PATH UPSTREAM, and this file said
-# something weaker than the truth about it. A [csrs] name with no test list
-# makes genchecks emit a .sby reading `rvfi_csrc_check.sv` -- a filename
-# nobody has ever written. Not "does not exist at the pin", which implies a
-# pin bump would fix it: c992aa61 IS upstream main's HEAD (2026-07-16, zero
-# commits behind), `git log --all --diff-filter=AD -- checks/
-# rvfi_csrc_check.sv` is EMPTY, and the string `rvfi_csrc_check` appears in
-# no branch and no tag. There is no future version to wait for. The three
-# `#omit csrc_<name>_ch0` lines that used to sit below are gone because all
-# three CSRs now carry a test list, so genchecks never reaches that branch.
+# This is not the set of CSRs the core implements. It is the subset
+# rvfi_csrw_check.sv can say something true about, and adding a WARL CSR
+# (mtvec, mepc, mcause, mstatus) or a read-only-zero one (mie, mip, mtval) puts
+# a FAIL on a correct core: that check has no WARL model, it asserts that every
+# bit the instruction offered appears set in what landed, and masked bits do not
+# land. Those are checked field by field in test/csr_tb.v instead. The csrc_*
+# models do read a RISCV_FORMAL_CSRC_MASK and so can state a WARL CSR, but a
+# name here generates its csrw_* check whether or not it also carries a test
+# list.
 #
-# THIS LIST IS NOT "the CSRs this core implements." rtl/csrs.v implements
-# ADR-0005's whole set; this is the subset riscv-formal's csrw check can say
-# anything true about. `mtvec`, `mepc`, `mcause` and `mstatus` are
-# deliberately absent, and adding them would put a FAIL on a CORRECT core:
+# A name here also makes the generated rvfi_macros.vh declare
+# rvfi_csr_<name>_{rmask,wmask,rdata,wdata}, which formal/wrapper.v connects to
+# littlecpu. Adding a CSR is therefore new `ifdef RISCV_FORMAL` output in
+# rtl/csrs.v -- which exports shadows for these three and no others -- plus a
+# re-run of `make -C formal nonperturbation`.
 #
-#   checks/rvfi_csrw_check.sv has NO WARL MODEL. For a CSRRW it sets
-#   `csr_insn_smask = csr_insn_arg` -- every bit of the operand -- and then
-#   asserts `(csr_insn_smask & ~effective_csr_insn_wdata) == 0`, i.e. every
-#   bit the instruction offered must appear set in what landed. Write 0x03 to
-#   a correctly WARL-masked `mtvec` (bits [1:0] are the mode field, forced to
-#   direct) and 0x00 lands, so the assertion fails. No reported wmask rescues
-#   it either: `effective_csr_insn_wdata` falls back to `csr_insn_rdata` on
-#   bits the wmask clears, and that is also 0 there.
+# `inc` is spelled here with no `csrc_inc` line in [depth] on purpose: that is
+# what makes genchecks consider and drop those two checks, which is what
+# requires their `#omit` lines below. Delete the word and the decline becomes
+# prose only. rvfi_csrc_inc_check.sv is red on a correct core here -- it clears
+# `csr_written` every non-check cycle, so its post-write fallback lives one
+# cycle, and CSR serialization (invariant 5) means two CSR retires are never
+# adjacent. Measured PASS at 6..12, red at 13..16; no depth escapes it.
 #
-# So a WARL CSR on this list would be checking riscv-formal's simplification
-# against the RISC-V spec, not this core against either. Those four are
-# checked in test/csr_tb.v, field by field, which is where a WARL mask can be
-# stated as what it is.
+# `upcnt` says the counter strictly increases between two reads, with writes
+# assumed away. It does not say minstret advances by exactly the non-trapping
+# issues, so ADR-0027's rule is narrowed here rather than closed:
+# test/asm/minstret.S and test/csr_tb.v still carry that half.
 #
-# DOES THAT WARL BAR ALSO BIND THE csrc_* MODELS? NO -- and the paragraph
-# above reads like a blanket rule, so this is worth stating rather than
-# leaving to be assumed either way. rvfi_csrc_{any,const,zero}_check.sv each
-# read RISCV_FORMAL_CSRC_MASK and AND it into the values they compare, and
-# csrc_any additionally assumes the offered source value already lies inside
-# the mask. A WARL CSR therefore CAN be stated to a csrc model --
-# `mtvec any_mask="32'h fffffffc"` is the spelling -- where
-# rvfi_csrw_check.sv has no such hatch anywhere in it.
-#
-# WHAT ACTUALLY KEEPS mtvec/mepc/mcause/mstatus OFF THIS LIST IS TWO OTHER
-# THINGS, and neither is a checks.cfg question:
-#
-#   1. rtl/csrs.v exports RVFI shadow payloads for exactly three CSRs
-#      (`rvfi_mcycle`, `rvfi_minstret`, `rvfi_mscratch`). A fourth name here
-#      makes the generated rvfi_macros.vh declare
-#      rvfi_csr_<name>_{rmask,wmask,rdata,wdata}, which formal/wrapper.v's
-#      `RVFI_CONN` then connects to a `littlecpu` that has no such ports.
-#      Adding a CSR is therefore new `ifdef RISCV_FORMAL` output logic in
-#      rtl/, a wider shadow payload, and a re-run of
-#      `make -C formal nonperturbation` -- a change to the core's
-#      instrumentation, not to this file.
-#   2. A name here generates its csrw_* check whether or not it also carries
-#      a test list, and there is no way to ask for one without the other
-#      short of a `[filter-checks]` entry. For the read-only-zero CSRs the
-#      `zero` model would suit -- `mie` 0x304, `mip` 0x344, `mtval` 0x343 --
-#      that csrw check is red on a correct core: their addresses sit in the
-#      read/WRITE quadrant (addr[11:8] == 4'b0011), so rvfi_csrw_check's
-#      `csr_illacc` does NOT expect a trap, and it then asserts that every
-#      bit the instruction offered landed. Nothing lands. Same shape as the
-#      WARL failure above, different cause.
-#
-# That is why `mie`/`mip`/`mtval`/`mstatush` are not here with `zero`, and why
-# `misa`/`mvendorid`/`marchid`/`mimpid`/`mhartid`/`mconfigptr` are not here
-# with `const`.
-# Both families are declined for want of RTL, not for want of a depth line,
-# so neither gets an `#omit` -- genchecks never considers a CSR nobody
-# named.
-#
-# `mscratch` is on the list precisely because it has no WARL mask at all --
-# every bit round-trips -- so csrw_mscratch_ch0 is a clean statement about
-# the Zicsr access path itself: read value to rd, set/clear semantics, and no
-# memory access.
-#
-# What csrw_mscratch_ch0 does NOT see, measured rather than assumed: deleting
-# the CSRRS/CSRRC rs1==x0 write suppression from rtl/decoder.v leaves it
-# PASSing. The check reasons about the reported masks and data, and a
-# suppressed-write-that-fires computes `rdata | 0` -- the same value, with
-# smask and cmask both 0 -- so no assertion can distinguish it. That rule is
-# therefore checked in test/decoder_tb.v (which does fail on that mutation),
-# and it only becomes architecturally observable at all once an illegal write
-# to a read-only CSR raises a trap. A mutation the check DOES catch, for the
-# record: making CSRRC compute `rdata | arg` instead of `rdata & ~arg` flips
-# it to a counterexample at depth 30 (`cmask & effective_wdata == 0`).
-#
-# ---- the counter models, and the one that had to be declined -------------
-#
-# `minstret inc` was the check this ladder most wanted -- ADR-0027's rule is
-# otherwise checked only by test/asm/minstret.S asserting on values it
-# computed itself -- and IT IS RED ON A CORRECT CORE. Measured, not argued:
-# csrc_inc_minstret_ch0 at `1 15` reports
-#
-#     bad state property 0 reachable at bound k = 15 SATISFIABLE
-#
-# against unmodified rtl/, and PASSes with ONE added testbench assumption
-# forbidding CSR writes to 0xB02 and nothing else changed.
-#
-# The model is why. rvfi_csrc_inc_check.sv clears `csr_written` at the top
-# of EVERY non-check cycle, so its `csr_insn_rdata >= wdata_shadow` fallback
-# is live for exactly one cycle after a write. On any longer gap the
-# assertion compares the check-cycle read against `rdata_shadow` -- which is
-# the value the WRITING instruction read, i.e. the value from BEFORE the
-# write. `minstret` is writable (ADR-0005) and CSR instructions serialize
-# (invariant 5), so two CSR retires on this core can never be one cycle
-# apart and the fallback is unreachable by construction. A write of a
-# smaller value followed by a read is then a counterexample against correct
-# hardware.
-#
-# No depth escapes it, swept: PASS at 6..12 (no write-then-read pair fits in
-# the window yet) and red at 13, 14, 15 and 16. `mcycle inc` is red for the
-# identical reason. Both are declined in the `#omit` block below.
-#
-# `upcnt` carries the property instead, and is STRICTLY STRONGER on the part
-# it does cover: rvfi_csrc_upcnt_check.sv assumes writes to the CSR away
-# outright (`assume(!(csr_write_valid && csr_insn_under_test))`) and asserts
-# a STRICT increase between the two reads, where `inc` only asserts `>=`.
-#
-# WHAT csrc_upcnt_minstret_ch0 DOES AND DOES NOT SAY ABOUT ADR-0027. It says
-# `minstret` strictly increases between any two reads, with writes assumed
-# away. It does NOT say it advances by exactly the number of non-trapping
-# issues: a core that also counted trapping issues would still increase, and
-# would still pass. ADR-0027's rule is narrowed here, not closed --
-# test/asm/minstret.S and test/csr_tb.v remain the only things checking the
-# "non-trapping" half, and they check it against assertions this repo wrote.
-#
-# `inc` IS SPELLED BELOW ON PURPOSE with no `csrc_inc` line in [depth]. That
-# is what makes genchecks CONSIDER and drop the two checks, which is what
-# puts them in formal/genchecks-audit.py's `dropped` set and so REQUIRES the
-# `#omit` declarations. Delete the word and the decline becomes prose only;
-# leave it and the decline is enforced in both directions like every other
-# one in this file.
-#
-# `mscratch any` is the round-trip statement: rvfi_csrc_any_check.sv shadows
-# a CSRRW's source operand and its reported wdata, and asserts a LATER read
-# returns it. That is a claim about the register, and csrw_mscratch_ch0
-# cannot make it -- measured, by deleting `MSCRATCH: mscratch <= warl;` from
-# rtl/csrs.v so the write is reported but never lands: csrc_any_mscratch_ch0
-# goes red and csrw_mscratch_ch0 stays PASS, because every value csrw
-# reasons about is derived from `warl` rather than from the register.
+# `mscratch any` is the only check here that asserts a CSR write sticks. Delete
+# `MSCRATCH: mscratch <= warl;` from rtl/csrs.v and csrc_any_mscratch_ch0 goes
+# red while csrw_mscratch_ch0 stays PASS, because every value csrw reasons about
+# comes from the reported write rather than from the register.
 mcycle   inc upcnt
 minstret inc upcnt
 mscratch any
 
 # ------------------------------------------------------------------------
-# THE CHECKS UPSTREAM OFFERS THAT THIS LADDER DECLINES.
+# [depth] below is the list of checks that EXIST, not a tuning table. Both of
+# genchecks' call sites return early on a check with no depth line, so such a
+# check is not generated at all -- no .sby, no directory, no status, no warning,
+# exit 0. A never-generated check is then missing from the results and from
+# formal/EXPECTED_FAIL at once, so set equality reports a clean match on the
+# smaller ladder (ADR-0033).
 #
-# READ THIS BEFORE READING [depth] AS A TUNING TABLE. It is not one. It is
-# the list of checks that EXIST: both of genchecks' call sites end with
-# `if depth_cfg is None: return`, so a check with no line below is not
-# generated at all -- no .sby, no directory, no status file, no warning,
-# exit 0. Deleting a line silently shrinks the ladder, and because a
-# never-generated check is missing from the results AND from
-# formal/EXPECTED_FAIL at once, that file's set-equality would report a
-# clean match on the smaller ladder (ADR-0033, gap 1).
+# The declined set is therefore declared, not described. Each `#omit` line names
+# one check genchecks considered and skipped, with its reason.
+# formal/genchecks-audit.py traces the generator's own get_depth_cfg calls and
+# set-equalities everything it dropped against these lines in both directions,
+# so a check upstream adds at the next pin bump fails generation until someone
+# rules on it. genchecks' cfg parser drops `#` lines, so none of this can
+# perturb generation.
 #
-# So the declined set is DECLARED, not described. Each `#omit` line below
-# names one check genchecks considered and skipped, with its reason.
-# formal/genchecks-audit.py traces genchecks' own get_depth_cfg calls,
-# collects everything it dropped, and set-equalities that against these
-# lines in both directions -- so the COUNT here is derived from the
-# generator's behaviour rather than asserted in prose, and a check that
-# upstream adds at the next pin bump (ADR-0013) fails generation until
-# someone rules on it. Its sibling assertion is formal/EXPECTED_CHECKS,
-# which does the same for the checks that ARE generated.
+#   [BLOCKED]  the property is wanted and there is no hardware here to state it
+#              about -- a burn-down owned by the memory-system ADR (ADR-0044,
+#              which tabulates all eleven).
+#   [DESIGN]   declined on the merits; no hardware change reopens it.
 #
-# genchecks' cfg parser drops every line starting with `#`, so these
-# declarations are invisible to it and cannot perturb generation.
+# The tag is free-form to the audit script, which captures only the check name.
 #
-# EVERY `#omit` LINE CARRIES A CLASS TAG, and the distinction is the one a
-# future reader most needs and could least recover:
-#
-#   [BLOCKED]  Declined for want of HARDWARE THAT DOES NOT EXIST YET. The
-#              property is wanted; there is nothing here to state it about.
-#              These are a BURN-DOWN, owned by the memory-system ADR
-#              (ADR-0044 has the eleven tabulated by name), and each one is
-#              either deleted, re-tagged [DESIGN], or re-stated with what it
-#              is still blocked on when that work lands.
-#
-#   [DESIGN]   Declined ON THE MERITS. No hardware change reopens it. Either
-#              the upstream model is wrong for this core, or the property is
-#              held better somewhere else in this tree.
-#
-# The tag is prose like the rest of the line -- formal/genchecks-audit.py's
-# OMIT_RE captures the check NAME and treats everything after it as a free-
-# form reason, so tagging cannot perturb the set equality or generation.
-#
-# The reasons, grouped. Nothing here is a depth problem:
-#
-# 1. `fault` and every `*_fault` variant model a bus that can refuse a
-#    transaction. This core's bus cannot: imem_data/imem_data2/mem_rdata
-#    are free every cycle with no fault line and no handshake (invariant 1,
-#    ADR-0015, formal/wrapper.v). There is nothing here to refuse anything,
-#    so there is no property to state -- which is why these are [BLOCKED]
-#    and not [DESIGN].
-#
-#    THE SECOND HALF OF THIS ENTRY USED TO READ AS SETTLED AND IS NOT.
-#    A bus fault is raised by the memory, i.e. AFTER decode, and invariant 2
-#    says every trap is detected and committed IN decode. Those two coexist
-#    today only because no access fault is reachable on this core. A memory
-#    system that can refuse a transaction therefore forces a ruling on
-#    invariant 2 -- and the honest options (no faulting bus at all; faults
-#    resolved in decode by construction from a static address-range decode;
-#    or invariant 2 changes) are recorded in ADR-0044, DELIBERATELY UNDECIDED.
-#    Do not read "invariant 2 forbids it" here as the decision having been
-#    taken. It needs that ADR before it needs a depth.
-#
-#    Worth knowing before reopening fault_ch0, read off checks/
-#    rvfi_fault_check.sv at the pin: it splits three ways. wfault asserts
-#    mcause == 7 and rfault mcause == 5 -- both post-decode. ifault asserts
-#    mcause == 1, an INSTRUCTION access fault, which arrives with the fetched
-#    instruction in the cycle decode reads it and so sits inside invariant 2
-#    unchanged. And its whole mcause half is under `RISCV_FORMAL_CSR_MCAUSE`,
-#    which genchecks emits only for a CSR named in [csrs] -- where mcause is
-#    absent for the WARL reason above. So that check needs three things, not
-#    one.
-#
-# 2. All nine bus_* need `RISCV_FORMAL_BUS` -- a second RVFI interface:
-#    bus_valid, bus_insn, bus_data, bus_fault, bus_addr, bus_rmask,
-#    bus_wmask, bus_rdata, bus_wdata. The core drives zero of them. The
-#    three io ones additionally need `rvformal_addr_io`, a distinguished
-#    MMIO region with ordering semantics; ADR-0008's map has a tohost word,
-#    not a region the RTL treats differently, and there is no ordering to
-#    check with one outstanding access at a time. bus_imem and bus_dmem are
-#    the only two whose *property* is meaningful here -- and
-#    formal/imemcheck.sv and formal/dmemcheck.sv already check it against
-#    the real split imem_addr/imem_addr2 interface (ADR-0003), and both
-#    pass. Adopting the bus_* forms would mean plumbing nine RVFI outputs to
-#    re-derive a result already held, and would put an `ifdef RISCV_FORMAL`
-#    value on a path the core reads -- exactly what ADR-0020's
-#    non-perturbation argument depends on nothing doing.
-#
-#    All nine are tagged [BLOCKED], because a memory system with a real bus
-#    is what makes any of them statable and the eventual ADR has to rule on
-#    each by name. TWO OF THE NINE CARRY A STANDING [DESIGN] ARGUMENT AS
-#    WELL: bus_imem_ch0 and bus_dmem_ch0 would re-derive a property
-#    formal/imemcheck.sv and formal/dmemcheck.sv already hold, and that stays
-#    true whatever the memory turns out to be. Expect those two to be
-#    re-tagged [DESIGN] rather than adopted.
-#
-# 3. The two csrc_inc_* are declined because rvfi_csrc_inc_check.sv is RED
-#    ON A CORRECT CORE here. The counterexample, the depth sweep that shows
-#    no depth escapes it, and the reading of the model that explains it are
-#    in the [csrs] block above; `upcnt` states the surviving half of the
-#    property and is on the ladder for both counters.
-#
-#    This entry named three DIFFERENT checks until the counter models
-#    landed -- `csrc_mcycle_ch0`, `csrc_minstret_ch0`, `csrc_mscratch_ch0`,
-#    declined because a bare [csrs] name emits a .sby reading
-#    `rvfi_csrc_check.sv`, "which does not exist AT THE PIN". The fact was
-#    right and the phrasing was misleading: it reads as though a pin bump
-#    would fix it. IT WOULD NOT -- that file HAS NEVER EXISTED UPSTREAM
-#    (evidence in the [csrs] block: the pin is upstream main's HEAD, the
-#    add/delete log for the path is empty, and the string appears in no
-#    branch or tag). All three CSRs carry a test list now, so genchecks
-#    never reaches the bare branch and never considers those three names.
-#
-# 4. `cover` is not lost, it is relocated: formal/cover.sby runs it
-#    standalone with this repo's own five goals (>=2 loads, >=2 stores, >=2
-#    compressed and >=2 uncompressed retires in a single trace) rather than
-#    genchecks' default, which is precisely why it is not wanted on the
-#    generated ladder as well.
-#
-# 5. `causal_io` needs the same `rvformal_addr_io` region as the three bus
-#    io checks, for the same reason: there isn't one. [BLOCKED], with them.
-#
-# COUNTING THE TWO CLASSES, so the split is not left to be inferred: of the
-# fourteen lines below, ELEVEN are [BLOCKED] -- fault_ch0, all nine bus_*,
-# and causal_io_ch0. THREE are [DESIGN] and no hardware reopens them: the
-# two csrc_inc_* (reason 3) and `cover` (reason 4). The fourteen is derived
-# -- formal/genchecks-audit.py prints it and set-equalities it both ways --
-# so re-derive it after a pin bump rather than trusting this paragraph.
-#
-# THE ELEVEN DO NOT ALL TURN ON THE SAME DECISION, and reading them as one
-# group is the mistake this paragraph exists to prevent. Sorted by blocker:
-#
-#   a faulting bus (5)      fault_ch0 and the four *_fault. THESE FIVE, AND
-#                           ONLY THESE FIVE, are the ones that put invariant
-#                           2 in question.
-#   an IO region (4)        the three bus_dmem_io_* non-fault forms and
-#                           causal_io_ch0. A memory-MAP question with no
-#                           invariant 2 content whatever. (The two io_*_fault
-#                           checks need this AND a faulting bus, and are
-#                           counted above.)
-#   BUS plumbing only (2)   bus_imem_ch0, bus_dmem_ch0 -- which also carry
-#                           the standing [DESIGN] argument in reason 2.
-#
-# And bus_dmem_io_order_ch0 is NOT blocked on the memory system at all: it
-# is blocked on THIS CORE, which has one access outstanding at a time
-# (ADR-0015). A second one is a pipeline change with everything invariant 8
-# would have to say about it, so no memory design reopens that check either.
-#
-# THREE checks that used to sit in this list are now ON the ladder, and
-# their absence was the hole ADR-0033 found.
-#
-#   ill_ch0         reads only ordinary RVFI ports this core already drives,
-#                   and FAILS today -- rvfi_trap is hardwired 0 -- so
-#                   leaving it out kept a known-red property off the ladder
-#                   AND out of formal/EXPECTED_FAIL at the same time. It is
-#                   now generated, red, and baselined, which is the system
-#                   working; the M3 trap work retires it.
-#
-#   causal_mem_ch0  runs entirely off standard RVFI mem signals and needs no
-#                   RISCV_FORMAL_BUS at all, so there was never a reason to
-#                   decline it. PASSes.
-#
-#   hang            was going to be declined here as "subsumed by the
-#                   passing liveness_ch0". Reading the two models says
-#                   otherwise, and the difference is the whole point of this
-#                   block. rvfi_liveness_check.sv opens with
-#                   `assume(rvfi_valid[...])` at its trig cycle: it bounds
-#                   the gap from one retire to the next, and is VACUOUS on a
-#                   core that never retires at all. rvfi_hang_check.sv
-#                   asserts a retire happened by its check cycle with no
-#                   such assumption, which is a strictly different property.
-#                   formal/cover.sby exhibits retires, but a cover witness
-#                   is not a proof of an assertion. So the reason for
-#                   omitting it evaporated on inspection, and the check went
-#                   on the ladder instead. PASSes in ~3s.
-#
+# fault_ch0 and the four *_fault forms are the five that put invariant 2 in
+# question: a bus fault is raised by the memory, i.e. after decode, and
+# invariant 2 says every trap is committed in decode. The two coexist today only
+# because no access fault is reachable on this core. ADR-0044 records the
+# options and deliberately picks none, so do not read these lines as that
+# ruling having been made.
 #omit fault_ch0                   [BLOCKED] needs a bus that can refuse, rvfi_mem_fault{,_rmask,_wmask}, and mcause in [csrs]; and it puts invariant 2 in question -- ADR-0044
 #omit bus_imem_ch0                [BLOCKED] needs RISCV_FORMAL_BUS; property already held by formal/imemcheck.sv, so expect [DESIGN] on review
 #omit bus_imem_fault_ch0          [BLOCKED] needs RISCV_FORMAL_BUS and a bus that can refuse a transaction
@@ -377,216 +98,56 @@ mscratch any
 # ------------------------------------------------------------------------
 
 [depth]
-# `reg` used to carry a fourth column here, a per-check wall-clock `timeout`
-# in seconds, read by a `timeout=` parameter this repo had added to its
-# vendored genchecks copy. Upstream genchecks has no such parameter, and
-# re-vendoring from the pin (ADR-0013 -- the pin is current; it was the fork
-# that was stale) dropped it. That is deliberate and the column is gone:
-# ADR-0022 added the bound because `reg_ch0` under `smtbmc yices` would sit
-# in the solver until the then-nightly's `timeout-minutes: 300` killed the
-# *whole job*, and ADR-0024 then replaced that engine with `btor btormc`,
-# under which the same check at the same depth converges in ~8-12s. The
-# condition the bound existed for no longer holds. THE BACKSTOP IS NOW MUCH
-# TIGHTER AND IS WORTH KNOWING BEFORE RAISING A DEPTH: there is no nightly
-# (ADR-0050), and the ladder's only job-level bound is the required `formal`
-# job's `timeout-minutes: 20` in `.github/workflows/ci.yml` -- against a
-# whole-job measurement of 4m22s. A non-converging check burns the whole
-# remaining budget and takes the four hand-authored tasks down with it. If a
-# check ever needs a real
-# per-check bound again, sby's `[options] timeout` is the place, and getting
-# genchecks to emit it means forking genchecks again -- which is the cost
-# this re-vendor was paying down, so weigh it accordingly.
+# Depths are derived, not inherited (ADR-0025), from two figures the ladder
+# measures about itself in seconds each:
 #
-# Depths are DERIVED, not inherited. ADR-0025 established that rule; ADR-0046
-# re-derived the numbers for the five-reason pipeline after ADR-0042 added the
-# operand-fetch cycle, and replaced the hand-tracing with two measurements the
-# ladder makes about itself. A reader can reproduce both in about ten seconds:
+#   F = 6   worst-case first retire. Sweep `hang`'s check cycle: red at 6, PASS
+#           at 7 -- rvfi_hang_check.sv asserts on a registered flag, so the flip
+#           point is F + 1.
+#   G = 4   worst-case gap between two retires. Sweep `liveness`'s trig-to-check
+#           distance: red at 3, PASS at 4. The gap-3 counterexample is also this
+#           measurement's non-vacuity witness, since rvfi_liveness_check.sv
+#           opens with `assume(rvfi_valid)` at its trig cycle.
 #
-#   F = 6   the WORST-CASE FIRST RETIRE. The latest cycle by which SOME
-#           instruction must have retired, counting from the DUT's reset.
-#           Measured by sweeping `hang`'s check cycle: red at 6, PASS at 7.
-#           rvfi_hang_check.sv asserts on a registered flag, so the flip point
-#           is F + 1.
+# To re-measure: copy this file with only the `hang` (or `liveness`) line in
+# [depth], run `python3 genchecks-local.py <copy>`, and sweep the last column.
+# Any change that adds a stall reason, lengthens a stage or widens the
+# scoreboard past its three fixed slots has to do that before it lands. The
+# figures the table is checked against are the single hop F + G = 10 and the two
+# hops F + 2G = 14, and `insn 15` and `reg 15 20` clear 14 by one cycle -- the
+# thinnest margin here.
 #
-#   G = 4   the WORST-CASE RETIRE GAP. The most cycles that can separate two
-#           consecutive retires. Measured by sweeping `liveness`'s trig-to-
-#           check distance: red at 3, PASS at 4, and stable with trig at 10,
-#           15 and 20. The gap-3 counterexample is also this measurement's own
-#           non-vacuity witness -- rvfi_liveness_check.sv opens with
-#           `assume(rvfi_valid)` at its trig cycle, so an unreachable trig
-#           would make it PASS at every gap instead of failing at 3.
+# The first column of a [depth] line is RISCV_FORMAL_RESET_CYCLES, which
+# checks/rvfi_testbench.sv wires to the CHECKER's shadow state only; the DUT is
+# held in reset for cycle 0 regardless. So a two-column check has to clear G
+# over its depth-minus-start window, not F + G, and `reg 15 20` is a window of 5
+# against G = 4 rather than something vacuous.
 #
-# TO RE-MEASURE after a pipeline change: copy this file with only the `hang`
-# (or `liveness`) line in [depth], run `python3 genchecks-local.py <copy>`, and
-# sweep the last column. Nothing else has to run, and it is seconds per point.
+# csrc_upcnt and csrc_any are the only two-retire checks here, and F and G do
+# not bound them: they shadow a value from one retire of a CSR instruction
+# naming the CSR under test and assert against a second, and CSR instructions
+# serialize. Their floor is measured at 9 -- three one-line mutations of
+# rtl/csrs.v each PASS at 6..8 and go red at 9..16 -- and 15 clears it.
 #
-# WHERE THE FIVE STALL REASONS LAND (CLAUDE.md invariant 8; ADR-0004, ADR-0009,
-# ADR-0015, ADR-0026, ADR-0042). This is the accounting F and G confirm:
+# A depth below its floor does not fail; it goes green having stopped asking.
+# The probe for the 70 insn_* checks: delete rtl/executor.v's `rs2[4:0]` shift
+# masking and insn_sll_ch0/insn_srl_ch0/insn_sra_ch0 each report a
+# counterexample at the depth below. Sweep `insn` down on that same mutation and
+# the counterexample survives to 5 and disappears at 4, where no instruction can
+# retire and `assume(rvfi_valid && spec_valid)` is unsatisfiable. Reach for it
+# before believing any insn_* result taken under a changed configuration.
+# The three csrc_* checks have one-line probes of their own:
+# `assign mcycle_plus = mcycle;`, `assign minstret_plus = minstret;`, and
+# deleting `MSCRATCH: mscratch <= warl;` from rtl/csrs.v.
 #
-#   base latency      3   decoder_out -> executor_out -> accessor_out/retire
-#                         (writeback is combinational off accessor_out)
-#   + reset           1   the DUT's reset is high for cycle 0 only -- see the
-#                         note on RESET_CYCLES below, it is NOT the first
-#                         [depth] column
-#   + operand fetch   1   ADR-0042's fifth reason. The first instruction of any
-#                         trace pays it unconditionally (`!read_taken`)
-#   = unstalled floor 5   the EARLIEST any instruction can retire
-#   + load or divide  1   ADR-0015's load-response turnaround, or `state ==
-#                         divide`, which ALTOPS collapses to one cycle
-#   = F               6
+# Depths move only on evidence, in either direction (ADR-0025). There is no
+# per-check wall bound, and the ladder's only budget is the `formal` job's
+# `timeout-minutes: 20` against a 4m22s whole-job measurement, so a raised depth
+# that stops converging takes the four hand-authored tasks down with it.
 #
-#   scoreboard        2   ADR-0004's worst-case RAW bubble: a live producer is
-#                         tracked in decoder_out and executor_out, no longer
-#   + producer slot   1   accessor_pending (loads only), or the divider's one
-#                         extra cycle of executor_out.valid == 0
-#   + drain           1   the producer's own retire, which the dependent waits
-#                         out rather than overlapping
-#   = G               4
-#
-# TWO OF THE FIVE REASONS ADD NOTHING TO G, and both are non-obvious enough to
-# be worth stating rather than leaving for the next reader to re-derive:
-#
-#   * The operand-fetch cycle is ABSORBED. A RAW hazard, a serialization hold
-#     and a divider/accessor freeze all hold the PC, and holding the PC holds
-#     the rs1/rs2 address pair with it -- so the operand read completes during
-#     the first held cycle and `operand_stall` is already low on the second.
-#     MEASURED: forcing `assign operand_stall = 1'b0` in rtl/decoder.v moves
-#     `hang`'s flip point from 7 to 6 and leaves `liveness`'s gap at 4. It
-#     moves F by one and does not move G at all.
-#
-#   * Serialization REPLACES the scoreboard term rather than stacking on it.
-#     rtl/decoder.v's `pipe_drained` requires all four in-flight slots empty;
-#     `live_producer` requires only a matching rd. So for a csrr*/mret the
-#     serialization stall strictly dominates the RAW stall and the two cannot
-#     be added. ADR-0025's addendum estimated "+3, additive" and thereby
-#     over-stated the two figures below by 2.
-#
-# THE TWO FIGURES THE DEPTHS ARE CHECKED AGAINST:
-#
-#   single hop  F + G  = 10   one producer, one dependent, both maximally
-#                             stalled -- the shortest trace that exercises a
-#                             real hazard end to end
-#   two hops    F + 2G = 14   one extra hop of margin. Past it, a longer
-#                             dependency chain relocates the identical
-#                             interaction rather than reaching new scoreboard
-#                             state: live_producer reads three FIXED slots and
-#                             is memoryless beyond them (ADR-0025).
-#
-# HOW A [depth] LINE IS READ, because getting this backwards makes `reg 15 20`
-# look vacuous by construction. genchecks emits the first column of a
-# check_cons line as `RISCV_FORMAL_RESET_CYCLES`, and checks/rvfi_testbench.sv
-# wires that to the CHECKER's reset only (`cycle < RISCV_FORMAL_RESET_CYCLES`).
-# The DUT gets the testbench's own `reset` port, which `assume(reset ==
-# $initstate)` pins to cycle 0. So the first column is how long the check's
-# shadow state is held clear, not how long the core is held in reset, and a
-# two-column check has to clear G over its (depth - start) window -- not
-# F + G.
-#
-#   insn 15     check_insn: RESET_CYCLES 1, CHECK_CYCLE 15. One retire, at
-#               cycle 15 exactly. Must clear the two-hop 14, and CLEARS IT BY
-#               ONE CYCLE. That is the thinnest margin on this table and the
-#               reason ADR-0046 exists; it was 2 before ADR-0042.
-#   ill 15      byte-for-byte insn's configuration (check_cons(..., depth=0),
-#               one column, RESET_CYCLES defaulting to 1), and
-#               rvfi_ill_check.sv asserts on one retiring instruction's own
-#               values -- the same instruction-lifetime question. Same floor,
-#               same number.
-#   csrw 30     check_insn again, and a csrr* is the serializing case, so its
-#               floor is the same 14. Ample.
-#   reg 15 20   window 5 against G = 4. rvfi_reg_check.sv needs a producer
-#               retire inside the window and the checked retire at its end.
-#   pc_fwd 10 30 / pc_bwd 10 30      window 20 against G = 4.
-#   causal 10 20 / causal_mem 10 20  window 10 against G = 4. causal_mem is
-#               rvfi_causal_check.sv's argument over memory bytes instead of
-#               register indices, over the same rvfi_valid/rvfi_order stream,
-#               so it takes causal's numbers rather than a fresh derivation.
-#   liveness/unique 1 10 30          trig-to-check 20 against G = 4.
-#   hang 1 30   30 against F + 1 = 7.
-#
-#   csrc_upcnt 1 15 / csrc_any 1 15  THE ONLY TWO-RETIRE CHECKS ON THIS
-#               LADDER, and the reason they get their own paragraph. Every
-#               other check above bounds ONE instruction's lifetime or the
-#               gap between two arbitrary retires. These shadow a value from
-#               one retire of a *CSR instruction naming the CSR under test*
-#               and assert against a SECOND one landing exactly on the check
-#               cycle -- and CSR instructions serialize (invariant 5), so
-#               those two retires are far apart. F and G do not bound that:
-#               neither figure is about two retires of a particular kind.
-#
-#               RESET_CYCLES is 1, and that is a choice rather than a derived
-#               number. It holds the checker's shadow clear for cycle 0 alone
-#               -- the same cycle the DUT is in reset -- so the checker sees
-#               every retire the core makes and the first of the two reads
-#               can land anywhere. Holding it longer only shrinks the window
-#               the first read has to land in; nothing is bought.
-#
-#               THE FLOOR IS MEASURED AT 9, three independent ways. Each is
-#               a one-line mutation of rtl/csrs.v plus a sweep of the check
-#               cycle, looking for where the counterexample DISAPPEARS --
-#               the same method the insn_* probe below uses:
-#
-#                 mutation                              PASS    red
-#                 mcycle_plus   = mcycle                 6..8   9..16
-#                 minstret_plus = minstret               6..8   9..16
-#                 delete `MSCRATCH: mscratch <= warl;`   6..8   9..16
-#
-#               All three flip at the same cycle, so 9 is a property of this
-#               pipeline (the earliest two CSR retires can land with the
-#               second on the check cycle) rather than of any one model.
-#
-#               15 CLEARS THAT BY SIX, and is the same number `insn` carries
-#               for the same reason: it is one cycle past the two-hop figure
-#               F + 2G = 14, which is the margin this table uses everywhere
-#               a longer trace could stack a second stall against the first.
-#               Both checks PASS on unmodified rtl/ at exactly these numbers.
-#
-# A DEPTH BELOW ITS FLOOR DOES NOT FAIL -- IT GOES GREEN HAVING STOPPED ASKING,
-# and that is exhibited here rather than argued. Delete rtl/executor.v's
-# `rs2[4:0]` shift masking (an already-fixed historical defect) and
-# insn_sll_ch0, insn_srl_ch0 and insn_sra_ch0 each report
-#
-#     bad state property 9 reachable at bound k = 15 SATISFIABLE
-#
-# at the depth configured below. Sweep `insn` downward on that same mutation
-# and the counterexample survives to depth 5 and DISAPPEARS at depth 4: no
-# instruction can retire at cycle 4, so `assume(rvfi_valid && spec_valid)` is
-# unsatisfiable and the check PASSes on a core that is broken. The flip lands
-# at exactly the unstalled floor derived above.
-#
-# THAT MUTATION IS THIS LADDER'S LIVENESS PROBE FOR THE 70 insn_* CHECKS -- the
-# counterpart of deleting the rs2 write-through bypass for reg_ch0 (ADR-0040,
-# ADR-0042). Reach for it before believing any insn_* result taken under a
-# changed configuration. It is specific rather than a blanket break:
-# insn_slli_ch0 (immediate shamt, untouched) and insn_add_ch0 stay PASS on it.
-# It also survives deleting formal/wrapper.v's imem-stability assumption --
-# same property, same bound, same floor -- so that assumption is not what makes
-# the ladder able to catch this (ADR-0046).
-#
-# THE THREE csrc_* CHECKS HAVE THEIR OWN NAMED PROBES, one line each, in the
-# table under `csrc_upcnt 1 15` above. At the shipping depths:
-#
-#   csrc_upcnt_mcycle_ch0    `assign mcycle_plus   = mcycle;`
-#   csrc_upcnt_minstret_ch0  `assign minstret_plus = minstret;`
-#   csrc_any_mscratch_ch0    delete `MSCRATCH: mscratch <= warl;`
-#
-# each give `bad state property 0 reachable at bound k = 15 SATISFIABLE`. The
-# third is also the one that says what csrc_any_mscratch_ch0 ADDS: on that same
-# mutation -- the write reported over RVFI but never landing in the register --
-# csrw_mscratch_ch0 stays PASS at its own depth 30, because every value
-# rvfi_csrw_check.sv reasons about is derived from the reported `warl` rather
-# than from the register the next read returns.
-#
-# Every depth below clears its floor. A raised sweep at roughly double these
-# numbers flipped no verdict among the checks that returned; see ADR-0046 for
-# exactly what it did and did not cover, and ADR-0025 for the rule these
-# numbers move under -- depths move ONLY on empirical evidence, in either
-# direction. Do not raise one to make something green; do not lower one to make
-# a sweep finish.
-#
-# ALL OF THE ABOVE ASSUMES `RISCV_FORMAL_ALTOPS` (see [defines]). Without it
-# the real divider holds executor_out.valid for 32 cycles, F becomes ~37 and G
-# ~36, and every number here must be re-derived. ADR-0045 decided against
-# dropping ALTOPS; if that is ever revisited, this table is part of the cost.
+# All of the above assumes RISCV_FORMAL_ALTOPS (see [defines]). Without it the
+# real divider holds executor_out.valid for 32 cycles, F becomes ~37 and G ~36,
+# and every number here must be re-derived.
 insn           15
 reg      15    20
 pc_fwd   10    30

--- a/formal/complete.sv
+++ b/formal/complete.sv
@@ -2,9 +2,8 @@ module rvfi_testbench (
   input var clk,
   output logic [31:0] imem_addr,
   input  logic [31:0] imem_data,
-  // ADR-0003: the dual-word fetch window's second word. Left fully free
-  // per cycle, same rationale as imem_data below (no cross-cycle latency to
-  // model, CLAUDE.md invariant 1).
+  // The dual-word fetch window's second word (ADR-0003), left fully free per
+  // cycle for the same reason imem_data is.
   output logic [31:0] imem_addr2,
   input  logic [31:0] imem_data2,
   output logic [31:0] mem_addr,
@@ -19,60 +18,29 @@ module rvfi_testbench (
   `RVFI_WIRES
   logic trap;
 
-  // ADR-0006: "finish [complete.sv] by driving imem/dmem inputs rand-stable".
-  // Without this, imem_data/mem_rdata are free every cycle (see wrapper.v),
-  // which is fine for the single-retire insn_* checks but not for this
-  // whole-ISA walk: a load that doesn't see back what an earlier store in
-  // the same trace wrote would fail rvfi_isa_rv32imc's spec check for
-  // reasons that have nothing to do with the core.
+  // A one-address write-through shadow of the data bus: the most recent store
+  // only, not a memory array. Without it mem_rdata is free every cycle (see
+  // wrapper.v), and a load that did not see back what an earlier store in the
+  // same trace wrote would fail rvfi_isa_rv32imc's spec check for reasons that
+  // have nothing to do with the core. A read of an address some earlier,
+  // since-overwritten store touched is still left free. dmemcheck.sv carries
+  // the fuller version of this argument.
   //
-  // imem is left fully free per cycle, deliberately not made rand-stable:
-  // rtl/fetcher.v drives imem_addr = pc and out.instr = imem_data
-  // combinationally with no cross-cycle latency (CLAUDE.md invariant 1), so
-  // nothing here depends on two different cycles' fetches of the same
-  // address agreeing.
+  // imem is deliberately NOT made stable this way: rtl/fetcher.v drives
+  // imem_addr = pc and out.instr = imem_data combinationally, with no
+  // cross-cycle latency, so nothing here depends on two cycles' fetches of the
+  // same address agreeing.
   //
-  // dmem gets a single-address write-through shadow -- the most recent
-  // store only, not a full memory array -- which is enough to let the
-  // common store-then-immediately-reload pattern through. A read of an
-  // address some *earlier*, since-overwritten store touched stays free;
-  // see dmemcheck.sv for the fuller version of this same argument (why
-  // $past(mem_addr), and why the address-0/idle-default coincidence is
-  // harmless: rtl/accessor.v only reads mem_rdata the cycle after a real
-  // load request).
-  //
-  // ADR-0049 -- fact / discharge / scope for the `assume` twenty lines below,
-  // which ADR-0049's census covered but could not annotate (this file was
-  // carved out of that change and handed here):
-  //
-  //   FACT MODELLED. The data bus returns, one cycle after the request,
-  //     whatever the most recent store to that same address wrote. That is
-  //     store-to-load forwarding for one address, not a memory: a read of an
-  //     address written by some earlier, since-overwritten store is left free.
-  //
-  //   DISCHARGED: NOWHERE, and there is no structural argument behind it
-  //     either -- this is the weaker of the two answers ADR-0049 clause 2
-  //     admits, and it is the honest one. The only writable memory in the tree
-  //     is rtl/memory.v, which answers any address at or past 4*RAM with
-  //     `mem_rdata <= mem_wdata` rather than with stored data, and `mem_addr`
-  //     here is a free 32-bit value, so the modelled memory and the real
-  //     module disagree over the overwhelming majority of the address space.
-  //     test/mem_tb.v does not close this: it asserts only that an
-  //     out-of-range read does not alias ram[0], never what one returns.
-  //     ADR-0044 rules the placeholder out as a starting point and does not
-  //     replace it, so when the real memory system is built there is no check
-  //     anywhere that will hold it to what this proof assumed of it. That is
-  //     ADR-0049's finding F4, restated at the site it is about; do not invent
-  //     a discharge for it.
-  //
-  //   SCOPE. `complete`'s single assert(spec_valid && !spec_trap) -- this task
-  //     has exactly one assertion, and the assume is guarded besides
-  //     (dmem_shadow_valid, no store last cycle, same address). It is
-  //     therefore no wider than what it was written for. Unlike
-  //     rtl/executor.v's operand cap (ADR-0049 F1) it constrains a DUT INPUT
-  //     rather than the core, so it narrows the environment and can only make
-  //     the trace set smaller, never make the core's job easier on a trace
-  //     that survives.
+  // Nothing discharges this assumption, and there is no structural argument
+  // behind it either (ADR-0049 F4). The only writable memory in the tree is
+  // rtl/memory.v, which answers any address at or past 4*RAM with
+  // `mem_rdata <= mem_wdata` rather than with stored data, while mem_addr here
+  // is a free 32-bit value -- so the modelled memory and the real module
+  // disagree over most of the address space, and test/mem_tb.v never says what
+  // an out-of-range read returns. Do not invent a discharge for it. What limits
+  // the damage is that it constrains a DUT input rather than the core, so it
+  // can only shrink the trace set, never make the core's job easier on a trace
+  // that survives.
   logic [31:0] dmem_shadow;
   logic [31:0] dmem_shadow_addr;
   logic        dmem_shadow_valid = 0;
@@ -92,13 +60,11 @@ module rvfi_testbench (
       assume(mem_rdata == dmem_shadow);
   end
 
-  // ADR-0054: the fetch address one cycle early, for a synchronous memory.
-  // Unread here -- this environment answers `imem_data` freely against
-  // `imem_addr` in the same cycle -- but connected rather than left dangling,
-  // so every instantiation of the core names every port.
+  // The fetch address one cycle early, for a synchronous memory (ADR-0054).
+  // Unread here, since this environment answers imem_data in the same cycle,
+  // but connected rather than left dangling.
   logic [31:0] imem_addr_next;
 
-  // Instantiate the actual top-level CPU module (was stale "riscv" with Wishbone interface)
   littlecpu wrapper (
     .clk(clk),
     .reset(reset),
@@ -147,141 +113,92 @@ module rvfi_testbench (
     .spec_mem_wdata(spec_mem_wdata)
   );
 
-  // ----------------------------------------------------------------------
-  // THE DECLARED EXCLUSION SET
-  // ----------------------------------------------------------------------
+  // The declared exclusion set.
   //
-  // What this check says: every retire this core reports is an instruction
-  // riscv-formal's whole-ISA spec model RECOGNISES (spec_valid) and agrees is
-  // non-trapping (!spec_trap). It is the only thing in the tree that walks the
-  // ISA as a whole rather than one instruction at a time -- the 70 insn_*
-  // ladder checks each constrain rvfi_insn to their own encoding, so an
-  // encoding no insn_* names is invisible to all of them.
+  // riscv-formal ships no spec model at all for two opcode classes at the pin,
+  // so spec_valid is 0 on every such retire and the assertion below fails on
+  // correct hardware. Measured with `insn_excluded` forced to 0: FAIL at step
+  // 5, on a non-trapping FENCE retire the model has never heard of. To
+  // reproduce, copy this file and complete.sby under another name and edit the
+  // copy -- check-complete-exclusions.py rejects an insn_excluded that is not
+  // the disjunction of the declared wires, so editing in place will not run.
   //
-  // It cannot be that for the WHOLE ISA, because riscv-formal ships no spec
-  // model at all for two opcode classes at formal/pin.mk's SHA. Not a weaker
-  // model, none: there is no insns/insn_fence.v, no insn_ecall.v, no
-  // insn_csrrw.v, and isa_rv32imc.txt names none of them. spec_valid is
-  // therefore 0 on every such retire and the assertion fails on correct
-  // hardware. Measured, by running this same harness with `insn_excluded`
-  // forced to 0: `DONE (FAIL, rc=2)` in 15s, counterexample at step 5, with
+  // Excluding an opcode from an assertion is weakening a check, admissible only
+  // if recorded (ADR-0010, one level up). Each entry names its encoding and its
+  // reason, formal/COMPLETE_EXCLUSIONS carries the same set as a baseline, and
+  // check-complete-exclusions.py compares the two in both directions before
+  // this check may run. It also re-derives "no spec model at the pin" from the
+  // clone, so an entry that stops being true at a future pin fails rather than
+  // quietly over-excluding.
   //
-  //   rvfi_insn = 0x0000000f  (FENCE)  rvfi_trap = 0
-  //   spec_valid = 0                   spec_trap = 0
+  // Each predicate keys on the encoding out of rvfi_insn and on nothing the
+  // core decodes, so a core that wrongly decodes an ADD as a FENCE cannot
+  // excuse itself from its own check -- it still retires an OP encoding and is
+  // still asserted on. check-complete-exclusions.py enforces that shape
+  // textually, because a one-line edit to use a decoder flag instead would not
+  // look like it had broken anything.
   //
-  // -- a correct, non-trapping retire of an instruction the model has never
-  // heard of. That is the whole reason this file needs an exclusion set, and
-  // it is reproducible: copy complete.sv and complete.sby under another name,
-  // set `insn_excluded` to 1'b0 in the copy, and run `sby -f` on it. (Editing
-  // this file in place does not work, and deliberately so --
-  // check-complete-exclusions.py rejects an insn_excluded that is not the
-  // disjunction of the declared wires, and `complete` will not run until it
-  // passes.)
-  //
-  // EXCLUDING AN OPCODE FROM AN ASSERTION IS WEAKENING A CHECK. It is
-  // legitimate here only under ADR-0010's rule one level up -- restrict the
-  // proof, and RECORD the restriction -- which is why each entry below names
-  // its encoding and its reason, why formal/COMPLETE_EXCLUSIONS carries the
-  // same set as a baseline, and why formal/check-complete-exclusions.py
-  // compares the two as sets in BOTH directions (ADR-0014's contract) before
-  // this check is allowed to run. Adding an entry without moving the baseline
-  // fails; removing one without moving the baseline fails; and the script also
-  // re-derives "no spec model at the pin" from the clone, so an entry that
-  // stops being true at a future pin fails rather than quietly over-excluding.
-  //
-  // THE PREDICATE KEYS ON THE ENCODING, NOT ON ANY CORE-SUPPLIED FLAG. It
-  // reads rvfi_insn and nothing else -- no is_fence, no is_csr, nothing out of
-  // rtl/decoder.v. A core that wrongly decodes an ADD as a FENCE must not be
-  // able to excuse itself from its own check; with the test written this way,
-  // such a core still retires an OP encoding and is still asserted on.
-  // check-complete-exclusions.py enforces that shape textually, because it is
-  // the kind of property a later one-line edit ("just use the shadow flag,
-  // it's already there") destroys without looking like it did.
-  //
-  // rvfi_insn[1:0] == 2'b11 is the whole width discriminator: RVFI reports a
+  // rvfi_insn[1:0] == 2'b11 is the width discriminator: RVFI reports a
   // compressed retire as a zero-extended 16-bit value, and no RVC encoding has
-  // both low bits set. cover.sv already counts long vs compressed retires with
-  // the same test.
+  // both low bits set.
   wire        insn_uncompressed = rvfi_insn[1:0] == 2'b11;
   wire [6:0]  insn_opcode       = rvfi_insn[6:0];
 
   // EXCLUDE MISC-MEM 0001111 fence fence.i
-  //   riscv-formal has no spec model for either at the pin. rtl/decoder.v
-  //   makes both the NOPs ADR-0005 specifies -- one hart and no icache, so a
-  //   conformant fence.i is a NOP (ADR-0002 as amended by ADR-0048) -- and
-  //   they retire non-trapping, so unlike ecall/ebreak they are not already
-  //   excused by the !rvfi_trap guard below. This is the class the measured
-  //   failure above came from.
+  //   No spec model at the pin. rtl/decoder.v makes both the NOPs ADR-0005
+  //   specifies, and they retire non-trapping, so unlike ecall/ebreak they are
+  //   not already excused by the !rvfi_trap guard below. This is the class the
+  //   measured failure above came from.
   wire exclude_misc_mem = insn_uncompressed && insn_opcode == 7'b0001111;
 
   // EXCLUDE SYSTEM 1110011 ecall ebreak mret wfi csrrw csrrs csrrc csrrwi csrrsi csrrci
-  //   riscv-formal has no spec model for any of the ten at the pin -- the
-  //   whole of M3's behaviour. CLAUDE.md's standing caveat says so in prose;
-  //   this is that caveat mechanised. `mret`, `wfi` and the six csrr* forms
-  //   retire non-trapping and would otherwise fail here. `ecall`/`ebreak` are
-  //   already excused by the !rvfi_trap guard (they raise causes 11 and 3),
-  //   and stay named anyway: the entry is a statement about which encodings
-  //   have no oracle, not about which ones happen to reach the assertion
-  //   today. What checks these instead: test/asm/trap.S, test/asm/csr.S,
+  //   No spec model at the pin for any of the ten -- the whole of M3's
+  //   behaviour. `mret`, `wfi` and the six csrr* forms retire non-trapping and
+  //   would otherwise fail here; `ecall`/`ebreak` are already excused by the
+  //   !rvfi_trap guard and are named anyway, because this entry states which
+  //   encodings have no oracle rather than which reach the assertion today.
+  //   What checks them instead: test/asm/trap.S, test/asm/csr.S,
   //   test/csr_tb.v, test/decoder_tb.v and rtl/decoder.v's component proof --
-  //   this repo's own assertions, not an oracle (ADR-0033).
+  //   this repo's own assertions, not an oracle.
   wire exclude_system = insn_uncompressed && insn_opcode == 7'b1110011;
 
   wire insn_excluded = exclude_misc_mem || exclude_system;
 
-  // NO COMPRESSED ENTRY, AND THAT IS A RESULT RATHER THAN AN OVERSIGHT. The
-  // one compressed encoding this core implements that isa_rv32imc.txt does not
-  // name is C.EBREAK (16'h9002, ADR-0048), and it raises BREAKPOINT, so it
-  // reaches this assertion only if the core reports it as a NON-trapping
-  // retire -- in which case spec_valid is 0 for 0x00009002 and this check
-  // fires. Excluding it would have thrown that away. Every other compressed
-  // encoding the decoder accepts has a model.
+  // There is no compressed entry, and that is a result. The one compressed
+  // encoding this core implements that isa_rv32imc.txt does not name is
+  // C.EBREAK (16'h9002, ADR-0048), and it raises breakpoint -- so it reaches
+  // the assertion only if the core reports it as a non-trapping retire, at
+  // which point spec_valid is 0 and this check fires. Excluding it would throw
+  // that away.
 
-  // ----------------------------------------------------------------------
-  // THE CHECK
-  // ----------------------------------------------------------------------
-  //
   // The !rvfi_trap term is core-supplied, unlike the exclusion predicate, and
-  // it has to be: a trapping retire has no spec-value obligation (ADR-0028),
-  // and under RISCV_FORMAL_ALIGNED_MEM the spec model reports spec_trap on a
-  // misaligned lw that this core correctly refuses to perform. An illegal
-  // encoding is the sharper case -- it retires with rvfi_trap and has no spec
-  // model by definition, so `assert(spec_valid)` cannot be hoisted out of the
-  // guard. The consequence is honest and worth stating: a core that claimed
-  // rvfi_trap on everything would pass this vacuously. That is what
-  // complete_cover.sby is for -- it witnesses a real non-trapping retire of
-  // every opcode class this exclusion set does NOT cover, so "the assertion
-  // was reached, class by class" is measured rather than assumed.
+  // has to be: a trapping retire has no spec-value obligation (ADR-0028), and
+  // an illegal encoding retires with rvfi_trap and has no spec model by
+  // definition, so `assert(spec_valid)` cannot be hoisted out of the guard. The
+  // cost is that a core claiming rvfi_trap on everything would pass this
+  // vacuously, which is what the cover goals below exist to rule out.
   always_comb begin
     if (!reset && rvfi_valid && !rvfi_trap && !insn_excluded) begin
       assert(spec_valid && !spec_trap);
     end
   end
 
-  // ----------------------------------------------------------------------
-  // ANTI-VACUITY: every non-excluded opcode class really does retire
-  // ----------------------------------------------------------------------
+  // Anti-vacuity: every non-excluded opcode class really does retire. sby's
+  // `mode bmc` strips cover cells and `mode cover` strips assertions, so these
+  // are inert in complete.sby's run and are the whole of complete_cover.sby's.
+  // Each goal is a non-trapping, non-excluded retire of one class -- a cycle on
+  // which the assertion above was live and had something to say.
   //
-  // sby's `mode bmc` strips cover cells and `mode cover` strips assertions, so
-  // these sit inert in complete.sby's run and are the whole point of
-  // complete_cover.sby's. Each goal is a NON-TRAPPING, NON-EXCLUDED retire of
-  // one opcode class -- i.e. a cycle on which the assertion above was live and
-  // had something to say. Together they are the demonstration that the
-  // exclusion set did not swallow the ISA.
+  // `complete_live` repeats the assertion's guard as a wire rather than a
+  // macro: a macro leaks into every file read after it in the same yosys
+  // invocation, and sby reports a macro-expanded cover statement against the
+  // macro's source range, so all twelve goals would resolve to overlapping
+  // spans and could not be told apart in the summary.
   //
-  // `complete_live` is character-for-character the assertion's guard, and it
-  // is a wire rather than a `define` for two reasons: a macro defined in one
-  // file leaks into every file read after it in the same yosys invocation, and
-  // -- measured -- a macro-expanded cover statement is reported by sby against
-  // the source range of the MACRO, so all twelve goals resolve to overlapping
-  // spans and cannot be told apart in the PASS summary. One wire, twelve
-  // one-line goals, twelve distinct locations.
-  //
-  // `insn_excluded` is redundant on the nine uncompressed goals (an opcode has
-  // one value, and it is not one of the two excluded ones) and is kept for
-  // exactly that reason: if a future entry did shadow one of these classes,
-  // the goal would go unreachable and this task would fail, rather than the
-  // assertion going quiet with nothing to say about it.
+  // `insn_excluded` is redundant on the nine uncompressed goals and kept for
+  // that reason: a future exclusion that shadowed one of these classes makes
+  // the goal unreachable and fails this task, instead of leaving the assertion
+  // quiet with nothing to say.
   wire complete_live = !reset && rvfi_valid && !rvfi_trap && !insn_excluded;
   cover property (complete_live && insn_uncompressed && insn_opcode == 7'b0000011); // LOAD
   cover property (complete_live && insn_uncompressed && insn_opcode == 7'b0010011); // OP-IMM

--- a/test/asm/riscv_test.h
+++ b/test/asm/riscv_test.h
@@ -1,51 +1,36 @@
-// Local, minimal riscv_test.h (ADR-0008).
+// Local, minimal riscv_test.h (ADR-0008). This core has no privilege modes and
+// no PMP, so none of upstream riscv-tests' env/p setup belongs here.
+// RVTEST_PASS/RVTEST_FAIL write the riscv-tests `tohost` encoding to a fixed
+// doubleword at the base of RAM and spin; both cxxrtl runners, the iverilog
+// bench and the Sail model watch that address and terminate on it, so nothing
+// depends on ecall or mtvec. See RVTEST_DATA_BEGIN for why the width matters.
 //
-// Unlike upstream riscv-tests' env/p/riscv_test.h, this core has no privilege
-// modes and no PMP, so none of that setup belongs here. RVTEST_CODE_BEGIN just
-// establishes `_start` and zeroes the test-number register;
-// RVTEST_PASS/RVTEST_FAIL write the riscv-tests `tohost` encoding (ADR-0008) to
-// a fixed doubleword at the base of RAM and spin. The cxxrtl runner
-// (test/cxxrtl.cc) and the iverilog bench watch that address for the magic
-// write instead of relying on ecall/mtvec; the Sail model (ADR-0032) speaks
-// the same HTIF protocol and terminates on it. See RVTEST_DATA_BEGIN for why
-// the doubleword width is not cosmetic.
+// The trap macros at the bottom are opt-in, and RVTEST_CODE_BEGIN must stay
+// untouched by them so the other tests keep assembling to the same bytes. A
+// test opts in with RVTEST_TRAP_DATA (in .data), RVTEST_TRAP_HANDLER (in .text)
+// and RVTEST_INSTALL_TRAP_HANDLER.
 //
-// The trap-handler macros at the bottom are strictly opt-in and
-// RVTEST_CODE_BEGIN is deliberately untouched by them: the suite's other tests
-// must keep assembling to the same bytes, and must not start executing CSR
-// instructions before the CSR RTL exists (M3). A test opts in by invoking
-// RVTEST_TRAP_HANDLER (in .text) and RVTEST_TRAP_DATA (in .data) and then
-// installing the handler with RVTEST_INSTALL_TRAP_HANDLER.
+// Three constraints on trap tests:
 //
-// Three constraints on trap tests, none of them optional, all of them
-// consequences of decisions recorded elsewhere:
+//   1. The handler cannot read the faulting instruction -- this core is Harvard
+//      with disjoint buses (ADR-0008), so no load reaches ROM and nothing can
+//      inspect insn[1:0] to choose between mepc+2 and mepc+4. The resume path
+//      adds 4 unconditionally, so every trapping instruction in a resuming test
+//      must be wrapped in `.option norvc` / `.option pop`: the assembler
+//      compresses freely at -march=rv32imc_zicsr, and a `lw` that became a
+//      `c.lw` would make the resume skip a whole instruction. Tests that
+//      terminate from inside the handler are unconstrained.
+//   2. Install the handler before faulting. `mtvec` resets to 0, which is
+//      `_start` (ADR-0029), so a trap taken before installation restarts the
+//      program.
+//   3. Trap tests must self-check in band. riscv-formal ships no spec model for
+//      csrr*/ecall/ebreak/mret at the pinned SHA, so `spec_valid` is 0 for all
+//      of them and the per-retire monitor has nothing to say about the very
+//      instructions these tests exercise. A passing trap test was checked
+//      against its own assertions, not against an oracle.
 //
-//   1. **The handler cannot read the faulting instruction.** This core is
-//      Harvard with physically disjoint buses (ADR-0008): no load can reach
-//      ROM. So a handler cannot inspect insn[1:0] to decide whether to resume
-//      at mepc+2 or mepc+4. The resume path here adds 4 unconditionally, which
-//      means **every trapping instruction in a resuming test must be
-//      uncompressed** -- wrap it in `.option norvc` / `.option pop`, because
-//      the assembler compresses freely at -march=rv32imc_zicsr (ADR-0014's
-//      sunset note) and would otherwise silently turn a 4-byte `lw` into a
-//      2-byte `c.lw`, after which the resume skips a whole instruction. Tests
-//      that instead terminate from inside the handler are unconstrained.
-//   2. **Install the handler before faulting.** `mtvec` resets to 0, which is
-//      `_start` (ADR-0029), so a trap taken before installation silently
-//      restarts the program. Both sim legs are supposed to make that loud, but
-//      the discipline is the actual fix.
-//   3. **Trap tests must self-check in band.** riscv-formal ships no spec model
-//      for csrr*/ecall/ebreak/mret at the pinned SHA, so `spec_valid` is 0 for
-//      all of them and the per-retire monitor -- the thing that makes every
-//      other test self-checking (ADR-0019) -- has nothing to say about the
-//      instructions these tests exist to exercise. Hence the handler records
-//      mcause/mepc/a trap count into RAM and the test body asserts on them
-//      with the ordinary TEST_CASE machinery. Do not assume a passing trap
-//      test was cross-checked against an oracle; it was checked against
-//      whatever the test itself asserts.
-//
-// The handler clobbers t0 and t1 and nothing else, so a test body must not
-// hold live values in those registers across an instruction that may trap.
+// The handler clobbers t0 and t1, so a test body must not hold live values
+// there across an instruction that may trap.
 
 #ifndef __RISCV_TEST_H
 #define __RISCV_TEST_H
@@ -53,10 +38,9 @@
 // riscv-tests' test_macros.h expects TESTNUM to already be defined.
 #define TESTNUM gp
 
-// All 51 riscv-tests-derived `.S` files in this suite include RVTEST_RV64U
-// to mark "this is a plain unprivileged integer test" — a leftover of
-// upstream's env selection, not an XLEN claim. It expands to nothing here:
-// this core is RV32 only (ADR-0002) and there is no privilege setup to do.
+// A leftover of upstream's env selection that the `.S` files still invoke, not
+// an XLEN claim. It expands to nothing: this core is RV32 only (ADR-0002) and
+// has no privilege setup to do.
 #define RVTEST_RV64U
 
 #define RVTEST_CODE_BEGIN                                                    \
@@ -66,32 +50,18 @@
 _start:                                                                      \
         li      TESTNUM, 0;
 
-// Nothing should ever reach here — RVTEST_PASS/RVTEST_FAIL each end in an
-// infinite loop after the tohost write — but spin rather than fall off the
-// end of ROM if a test is malformed.
+// Unreachable in a well-formed test, since RVTEST_PASS/RVTEST_FAIL each end in
+// an infinite loop -- but spin rather than run off the end of ROM.
 #define RVTEST_CODE_END                                                      \
 1:      j       1b
 
-// Both verdict macros write the doubleword's UPPER word first and the verdict
-// itself last, and the order is deliberate (ADR-0039). This core has no 64-bit
-// store, so the doubleword `tohost` is written as two `sw`s; Sail's HTIF fires
-// on each half-write once the other half has been seen, so writing the upper
-// (always-zero) word first makes the verdict store the single event that
-// terminates the reference model -- the same store test/cxxrtl.cc and
-// test/cosim.cc already stop on when RAM_BASE's low word goes non-zero. Both
-// sides then end on the same instruction. Writing them the other way round
-// works too, but leaves the reference model running one store longer than the
-// core, for no gain.
-//
-// Neither store writes a register, so the sequence of architectural
-// register-file states -- which is what ADR-0032's co-simulation compares --
-// is unchanged by this pair. Read that narrowly: measured across the whole
-// suite, the register-change EVENT COUNT is identical (7076 before, 7076
-// after, no program differing), which is the claim. What does move is 382
-// register VALUES that are addresses, because .text grows by these two stores
-// and .data by tohost's padding -- .data addresses by +4, .text addresses by
-// +8, and nothing by anything else (ADR-0041). Both sides of the
-// co-simulation read the same ELF, so none of it is visible there.
+// The upper word is written first and the verdict last, and the order matters:
+// this core has no 64-bit store, so the doubleword goes out as two `sw`s, and
+// Sail's HTIF fires on whichever half-write completes the pair. Writing the
+// always-zero upper word first makes the verdict store the single event that
+// stops the reference model -- the same store the cxxrtl runners stop on when
+// RAM_BASE's low word goes non-zero -- so both sides end on the same
+// instruction (ADR-0039).
 #define RVTEST_PASS                                                          \
         li      TESTNUM, 1;                                                 \
         la      t0, tohost;                                                 \
@@ -107,29 +77,12 @@ _start:                                                                      \
         sw      TESTNUM, 0(t0);                                             \
 1:      j       1b
 
-// `tohost` is a full DOUBLEWORD, 8-byte aligned, and both of those are
-// load-bearing rather than cosmetic (ADR-0039, amending ADR-0008).
-//
-// The riscv-tests HTIF protocol this encoding is borrowed from defines
-// `tohost` as a 64-bit location, and every consumer that speaks HTIF -- the
-// Sail RISC-V model among them -- claims the whole doubleword at the symbol
-// as an IO window the moment it sees the symbol in the ELF. It was a 32-bit
-// `.word` here, so `.data` (every load/store test's TEST_DATA, ADR-0008 puts
-// it immediately after) began four bytes INSIDE that window: the reference
-// model answered every `lw` from RAM_BASE+4 with zero. Eight programs
-// "diverged" for a reason that was entirely this file's fault.
-//
-// Padding it is what makes the co-simulation leg (ADR-0032) able to hand Sail
-// the same ELF the other two legs run, unmodified, and to terminate on the
-// verdict rather than on an instruction budget.
-//
-// Nothing else moves. `tohost` is still the first thing in the RAM region and
-// still the low word at RAM_BASE, so test/cxxrtl.cc's `ram_data[0]`,
-// test/cosim.cc's, and test/testbench.v's RAM decode are all unchanged; the
-// `.data` that follows simply starts four bytes later. RVTEST_PASS/FAIL still
-// write it with a 32-bit `sw` -- this core has no 64-bit store -- and the
-// upper word stays zero, which is what makes the low word alone a faithful
-// read of the riscv-tests encoding on a little-endian machine.
+// `tohost` must stay a full doubleword, 8-byte aligned. HTIF defines it as a
+// 64-bit location, and every consumer that speaks the protocol -- Sail among
+// them -- claims the whole doubleword at the symbol as an IO window as soon as
+// it sees the symbol in the ELF. As a 32-bit `.word` it put the start of `.data`
+// four bytes inside that window, and Sail answered every load from there with
+// zero (ADR-0039, amending ADR-0008).
 #define RVTEST_DATA_BEGIN                                                    \
         .pushsection .tohost,"aw",@progbits;                                \
         .align  3;                                                          \
@@ -142,16 +95,8 @@ tohost:                                                                      \
 
 #define RVTEST_DATA_END
 
-// ---------------------------------------------------------------------------
-// Opt-in trap support (M3). Nothing above this line references any of it, so a
-// test that does not invoke these macros assembles to exactly the bytes it did
-// before they existed. Read the three constraints at the top of this file
-// before writing a trap test.
-// ---------------------------------------------------------------------------
-
-// Where the handler records what it saw. Invoke inside the data section (after
-// RVTEST_DATA_BEGIN) so it lands in RAM, which is the only memory a load can
-// reach on this Harvard core (ADR-0008).
+// Where the handler records what it saw. Invoke it after RVTEST_DATA_BEGIN so
+// it lands in RAM, the only memory a load can reach on this Harvard core.
 #define RVTEST_TRAP_DATA                                                     \
         .align  2;                                                          \
         .global trap_count;                                                 \
@@ -164,23 +109,19 @@ trap_cause:                                                                  \
 trap_epc:                                                                    \
         .word   0;
 
-// The recording handler: bump `trap_count`, store `mcause` and `mepc`, then
-// resume at mepc+4 via `mret`.
+// The recording handler: bump `trap_count`, store `mcause` and `mepc`, resume
+// at mepc+4. The +4 is unconditional (constraint 1 at the top of this file), so
+// the trapping instruction must be uncompressed. Clobbers t0 and t1.
 //
-// +4 is unconditional because the handler cannot look at the faulting
-// instruction to find out whether it was 2 or 4 bytes (constraint 1 at the top
-// of this file) — so the trapping instruction must be uncompressed. Clobbers
-// t0 and t1.
-//
-// Invoke it in .text somewhere control cannot fall into — after TEST_PASSFAIL
-// is the convention, since both of those paths end in an infinite loop.
+// Invoke it in .text somewhere control cannot fall into -- after TEST_PASSFAIL
+// by convention, since both of those paths end in an infinite loop. The
 // `.align 2` satisfies mtvec's 4-byte-aligned WARL base (ADR-0005).
 //
-// The body is `.option norvc` and straight-line, so every instruction in it is
-// exactly 4 bytes and `(trap_handler_end - trap_handler) / 4` is the number of
-// instructions one trap entry retires. A test that reasons about `minstret`
-// across a trap (ADR-0027) should compute that expression rather than hardcode
-// a count, so editing this macro cannot silently invalidate it.
+// The body is `.option norvc` and straight-line, so every instruction is 4
+// bytes and `(trap_handler_end - trap_handler) / 4` is how many instructions
+// one trap entry retires. A test reasoning about `minstret` across a trap
+// should compute that rather than hardcode a count, so editing this macro
+// cannot silently invalidate it.
 #define RVTEST_TRAP_HANDLER                                                  \
         .align  2;                                                          \
 trap_handler:                                                                \
@@ -202,18 +143,17 @@ trap_handler:                                                                \
 trap_handler_end:                                                            \
         .option pop;
 
-// The alternative handler: any trap is a test failure, reported against
-// whatever test number was live when it happened. Terminates from inside the
-// handler, so it is not subject to the uncompressed-instruction constraint.
-// Define at most one of RVTEST_TRAP_HANDLER / RVTEST_TRAP_HANDLER_FATAL per
-// test — they share the `trap_handler` symbol.
+// Any trap is a test failure, reported against whatever test number was live.
+// It terminates from inside the handler, so the uncompressed-instruction
+// constraint does not apply. Use at most one of the two handlers per test --
+// they share the `trap_handler` symbol.
 #define RVTEST_TRAP_HANDLER_FATAL                                            \
         .align  2;                                                          \
 trap_handler:                                                                \
         RVTEST_FAIL
 
-// Point mtvec at the handler. Direct mode: mtvec[1:0] = 0, which the handler's
-// `.align 2` guarantees. Clobbers t0.
+// Point mtvec at the handler, direct mode -- mtvec[1:0] = 0, which the
+// handler's `.align 2` guarantees. Clobbers t0.
 #define RVTEST_INSTALL_TRAP_HANDLER                                          \
         la      t0, trap_handler;                                           \
         csrw    mtvec, t0;


### PR DESCRIPTION
Closes JEF-719 (this run's slice of it — four files; `rtl/` is a sibling's).

Comments only. Every config value, YAML key and line of script is byte-identical
to `main`:

```
$ git diff -U0 origin/main | grep '^[+-]' | grep -v '^[+-][+-]' \
    | grep -vE '^[+-]\s*(#|//)' | grep -vE '^[+-]\s*$' | wc -l
0
```

The default was delete. What survives tells the reader something the code does
not already say, in one or two sentences, or is a tripwire whose removal would
let a defect back in. Banners, history, restatement and emphasis furniture are
gone. `rtl/` is untouched.

## Line-count delta per file

| File | Lines | Comment lines |
|---|---|---|
| `formal/checks.cfg` | 621 → 182 (**-439**) | 578 → 139 (**-439**) |
| `.github/workflows/ci.yml` | 925 → 640 (**-285**) | 517 → 232 (**-285**) |
| `formal/complete.sv` | 298 → 215 (**-83**) | 181 → 98 (**-83**) |
| `test/asm/riscv_test.h` | 221 → 161 (**-60**) | 132 → 73 (**-59**) |

`checks.cfg`'s comment counts include the fourteen `#omit` lines, which are
config rather than commentary; commentary proper goes 564 → 125.

## Stale claims found and corrected, not shortened

Every surviving factual claim in `ci.yml` was re-verified against the file it
describes. Four were wrong:

1. The `test` job's comment named **six** unit benches. `UNIT_BENCHES` has
   **seven** — `imem_tb` was missing. The same comment claimed that step is "the
   only place any iverilog simulation runs on this workflow", which stopped
   being true when `elaborate` gained a graded `vvp` step.
2. The `elaborate` header said "Neither leg runs a single test vector; both just
   prove the design elaborates." Its third step runs `vvp testbench.vvp`, and it
   is graded (ADR-0055).
3. The `fit` job offered `make fit FIT_MAX_LC=4100 -> exit 2` as its probe.
   `FIT_MAX_LC` **is** 4100 now, and the tree measures ~3875 locally, so the
   probe was inert. The ratchet's failure directions are probed hermetically in
   `test/probe_gates.sh` (group 12), and the comment points there instead.
4. `riscv_test.h` said "All 51 riscv-tests-derived `.S` files"; 55 include the
   macro. Counts a human has to maintain by hand were dropped, not re-pinned.

Also: `grep -c continue-on-error .github/workflows/ci.yml` returned **5**, all
of it prose inside comments *discussing* the directive. The real directive count
was and is 0, but CLAUDE.md's claim that the grep returns 0 was false in letter.
It returns **0** now.

## Config that reads like commentary, preserved byte-exact

- `formal/checks.cfg`'s fourteen `#omit` lines. `genchecks` reads them, and
  ADR-0033's rule is that the declined set is *declared*, not described. All
  fourteen are unchanged to the byte, class tag and reason included.
- `formal/complete.sv`'s `// EXCLUDE <CLASS> <opcode> <mnemonics>` headers and
  the reason block under each. `check-complete-exclusions.py` matches the header
  with `DECL_RE`, requires at least 40 characters of contiguous reason beneath
  it, and requires the wire on the very next line.
  `make -C formal complete-exclusions` passes.

## Five before/after pairs

**1. Outright deletion — `ci.yml`, workflow permissions.** The directive says
this; the comment said it again.

```diff
-# Least privilege: nothing in this workflow pushes, comments, or writes
-# back anywhere. Set once at workflow level so no job needs a wider
-# permissions: block of its own.
 permissions:
   contents: read
```

**2. Outright deletion — `checks.cfg`, the `[depth]` timeout column.** Twenty
lines about a column that no longer exists, an engine that was replaced and an
ADR that superseded it. Git has all of it. The one live fact inside — that the
ladder's only budget is the `formal` job's 20 minutes, so a raised depth can
take the hand-authored tasks down with it — is now one sentence at the end of
the section.

```diff
-# `reg` used to carry a fourth column here, a per-check wall-clock `timeout`
-# in seconds, read by a `timeout=` parameter this repo had added to its
-# vendored genchecks copy. Upstream genchecks has no such parameter, and
-# re-vendoring from the pin (ADR-0013 -- the pin is current; it was the fork
-# that was stale) dropped it. That is deliberate and the column is gone:
-# ADR-0022 added the bound because `reg_ch0` under `smtbmc yices` would sit
-# in the solver until the then-nightly's `timeout-minutes: 300` killed the
-# *whole job*, and ADR-0024 then replaced that engine with `btor btormc`,
-# under which the same check at the same depth converges in ~8-12s. The
-# condition the bound existed for no longer holds. THE BACKSTOP IS NOW MUCH
-# TIGHTER AND IS WORTH KNOWING BEFORE RAISING A DEPTH: there is no nightly
-# (ADR-0050), and the ladder's only job-level bound is the required `formal`
-# job's `timeout-minutes: 20` in `.github/workflows/ci.yml` -- against a
-# whole-job measurement of 4m22s. A non-converging check burns the whole
-# remaining budget and takes the four hand-authored tasks down with it. If a
-# check ever needs a real
-# per-check bound again, sby's `[options] timeout` is the place, and getting
-# genchecks to emit it means forking genchecks again -- which is the cost
-# this re-vendor was paying down, so weigh it accordingly.
```

**3. `checks.cfg` — the `#omit` block's preamble, ~130 lines → 20.** Before, in
part (the full block ran a five-item numbered reason list, then a paragraph
counting the two classes, then a paragraph re-sorting eleven of them by blocker,
then three struck entries kept as markers):

```
# COUNTING THE TWO CLASSES, so the split is not left to be inferred: of the
# fourteen lines below, ELEVEN are [BLOCKED] -- fault_ch0, all nine bus_*,
# and causal_io_ch0. THREE are [DESIGN] and no hardware reopens them: the
# two csrc_inc_* (reason 3) and `cover` (reason 4). The fourteen is derived
# -- formal/genchecks-audit.py prints it and set-equalities it both ways --
# so re-derive it after a pin bump rather than trusting this paragraph.
#
# THE ELEVEN DO NOT ALL TURN ON THE SAME DECISION, and reading them as one
# group is the mistake this paragraph exists to prevent. Sorted by blocker:
```

After — the two tags, and the one thing the `#omit` lines themselves cannot
carry:

```
#   [BLOCKED]  the property is wanted and there is no hardware here to state it
#              about -- a burn-down owned by the memory-system ADR (ADR-0044,
#              which tabulates all eleven).
#   [DESIGN]   declined on the merits; no hardware change reopens it.
#
# The tag is free-form to the audit script, which captures only the check name.
#
# fault_ch0 and the four *_fault forms are the five that put invariant 2 in
# question: a bus fault is raised by the memory, i.e. after decode, and
# invariant 2 says every trap is committed in decode. The two coexist today only
# because no access fault is reachable on this core. ADR-0044 records the
# options and deliberately picks none, so do not read these lines as that
# ruling having been made.
```

The counts go because `genchecks-audit.py` derives them and set-equalities them
both ways, which the deleted text said about itself.

**4. `test/asm/riscv_test.h` — the `RVTEST_DATA_BEGIN` block, 23 lines → 6.**
Before:

```
// `tohost` is a full DOUBLEWORD, 8-byte aligned, and both of those are
// load-bearing rather than cosmetic (ADR-0039, amending ADR-0008).
// ... [HTIF paragraph] ...
// Eight programs "diverged" for a reason that was entirely this file's fault.
// ... [what the padding buys the co-sim leg] ...
// Nothing else moves. `tohost` is still the first thing in the RAM region and
// still the low word at RAM_BASE, so test/cxxrtl.cc's `ram_data[0]`, ...
```

After — the tripwire kept, the story dropped:

```
// `tohost` must stay a full doubleword, 8-byte aligned. HTIF defines it as a
// 64-bit location, and every consumer that speaks the protocol -- Sail among
// them -- claims the whole doubleword at the symbol as an IO window as soon as
// it sees the symbol in the ELF. As a 32-bit `.word` it put the start of `.data`
// four bytes inside that window, and Sail answered every load from there with
// zero (ADR-0039, amending ADR-0008).
```

**5. `ci.yml` — "no pipe on the graded command", stated four times in full, now
once.** Before: four separate steps, each spending ~8 lines re-deriving
`bash -e {0}` from scratch. After, one full statement at the `fit` step and
three one-line pointers to it:

```
        # Never pipe a graded command in a `run:` block. Without an explicit
        # `shell:` key the step is `bash -e {0}` -- errexit but not pipefail --
        # so `cmd | tee` takes its status from `tee` and always succeeds. This
        # repo shipped exactly that once (ADR-0037). Redirect, take the status
        # off the unpiped command, then publish. The same pattern below in
        # `soc-timing`, `nonperturbation` and the `formal` gate is this rule.
```

```
        # Redirected rather than piped -- see the `fit` job's step for why.
```

The `formal` gate step keeps one extra sentence, because its demonstration is
specific to it: with the pipe in place, a deliberately wrong
`formal/EXPECTED_FAIL` printed "Failure list does NOT match" and the job still
reported success.

## Tripwires dropped

**None.** Every warning whose deletion could let a defect back in was kept, in
one or two sentences. Specifically retained: `[depth]` is the list of checks
that exist, not a tuning table; the `inc` spelling in `[csrs]` is what makes
`genchecks` consider-and-drop, so deleting it turns the decline into prose;
adding a WARL or read-only-zero CSR to `[csrs]` fails on a correct core; a depth
below its floor goes green having stopped asking, with the `rs2[4:0]` probe;
`insn 15` and `reg 15 20` clear their floor by one cycle, so re-measure F and G
before adding a stall reason; do not spell `ci.yml`'s source list out again;
`complete.sv`'s exclusion predicates must key on the encoding, never on a
decoder flag; `complete.sv`'s dmem assumption is discharged nowhere, so do not
invent a discharge; a trapping instruction in a resuming test must be
uncompressed; `tohost` must stay an aligned doubleword.

Three claims were *narrowed* rather than dropped, because the wider version was
unverifiable prose. The `insn_add_ch0` RSS figure survives as "around 876 MiB"
where it drives `JOBS` and goes where it was only narrating. The cell-count
history (4236 → 4208 → 4187) is replaced by the fact that actually binds: two
yosys builds sit ~21 cells apart on identical RTL. And CI's required-job list is
now only the live `gh api` command, since the enumeration written into the file
had already gone stale twice.

## Gates, all run on this branch

| Gate | Result |
|---|---|
| `make -C formal check JOBS=4` | **85 checks: 85 pass, 0 fail.** Failure list matches `EXPECTED_FAIL` exactly (name and status); generated set matches `EXPECTED_CHECKS` exactly (85 checks) |
| `make test` | **56/56 passed**, failure list matches `test/EXPECTED_FAIL` exactly |
| `make test-units` | seven benches, all pass (prerequisite of `make test`) |
| `make probe-gates` | pass (prerequisite of `make test`) |
| `make lint` | svlint clean in both passes |
| `make -C formal complete-exclusions` | PASS, 2 entries, both directions |
| `yaml.safe_load(ci.yml)` | parses |
| `grep -c continue-on-error ci.yml` | **0** (was 5, all of it prose) |

The ladder generating the identical 85 checks is the load-bearing result:
`checks.cfg` lost 439 lines and both set equalities still match in both
directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
