### PR TITLE
JEF-737: the fetch loop is not two levels too deep — a measured null

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -254,7 +254,8 @@ now carries `make fit`'s table-presence check and ratchet, and `soc/cell_census.
 Makefile so there is one copy of the logic. `check-unit-benches` needed no extraction: its three
 branches are probed by invoking the real target against the real `test/*_tb.v` tree with
 `UNIT_BENCHES`/`UNIT_BENCH_SRC_*` overridden on the command line, which is what its own comment
-already commits to being possible. `test/probe_gates.sh` is **122** probes now, up from 108.
+already commits to being possible. `test/probe_gates.sh` is **125** probes now, up from 108
+(ADR-0058 added three for `soc/timing_split.py`'s LUT-versus-carry depth split).
 **`make soc-timing` joins CI in the `soc-timing` job**, mirroring `fit`: non-required, for the same
 reason (ADR-0036) — it publishes the census and the logic/routing split to the step summary whether
 it passes or fails. It is the first job needing both the RISC-V cross compiler and the OSS CAD
@@ -768,7 +769,7 @@ make test           # assemble test/asm/*.S, run under cxxrtl, pass/fail table w
                     # both ways before a single program is assembled -- so a suite
                     # that SHRANK is red, not a smaller table that still "passes".
                     # Also runs `make probe-gates` (ADR-0053).
-make probe-gates    # forces all 122 graded comparisons in the grading scripts to
+make probe-gates    # forces all 125 graded comparisons in the grading scripts to
                     # FAIL and requires each to fail for its own reason. Hermetic
                     # (stubs, no toolchain); a prerequisite of `test` on purpose,
                     # so it is in CI's required job. All fork, no work: ~68-90s of
@@ -806,6 +807,8 @@ make soc-timing     # THE SoC PLACE-AND-TIME FLOW (ADR-0054), and NOT `make fit`
                     # 20/30 EBR, 2/4 SPRAM, 8/8 GB; 88.51 ns = 11.30 MHz,
                     # 38.7% logic / 61.3% routing, over
                     # imem.in_range -> decode -> next PC -> imem.in_range2.
+                    # THE 41 LEVELS ARE 25 LUT + 17 CARRY, at 3.31 ns and
+                    # 0.34 ns each; read them apart (ADR-0058).
                     # DOES NOT MEET ADR-0038's DECLARED 12 MHz, and that intent
                     # is unchanged. Ratchets on SOC_MIN_MHZ (10.0 -- this line
                     # said 10.5 and the Makefile never did; ADR-0057), a
@@ -817,7 +820,9 @@ make soc-timing     # THE SoC PLACE-AND-TIME FLOW (ADR-0054), and NOT `make fit`
                     # constraints, not correctness ones, ADR-0036). The
                     # census (soc/cell_census.py) and the ratchet
                     # (soc/timing_split.py) are both probed hermetically in
-                    # test/probe_gates.sh. `SOC_PROG=lw.S` picks the program.
+                    # test/probe_gates.sh. `SOC_PROG=lw.S` picks the program,
+                    # `SOC_SEED=3` places it differently -- one placement is a
+                    # sample, and main's own spread is 1.2% (ADR-0058).
                     # Probe: `make soc-timing SOC_MIN_MHZ=99` exits 1.
 
 make -C formal components_decoder   # component proofs. THREE tasks, all with real assertions:
@@ -1137,6 +1142,27 @@ longer quietly widen.
   `rtl/regfile.v` placed alone at 86% routing (ADR-0038): the whole SoC is still routing-dominated,
   just less extremely than an isolated 32:1 mux. **ADR-0038's declared 12 MHz is an intent and this
   measurement does not move it**; the design misses it by 6%.
+- **Those 41 logic levels are 25 LUT levels and 17 carry hops, and quoting the single number is how
+  this repo talked itself into a sprint** (ADR-0058). A LUT level costs **3.31 ns** — its own delay
+  plus the `LocalMux` + `InMux` into it — and a `carryin -> carryout` hop costs **0.34 ns** and no
+  interconnect at all. Per-level interconnect is paid about 23 times, not 41, and a change that
+  trades a carry hop for a LUT level gets shallower by icetime's count and slower in nanoseconds.
+  `make soc-timing` prints both counts and both per-hop costs now.
+- **The fetch loop is not uniquely critical: a second path sits within 1.7% of it** (ADR-0058).
+  Decode → `stall` → `instret` → `minstret`'s 64-bit counter measures 87.04 ns against the loop's
+  88.51, and the baseline already reaches 87.43 at one of its four placements. **So any change that
+  shortens only the fetch loop is capped at about 11.5 MHz and cannot clear the churn bands.** Two
+  restructurings were built and measured against this: computing the ROM's range flag in parallel
+  with the `next_pc` mux (measured at its ceiling, with the comparator deleted outright — 1.8%
+  *slower*, four placements, no overlap) and flattening the `next_pc` priority chain into a one-hot
+  mux (inside the noise at best, 6% worse at worst, because a wide flat mux routes worse than a
+  chain on a path that is 61% interconnect). Sharing the JALR target with the effective-address
+  adder costs 5–7%, and muxing the addends instead of the sums costs 4–6% — a LUT in front of an
+  adder puts a whole carry chain after it. **The lever is the decode head** (`imem.in_range → instr
+  → {rs1/rs2, immediate, hazard}`), which every one of these paths shares.
+- **`SOC_SEED=<n>` places the same netlist differently**, because one placement is a sample. The
+  spread on unmodified `main` is 87.43–88.51 ns across four placements (1.2%), and ADR-0057 measured
+  1–2% generally. Compare distributions.
 - **`make soc-timing` has a churn axis of about 3.6%, three times `make fit`'s, and it is measured.**
   Two logically identical spellings of `rtl/memory.v`'s write/read arms — a module **not on the
   critical path** — give **88.51 ns / 41 logic levels** and **91.67 ns / 53**, on 11 logic cells'

--- a/Makefile
+++ b/Makefile
@@ -847,9 +847,17 @@ soc.json: $(SOC_SRCS) soc-rom
 #
 # `.DELETE_ON_ERROR` at the top of this file is why the `||` matters: without
 # tolerating the status, make deletes the `.asc` nextpnr just wrote.
+#
+# `SOC_SEED=<n>` places the same netlist differently. One placement of one build
+# is a sample, not a measurement: ADR-0057 measured the spread across four
+# placements at 1-2% for this design and ADR-0058 saw 87.43 to 88.51 ns on
+# unmodified `main`, which is wider than several changes worth arguing about.
+# Compare distributions, not single runs.
+SOC_SEED ?=
+
 soc.asc: soc.json soc/littlesoc.pcf
 	@echo 'nextpnr: placing and routing littlesoc on up5k/sg48 (log: soc.pnr.log)'
-	@nextpnr-ice40 --up5k --package sg48 --json $< --pcf soc/littlesoc.pcf \
+	@nextpnr-ice40 --up5k --package sg48 --json $< --pcf soc/littlesoc.pcf $(if $(SOC_SEED),--seed '$(SOC_SEED)') \
 	  --asc $@ > soc.pnr.log 2>&1 || true
 	@test -s $@ || { \
 	  echo '*** make soc-timing: nextpnr produced no bitstream, so NOTHING was'; \

--- a/docs/adr/0058-the-fetch-loop-is-not-two-levels-too-deep.md
+++ b/docs/adr/0058-the-fetch-loop-is-not-two-levels-too-deep.md
@@ -1,0 +1,173 @@
+# ADR-0058: The fetch loop is not two levels too deep
+
+**Status:** Accepted · 2026-08-02 · *A measured null. Two restructurings of the fetch loop were
+proposed against
+[ADR-0054](0054-the-memory-system-and-the-first-real-timing-number.md)'s 11.30 MHz measurement and
+[ADR-0057](0057-what-writable-text-costs-in-ladder-depth-and-in-nanoseconds.md)'s finding that
+writable text costs a further 8.5%. Both were built and measured; both are slower than what is
+checked in. Corrects how ADR-0054's "41 logic levels" should be read.*
+
+## What was proposed, and what it rested on
+
+ADR-0054 named the critical path `imem.in_range → decode → next PC → imem.in_range2` and reported
+88.51 ns over **41 logic levels**, 38.7% logic and 61.3% routing, with `LocalMux` + `InMux` at
+41.2 ns of the 54.3 ns of routing and all distance routing (the `Span4Mux` family) at 5.5 ns. The
+reading taken from that was: the cost is depth, per-level interconnect is paid 41 times, and so
+floorplanning cannot help but fewer levels can. Two candidates followed.
+
+1. **Compute the ROM's range flag in parallel with the `next_pc` mux** instead of after it, so the
+   comparator stops hanging off the tail of whichever adder wins. Carry-select in shape.
+2. **Flatten the `next_pc` priority chain.** Eight arms in priority order is eight levels; a flat
+   mux with a one-hot select computed in parallel is about two.
+
+Neither needs a flush or a forwarding network — both are re-expressions of logic that already
+exists — so neither is blocked by an invariant. They are blocked by the measurements below.
+
+## The premise is wrong: 41 levels are not 41 interconnect hops
+
+The 41 levels are **25 LUT/setup hops and 17 carry hops**, and the two cost an order of magnitude
+apart. A `carryin -> carryout` hop stays inside the carry chain and is entered through no
+interconnect at all; every other LogicCell40 hop arrives through a `LocalMux` and an `InMux`. On the
+baseline path:
+
+| hop kind | count | ns each |
+|---|---|---|
+| LUT level, with the interconnect into it | 25 | **3.31** |
+| carry hop | 17 | **0.34** |
+
+`LocalMux` x23 and `InMux` x24 in the report say the same thing directly: per-level interconnect is
+paid about 23 times, not 41. **Every conclusion below follows from that one number.** A change that
+trades a carry hop for a LUT level makes the design shallower by icetime's count and slower in
+nanoseconds, and both candidates are that trade.
+
+`soc/timing_split.py` prints the two counts and the two per-hop costs now, so the misreading cannot
+be taken from `make soc-timing`'s own output again.
+
+## Method
+
+`make soc-timing` with `SOC_PROG=add.S`, four placements per variant (the default plus
+`nextpnr-ice40 --seed 1/2/3`), which is ADR-0057's method. **Homebrew Yosys 0.67+post
+(`b8e7da6f`)**, nextpnr-0.10-108-g68c1acd8, icetime from the same install; machine load 8–15
+throughout, on 10 cores. nextpnr is seeded, so every figure is reproducible run to run; load moves
+wall time and not the numbers.
+
+**The baseline reproduces ADR-0057's four placements exactly** — 87.43 · 87.55 · 87.94 · 88.51 ns
+at 4041 logic cells — so the rows below are a comparison rather than four measurements from
+different worlds.
+
+`SOC_SEED` was added to the Makefile in this change, because a placement spread is now something two
+ADRs have needed and neither could take with the tracked flow.
+
+## The measurements
+
+| variant | LC | icetime ns, four placements | MHz |
+|---|---|---|---|
+| baseline (`main`) | 4041 | 87.43 · 87.55 · 87.94 · 88.51 | 11.30 – 11.44 |
+| candidate 1, **at its ceiling** | 3978 | 88.98 · 89.32 · 89.39 · 89.41 | 11.18 – 11.24 |
+| candidate 2, flat one-hot mux | 4059 | 87.43 · 90.03 · 92.24 · 94.10 | 10.63 – 11.44 |
+| both together | 3990 | 84.44 · 86.30 · 87.55 · 89.00 | 11.24 – 11.84 |
+
+- **Candidate 1 is a regression, and it was not even implemented — its ceiling was.** Rather than
+  replicate the comparator per source, the flags were forced high, which deletes the range check
+  entirely. No implementation can beat that, and it measures 88.98–89.41 against 87.43–88.51: four
+  placements, no overlap with the baseline, **1.8% slower at the median**. The loop re-terminates at
+  the ROM's data register (`imem.even_data`) instead of its range flag, and that ending is longer
+  than the comparator's carry chain was. The 17 carry hops the ceiling deletes were worth 5.8 ns of
+  88.51.
+- **Candidate 2 is inside the noise at best and 6% worse at worst.** Its spread straddles the
+  baseline's and is three times as wide. At seed 3 it does what it was supposed to do — the critical
+  path leaves the fetch loop — and the design measures 87.43 ns, which is the number the baseline
+  already reaches at its own best placement.
+- **Together they are 0.9% faster at the median, on distributions that overlap heavily** (84.44–89.00
+  against 87.43–88.51). That is inside the 1–2% placement band before ADR-0054's 3.6% edit band is
+  considered, and the row contains candidate 1's ceiling rather than candidate 1 — so the number
+  describes a design that cannot ship and is not evidence of anything even so.
+
+Area: candidate 2 costs 18 cells and candidate 1's ceiling *saves* 63, both against ADR-0038's ±50
+churn floor, so only the second is outside it and only because it is a deletion. `make fit` is
+unchanged and was not re-run for candidate 1: its top is `littlecpu` with the memories external
+(ADR-0038 decision 1), and `rtl/imemory.v` is not in `FIT_SRCS` at all — a candidate-1 change is
+invisible to that number by construction.
+
+## Why candidate 2 cannot win, whatever it is spelled like
+
+Four spellings were built and each measured at two placements. The flat mux is the one the proposal
+names, so it is the one that went on to four placements in the table above:
+
+| spelling | ns (two placements) | against baseline |
+|---|---|---|
+| hold/issue split, priority arms kept, three adders | 88.76 · 86.04 | neutral |
+| the same split, plus `(* parallel_case *)` — a flat one-hot mux | 94.10 · 90.03 | **+4%** |
+| the same split, with the JALR target sharing the effective-address adder | 92.96 · 94.45 | **+6%** |
+| one adder, addends muxed instead of sums | 93.79 · 91.18 | **+4%** |
+
+Three separate mechanisms, all the same shape:
+
+- **A flat one-hot mux routes worse than a priority chain here.** Routing went 54.49 → 59.73 ns while
+  logic stayed flat. Six 32-bit sources fanning into a wide OR is more interconnect than a chain abc
+  already maps well, and interconnect is 61% of this path.
+- **Sharing an adder puts an unrelated cone in series.** Writing the JALR target as
+  `mem_addr_calc & ~1` — the same sum a load or a store computes, and the same hardware — costs 5–7%.
+  yosys was not sharing them, and making it share puts the load/store address logic on the fetch
+  loop. The RTL reads better and the design is measurably worse.
+- **Muxing the addends instead of the sums is the wrong way round on this fabric.** A LUT in front of
+  a 32-bit adder puts a whole carry chain *after* that LUT; three parallel adders let three chains
+  run while decode settles and pay LUT levels only at the mux. The textbook advice assumes a
+  balanced-tree adder, and this part does not have one.
+
+The checked-in structure is already the one this fabric wants, and it is a coincidence of the
+ADR-0054 refactor rather than something anybody tuned.
+
+## The cap, which is the part worth keeping
+
+**The fetch loop is not uniquely critical. There is a second path within 1.7% of it.** Deleting the
+stall term from `next_pc` — throwaway RTL, function-breaking — gives 87.04 ns with the critical path
+on `por_done → riscv.csrs.minstret[56]`: decode → `stall` → `instret` → the 64-bit counter's carry
+chain. Candidate 2 at seed 3 lands on the same path at 87.43 ns.
+
+So **any change that shortens only the fetch loop is capped at about 87 ns / 11.5 MHz**, and the
+baseline already reaches 87.43 at one of its four placements. A 1.7% ceiling is half the edit band;
+there is no way to demonstrate such a change even if it works.
+
+Removing the redirect mux entirely — the other throwaway ceiling — gives 77.02 · 78.15 ns, and its
+critical path is `pc → riscv.csrs.mscratch[7]`. That 12% is real but it is **not the mux's depth**:
+what leaves the loop with the mux is `immediate`, `stall` and `trap_pending`, the whole decode cone
+between the fetched instruction and the adders. Those three feed the second and third paths too,
+which is why they cluster.
+
+**The head is shared and the tails are not.** Shortening a tail uncovers the next path; the only
+change that moves this design's Fmax is one that shortens `imem.in_range → instr → {rs1/rs2,
+immediate, hazard}`, and none of that is in either candidate.
+
+## Decision
+
+**No RTL change.** Both candidates are declined on measurement, not on judgement, and the
+alternative spellings are declined with them.
+
+**Nothing in `rtl/` or `formal/` ships from this ADR.** The scratch variants live in this pull
+request's history. What ships is the tables above, the corrected depth reporting in
+`soc/timing_split.py` with its probes, and `SOC_SEED`.
+
+The readability question the ticket raised is answered the same way: the flat mux does not read
+better than what is there. The hold/issue split — reset and stall as machine overrides, the five
+instruction redirects below them — is arguable and was built; it is a wash on reading and a wash on
+timing, so it is not worth the diff. ADR-0054's chain says the priority order plainly and the order
+is the thing a reader needs.
+
+## Consequences
+
+- **ADR-0054's "41 logic levels" should be quoted as 25 LUT levels and 17 carry hops.** The
+  measurement is unchanged; the reading is corrected, and `make soc-timing` prints both numbers now.
+- **The next attempt at this should target the decode head, not the fetch loop's tail**, and should
+  expect to fix two paths rather than one. `immediate`'s eighteen-way mux and the `rs1`/`rs2`
+  selection feeding `hazard` are where the LUT levels are; both are on more than one near-critical
+  path.
+- **A single `make soc-timing` run is not a measurement.** `SOC_SEED` exists so a spread can be taken
+  with the tracked flow; ADR-0057 needed one and ADR-0054's churn figure is a different axis again.
+  A delta has to clear the placement band (1–2%) and the edit band (3.6%), and this design's own
+  baseline spans 1.2% across four placements.
+- **ADR-0038's 12 MHz intent is untouched.** Nothing here moves the measurement in either direction,
+  and ADR-0057 condition 3's question — what to do about the intent when writable text takes the
+  design to about 15% short — is still open and still belongs to the change that lands it.
+- ADR-0057's own attribution stands and this ADR agrees with it in shape: the expensive things on
+  this part are interconnect and cones, not gate counts or level counts.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -62,6 +62,7 @@ and what it costs. Reversing one is fine — write a new ADR that supersedes it.
 | [0055](0055-the-iverilog-leg-is-graded-in-ci-without-the-multi-program-runner.md) | The iverilog leg is graded in CI, without the multi-program runner | Accepted · closes part of the `make waves` bullet in CLAUDE.md's "what does not work" |
 | [0056](0056-the-makefile-embedded-ratchets-get-probes-and-soc-timing-gets-a-job.md) | The Makefile-embedded ratchets get probes, and `soc-timing` gets a job | Accepted · extends 0053, follows 0052 |
 | [0057](0057-what-writable-text-costs-in-ladder-depth-and-in-nanoseconds.md) | What writable text costs, in ladder depth and in nanoseconds | Accepted · re-runs 0046's derivation and 0054's timing; corrects 0054's `SOC_MIN_MHZ` |
+| [0058](0058-the-fetch-loop-is-not-two-levels-too-deep.md) | The fetch loop is not two levels too deep | Accepted · a measured null; corrects how 0054's logic-level count reads |
 
 0001–0007 came from the design brief
 ([`docs/ideas/finish-the-rewrite.md`](../ideas/finish-the-rewrite.md)). 0008–0011 came out of

--- a/soc/timing_split.py
+++ b/soc/timing_split.py
@@ -17,6 +17,14 @@ Also prints the path's start point, its end point and its logic depth, because
 "the critical path is named, not just timed" is the difference between a number
 you can act on and one you can only quote.
 
+THE DEPTH IS PRINTED AS TWO NUMBERS, because icetime's single one is not a cost.
+A `carryin -> carryout` hop stays inside the carry chain and needs no
+interconnect at all; every other LogicCell40 hop is entered through a LocalMux
+and an InMux. On the SoC's own critical path that is 0.34 ns against 3.31 --
+roughly tenfold -- so a design that trades a carry hop for a LUT level gets
+shorter by icetime's count and slower in nanoseconds. Read the two apart before
+deciding a path is deep (ADR-0058).
+
 `--min-mhz` grades the result. The check lives HERE rather than in the Makefile
 because this is the thing that already parses the report: a second parser --
 which is what the first version of `make soc-timing` had, as a `python3 -c` -- is
@@ -32,8 +40,15 @@ import sys
 # A LUT or flip-flop evaluating. Everything else icetime lists is interconnect.
 LOGIC_CELLS = {"LogicCell40"}
 
-# `<indent><instance> (<CellType>) [something]: <t> ns`
-HOP = re.compile(r"^\s+(\S+) \((\w+)\)[^:]*: ([0-9.]+) ns")
+# A hop that stays inside the carry chain: `carryin -> carryout`. The chain's
+# entry hop (`in2 -> carryout`) is driven by an ordinary LUT input and counts
+# with the LUT levels, which is what makes this the interconnect-free set.
+CARRY_HOP = "carryin -> carryout"
+# The interconnect that belongs to the carry chain rather than to a LUT level.
+CARRY_ROUTING = {"ICE_CARRY_IN_MUX"}
+
+# `<indent><instance> (<CellType>)<description>: <t> ns`
+HOP = re.compile(r"^\s+(\S+) \((\w+)\)([^:]*): ([0-9.]+) ns")
 # The named nets between hops: `<cumulative> ns <net> (<name>)`
 NET = re.compile(r"^\s+[0-9.]+ ns \S+ \((.+)\)\s*$")
 # The last line of the path listing: `              lcout -> <endpoint>`
@@ -56,6 +71,9 @@ def main():
 
     logic = 0.0
     routing = 0.0
+    carry_ns = 0.0
+    carry_hops = 0
+    lut_hops = 0
     per_cell = collections.defaultdict(float)
     counts = collections.Counter()
     # The first named net on the path is the readable name for where it starts:
@@ -69,13 +87,20 @@ def main():
     for line in open(args.report):
         hop = HOP.match(line)
         if hop:
-            kind, delay = hop.group(2), float(hop.group(3))
+            kind, what, delay = hop.group(2), hop.group(3).strip(), float(hop.group(4))
             counts[kind] += 1
             per_cell[kind] += delay
             if kind in LOGIC_CELLS:
                 logic += delay
+                if what == CARRY_HOP:
+                    carry_hops += 1
+                    carry_ns += delay
+                else:
+                    lut_hops += 1
             else:
                 routing += delay
+                if kind in CARRY_ROUTING:
+                    carry_ns += delay
             continue
         net = NET.match(line)
         if net and start_point is None:
@@ -114,7 +139,10 @@ def main():
     print(f"critical path : {reported_total:.2f} ns  ({1000 / reported_total:.2f} MHz)")
     print(f"  logic       : {logic:6.2f} ns  {100 * logic / walked:4.1f}%")
     print(f"  routing     : {routing:6.2f} ns  {100 * routing / walked:4.1f}%")
-    print(f"  logic levels: {levels}")
+    print(f"  logic levels: {levels} by icetime; {lut_hops} LUT/setup + {carry_hops} carry by hop")
+    per_lut = (walked - carry_ns) / lut_hops if lut_hops else 0.0
+    per_carry = carry_ns / carry_hops if carry_hops else 0.0
+    print(f"  per level   : {per_lut:.2f} ns per LUT level, {per_carry:.2f} ns per carry hop")
     print(f"  start       : {start_point}")
     print(f"  end         : {end_point}")
     print()

--- a/test/probe_gates.sh
+++ b/test/probe_gates.sh
@@ -73,7 +73,7 @@ REPO=$(cd "$HERE/.." && pwd)
 # reason test/exec_tb.v pins its vector count: a probe that is deleted, or that
 # stops being reached by an early `return`, would otherwise reduce the coverage
 # of this file while it kept printing a green summary.
-PROBES_EXPECTED=122
+PROBES_EXPECTED=125
 
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/littlecpu-probe.XXXXXX") || {
   echo "error: could not create a temporary directory under ${TMPDIR:-/tmp}." >&2
@@ -1015,6 +1015,43 @@ d=$(ts_fixture)
 sed -i.bak 's/^Total path delay: 1.50 ns/Total path delay: 5.00 ns/' "$d/report.rpt"
 probe "a hop sum that does not reconcile blames the script, not the design" 1 \
   "summed hops come to" "$TS $d/report.rpt --min-mhz 10.0"
+
+# A carry hop needs no interconnect and a LUT level does, so one costs about a
+# tenth of the other and the two must not be added up (ADR-0058).
+ts_carry_fixture() {
+  local d; d=$(new_case)
+  cat > "$d/report.rpt" <<'RPT'
+ lut1 (LogicCell40) in0 -> lcout: 1.00 ns
+   1.00 ns netA (start_point)
+ cin1 (ICE_CARRY_IN_MUX) carryinitin -> carryinitout: 0.50 ns
+ c1 (LogicCell40) carryin -> carryout: 0.25 ns
+   1.75 ns netB (mid_point)
+              lcout -> end_point
+Total path delay: 1.75 ns
+Total number of logic levels: 2
+RPT
+  printf '%s' "$d"
+}
+
+d=$(ts_carry_fixture)
+probe "a carry hop is counted apart from a LUT level" 0 \
+  "1 LUT/setup + 1 carry" "$TS $d/report.rpt"
+
+d=$(ts_carry_fixture)
+probe "the carry chain's own interconnect is charged to the carry hop" 0 \
+  "1.00 ns per LUT level, 0.75 ns per carry hop" "$TS $d/report.rpt"
+
+d=$(new_case)
+cat > "$d/report.rpt" <<'RPT'
+ cin1 (ICE_CARRY_IN_MUX) carryinitin -> carryinitout: 0.50 ns
+ c1 (LogicCell40) carryin -> carryout: 0.25 ns
+   0.75 ns netA (start_point)
+              lcout -> end_point
+Total path delay: 0.75 ns
+Total number of logic levels: 1
+RPT
+probe "a path with no LUT level at all reports zero rather than dividing by it" 0 \
+  "0.00 ns per LUT level" "$TS $d/report.rpt"
 
 # ===========================================================================
 # 10. soc/cell_census.py -- make soc-timing's SPRAM/EBR census.


### PR DESCRIPTION
Closes JEF-737.

Both candidates were built and measured. Both are slower than what is checked in, so **no `rtl/` file changes**. ADR-0058 carries the tables; this is the summary.

## The premise did not survive the first measurement

ADR-0054's **41 logic levels** are **25 LUT levels and 17 carry hops**, and they do not cost the same:

| hop kind | count | ns each |
|---|---|---|
| LUT level, with the `LocalMux` + `InMux` into it | 25 | **3.31** |
| `carryin -> carryout` | 17 | **0.34** |

`LocalMux` x23 and `InMux` x24 say it directly: per-level interconnect is paid about **23** times, not 41. Both candidates trade carry hops for LUT levels, which is the wrong direction here by roughly tenfold.

## Measurements

Four placements per variant (default plus `--seed 1/2/3`), ADR-0057's method. **Homebrew Yosys 0.67+post (`b8e7da6f`)**, nextpnr-0.10-108-g68c1acd8, icetime from the same install; machine load **8–20 on 10 cores** with two sibling agents running. nextpnr is seeded, so load moves wall time and not the numbers. The baseline reproduces ADR-0057's four placements exactly, so these are a comparison rather than a fresh world.

| variant | LC | icetime ns, four placements | MHz |
|---|---|---|---|
| baseline (`main`) | 4041 | 87.43 · 87.55 · 87.94 · 88.51 | 11.30 – 11.44 |
| **candidate 1**, at its ceiling | 3978 | 88.98 · 89.32 · 89.39 · 89.41 | 11.18 – 11.24 |
| **candidate 2**, flat one-hot mux | 4059 | 87.43 · 90.03 · 92.24 · 94.10 | 10.63 – 11.44 |
| both together | 3990 | 84.44 · 86.30 · 87.55 · 89.00 | 11.24 – 11.84 |

- **Candidate 1 was measured at its ceiling** — the range flags forced high, deleting the comparator outright rather than replicating it per source. No implementation can beat that, and it is **1.8% slower at the median with no overlap across four placements**. The loop re-terminates at the ROM's data register instead of its range flag, and that ending is longer than the carry chain was. The 17 carry hops it deletes were worth 5.8 ns of 88.51.
- **Candidate 2 is inside the noise at best and 6% worse at worst.** At seed 3 it does what it was meant to — the critical path leaves the fetch loop — and the design measures 87.43 ns, which is the number the baseline already reaches at its own best placement.
- **Together: 0.9% faster at the median on heavily overlapping distributions**, inside the 1–2% placement band before ADR-0054's 3.6% edit band. That row also contains candidate 1's ceiling rather than candidate 1, so it describes a design that cannot ship.

Two further spellings of candidate 2, two placements each: sharing the JALR target with the effective-address adder is **+6%** (yosys was not sharing them; making it share puts the load/store address cone on the fetch loop), and muxing the addends instead of the sums is **+4%** (a LUT in front of a 32-bit adder puts a whole carry chain after it).

**Area.** Candidate 2 costs 18 cells and candidate 1's ceiling saves 63, against ADR-0038's ±50 floor. `make fit` is unchanged at **3875 / 4100** and was not re-run for candidate 1 — `rtl/imemory.v` is not in `FIT_SRCS`, so that change is invisible to it by construction.

## The finding worth keeping: there is a cap

Deleting the stall term from `next_pc` (throwaway RTL) gives **87.04 ns** with the critical path on `por_done → riscv.csrs.minstret[56]` — decode → `stall` → `instret` → the 64-bit counter. Candidate 2 at seed 3 lands on that same path.

**So any change that shortens only the fetch loop is capped at about 87 ns / 11.5 MHz**, and the baseline already reaches 87.43 at one of its four placements. A 1.7% ceiling is half the edit band; such a change could not be demonstrated even if it worked. The lever is the decode head — `imem.in_range → instr → {rs1/rs2, immediate, hazard}` — which every one of these paths shares.

## Readability

Asked directly, since the ticket made it the deciding question: **the flat mux does not read better than what is there, and I would not ship it even if it were free.** The hold/issue split (reset and stall as machine overrides, the five instruction redirects below them) is arguable and was built; it is a wash on reading and a wash on timing, so it is not worth the diff. ADR-0054's chain states the priority order plainly and the order is what a reader needs.

## What ships

- `docs/adr/0058-…` — the tables, the attribution, the cap.
- `soc/timing_split.py` — prints the two depth counts and the two per-hop costs, so `make soc-timing`'s own output cannot produce this misreading again. Three probes in `test/probe_gates.sh` (122 → **125**), including the divide-by-zero direction.
- `Makefile` — `SOC_SEED=<n>`, because two ADRs have now needed a placement spread and neither could take one with the tracked flow.

## Gates

| gate | result |
|---|---|
| `make -C formal check JOBS=4` | **85 checks, 85 pass**, both set equalities exact |
| `components_decoder` / `_executor` / `_pcloop` | PASS by k-induction |
| `make test` | **56/56**, `test/EXPECTED_FAIL` empty |
| `make test-units` | seven benches green |
| `make cosim-suite` | **56/56 agreed**, `test/COSIM_EXPECTED_FAIL` empty |
| `make -C formal nonperturbation` | PASS |
| `make lint` | clean in both passes |
| `make fit` | 3875 / 4100 |
| `make soc-timing` / `SOC_SEED=3` | 11.30 MHz / 11.44 MHz, both over the 10.0 floor |

AC 5's three assertions — `formal/pcloop.sv`, the decoder's `FORMAL` block and `test/decoder_tb.v` on `pc == $past(next_pc)` — pass unchanged, which is trivially true here: nothing they read was touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJ77ZZJ6pDiL3vj3Qw9hKs
