### PR TITLE
JEF-719: rewrite the comments in the executor, CSR and regfile files to plain English

### DIFF
--- a/rtl/csrs.v
+++ b/rtl/csrs.v
@@ -3,57 +3,40 @@
 `include "structs.v"
 // The machine-mode CSR file (ADR-0005).
 //
-// This is a *sibling of the decoder*, not a pipeline stage. Every access is
-// read and committed in decode, on the same edge the accessing instruction
-// issues, so no CSR state exists anywhere downstream: there is nothing to
-// forward, nothing to replay, and no "what does mcycle read with three
-// instructions in flight" corner. CLAUDE.md invariant 5 (CSR instructions
-// serialize) is enforced in rtl/decoder.v, not here -- this module has no
-// idea a stall exists and does not need one.
+// This is a sibling of the decoder, not a pipeline stage. Every access is read
+// and committed in decode on the same edge the accessing instruction issues, so
+// no CSR state exists downstream: nothing to forward, nothing to replay, and no
+// "what does mcycle read with three instructions in flight" corner. CLAUDE.md
+// invariant 5 (CSR instructions serialize) is enforced in rtl/decoder.v; this
+// module has no idea a stall exists.
 //
-// The CSR set is ADR-0005's. It is a FLOOR, not a closed list: every register
-// the privileged spec lists unconditionally for RV32 machine mode is here,
-// because trapping on a mandatory register is non-conformant however minimal
-// the set is. ADR-0005 headed this list "exact" until ADR-0048, and that word
-// is why two mandatory registers stayed missing through a spec read looking
-// for exactly that -- it made a conformance gap read as a scope decision.
-//
-//   read/write   mstatus (MIE/MPIE; MPP is WARL -> 2'b11), mtvec (direct
-//                mode, base 4-byte aligned), mepc (bit 0 always clear --
-//                only bit 0, because C makes 2-byte targets legal), mcause,
-//                mscratch, mcycle/mcycleh, minstret/minstreth
-//   read/write,  mstatush -- writable by encoding, no implemented fields, so
-//   no fields    a write is a legal WARL no-op and must not trap
-//   read-only    mtval = 0, mie = 0, mip = 0 (no interrupt sources),
-//                misa = 0x4000_1104 (RV32IMC), mvendorid/marchid/mimpid/
-//                mhartid = 0, mconfigptr = 0
+// The set below is a floor, not a closed list: every register the privileged
+// spec lists unconditionally for RV32 machine mode is here, because trapping on
+// a mandatory register is non-conformant however minimal the set is.
 //
 // Trap entry and `mret` are the second write port, and the only architectural
-// CSR update no CSR *instruction* performs. They arrive from the decoder on
-// the edge the trapping instruction (or the `mret`) issues, because that is
-// where every trap is detected and committed (CLAUDE.md invariant 2,
-// ADR-0005). `mtvec_value`/`mepc_value` go back out to the decoder, which owns
-// the PC (invariant 1) and therefore has to be the thing that redirects it.
+// CSR update no CSR instruction performs. They arrive from the decoder on the
+// edge the trapping instruction issues, because that is where every trap is
+// detected and committed (invariant 2). `mtvec_value`/`mepc_value` go back out
+// to the decoder, which owns the PC and therefore has to redirect it.
 //
-// A trap does NOT raise a trap here: this module never decides that an access
-// is illegal. `implemented` feeds the decoder's `instr_valid` term and the
-// read-only test is on the ADDRESS (addr[11:10] == 2'b11), so both illegal-CSR
-// rules are decided in rtl/decoder.v alongside every other trap cause -- one
-// priority encoder, one commit point, one ADR (ADR-0030) covering all five.
+// This module never decides that an access is illegal. `implemented` feeds the
+// decoder's `instr_valid` term and the read-only test is on the address
+// (addr[11:10] == 2'b11), so both illegal-CSR rules are decided in
+// rtl/decoder.v alongside every other trap cause (ADR-0030).
 module csrs(
   input  logic clk,
   input  logic reset,
 
-  // ---- the decode-stage access port -------------------------------------
-  // `addr` is instr[31:20], presented combinationally every cycle; `rdata`
-  // and `implemented` answer it the same cycle, because the decoder needs
-  // the read value in time to register it into decoder_out at this edge.
+  // The decode-stage access port. `addr` is instr[31:20], presented
+  // combinationally every cycle; `rdata` and `implemented` answer it the same
+  // cycle, because the decoder needs the read value in time to register it into
+  // decoder_out at this edge.
   //
-  // `ren`/`wen` describe the instruction the decoder is *issuing* this edge.
+  // `ren`/`wen` describe the instruction the decoder is issuing this edge.
   // Zicsr's suppression rules (CSRRS/CSRRC with a zero source suppress the
-  // write; CSRRW with rd == x0 suppresses the read) are resolved in the
-  // decoder, where the operand fields live, and arrive here already applied
-  // -- so `wen` means "commit this", full stop.
+  // write; CSRRW with rd == x0 suppresses the read) are resolved in the decoder,
+  // where the operand fields live, so `wen` here means "commit this".
   input  logic [11:0] addr,
   input  logic        ren,
   input  logic        wen,
@@ -61,18 +44,17 @@ module csrs(
   output logic [31:0] rdata,
   output logic        implemented,
 
-  // ADR-0027: minstret counts non-trapping *issues*. High for exactly the
-  // cycles the decoder issues one.
+  // minstret counts non-trapping issues, so this is high for exactly the cycles
+  // the decoder issues one (ADR-0027).
   input  logic        instret,
 
-  // ---- trap entry and mret (ADR-0005 / ADR-0028) -------------------------
   // `trap_entry` is high for exactly the cycle the decoder commits a trap;
   // `mret_entry` for exactly the cycle it commits an `mret`. They cannot
-  // coincide with each other (a trapping instruction does not also execute)
-  // nor with `wen` (the decoder gates `csr_wen` on a NON-trapping commit, and
-  // `mret` is not a CSR access), so the three write paths below need no
-  // priority between them -- but the code says so explicitly rather than
-  // relying on last-assignment-wins.
+  // coincide with each other (a trapping instruction does not also execute) nor
+  // with `wen` (the decoder gates `csr_wen` on a non-trapping commit, and `mret`
+  // is not a CSR access), so the three write paths below need no priority
+  // between them -- the code states the exclusion rather than relying on
+  // last-assignment-wins (ADR-0028).
   input  logic        trap_entry,
   input  logic [31:0] trap_cause,
   input  logic [31:0] trap_epc,
@@ -82,28 +64,21 @@ module csrs(
   output logic [31:0] mepc_value
  `ifdef RISCV_FORMAL
   ,
-  // ADR-0006 shadow payloads, for exactly the CSRs formal/checks.cfg's
-  // `[csrs]` list names. Combinational off this cycle's access; the decoder
-  // latches them into the issuing instruction's shadow so they ride to
-  // writeback on the ordinary valid-bit protocol.
+  // Shadow payloads for exactly the CSRs formal/checks.cfg's `[csrs]` list
+  // names. Combinational off this cycle's access; the decoder latches them into
+  // the issuing instruction's shadow so they ride to writeback on the ordinary
+  // valid-bit protocol.
   output rvfi_csr64 rvfi_mcycle,
   output rvfi_csr64 rvfi_minstret,
   output rvfi_csr32 rvfi_mscratch
  `endif
 );
-  // CSR addresses (RISC-V privileged spec, Ch. 2). Named rather than spelled
-  // as hex at each use site for the same reason the decoder names its
-  // register-index fields.
   localparam logic [11:0] MSTATUS   = 12'h300;
   localparam logic [11:0] MISA      = 12'h301;
-  // RV32-mandatory, and read-only zero here. Both are listed unconditionally in
-  // the privileged spec's machine-mode CSR table, so a core that traps on them
-  // is non-conformant however small its implemented set is -- which is why
-  // ADR-0005's "exact" set widens to include them rather than declining them.
-  // Zero is a legal value for each, not a stub: mstatush's only fields are SBE
-  // and MBE, and 0 means little-endian data accesses in M-mode, which is what
-  // this core does; mconfigptr = 0 is the spec's own encoding for "no
-  // configuration data structure exists".
+  // Both read-only zero, and zero is a legal value for each rather than a stub:
+  // mstatush's only fields are SBE and MBE, where 0 means the little-endian
+  // M-mode data accesses this core does, and mconfigptr = 0 is the spec's own
+  // encoding for "no configuration data structure exists".
   localparam logic [11:0] MSTATUSH  = 12'h310;
   localparam logic [11:0] MCONFIGPTR = 12'hF15;
   localparam logic [11:0] MIE       = 12'h304;
@@ -122,23 +97,19 @@ module csrs(
   localparam logic [11:0] MIMPID    = 12'hF13;
   localparam logic [11:0] MHARTID   = 12'hF14;
 
-  // RV32 I M C, MXL = 1. CLAUDE.md's ISA target; the C bit stopped being an
-  // untested claim when ADR-0003's fetch window landed.
+  // RV32 I M C, MXL = 1 -- CLAUDE.md's ISA target.
   localparam logic [31:0] MISA_VALUE = 32'h4000_1104;
 
-  // ---- state ------------------------------------------------------------
   logic [63:0] mcycle, minstret;
   logic [31:0] mscratch, mtvec, mepc, mcause;
-  // mstatus is three fields, not a register: MPP is hardwired to M-mode
-  // (WARL, and this core has no other mode), and every other bit is 0.
+  // mstatus is three fields rather than a register: MPP is hardwired to M-mode
+  // (WARL, and this core has no other mode) and every other bit is 0.
   logic        mstatus_mie, mstatus_mpie;
 
   // Halves of the two counters, selected out here rather than inside the
-  // always_* blocks below. A constant part-select taken inside an always_*
-  // block defeats iverilog's sensitivity analysis and draws a `sorry:` note;
-  // CLAUDE.md says warnings are errors and names rtl/executor.v as the one
-  // documented exception, so this file uses named continuous assigns
-  // throughout.
+  // always_* blocks below. A constant part-select taken inside an always_* block
+  // defeats iverilog's sensitivity analysis and draws a `sorry:` note, so this
+  // file uses named continuous assigns throughout (ADR-0034).
   logic [31:0] mcycle_lo, mcycle_hi, minstret_lo, minstret_hi;
   assign mcycle_lo   = mcycle[31:0];
   assign mcycle_hi   = mcycle[63:32];
@@ -149,17 +120,14 @@ module csrs(
   // MPP = 2'b11 at [12:11]; MPIE at [7]; MIE at [3]; everything else 0.
   assign mstatus_value = {19'b0, 2'b11, 3'b0, mstatus_mpie, 3'b0, mstatus_mie, 3'b0};
 
-  // The two registers the decoder redirects the PC through. Straight
-  // continuous assigns of the register outputs, i.e. the values as of the
-  // START of the issuing cycle. That is the right phase and not an accident:
-  // decode issues at most one instruction per cycle, so a trapping
-  // instruction and a `csrw mtvec` are never the same edge, and the trap must
-  // vector through the mtvec that was architecturally in place when it
-  // issued.
+  // The two registers the decoder redirects the PC through, as of the start of
+  // the issuing cycle. That phase is the right one: decode issues at most one
+  // instruction per cycle, so a trapping instruction and a `csrw mtvec` are
+  // never the same edge, and the trap must vector through the mtvec that was
+  // architecturally in place when it issued.
   assign mtvec_value = mtvec;
   assign mepc_value  = mepc;
 
-  // ---- read mux ---------------------------------------------------------
   always_comb begin
     implemented = 1'b1;
     (* parallel_case *)
@@ -186,19 +154,17 @@ module csrs(
     endcase
   end
 
-  // ---- WARL ------------------------------------------------------------
-  // `warl` is the value the addressed CSR holds *after* this write, with the
-  // legal-value mask already applied. Defined for every address, including
-  // the read-only ones (where "after this write" is the unchanged value, so
-  // it falls back to `rdata`) -- that uniformity is what lets the RVFI report
-  // below tell the truth about what landed rather than echoing back an
-  // operand the mask threw away.
+  // `warl` is the value the addressed CSR holds after this write, with the
+  // legal-value mask already applied. It is defined for every address, including
+  // the read-only ones (where it falls back to `rdata`), and that uniformity is
+  // what lets the RVFI report below tell the truth about what landed rather than
+  // echo back an operand the mask threw away.
   logic [31:0] wdata_mtvec, wdata_mepc, wdata_mstatus;
   // Direct mode only: mtvec[1:0] is the mode field, and a 4-byte-aligned
   // base leaves it zero either way.
   assign wdata_mtvec   = {wdata[31:2], 2'b00};
-  // Only bit 0 is forced -- C makes 2-byte branch targets legal, so bit 1
-  // is a legal value here and must survive (ADR-0005).
+  // Only bit 0 is forced: C makes 2-byte branch targets legal, so bit 1 is a
+  // legal value here and must survive.
   assign wdata_mepc    = {wdata[31:1], 1'b0};
   assign wdata_mstatus = {19'b0, 2'b11, 3'b0, wdata[7], 3'b0, wdata[3], 3'b0};
 
@@ -221,18 +187,15 @@ module csrs(
   assign warl_mie  = warl[3];
   assign warl_mpie = warl[7];
 
-  // Trap entry writes mepc through the SAME WARL mask an explicit `csrw mepc`
+  // Trap entry writes mepc through the same WARL mask an explicit `csrw mepc`
   // goes through. `trap_epc` is an instruction address, so bit 0 is already
-  // clear and the mask changes nothing today -- it is here so that the mask is
-  // stated in one place rather than two, and so a reader can see that bit 1 is
-  // deliberately preserved: C makes 2-byte targets legal (ADR-0005), and a
-  // mask that cleared bit 1 too would resume two bytes early after any fault
-  // at `pc % 4 == 2`. test/asm/trap.S faults a compressed instruction at
-  // exactly that alignment for this reason.
+  // clear and the mask changes nothing today; what it states is that bit 1 is
+  // preserved, because a mask that cleared it too would resume two bytes early
+  // after a fault at `pc % 4 == 2`. test/asm/trap.S faults a compressed
+  // instruction at exactly that alignment.
   logic [31:0] trap_epc_warl;
   assign trap_epc_warl = {trap_epc[31:1], 1'b0};
 
-  // ---- the counters -----------------------------------------------------
   logic wr_mcycle, wr_mcycleh, wr_minstret, wr_minstreth, wr_mscratch;
   assign wr_mcycle    = wen && addr == MCYCLE;
   assign wr_mcycleh   = wen && addr == MCYCLEH;
@@ -240,27 +203,17 @@ module csrs(
   assign wr_minstreth = wen && addr == MINSTRETH;
   assign wr_mscratch  = wen && addr == MSCRATCH;
 
-  // ADR-0005's "an explicit write to a counter takes precedence over that
-  // cycle's increment" -- and the privileged spec's own "any CSR write takes
-  // precedence over the automatic increment" (20211203 §3.1.11) -- are
-  // statements about the 64-BIT COUNTER, not about the half whose address the
-  // instruction happens to name. mcycle and mcycleh are two views of one
-  // register, so a write to either half suppresses that cycle's increment of
-  // the whole thing. Hence a `_tick` term per counter rather than the two
-  // per-half overrides below doing the job on their own.
+  // "Any CSR write takes precedence over the automatic increment" (priv spec
+  // 20211203 §3.1.11) is a statement about the 64-bit COUNTER, not about the
+  // half whose address the instruction names: mcycle and mcycleh are two views
+  // of one register, so a write to either half suppresses that cycle's increment
+  // of the whole thing. Hence a `_tick` term per counter rather than the two
+  // per-half overrides below doing the job alone.
   //
-  // Suppressing per half instead is wrong only at the carry boundary, and
-  // wrong there in a way that nothing else in this repo can see. With
-  // mcycle == 32'hffff_ffff the increment's carry lands in the HIGH half while
-  // the explicit write replaces the low one, so `csrw mcycle` advances mcycleh
-  // by one -- contradicting the invariant the RVFI report at the bottom of this
-  // file is built to satisfy, and doing it once every 2**32 cycles and only if
-  // a write falls on that exact cycle. checks/rvfi_csrw_check.sv reads the
-  // SELF-REPORTED masks and never observes the register; every ladder check is
-  // `mode bmc` from reset; and a `.S` program can land a write on that cycle
-  // only by calibrating instruction spacing first, which is a test that stops
-  // testing the moment the spacing changes. test/csr_tb.v drives this port
-  // directly and is the one place it is deterministic (ADR-0048).
+  // Suppressing per half instead differs only at the carry boundary, where the
+  // increment's carry lands in the high half while the write replaces the low
+  // one -- so `csrw mcycle` advances mcycleh. test/csr_tb.v is the only thing
+  // that can see it (ADR-0048).
   logic mcycle_tick, minstret_tick;
   assign mcycle_tick   = !wr_mcycle   && !wr_mcycleh;
   assign minstret_tick = !wr_minstret && !wr_minstreth && instret;
@@ -286,11 +239,10 @@ module csrs(
       mcycle       <= 64'b0;
       minstret     <= 64'b0;
       mscratch     <= 32'b0;
-      // ADR-0029: mtvec resets to 0. The spec leaves it implementation-
-      // defined and 0 is the readable choice; test/asm/sections.lds puts
-      // .text there, so both sim legs are expected to make a trap taken
-      // before a handler is installed loud rather than let it look like a
-      // silent program restart.
+      // The spec leaves mtvec's reset value implementation-defined. 0 puts it
+      // at test/asm/sections.lds's .text, so both sim legs catch a trap taken
+      // before a handler is installed rather than let it look like a silent
+      // program restart (ADR-0029).
       mtvec        <= 32'b0;
       mepc         <= 32'b0;
       mcause       <= 32'b0;
@@ -310,26 +262,22 @@ module csrs(
           MSCRATCH: mscratch <= warl;
           MEPC:     mepc     <= warl;
           MCAUSE:   mcause   <= warl;
-          // The counters are driven unconditionally above (an explicit write
-          // is folded into *_next so it beats the increment); every other
-          // address is read-only or unimplemented, and a write to one is a
-          // no-op here by construction rather than by omission.
+          // The counters are driven unconditionally above, with an explicit
+          // write folded into *_next so it beats the increment. Every other
+          // address is read-only or unimplemented.
           default: ;
         endcase
       end
-      // ---- trap entry / mret (ADR-0005) ----------------------------------
-      // The privileged-spec sequence, written out: a trap saves the faulting
-      // PC and the cause, pushes MIE into MPIE and disables interrupts; `mret`
-      // pops it back and leaves MPIE set. There are no interrupts on this core
-      // (mie/mip are read-only zero), so MIE/MPIE are architectural state a
-      // program can observe through mstatus rather than something that gates
-      // anything -- which is exactly why they have to be right: nothing else
-      // would notice if they were not.
+      // The privileged-spec sequence: a trap saves the faulting PC and the
+      // cause, pushes MIE into MPIE and disables interrupts; `mret` pops it back
+      // and leaves MPIE set. This core has no interrupts (mie/mip are read-only
+      // zero), so MIE/MPIE gate nothing and are only observable through mstatus
+      // -- nothing but test/csr_tb.v would notice them being wrong.
       //
-      // `else if` rather than two independent `if`s: mutually exclusive by
-      // construction (see the port comments), and stating the exclusion here
-      // means a future cause that broke it fails loudly at the priority
-      // encoder in rtl/decoder.v rather than silently double-writing mstatus.
+      // `else if` rather than two independent `if`s: the two are mutually
+      // exclusive by construction (see the port comments), and stating that here
+      // means a future cause that broke it fails at rtl/decoder.v's priority
+      // encoder rather than silently double-writing mstatus.
       if (trap_entry) begin
         mepc         <= trap_epc_warl;
         mcause       <= trap_cause;
@@ -343,17 +291,15 @@ module csrs(
   end
 
  `ifdef RISCV_FORMAL
-  // ---- RVFI CSR reporting ------------------------------------------------
   // Write-only with respect to the core: nothing below drives a signal any
-  // non-`ifdef` logic reads, which is the structural argument ADR-0020's
-  // non-perturbation guarantee rests on. Do not break it.
+  // non-`ifdef` logic reads. That is the structural argument the
+  // non-perturbation guarantee rests on (ADR-0047), so do not break it.
   //
-  // The two counters are ONE 64-bit RVFI CSR each, with mcycleh/minstreth
-  // addressing the upper half of the same report -- which is why the masks
-  // are built per half. riscv-formal's rvfi_csrw_check asserts that a write
-  // through the low address leaves the high half unchanged (and vice versa),
-  // computed from these reported values, so a mask that claimed both halves
-  // would fail on a correct core.
+  // The two counters are one 64-bit RVFI CSR each, with mcycleh/minstreth
+  // addressing the upper half of the same report, which is why the masks are
+  // built per half. rvfi_csrw_check asserts that a write through the low address
+  // leaves the high half unchanged, computed from these reported values, so a
+  // mask claiming both halves fails on a correct core.
   logic rd_mcycle, rd_mcycleh, rd_minstret, rd_minstreth, rd_mscratch;
   assign rd_mcycle    = ren && addr == MCYCLE;
   assign rd_mcycleh   = ren && addr == MCYCLEH;
@@ -361,11 +307,11 @@ module csrs(
   assign rd_minstreth = ren && addr == MINSTRETH;
   assign rd_mscratch  = ren && addr == MSCRATCH;
 
-  // What the *instruction* wrote, which is not what the register will hold:
-  // the free-running increment is not this instruction's doing, and RVFI's
-  // wdata is the instruction's write. Reporting the incremented value with a
-  // zero wmask would be harmless (rvfi_csrw_check masks it away) but would
-  // read as though the CSR instruction had bumped the counter.
+  // What the instruction wrote, which is not what the register will hold: the
+  // free-running increment is not this instruction's doing, and RVFI's wdata is
+  // the instruction's write. Reporting the incremented value with a zero wmask
+  // would be harmless (rvfi_csrw_check masks it away) but would read as though
+  // the CSR instruction had bumped the counter.
   logic [31:0] mcycle_next_lo_reported, mcycle_next_hi_reported;
   logic [31:0] minstret_next_lo_reported, minstret_next_hi_reported;
   assign mcycle_next_lo_reported   = wr_mcycle    ? warl : mcycle_lo;

--- a/rtl/executor.v
+++ b/rtl/executor.v
@@ -7,18 +7,15 @@ module executor(
 
   // inputs
   input  decoder_output in,
-  // ADR-0009-style stall broadcast from the accessor (ADR-0015): high for the
-  // one cycle a load's response is still in flight there. Upstream of the
-  // stalling stage freezes — the executor is upstream of the accessor, so it
-  // must freeze (emit a bubble) rather than advance, or a fresh instruction
-  // would collide with the completing load over the accessor's single output
-  // register and the single-port memory bus.
+  // High for the one cycle a load's response is still in flight in the accessor
+  // (ADR-0015). The executor is upstream of it and must freeze rather than
+  // advance, or a fresh instruction collides with the completing load over the
+  // accessor's single output register and the single-port memory bus.
   input  logic accessor_stall,
   // outputs
   output executor_output out,
-  // ADR-0009: broadcast to littlecpu.v (and from there back to the decoder)
-  // whenever a multi-cycle divide is in flight, so decode freezes upstream
-  // and bubbles downstream until it drains.
+  // Broadcast to littlecpu.v, and from there back to the decoder, whenever a
+  // multi-cycle divide is in flight.
   output logic stalled
 );
   logic [31:0] rs1, rs2;
@@ -41,35 +38,32 @@ module executor(
   always_comb
     stalled = state != init;
 
-  // ADR-0009: once decode is stalled for a divide, it bubbles (rather than
-  // literally holding `in` unchanged) so the executor doesn't misread a
-  // stale in-flight instruction the moment it returns to `init` — see
-  // rtl/decoder.v. That means `in` cannot be relied on at completion time,
-  // so the op-select and operand signs the last iteration needs are latched
-  // here at issue, once, instead of read live off `in` 32 iterations later.
+  // Once decode is stalled for a divide it bubbles, rather than holding `in`
+  // unchanged, so that the executor cannot misread a stale in-flight instruction
+  // the moment it returns to `init` (ADR-0009). `in` is therefore not to be
+  // trusted at completion time, and the op-select and operand signs the last
+  // iteration needs are latched here at issue instead.
   logic op_is_div, op_is_divu, op_is_rem, op_is_remu, op_sign_x, op_sign_y;
 
  `ifdef RISCV_FORMAL_ALTOPS
   // The operands as latched by the ALTOPS issue arm below, named so the
-  // completion arm reads them as operands rather than as slices of the
-  // divider's working registers. Raw rs1/rs2 -- ALTOPS does no magnitude
-  // conversion, so no sign wrapper applies here (contrast ADR-0012).
+  // completion arm reads them as operands rather than as slices of the divider's
+  // working registers. Raw rs1/rs2: ALTOPS does no magnitude conversion, so the
+  // sign wrapper above does not apply.
   logic [31:0] div_alt_rs1, div_alt_rs2;
   assign div_alt_rs1 = mul_div_x[31:0];
   assign div_alt_rs2 = mul_div_y[62:31];
  `endif
 
-  // multiply: continuous assignments, so the product tracks the operands every cycle
-  // instead of being latched once at time 0. sign_x covers is_mulh (signed rs1) and
-  // is_mulhsu (rs1 is signed, rs2 is unsigned); sign_y covers only is_mulh. Extension
-  // bits come from bit 31 (the true sign bit), not bit 0.
+  // Continuous assignments, so the product tracks the operands every cycle
+  // instead of being latched once at time 0. sign_x covers is_mulh (signed rs1)
+  // and is_mulhsu (rs1 signed, rs2 unsigned); sign_y covers only is_mulh.
   logic mul_sign_x, mul_sign_y;
   assign mul_sign_x = in.rs1[31] & (in.is_mulh | in.is_mulhsu);
   assign mul_sign_y = in.rs2[31] & in.is_mulh;
   logic signed [63:0] multiply;
   assign multiply = $signed({mul_sign_x, in.rs1}) * $signed({mul_sign_y, in.rs2});
 
-  // state machine
   always_ff @(posedge clk) begin
     if (reset) begin
       state <= init;
@@ -85,25 +79,22 @@ module executor(
       op_sign_x <= 0;
       op_sign_y <= 0;
     end else if (accessor_stall) begin
-      // Freeze: emit a bubble and hold every other register (state,
-      // mul_div_*, op_*) unchanged. Never overlaps with a real divide in
-      // progress — decode already freezes everything upstream of the
-      // executor while dividing, so a load can't reach the accessor (and
-      // assert accessor_stall) until the divide has long since drained.
+      // Freeze: emit a bubble and hold every other register unchanged. This
+      // never overlaps a divide in progress, because decode freezes everything
+      // upstream while dividing, so no load can reach the accessor until the
+      // divide has drained.
       out <= 0;
     end else begin
       (* parallel_case, full_case *)
       case (state)
         init: begin
-          // ADR-0009: a bubble (in.valid == 0) propagates straight through as
-          // a bubble here too, except when it's the one real cycle a divide
-          // is issued (out.valid held low below until the divide completes).
+          // A bubble propagates straight through, except on the cycle a divide
+          // issues, where out.valid is held low below until it completes.
           out.valid <= in.valid;
          `ifdef RISCV_FORMAL
-          // Latched here, once, at issue -- same reasoning as op_is_div/
-          // op_sign_x below: this is the only cycle `in` is trustworthy for
-          // a divide, and out.rd/out.rd_data follow the same rule (set here,
-          // held unchanged for the whole divide, read back at completion).
+          // Latched at issue for the same reason as op_is_div/op_sign_x below,
+          // as are out.rd and out.rd_data: this is the only cycle `in` is
+          // trustworthy for a divide.
           out.rvfi <= in.rvfi;
          `endif
           out.rd <= in.rd;
@@ -123,9 +114,8 @@ module executor(
             in.is_add: out.rd_data <= rs1 + rs2;
             in.is_lui: out.rd_data <= rs1;
             in.is_sub: out.rd_data <= rs1 - rs2;
-            // RV32I shift amount is rs2[4:0] only (RISC-V spec Vol I §2.4.2);
-            // the upper 27 bits are ignored, not folded into the shift as a
-            // wider count.
+            // The RV32I shift amount is rs2[4:0] only (spec Vol I §2.4.2): the
+            // upper 27 bits are ignored, not folded in as a wider count.
             in.is_sll: out.rd_data <= rs1 << rs2[4:0];
             in.is_slt: out.rd_data <= {31'b0, $signed(rs1) < $signed(rs2)};
             in.is_sltu: out.rd_data <= {31'b0, rs1 < rs2};
@@ -153,10 +143,9 @@ module executor(
             end
 
             in.is_div || in.is_divu || in.is_rem || in.is_remu: begin
-              // Latched regardless of which sub-path fires below: harmless
-              // for the div-by-zero/overflow short-circuits (state stays
-              // init, so completion never reads them back), and required for
-              // the real divide (see the comment on their declaration).
+              // Latched regardless of which sub-path fires below: harmless for
+              // the short-circuits, which never leave `init` and so never read
+              // them back, and required for the real divide.
               op_is_div <= in.is_div;
               op_is_divu <= in.is_divu;
               op_is_rem <= in.is_rem;
@@ -164,26 +153,25 @@ module executor(
               op_sign_x <= in.rs1[31];
               op_sign_y <= in.rs2[31];
              `ifndef RISCV_FORMAL_ALTOPS
+              // The two specified results (spec Vol I §7.2). Both stay in
+              // `init`, so neither enters the divider.
               if (rs2 == 0) begin
-                // Division by zero per RISC-V spec Vol I §7.2
                 if (in.is_rem || in.is_remu) out.rd_data <= rs1; // remainder = dividend
                 else out.rd_data <= 32'hffffffff; // quotient = -1 (div) or MAX_UINT (divu)
-                // state stays init; no division needed
               end else if ((in.is_div || in.is_rem) &&
                            rs1 == 32'h80000000 && rs2 == 32'hffffffff) begin
-                // Signed overflow: INT_MIN / -1 per RISC-V spec Vol I §7.2
+                // Signed overflow: INT_MIN / -1.
                 if (in.is_div) out.rd_data <= 32'h80000000; // quotient = INT_MIN
                 else out.rd_data <= 32'b0; // remainder = 0
-                // state stays init; no division needed
               end else begin
                 mul_div_counter <= 32;
                 state <= divide;
                 mul_div_store <= 0;
                 mul_div_x <= {32'b0, div_x};
                 mul_div_y <= {1'b0, div_y, 31'b0};
-                // The result isn't ready this cycle — ADR-0009's replay fix:
-                // downstream drains a bubble, not a repeat of whatever the
-                // executor last held, for the entire multi-cycle divide.
+                // The result is not ready this cycle, so downstream drains a
+                // bubble rather than a repeat of whatever the executor last held
+                // (ADR-0009).
                 out.valid <= 1'b0;
               end
              `else
@@ -195,11 +183,9 @@ module executor(
               out.valid <= 1'b0;
              `endif
             end
-            // A Zicsr access does not appear here at all: rtl/csrs.v reads
-            // and commits it in decode (ADR-0005) and the read result
-            // arrives as `is_add` with rs2 zeroed, so by the time it reaches
-            // this stage it IS an add. That is why decoder_output no longer
-            // carries is_csrrw/is_csrrs/is_csrrc -- see rtl/structs.v.
+            // A Zicsr access never appears here: rtl/csrs.v reads and commits it
+            // in decode (ADR-0005), and the read result arrives as `is_add` with
+            // rs2 zeroed, so by this stage it is an add.
             in.is_ecall || in.is_ebreak: ;
             in.is_valid_instr: ;
           endcase // case (1'b1)
@@ -217,9 +203,8 @@ module executor(
             mul_div_y <= mul_div_y >> 1;
             mul_div_counter <= mul_div_counter - 1;
           end else begin
-            // Uses the op-select and sign bits latched at issue, not `in`
-            // (which decode has long since bubbled) — see the comment on
-            // their declaration above.
+            // The op-select and sign bits latched at issue, not `in`, which
+            // decode has long since bubbled.
             (* parallel_case, full_case *)
             case (1'b1)
               op_is_div: out.rd_data <= op_sign_x != op_sign_y ? -mul_div_store[31:0] : mul_div_store[31:0];
@@ -231,16 +216,12 @@ module executor(
             state <= init;
           end
          `else
-          // Read the operands LATCHED AT ISSUE, not `in`. ALTOPS collapses the
-          // divide to a single cycle, so by the time this arm runs `in` already
-          // holds the next decoded instruction and `in.rs1`/`in.rs2` are that
-          // instruction's operands -- the placeholder would be computed from
-          // the wrong values. Same reasoning as the op_is_*/op_sign_* latches
-          // above: this is not the cycle `in` is trustworthy.
-          //
-          // The ALTOPS issue arm latches raw rs1/rs2 (unlike the real divider's
-          // arm, which latches magnitudes per ADR-0012), so these are exactly
-          // the values riscv-formal's placeholder model expects.
+          // The operands latched at issue, not `in`. ALTOPS collapses the divide
+          // to a single cycle, so by the time this arm runs `in` already holds
+          // the next decoded instruction and the placeholder would be computed
+          // from its operands. The ALTOPS issue arm latches raw rs1/rs2 rather
+          // than ADR-0012's magnitudes, which is what riscv-formal's placeholder
+          // model expects.
           (* parallel_case, full_case *)
           case (1'b1)
             op_is_div: out.rd_data <= (div_alt_rs1 - div_alt_rs2) ^ 32'h7f8529ec;
@@ -257,92 +238,58 @@ module executor(
     end
   end
 
-  // state machine
  `ifdef FORMAL
-  // ==== Executor component proof (ADR-0006 #2, ADR-0010, ADR-0049, ADR-0051) ====
-  //
-  // RESIDUAL, stated once and up front: **the multiplication operator itself is
-  // checked differentially, not exhaustively.** There is no miter here between
-  // two 32x32 products. ADR-0051 measured that such a miter returns no verdict
-  // in two minutes even standing completely alone -- no divider, no pipeline
-  // state, no operand cap, `mode bmc depth 1` -- because the obstacle is two
-  // structurally distinct `bvmul` terms, and neither bit width nor engine moves
-  // that. What this proof establishes instead is everything AROUND the product:
-  // the 33-bit operands the multiplier is handed, the slice of that product each
-  // variant retires, and three lemmas over the product term itself that are
-  // multiplications by a CONSTANT, which a solver sees as shifts and adds. The
-  // hole that leaves -- a `*` wrong for some operand pair no lemma names -- is
-  // covered by test/exec_tb.v's >=10,000 randomized differential vectors per op,
-  // which ADR-0010 makes the PRIMARY guarantee for this arithmetic and which
-  // this proof does not replace.
-  //
-  // The same decomposition move is what ADR-0012 already made for the divider:
-  // do not restate the operation, prove the wrapper around one shared term.
+  // The executor component proof. The multiplication operator itself is checked
+  // differentially rather than exhaustively -- there is no miter here between
+  // two 32x32 products, because such a miter returns no verdict in two minutes
+  // even standing alone (no divider, no pipeline state, no cap, `mode bmc depth
+  // 1`): the obstacle is two structurally distinct `bvmul` terms, and neither
+  // bit width nor engine moves it. What is proved instead is everything around
+  // the product -- the 33-bit operands the multiplier is handed, the slice of it
+  // each variant retires, and three lemmas over the term itself that multiply by
+  // a CONSTANT, which a solver sees as shifts and adds. The residual, a `*`
+  // wrong for some operand pair no lemma names, is covered by test/exec_tb.v's
+  // >= 10,000 randomized vectors per op, which ADR-0010 makes the primary
+  // guarantee for this arithmetic (ADR-0051; ADR-0012 made the same move for
+  // the divider).
   logic clocked;
   initial clocked = 0;
   always_ff @(posedge clk) clocked <= 1;
-  // FACT       reset is asserted before the first clock edge.
-  // DISCHARGED NOWHERE. Structural: every harness that instantiates this core
-  //            (test/testbench.v, formal/*.sv, the generated ladder's
-  //            RISCV_FORMAL_RESET_CYCLES) drives reset high initially. No
-  //            check asserts it, and "nowhere" is the honest answer (ADR-0049).
-  // SCOPE      the whole task. Unguarded, so in force over every assertion in
-  //            this block -- which is what it was written for: without it no
-  //            assertion here is meaningful, since `state` and the mul_div
-  //            registers have no defined value before the first edge.
-  // assume we've reset at clk 0
+  // Assumed: reset is asserted before the first clock edge. Every harness that
+  // instantiates this core drives it high initially, but no check asserts that,
+  // so this is discharged nowhere. It is unguarded and therefore in force over
+  // every assertion here, which is what it was written for -- `state` and the
+  // mul_div registers have no defined value before the first edge (ADR-0049).
   initial assume(reset);
   always_comb if(!clocked) assume(reset);
-  // `state` otherwise has no defined value before the first clock edge applies
-  // `reset`, which lets the solver "start" mid-divide for free at step 0 —
-  // pin it down explicitly so the arithmetic assertions below only fire on
-  // real, freshly-issued operations.
+  // Otherwise the solver may start mid-divide, for free, at step 0.
   initial state = init;
-  // The divide-family assertions below span many cycles; without this, the
-  // solver can re-assert `reset` mid-divide to jump straight from `divide` to
-  // `init` (out.rd_data zeroed by the reset branch, not computed by the
-  // divider) and "complete" a division in a handful of steps. Reset is a
-  // once-at-the-start pulse everywhere else in this design, so assume it
-  // stays low for the remainder of the trace.
-  //
-  // FACT       reset never returns after the first cycle.
-  // DISCHARGED NOWHERE. True of every harness in the tree; asserted by none.
-  // SCOPE      the whole task -- LARGER than what it was written for. The
-  //            paragraph above is about the divide-family assertions, but this
-  //            is an unguarded `always_comb assume`, so it equally excuses the
-  //            whole multiply section and the ADR-0015 freeze block from
-  //            ever seeing a mid-trace reset. That is harmless here (a
-  //            re-asserted reset is not a real environment) and is written
-  //            down because ADR-0049 clause 3 requires the reader to be told
-  //            the scope rather than left to infer it from proximity.
+  // Assumed: reset never returns after the first cycle. True of every harness in
+  // the tree and asserted by none, so again discharged nowhere. It was written
+  // for the divide-family assertions, which span many cycles and where a
+  // re-asserted reset would jump from `divide` to `init` with out.rd_data zeroed
+  // by the reset branch rather than computed by the divider. Being unguarded its
+  // scope is larger than that: it equally excuses the multiply section and the
+  // freeze block from ever seeing a mid-trace reset, which is harmless because a
+  // re-asserted reset is not a real environment.
   always_comb if (clocked) assume(!reset);
 
-  // This component proof stands alone (no accessor instantiated), so
-  // accessor_stall is a free input. It used to be assumed away entirely
-  // (`assume(!accessor_stall)`), which scoped the freeze branch at the top
-  // of the state machine out of this proof altogether. It is now left
-  // completely free — not even ADR-0015's at-most-one-consecutive-cycle
-  // bound is assumed, which makes this stronger than the real environment:
-  // a held stall just keeps the freeze obligations below in force. The
-  // price is a `!$past(accessor_stall)` guard on each of the four multiply
-  // SLICE assertions further down: a frozen edge computes nothing (out is
-  // bubbled), so an ungated assertion there would be asserting arithmetic
-  // about the bubble. The multiply section's other assertions -- the 33-bit
-  // operands and the three product lemmas -- are purely combinational over
-  // `in` and mention `out` nowhere, so a freeze cannot reach them and they
-  // need no guard. The divide-state invariants need none either (a freeze
-  // holds every register they mention), and the divide completion assertions'
-  // guard
-  // ($past(state) == divide && state == init) already implies the
-  // transition edge was not frozen — a frozen edge cannot change state.
+  // This proof stands alone with no accessor, so accessor_stall is left a free
+  // input -- not even ADR-0015's at-most-one-consecutive-cycle bound is assumed,
+  // which makes it stronger than the real environment. The price is the
+  // `!$past(accessor_stall)` guard on each of the four multiply slice assertions
+  // below: a frozen edge computes nothing, so an ungated assertion there would
+  // be asserting arithmetic about a bubble. Nothing else here needs it. The
+  // operand and lemma assertions are combinational over `in` and mention `out`
+  // nowhere, a freeze holds every register the divide invariants read, and the
+  // completion guard ($past(state) == divide && state == init) already implies
+  // an unfrozen edge, since a frozen one cannot change state.
 
-  // ADR-0015 freeze coverage: the cycle after accessor_stall is asserted,
-  // the executor emitted a bubble and held everything else — state, the
-  // divider datapath, and the op/sign latches — unchanged. This is the
-  // `else if (accessor_stall)` branch of the state machine, asserted rather
-  // than assumed out of existence. Guarded on !$past(reset) because reset
-  // wins over the freeze in the RTL (and the pre-reset initial values of
-  // the mul_div registers are free).
+  // The freeze branch itself: the cycle after accessor_stall, the executor
+  // emitted a bubble and held state, the divider datapath and the op/sign
+  // latches unchanged. Guarded on !$past(reset) because reset wins over the
+  // freeze in the RTL, and the pre-reset values of the mul_div registers are
+  // free.
   always_ff @(posedge clk)
     if (clocked && !reset && !$past(reset) && $past(accessor_stall)) begin
       assert(out == '0);
@@ -359,33 +306,17 @@ module executor(
       assert(op_sign_y == $past(op_sign_y));
     end
 
-  // ---- Executor arithmetic BMC (ADR-0006 component proof #2 / ADR-0010) ----
-  // The *primary* guarantee for real mul/div arithmetic is the randomized
-  // differential bench, test/exec_tb.v (>=10,000 vectors per op) — riscv-formal
-  // runs under RISCV_FORMAL_ALTOPS and never checks this arithmetic at all. This
-  // BMC is secondary and bounded-effort per ADR-0010. It was previously vacuous
-  // (PASS 0 0): these are its first real assertions.
+  // Assumed: the decoder emits at most one op-select flag per instruction. This
+  // proof stands alone, so without it the solver picks combinations no real
+  // instruction produces. It is discharged by rtl/decoder.v's own `$onehot`
+  // assertion under `instr_valid`, in components_decoder, which CI runs -- the
+  // one assume in this repo with a running discharge rather than a structural
+  // argument (ADR-0049). Unguarded, so it is in force over the freeze block and
+  // the divide invariants too, and correctly so.
   //
-  // The op-select flags (is_add, is_mul, ...) are guaranteed mutually exclusive
-  // by the decoder in the real pipeline; this component proof stands alone, so
-  // that has to be an explicit environmental assumption or the solver can pick
-  // nonsensical combinations no real instruction produces.
-  //
-  // FACT       the decoder emits at most one op-select flag per instruction.
-  // DISCHARGED rtl/decoder.v's `one_of` assertion -- `assert($onehot(...))`
-  //            under `instr_valid`, in components_decoder, which runs in CI
-  //            (.github/workflows/ci.yml's `components` job). This is the ONE
-  //            assume in this repo with a real, running discharge; every other
-  //            one is believed on structural grounds (ADR-0049's census).
-  // SCOPE      the whole task, and deliberately so. It was written for the
-  //            arithmetic assertions but is equally correct over the ADR-0015
-  //            freeze block and every divide invariant, because the decoder
-  //            really does emit at most one flag on every cycle of all of
-  //            them. Checked against rtl/structs.v while auditing: all 29
-  //            `is_*` fields of `decoder_output` are listed, and
-  //            `is_valid_instr` is correctly not among them. Adding a flag to
-  //            the struct without adding it here silently widens the
-  //            environment for every assertion below.
+  // All 29 `is_*` fields of `decoder_output` are listed here and
+  // `is_valid_instr` is deliberately not among them. Adding a flag to the struct
+  // without adding it here silently widens the environment for everything below.
   always_comb assume($onehot0({in.is_add, in.is_sub, in.is_xor, in.is_or, in.is_and,
     in.is_sll, in.is_slt, in.is_sltu, in.is_srl, in.is_sra, in.is_lui,
     in.is_mul, in.is_mulh, in.is_mulhu, in.is_mulhsu,
@@ -393,23 +324,14 @@ module executor(
     in.is_lb, in.is_lbu, in.is_lh, in.is_lhu, in.is_lw, in.is_sb, in.is_sh, in.is_sw,
     in.is_ecall, in.is_ebreak}));
 
-  // ---- Multiply: full 32-bit operands, no cap, decomposed ----------------
+  // Multiply, against free 32-bit operands: the divide invariant's cap below is
+  // guarded to the divide family, so nothing here is bounded. It was unguarded
+  // until ADR-0051, and an unguarded assume is proof-global, so these assertions
+  // ran against operands in 0..15 where every high half and every sign bit is
+  // zero -- MULH/MULHU/MULHSU asserted `out.rd_data == 0` and three of the four
+  // multiplier defects ADR-0010 names passed the proof written to catch them.
   //
-  // Until ADR-0051 these assertions ran against operands in 0..15, because the
-  // divide invariant's operand cap below was an UNGUARDED `always_comb assume`
-  // and an unguarded assume is proof-global (ADR-0049 finding F1). Every high
-  // half and every sign bit was constant zero, so MULH/MULHU/MULHSU asserted
-  // `out.rd_data == 0` and nothing more, and three of the four multiplier
-  // defects ADR-0010 names by hand PASSED the proof written to catch them. The
-  // cap is guarded to the divide family now, so everything below sees free
-  // 32-bit operands.
-  //
-  // The old shape here -- an independent `mul_ref_*` product mitered against
-  // `multiply` -- is gone, and its removal is deliberate rather than a
-  // simplification. At full width it is two structurally distinct `bvmul`
-  // terms, which is the miter the note at the top of this block records as
-  // returning no verdict in two minutes even in isolation. Decomposition takes
-  // its place: three obligations, each of which returns in seconds.
+  // Three obligations replace the miter, each returning in seconds:
   //
   //   (a) the 33-bit operands handed to `multiply` are the correct extensions
   //       of rs1/rs2 for the variant being issued;
@@ -417,34 +339,32 @@ module executor(
   //   (c) three constant-multiplication lemmas over `multiply` itself.
   //
   // (a) and (b) read the same product term the RTL does, so neither can see a
-  // product that is simply wrong -- which is exactly why (c) is not optional.
-  // It is the only part of this section that constrains the term's own value.
+  // product that is simply wrong. That is why (c) is not optional: it is the
+  // only part of this section that constrains the term's own value.
 
-  // ---- (a) the 33-bit operands ------------------------------------------
-  // MUL and MULHU take both operands unsigned; MULH takes both signed; MULHSU
-  // takes rs1 SIGNED and rs2 UNSIGNED. That asymmetry is the instruction's
-  // whole point, and having it backwards is one of the defects ADR-0010 names.
-  // The extensions are derived by WIDTH-EXTENDING ASSIGNMENT from a
-  // self-determined right-hand side, not by restating the RTL's
-  // `in.rs1[31] & (...)`, so a sign taken from the wrong bit disagrees here.
+  // (a) MUL and MULHU take both operands unsigned, MULH takes both signed, and
+  // MULHSU takes rs1 signed and rs2 unsigned -- an asymmetry ADR-0010 names
+  // getting backwards as a defect. The extensions are derived by width-extending
+  // assignment from a self-determined right-hand side rather than by restating
+  // the RTL's `in.rs1[31] & (...)`, so a sign taken from the wrong bit disagrees
+  // here.
   logic [32:0] rs1_sext33, rs2_sext33, rs1_zext33, rs2_zext33;
   assign rs1_sext33 = $signed(in.rs1);
   assign rs2_sext33 = $signed(in.rs2);
   assign rs1_zext33 = {1'b0, in.rs1};
   assign rs2_zext33 = {1'b0, in.rs2};
   logic [32:0] mul_op_x_ref, mul_op_y_ref;
-  // The `?:` selects between two ALREADY-COMPUTED 33-bit nets; no arithmetic
-  // sits in an arm of it. That is CLAUDE.md's twice-burned rule (ADR-0019's
-  // monitor DIV/REM models, then test/exec_tb.v's SRA reference): signed
-  // arithmetic in a reference model is a self-determined statement of its own.
+  // The `?:` selects between two already-computed 33-bit nets, with no
+  // arithmetic in an arm of it: signed arithmetic in a reference model must be a
+  // self-determined statement of its own, or IEEE 1800's sign-context rules
+  // silently evaluate it unsigned (ADR-0019).
   assign mul_op_x_ref = (in.is_mulh || in.is_mulhsu) ? rs1_sext33 : rs1_zext33;
   assign mul_op_y_ref = in.is_mulh ? rs2_sext33 : rs2_zext33;
   always_comb assert({mul_sign_x, in.rs1} == mul_op_x_ref);
   always_comb assert({mul_sign_y, in.rs2} == mul_op_y_ref);
 
-  // ---- (b) the retired slice of that same product ------------------------
-  // Sliced into plain 32-bit signals so $past() below applies to a simple
-  // signal rather than a part-select of a $past() result.
+  // (b) Sliced into plain 32-bit signals so the $past() below applies to a
+  // simple signal rather than to a part-select of a $past() result.
   logic [31:0] mul_lo, mul_hi;
   assign mul_lo = multiply[31:0];
   assign mul_hi = multiply[63:32];
@@ -462,121 +382,74 @@ module executor(
     if (clocked && !reset && !$past(reset) && !$past(accessor_stall) && $past(state) == init && $past(in.is_mulhsu))
       assert(out.rd_data == $past(mul_hi));
 
-  // ---- (c) constant-multiplication lemmas over `multiply` ----------------
-  // Each of these multiplies by a CONSTANT -- zero, zero and one -- so the
-  // solver sees shifts and adds rather than a second `bvmul` term, and each
-  // returns in seconds where the miter returns nothing at all. They catch what
-  // (a) and (b) structurally cannot: a masked high half, a product forced to a
-  // constant, a product that has stopped tracking its operands.
+  // (c) Each of these multiplies by a constant -- zero, zero and one -- so the
+  // solver sees shifts and adds rather than a second `bvmul` term. They catch
+  // what (a) and (b) structurally cannot: a masked high half, a product forced
+  // to a constant, a product that has stopped tracking its operands. The third
+  // is the load-bearing one, pinning all 64 bits of the product for a family of
+  // operand pairs, which is why deleting the high half fails here while (a) and
+  // (b) stay green.
   //
-  // The third is the load-bearing one. It pins all 64 bits of the product for
-  // an entire family of operand pairs -- the high half to the sign extension of
-  // rs1 and the low half to rs1 itself -- which is why deleting the high half
-  // fails HERE while (a) and (b) both stay green.
-  //
-  // An `in.rs2 == 32'hffffffff` lemma (multiply by -1, i.e. negate) is the
-  // obvious fourth and is measured NOT to work: no verdict in two minutes
-  // (ADR-0051). Do not add it back without re-measuring.
+  // An `in.rs2 == 32'hffffffff` lemma (multiply by -1) is the obvious fourth and
+  // is measured not to work -- no verdict in two minutes. Do not add it back
+  // without re-measuring (ADR-0051).
   always_comb if (in.rs1 == 32'b0) assert(multiply == 64'b0);
   always_comb if (in.rs2 == 32'b0) assert(multiply == 64'b0);
   always_comb if (in.rs2 == 32'h1 && !mul_sign_y)
     assert(multiply == {{32{mul_sign_x}}, in.rs1});
 
-  // Divide: an end-to-end assertion unrolling the restoring divider's full
-  // 33-cycle latency (out.rd_data correct N cycles after issue) is not provable
-  // by k-induction as such a property — sby's default engine depth here is 20
-  // steps, well short of 33, and induction can't "remember" that far back
-  // without restating the whole trajectory as an invariant anyway. So this
-  // proves a loop invariant instead (below), which needs only one induction
-  // step regardless of how many iterations the divider takes, and separately
-  // restricts operand MAGNITUDE to 15 (sign free) so the invariant's intermediate
-  // arithmetic stays comfortably inside 64 bits without wraparound (ADR-0010:
-  // "restrict it... record the restriction as a comment in the sby task" —
-  // recorded here rather than in formal/components.sby because the restriction
-  // is a property of this proof's invariant, so it belongs next to the
-  // invariant it constrains).
-  //
-  // The invariant, proved by ordinary one-step induction instead of unrolling:
-  // at every point while state == divide,
+  // The divider is proved through a loop invariant rather than by unrolling its
+  // 33-cycle latency, which sby's 20-step default depth cannot reach anyway. At
+  // every point while state == divide,
   //   dividend == remainder-so-far + quotient-so-far * (divisor << iterations-remaining)
-  // and remainder-so-far < (divisor << iterations-remaining). Both are
-  // preserved by each iteration of the shift/subtract loop regardless of how
-  // many iterations have run, which is exactly what makes them provable
-  // without unrolling the whole operation. At the last iteration (0 remaining)
-  // this collapses to the ordinary division identity dividend == remainder +
-  // quotient * divisor with 0 <= remainder < divisor, tying the invariant to
-  // real division and — combined with the assertions below — to out.rd_data.
-  // FACT       ADR-0010's recorded RESTRICTION -- a bound on the proof, not a
-  //            claim about the design. The values the divider actually LOADS
-  //            (`div_x`/`div_y`, i.e. the ADR-0012 magnitudes) are at most 15.
-  //            Bounding those is what keeps the loop invariant's intermediate
-  //            arithmetic (`mul_div_store * (div_y << mul_div_counter)`) inside
-  //            64 bits without wraparound.
-  // DISCHARGED NOWHERE, and nothing should discharge it: a restriction is not a
-  //            fact to be checked elsewhere. What covers the divider at full
-  //            width is test/exec_tb.v -- ADR-0010's PRIMARY guarantee --
-  //            with >=10,000 randomized vectors per divide-family op.
-  // SCOPE      the divide family ONLY: `is_div`/`is_divu`/`is_rem`/`is_remu`,
-  //            plus `state == divide`. Every multiply assertion above runs
-  //            against free 32-bit operands. This assume was UNGUARDED until
-  //            ADR-0051 and was therefore proof-global (ADR-0049 F1 and F5):
-  //            the multiply assertions asserted about operands in 0..15, where
-  //            every high half and every sign bit is zero, and the two
-  //            `op_sign_*` tie-backs below read `assert(0 == 0)`.
+  // and remainder-so-far < (divisor << iterations-remaining). Each iteration of
+  // the shift/subtract loop preserves both regardless of how many have run,
+  // which is what makes them provable in one induction step; at 0 iterations
+  // remaining they collapse to the division identity, tying the invariant to
+  // real division and, with the completion assertions below, to out.rd_data.
   //
-  // Two things about the shape of this cap are non-obvious and both are
-  // measured rather than reasoned:
+  // Assumed: the values the divider loads (`div_x`/`div_y`, the ADR-0012
+  // magnitudes) are at most 15, which keeps the invariant's intermediate
+  // arithmetic inside 64 bits without wraparound. This is ADR-0010's recorded
+  // restriction on the proof rather than a claim about the design, so nothing
+  // discharges it and nothing should; the divider at full width is covered by
+  // test/exec_tb.v. It is scoped to the divide family and `state == divide`, so
+  // every multiply assertion above runs against free 32-bit operands.
   //
-  // 1. The `|| state == divide` term is REQUIRED and is not redundant with the
+  // Two things about the shape of this cap are non-obvious and both were
+  // measured (ADR-0051):
+  //
+  // 1. The `|| state == divide` term is required and is not redundant with the
   //    op flags. k-induction may start in `divide` with every `is_div*` low, and
-  //    without that term the cap lapses in exactly those states -- the
-  //    `mul_div_store <= div_x` invariant then fails induction. Guarding on the
-  //    op flags alone does not work; do not rediscover this.
-  // 2. It caps `div_x`/`div_y`, NOT `in.rs1`/`in.rs2`, and that is what makes it
-  //    a MAGNITUDE cap. The `in.rs1 <= 32'h0f` form it replaces held bit 31 at
-  //    constant zero, so `op_sign_x`/`op_sign_y` were constant zero too and
-  //    ADR-0012's magnitude wrapper -- the entire reason this divider is allowed
-  //    to be unsigned -- had no coverage of any kind here: deleting either sign
-  //    restore PASSED (ADR-0049 F5). Capping the loaded magnitude instead leaves
-  //    the SIGN free for DIV/REM: `div_x <= 15` admits `in.rs1` anywhere in
-  //    -15..15, so `in.rs1[31]` is a free bit and the completion assertions at
-  //    the bottom of this block mean something. For DIVU/REMU, where `div_x` IS
-  //    `in.rs1`, it is the same 0..15 restriction as before, which is correct:
-  //    those operands have no sign to free.
-  //
-  //    Capping `$signed(in.rs1)` to -15..15 directly was built first and does
-  //    NOT work. It leaves `div_y` free up to ~2^32 for DIVU/REMU (where no
-  //    magnitude conversion happens, so a "small" negative operand is a huge
-  //    unsigned divisor), `mul_div_store * div_scaled_divisor` then wraps mod
-  //    2^64, and induction fails on the `mul_div_store <= div_x` bound below --
-  //    the very invariant that exists to rule wraparound solutions out.
-  //    Measured (ADR-0051): induction FAIL at 4s, basecase still crawling at
-  //    step 17 after 1m45s. Do not "simplify" this cap back onto in.rs1/in.rs2.
+  //    without that term the cap lapses in exactly those states, whereupon the
+  //    `mul_div_store <= div_x` invariant fails induction.
+  // 2. It caps `div_x`/`div_y` rather than `in.rs1`/`in.rs2`, which is what
+  //    makes it a MAGNITUDE cap and leaves the sign free: `div_x <= 15` admits
+  //    `in.rs1` anywhere in -15..15, so `in.rs1[31]` is a free bit and the
+  //    completion assertions below mean something. The `in.rs1 <= 32'h0f` form
+  //    it replaces held bit 31 at constant zero, so ADR-0012's magnitude wrapper
+  //    had no coverage here at all and deleting either sign restore passed.
+  //    Capping `$signed(in.rs1)` to -15..15 instead was built and does not work:
+  //    it leaves `div_y` free up to ~2^32 for DIVU/REMU, where no magnitude
+  //    conversion happens, so the product wraps mod 2^64 and induction fails on
+  //    the very bound that exists to rule wraparound out. Do not simplify this
+  //    cap back onto in.rs1/in.rs2.
   logic div_family;
   assign div_family = in.is_div || in.is_divu || in.is_rem || in.is_remu ||
                       state == divide;
   always_comb if (div_family) assume(div_x <= 32'h0000000f);
   always_comb if (div_family) assume(div_y <= 32'h0000000f);
 
-  // FACT       ADR-0009's stall protocol: the pipeline holds `in` steady for
-  //            the full duration of a multi-cycle divide, so the opcode
-  //            selection at capture time cannot be corrupted by a free-running
-  //            formal input mid-divide. (The real bug this would otherwise
-  //            hide: ADR-0012 records that the executor reads
-  //            is_div/is_divu/is_rem/is_remu fresh at capture time.)
-  // DISCHARGED NOWHERE. `rtl/decoder.v`'s own task asserts the pc holds on a
-  //            stalled cycle, not that `decoder_out` holds (ADR-0049's census).
-  // SCOPE      guarded on `state == divide || $past(state) == divide`, so
-  //            genuinely scoped to the divide assertions and to nothing else.
-  //            The one guarded assume in `rtl/` before ADR-0051; the cap above
-  //            is now the second.
+  // Assumed: ADR-0009's stall protocol holds `in` steady for the duration of a
+  // multi-cycle divide, so a free-running formal input cannot corrupt the opcode
+  // selection at capture time. Discharged nowhere -- rtl/decoder.v's own task
+  // asserts that the pc holds on a stalled cycle, not that `decoder_out` does.
+  // The guard scopes it to the divide assertions and nothing else.
   always_ff @(posedge clk)
-    // Covers both the first divide-state cycle (state == divide; otherwise
-    // that cycle's `in` is a free input that can disagree with what was just
-    // latched into mul_div_x/mul_div_y at issue) and the capture cycle
-    // ($past(state) == divide, state == init; otherwise the capture edge's
-    // `in.is_divu`/`is_remu` used below can disagree with the operands the
-    // divider actually ran on).
+    // It covers the first divide-state cycle, where `in` would otherwise be free
+    // to disagree with what was just latched into mul_div_x/mul_div_y, and the
+    // capture cycle, where `in.is_divu`/`is_remu` read below would otherwise be
+    // free to disagree with the operands the divider actually ran on.
     if (clocked && (state == divide || $past(state) == divide)) begin
       assume(in.rs1 == $past(in.rs1));
       assume(in.rs2 == $past(in.rs2));
@@ -586,13 +459,10 @@ module executor(
       assume(in.is_remu == $past(in.is_remu));
     end
 
-  // Ties the op_is_*/op_sign_* latches (see their declaration
-  // above) back to `in` while dividing, mirroring what the environmental
-  // assumption above already establishes about `in` staying constant. Without
-  // this as its own stated (one-step-inductive) invariant, k-induction has no
-  // intermediate fact linking a latch taken once at issue to `in.is_divu`
-  // read many cycles later at the completion assertions below, and induction
-  // (not just the base case) fails to close.
+  // Ties the op_is_*/op_sign_* latches back to `in` while dividing. Without this
+  // as a stated one-step-inductive invariant, k-induction has no intermediate
+  // fact linking a latch taken once at issue to the `in.is_divu` read many
+  // cycles later at the completion assertions, and induction fails to close.
   always_comb if (state == divide) assert(op_is_div == in.is_div);
   always_comb if (state == divide) assert(op_is_divu == in.is_divu);
   always_comb if (state == divide) assert(op_is_rem == in.is_rem);
@@ -600,26 +470,24 @@ module executor(
   always_comb if (state == divide) assert(op_sign_x == in.rs1[31]);
   always_comb if (state == divide) assert(op_sign_y == in.rs2[31]);
 
-  // k-induction otherwise has no reason to rule out an (unreachable) starting
-  // state with a wild mul_div_counter value — bound it to the range the RTL
-  // actually drives it through, so the counter can serve as an exact iteration
-  // count ("how many halvings of the divisor remain") in the invariant below.
+  // k-induction otherwise has no reason to rule out an unreachable starting
+  // state with a wild counter, and the invariant below reads it as an exact
+  // count of the divisor halvings remaining.
   always_comb if (state == divide) assert(mul_div_counter <= 32);
 
-  // Ties the actual mul_div_y register to the same "divisor scaled by
-  // iterations remaining" quantity the invariant below reasons about — without
-  // this, mul_div_y is a free register as far as the solver's concerned, and
-  // the comparison the RTL actually branches on (mul_div_x >= mul_div_y) has
-  // no connection to what the invariant expects it to be. Scoped to
-  // mul_div_counter > 0: at counter == 0, mul_div_y has taken its last
-  // (possibly LSB-dropping) right-shift and is no longer read by anything.
+  // Ties mul_div_y to the same "divisor scaled by iterations remaining" quantity
+  // the invariant below reasons about. Without it mul_div_y is a free register
+  // to the solver, and the comparison the RTL branches on (mul_div_x >=
+  // mul_div_y) has no connection to what the invariant expects. Scoped to
+  // counter > 0, since at 0 mul_div_y has taken its last, possibly
+  // LSB-dropping, right-shift and nothing reads it again.
   always_comb
     if (state == divide && mul_div_counter > 0)
       assert(mul_div_y == ({32'b0, div_y} << (mul_div_counter - 1)));
 
-  // Uses div_x/div_y (what the divider actually loaded), not in.rs1/in.rs2
-  // directly, so this covers is_div/is_rem's abs-value conversion too, not just
-  // the unsigned ops.
+  // div_x/div_y, what the divider actually loaded, rather than in.rs1/in.rs2 --
+  // so this covers is_div/is_rem's magnitude conversion and not just the
+  // unsigned ops.
   logic [63:0] div_scaled_divisor;
   assign div_scaled_divisor = ({32'b0, div_y}) << mul_div_counter;
   always_comb
@@ -628,30 +496,26 @@ module executor(
   always_comb
     if (state == divide)
       assert(mul_div_x < div_scaled_divisor);
-  // Without this, the equality invariant above is only an equation over
-  // 64-bit *modular* arithmetic, and the solver can satisfy it with a
-  // mul_div_store far outside any value the real 32-iteration algorithm would
-  // ever produce (a wraparound "solution" mod 2^64) as an induction starting
-  // point. True quotients never exceed the dividend for a divisor >= 1, so
-  // this is also a real fact about the algorithm, not just a proof crutch.
+  // Without this the equality invariant above is only an equation over 64-bit
+  // modular arithmetic, and the solver can satisfy it from an induction start
+  // whose mul_div_store is a wraparound solution mod 2^64. True quotients never
+  // exceed the dividend for a divisor >= 1, so this is a real fact about the
+  // algorithm rather than only a proof crutch.
   always_comb
     if (state == divide)
       assert(mul_div_store <= {32'b0, div_x});
 
-  // ---- completion: the four divide-family results ------------------------
+  // Completion: the four divide-family results. The signed pair
+  // (`div_ref`/`rem_ref`) is the only thing in this proof that exercises
+  // ADR-0012's magnitude wrapper -- the divider loop is unsigned, `div_x`/`div_y`
+  // are absolute values, and the sign is restored at capture. Under the old
+  // value cap those two capture arms could be deleted outright and the task
+  // still passed.
   //
-  // The signed pair (`div_ref`/`rem_ref`) is new in ADR-0051 and is the only
-  // thing in this proof that exercises ADR-0012's magnitude wrapper: the
-  // divider loop is unsigned, `div_x`/`div_y` are absolute values, and the sign
-  // is restored at capture. Under the old value cap those two capture arms
-  // could be deleted outright and the task still passed (ADR-0049 F5).
-  //
-  // Every signed operation below is a SELF-DETERMINED STATEMENT OF ITS OWN and
-  // is never an arm of a conditional -- CLAUDE.md's twice-burned rule. `div_q`
-  // and `div_r` are computed first; only the already-computed 32-bit results
-  // are then selected by the divide-by-zero mux, so no sign context can be
-  // taken away from the division itself the way ADR-0019's monitor models had
-  // it taken away from theirs.
+  // `div_q` and `div_r` are computed first and only the already-computed 32-bit
+  // results are selected by the divide-by-zero mux, so no sign context is taken
+  // away from the division itself the way ADR-0019's monitor models had it taken
+  // away from theirs.
   logic signed [31:0] div_srs1, div_srs2;
   assign div_srs1 = $signed(in.rs1);
   assign div_srs2 = $signed(in.rs2);
@@ -665,15 +529,13 @@ module executor(
   assign div_ref  = (in.rs2 == 0) ? 32'hffffffff : div_q;
   assign rem_ref  = (in.rs2 == 0) ? in.rs1 : div_r;
 
-  // ADR-0049 F3 applies to all four of these and is not a defect in them: the
-  // guard `$past(state) == divide && state == init` is UNREACHABLE in the
-  // basecase, because `components.sby` sets no depth (so `mode prove`'s
-  // basecase runs 20 steps) and the real divider needs 33 cycles from issue.
-  // The practical consequence, and the reason it is written here rather than
-  // left to be rediscovered: a mutation that breaks one of these reports
-  // `UNKNOWN (rc=4)` -- basecase pass, induction FAIL -- not `FAIL`. That is
-  // this assertion class's normal detection signal. Raising the basecase past
-  // 33 is a depth change needing its own evidence (ADR-0025).
+  // The guard `$past(state) == divide && state == init` is unreachable in the
+  // basecase: components.sby sets no depth, so `mode prove`'s basecase runs 20
+  // steps and the real divider needs 33 cycles from issue. A mutation that
+  // breaks one of these therefore reports `UNKNOWN (rc=4)` -- basecase pass,
+  // induction FAIL -- rather than `FAIL`, which is this assertion class's normal
+  // detection signal. Raising the basecase past 33 is a depth change needing its
+  // own evidence (ADR-0025, ADR-0049 F3).
   always_ff @(posedge clk)
     if (clocked && !reset && $past(state) == divide && state == init && $past(in.is_divu))
       assert(out.rd_data == divu_ref);

--- a/rtl/regfile.v
+++ b/rtl/regfile.v
@@ -10,38 +10,28 @@ module regfile(
   input  logic [4:0]  waddr,
   input  logic [31:0] wdata
 );
-  // TWO ARRAYS, ONE ARCHITECTURAL REGISTER FILE (ADR-0042). An ice40 EBR has
-  // one read port, so a second read port means a second copy of the state. The
-  // duplication is forced by the storage element, not chosen: both arrays are
-  // written from the same address and the same data word, every time, and
-  // `regs_a[i] == regs_b[i]` is an invariant test/regfile_tb.v asserts
-  // directly. Nothing else would notice them drifting -- test/cosim.cc reads
-  // regs_a alone, and reg_rs2 is the only consumer of regs_b.
-  //
-  // Before ADR-0042 this was one flip-flop array with a combinational 32:1 read
-  // mux, and nextpnr placed the core at 6971 logic cells, 132% of an up5k.
-  // Moving these two arrays into block RAM is what takes it to 79%; yosys
-  // infers the EBRs from the plain arrays below with no attribute and no
-  // explicit primitive.
+  // Two arrays, one architectural register file: an ice40 EBR has one read
+  // port, so a second read port means a second copy of the state. Both are
+  // written from the same address and data word every time, and
+  // `regs_a[i] == regs_b[i]` is asserted in test/regfile_tb.v because nothing
+  // else would notice them drifting -- test/cosim.cc reads regs_a alone, and
+  // reg_rs2 is the only consumer of regs_b. yosys infers the EBRs from these
+  // plain arrays with no attribute (ADR-0042).
   logic [31:0] regs_a[31:0];
   logic [31:0] regs_b[31:0];
   logic [31:0] read_a;
   logic [31:0] read_b;
 
-  // THE READ IS REGISTERED, so the operand for the address presented in cycle N
-  // appears on reg_rs1/reg_rs2 in cycle N+1 -- a whole cycle after decode needs
-  // it, because decode computes branch targets and load/store addresses from
-  // these values in the cycle it issues. So decode presents the address,
-  // bubbles for one cycle, and issues on the next: `operand_stall` in
-  // rtl/decoder.v. CLAUDE.md invariant 9 is the rule that makes it correct, and
-  // it is not local to this file.
+  // The read is registered, so the operand for the address presented in cycle N
+  // appears in cycle N+1 -- a cycle after decode needs it. Decode therefore
+  // presents the address, bubbles, and issues on the next cycle
+  // (`operand_stall` in rtl/decoder.v, CLAUDE.md invariant 9).
   //
-  // The write-first term is not decoration. Without it, a write committed at
-  // the very posedge that captures the read would be missed and the operand
-  // would be exactly one writeback stale -- the ADR-0004 defect, re-introduced
-  // one cycle earlier where the scoreboard cannot see it. An ice40 EBR has no
-  // write-first mode, so yosys builds this comparator and mux in fabric, which
-  // is the right place for it: it is the part a reader most needs to see.
+  // Without the write-first term a write committed at the very posedge that
+  // captures the read would be missed, leaving the operand exactly one writeback
+  // stale -- the ADR-0004 defect, one cycle earlier where the scoreboard cannot
+  // see it. An ice40 EBR has no write-first mode, so yosys builds this
+  // comparator and mux in fabric.
   always_ff @(posedge clk) begin
     read_a <= (wen && waddr == rs1) ? wdata : regs_a[rs1];
     read_b <= (wen && waddr == rs2) ? wdata : regs_b[rs2];
@@ -51,16 +41,14 @@ module regfile(
     end
   end
 
-  // Write-through bypass (ADR-0004, CLAUDE.md invariant 6), unchanged in intent
-  // from the flip-flop regfile: a write presented in the cycle the operand is
-  // USED forwards wdata directly instead of the value captured a cycle ago.
-  //
-  // The two forwarding points together -- write-first above, this bypass here
-  // -- are what make the operand the cycle-N architectural value *including* a
-  // cycle-N writeback, which is the whole observable content of invariant 6 and
-  // the reason ADR-0004's stall-only scoreboard needs no forwarding path for
-  // the writeback slot. Deleting either one is a direct invariant-6 violation;
-  // deleting the rs2 half of this one is the ladder's liveness probe (ADR-0040).
+  // Write-through bypass: a write presented in the cycle the operand is used
+  // forwards wdata directly instead of the value captured a cycle ago. Together
+  // with the write-first term above it makes the operand the cycle-N
+  // architectural value including a cycle-N writeback, which is the whole
+  // observable content of CLAUDE.md invariant 6 and the reason ADR-0004's
+  // stall-only scoreboard needs no forwarding path for the writeback slot.
+  // Deleting either point violates invariant 6; deleting the rs2 half of this
+  // one is the ladder's liveness probe for reg_ch0 (ADR-0040).
   // x0 always reads 0, regardless of wen/waddr.
   always_comb begin
     reg_rs1 = (rs1 == 5'd0) ? 32'b0 : (wen && waddr == rs1) ? wdata : read_a;

--- a/rtl/writeback.v
+++ b/rtl/writeback.v
@@ -10,11 +10,6 @@ module writeback(
   output logic wen,
   output logic [4:0] waddr,
   output logic [31:0] wdata
-  // ADR-0006 / CLAUDE.md invariant 3: "retire is `valid` reaching
-  // writeback, which gates wen and drives rvfi_valid" — this is that spot.
-  // `rvfi_trap` is no longer hardwired either: rtl/decoder.v computes it where
-  // every trap is detected and committed (invariant 2) and it rides the shadow
-  // down here like the CSR fields and everything else per-retire.
  `ifdef RISCV_FORMAL
   ,
   output logic        rvfi_valid,
@@ -34,9 +29,9 @@ module writeback(
   output logic [ 3:0] rvfi_mem_wmask,
   output logic [31:0] rvfi_mem_rdata,
   output logic [31:0] rvfi_mem_wdata,
-  // The CSRs formal/checks.cfg's `[csrs]` list names. mcycle/minstret are
-  // 64-bit RVFI CSRs (mcycleh/minstreth address the upper half of the same
-  // report, not a second CSR); mscratch is XLEN.
+  // The CSRs formal/checks.cfg's `[csrs]` list names. mcycle and minstret are
+  // 64-bit RVFI CSRs -- mcycleh/minstreth address the upper half of the same
+  // report rather than a second CSR.
   output logic [63:0] rvfi_csr_mcycle_rmask,
   output logic [63:0] rvfi_csr_mcycle_wmask,
   output logic [63:0] rvfi_csr_mcycle_rdata,
@@ -57,9 +52,8 @@ module writeback(
       waddr = 0;
       wdata = 32'b0;
     end else begin
-      // Retire is `valid` reaching writeback (CLAUDE.md invariant 3): a
-      // bubble must never commit a register write, so wen is gated on both
-      // valid and a non-zero destination.
+      // Retire is `valid` reaching writeback (CLAUDE.md invariant 3): a bubble
+      // must never commit a register write.
       wen = in.valid && (in.rd != 0);
       waddr = in.rd;
       wdata = in.rd_data;
@@ -67,48 +61,26 @@ module writeback(
   end // always_comb
 
  `ifdef RISCV_FORMAL
-  // Combinational, same as wen/waddr/wdata above: `in` is already a
-  // registered accessor_output, stable for exactly the one cycle it
-  // retires, so there is nothing to re-register here except the running
-  // order counter below.
-  // ADR-0028's convention for a TRAPPING retire, restated here because this is
-  // the drive site and a reader has no other way to learn that the oracle is
-  // silent about it. riscv-formal's checks/rvfi_insn_check.sv puts rd_addr,
-  // rd_wdata, pc_wdata and every mem_* assertion inside `if (!spec_trap)` and
-  // keeps only `assert(spec_trap == trap)` outside, so the ladder cannot tell
-  // a core that traps correctly from one that traps AND corrupts rd, writes
-  // memory, and redirects somewhere arbitrary. What this core commits to:
+  // What this core reports on a trapping retire, and what no oracle checks.
+  // riscv-formal's checks/rvfi_insn_check.sv puts rd_addr, rd_wdata, pc_wdata
+  // and every mem_* assertion inside `if (!spec_trap)`, so the ladder cannot
+  // tell a core that traps correctly from one that traps and also corrupts rd,
+  // writes memory and redirects somewhere arbitrary. The convention is
+  // rvfi_valid 1 (a trapping instruction does retire), rvfi_trap 1, rd_addr /
+  // rd_wdata / mem_rmask / mem_wmask 0, and pc_wdata = mtvec (ADR-0028).
   //
-  //   rvfi_valid  1   -- a trapping instruction DOES retire
-  //   rvfi_trap   1
-  //   rvfi_rd_addr / rvfi_rd_wdata            0
-  //   rvfi_mem_rmask / rvfi_mem_wmask         0
-  //   rvfi_pc_wdata                           mtvec
+  // None of it is enforced here. rtl/decoder.v suppresses `out.rd` and every
+  // execution flag on a trapping issue, so the values below are zero because
+  // nothing produced anything, and that redirect target is asserted in the
+  // decoder's own component proof. `reg` and `pc_fwd`/`pc_bwd` catch a broken
+  // one indirectly, but neither names traps in its title.
   //
-  // None of it is enforced here: it is enforced upstream, in rtl/decoder.v,
-  // by suppressing `out.rd` and every execution flag on a trapping issue, so
-  // the values below are zero because nothing produced anything -- not because
-  // this block masks them. TWO ladder checks catch it INDIRECTLY if that
-  // breaks -- `reg` for an rd that still lands, and `pc_fwd`/`pc_bwd` for a
-  // redirect that is misreported or not taken. Neither names traps in its
-  // title, the connection is not discoverable from CI output, and `reg` is
-  // itself inconclusive (ADR-0023), so this is thinner cover than it looks.
-  // ADR-0028 named a third, `dmemcheck`, for a store that still strobes the
-  // bus; ADR-0037 STRUCK it. The shadow it compares is not independent of the
-  // bus -- rtl/accessor.v builds rvfi_mem_wmask/wdata from the same
-  // mem_wstrb/write_request dmemcheck samples -- so a suppressed-but-executed
-  // store is reported faithfully by both and nothing desynchronises.
-  // Confirmed by mutation: dmemcheck stayed PASS. The one thing nothing on the ladder
-  // can see -- that the target is `mtvec` -- is asserted in rtl/decoder.v's
-  // component proof.
-  // A continuous assign rather than a line in the always_comb below, and that
-  // is the documented pattern rather than a style choice (ADR-0034): every
+  // A continuous assign rather than a line in the always_comb below: every
   // struct-field read inside an `always_comb` is a constant part-select
   // iverilog cannot build a precise sensitivity entry for, so it emits
-  // `sorry: constant selects in always_* processes are not fully supported`
-  // and falls back to whole-struct sensitivity. Safe, but a diagnostic, and
-  // CLAUDE.md caps the count at exactly 20. Adding this one line in there made
-  // it 21.
+  // `sorry: constant selects in always_* processes are not fully supported`.
+  // The fallback is safe but is a diagnostic, and CLAUDE.md caps the count at
+  // 20 (ADR-0034). This one line inside there made it 21.
   assign rvfi_trap = in.rvfi.trap;
 
   always_comb begin
@@ -118,12 +90,10 @@ module writeback(
     rvfi_rs2_addr = in.rvfi.rs2_addr;
     rvfi_rs1_rdata = in.rvfi.rs1_rdata;
     rvfi_rs2_rdata = in.rvfi.rs2_rdata;
-    // rd_addr/rd_wdata are not carried in the rvfi shadow -- `rd`/`rd_data`
-    // are already exactly the values needed (ADR-0006: no need to duplicate
-    // them). rd_wdata is masked to 0 alongside x0, matching the regfile's
-    // own write-through (CLAUDE.md invariant 6): a write "to" x0 must never
-    // report a nonzero rd_wdata even though rd_data itself is whatever the
-    // ALU produced.
+    // rd_addr/rd_wdata are not carried in the rvfi shadow; `rd`/`rd_data` are
+    // already the values needed. rd_wdata is masked to 0 alongside x0, matching
+    // the regfile's own write suppression: a write "to" x0 must not report a
+    // nonzero rd_wdata even though rd_data holds whatever the ALU produced.
     rvfi_rd_addr = in.rd;
     rvfi_rd_wdata = |in.rd ? in.rd_data : 32'b0;
     rvfi_pc_rdata = in.rvfi.pc_rdata;
@@ -135,18 +105,10 @@ module writeback(
     rvfi_mem_wdata = in.rvfi_mem_wdata;
   end
 
-  // Captured in decode (ADR-0005 commits every CSR access there), carried
-  // down the shadow, reported here at retire like everything else -- but as
-  // continuous assigns rather than inside the always_comb above, and that is
-  // not a style choice. Every struct-field read in that block is a constant
-  // part-select, which iverilog cannot build a precise sensitivity entry for
-  // ("sorry: constant selects in always_* processes are not fully
-  // supported"); it falls back to whole-struct sensitivity, which is safe but
-  // is a diagnostic, and CLAUDE.md says warnings are errors and caps the
-  // count. Adding twelve more reads in there added twelve more notes.
-  // A continuous assign has an exact sensitivity, so this says the same thing
-  // without them -- the same fix rtl/accessor.v and rtl/decoder.v already
-  // apply to their own payload reads.
+  // Captured in decode (ADR-0005 commits every CSR access there) and reported
+  // here at retire. Continuous assigns for the same sensitivity reason as
+  // rvfi_trap above: these twelve reads inside the always_comb are twelve more
+  // `sorry:` notes.
   assign rvfi_csr_mcycle_rmask   = in.rvfi.csr_mcycle.rmask;
   assign rvfi_csr_mcycle_wmask   = in.rvfi.csr_mcycle.wmask;
   assign rvfi_csr_mcycle_rdata   = in.rvfi.csr_mcycle.rdata;
@@ -160,8 +122,8 @@ module writeback(
   assign rvfi_csr_mscratch_rdata = in.rvfi.csr_mscratch.rdata;
   assign rvfi_csr_mscratch_wdata = in.rvfi.csr_mscratch.wdata;
 
-  // rvfi_order counts retires (RVFI spec: monotonically increasing, one per
-  // rvfi_valid cycle). The only genuinely sequential piece of RVFI state.
+  // The only sequential piece of RVFI state here: everything else is a
+  // combinational read of `in`, which is already registered upstream.
   always_ff @(posedge clk) begin
     if (reset) rvfi_order <= 64'b0;
     else if (rvfi_valid) rvfi_order <= rvfi_order + 64'b1;

--- a/test/csr_tb.v
+++ b/test/csr_tb.v
@@ -2,25 +2,21 @@
 `default_nettype none
 `include "structs.v"
 
-// The CSR file's own bench (ADR-0005), the same shape test/regfile_tb.v uses
-// for the register file: drive the access port directly and assert on what
-// comes back, rather than inferring it from a whole-pipeline run.
+// rtl/csrs.v's own bench: drive the access port directly rather than infer the
+// CSR file's behaviour from a whole-pipeline run. Three things it covers that
+// nothing else can.
 //
-// Three things this covers that nothing else can:
-//
-//  1. **The read mux**, including which addresses `implemented` accepts --
-//     that output feeds rtl/decoder.v's `instr_valid`, so an address wrongly
-//     accepted here becomes an instruction the core executes instead of
-//     rejecting, and an address wrongly rejected becomes an illegal
-//     instruction. Neither shows up as a CSR bug in a `.S` test; both show
-//     up as something stranger.
-//  2. **WARL masking**, per field, which the riscv-formal ladder structurally
-//     cannot check: rvfi_csrw_check.sv has no WARL model at all (see
-//     formal/checks.cfg's [csrs] note), so mtvec/mepc/mstatus are off the
-//     ladder on purpose and this is where they are checked.
-//  3. **Write suppression as seen from this side** -- wen low means nothing
-//     changes, for every CSR. Which *instructions* drive wen low is the
-//     decoder's business and is checked in test/decoder_tb.v.
+//  1. The read mux, including which addresses `implemented` accepts. That
+//     output feeds rtl/decoder.v's `instr_valid`, so an address wrongly
+//     accepted becomes an instruction the core executes and one wrongly
+//     rejected becomes an illegal instruction -- neither reads as a CSR bug in
+//     a `.S` test.
+//  2. WARL masking, per field, which the riscv-formal ladder structurally
+//     cannot check: rvfi_csrw_check.sv has no WARL model, so mtvec/mepc/mstatus
+//     are off formal/checks.cfg's [csrs] list on purpose.
+//  3. Write suppression as seen from this side -- wen low means nothing
+//     changes. Which instructions drive wen low is the decoder's business and
+//     is checked in test/decoder_tb.v.
 module csr_tb;
   logic clk = 0;
   always #5 clk = ~clk;
@@ -32,8 +28,8 @@ module csr_tb;
   logic [31:0] rdata;
   logic        implemented;
   logic        instret;
-  // ADR-0028's second write port. rtl/decoder.v drives these for exactly the
-  // cycle it commits a trap (or an mret); this bench drives them directly.
+  // The second write port. rtl/decoder.v drives these for exactly the cycle it
+  // commits a trap (or an mret); this bench drives them directly (ADR-0028).
   logic        trap_entry, mret_entry;
   logic [31:0] trap_cause, trap_epc;
   logic [31:0] mtvec_value, mepc_value;
@@ -156,17 +152,15 @@ module csr_tb;
     #1;
     reset = 1'b0;
 
-    // ---- reset values --------------------------------------------------
     check_read("mscratch resets to 0", 12'h340, 32'h0);
-    // ADR-0029: 0, deliberately, with the harness (not the RTL) making a
-    // trap taken before a handler is installed loud.
+    // 0 rather than an unmapped address: the harness, not the RTL, is what makes
+    // a trap taken before a handler is installed loud (ADR-0029).
     check_read("mtvec resets to 0", 12'h305, 32'h0);
     check_read("mepc resets to 0", 12'h341, 32'h0);
     check_read("mcause resets to 0", 12'h342, 32'h0);
     // MPP is hardwired to M-mode out of reset, MIE/MPIE clear.
     check_read("mstatus resets to MPP=M", 12'h300, 32'h0000_1800);
 
-    // ---- the read mux, and what `implemented` accepts --------------------
     check_read("misa", 12'h301, 32'h4000_1104);
     check_read("mie reads 0", 12'h304, 32'h0);
     check_read("mip reads 0", 12'h344, 32'h0);
@@ -179,29 +173,25 @@ module csr_tb;
     check_read("minstreth", 12'hB82, 32'h0);
     check_read("mcycleh", 12'hB80, 32'h0);
 
-    // The two RV32-mandatory registers this core trapped on until ADR-0048.
-    // They are here rather than among the "does not have" addresses below
-    // because the spec lists both unconditionally for RV32 machine mode, so
-    // `implemented` low on either is a conformance failure and not a scope
+    // The privileged spec lists both unconditionally for RV32 machine mode, so
+    // `implemented` low on either is a conformance failure rather than a scope
     // choice -- ADR-0005's set is a floor, not a closed list.
     check_read("mstatush reads 0", 12'h310, 32'h0);
     check_read("mconfigptr reads 0", 12'hF15, 32'h0);
 
     // mstatush is writable by encoding (addr[11:10] == 2'b00) and has no
-    // implemented fields, so a write is a legal WARL no-op. It must NOT trap
-    // and it must NOT retain -- getting either wrong is a conformance bug in
-    // opposite directions.
+    // implemented fields, so a write is a legal WARL no-op: it must neither trap
+    // nor retain, which are conformance bugs in opposite directions.
     poke(12'h310, 32'hFFFF_FFFF);
     check_read("mstatush still reads 0 after a write", 12'h310, 32'h0);
 
     // mconfigptr is read-only by encoding (addr[11:10] == 2'b11), so the
-    // decoder's existing illegal-CSR rule rejects a write to it before this
-    // file is ever asked. What is checked here is that the read side stayed
-    // put, which is the half rtl/csrs.v owns.
+    // decoder rejects a write before rtl/csrs.v is asked. Only the read side is
+    // this module's half.
     check_read("mconfigptr reads 0 after an attempted write", 12'hF15, 32'h0);
 
     // Addresses this core does not have. `implemented` low is what makes
-    // rtl/decoder.v call the instruction unrecognised (ADR-0005).
+    // rtl/decoder.v call the instruction unrecognised.
     peek(12'h7C0); // a custom/unimplemented machine CSR
     check_bit("0x7c0 is not implemented", implemented, 1'b0);
     check_hex("...and reads 0", rdata, 32'h0);
@@ -212,13 +202,11 @@ module csr_tb;
     peek(12'h000);
     check_bit("address 0 is not implemented", implemented, 1'b0);
 
-    // ---- plain read/write ------------------------------------------------
     poke(12'h340, 32'hdead_beef);
     check_read("mscratch round-trips every bit", 12'h340, 32'hdead_beef);
     poke(12'h342, 32'h0000_000b);
     check_read("mcause round-trips", 12'h342, 32'h0000_000b);
 
-    // ---- write suppression -----------------------------------------------
     // wen low changes nothing, even with a live address and data.
     addr = 12'h340;
     wdata = 32'h0;
@@ -229,16 +217,13 @@ module csr_tb;
     ren = 1'b0;
     check_read("wen low leaves mscratch alone", 12'h340, 32'hdead_beef);
 
-    // ---- WARL ------------------------------------------------------------
     // mtvec: direct mode, 4-byte aligned base. The two low bits never stick.
     poke(12'h305, 32'h0000_0103);
     check_read("mtvec masks bits [1:0]", 12'h305, 32'h0000_0100);
-    // mepc: bit 0 only. Bit 1 is a LEGAL value -- C makes 2-byte targets
-    // legal, so masking it too would be a bug, not extra safety.
+    // mepc masks bit 0 only. Bit 1 is a legal value -- C makes 2-byte targets
+    // legal -- so masking it too would be a bug rather than extra safety.
     poke(12'h341, 32'h0000_0103);
     check_read("mepc masks bit 0 only", 12'h341, 32'h0000_0102);
-    // mstatus: MPP survives a zero write; MIE and MPIE do not survive a
-    // one-write of the bits around them.
     poke(12'h300, 32'h0000_0000);
     check_read("mstatus MPP is hardwired to M", 12'h300, 32'h0000_1800);
     poke(12'h300, 32'hffff_ffff);
@@ -246,13 +231,11 @@ module csr_tb;
     poke(12'h300, 32'h0000_0008);
     check_read("mstatus MIE alone", 12'h300, 32'h0000_1808);
 
-    // Read-only CSRs ignore writes rather than trapping HERE. This module
-    // never decides an access is illegal: the read-only test is on the
-    // address (addr[11:10] == 2'b11) and it lives in rtl/decoder.v alongside
-    // every other trap cause (ADR-0005, ADR-0030). So these writes reaching
-    // this module at all is a case the real core no longer produces -- kept
-    // because the WARL fallback that swallows them is what makes the RVFI
-    // report tell the truth about what landed.
+    // Read-only CSRs ignore writes rather than trapping here: rtl/csrs.v never
+    // decides an access is illegal, and the read-only test on the address lives
+    // in rtl/decoder.v with every other trap cause. The real core therefore no
+    // longer produces these writes, but the WARL fallback that swallows them is
+    // what makes the RVFI report tell the truth about what landed.
     poke(12'h301, 32'hffff_ffff);
     check_read("misa ignores a write", 12'h301, 32'h4000_1104);
     poke(12'h304, 32'hffff_ffff);
@@ -264,7 +247,6 @@ module csr_tb;
     poke(12'hF14, 32'hffff_ffff);
     check_read("mhartid ignores a write", 12'hF14, 32'h0);
 
-    // ---- the counters ----------------------------------------------------
     // mcycle counts cycles on its own; nothing has to ask it to.
     peek(12'hB00);
     before_lo = rdata;
@@ -287,8 +269,8 @@ module csr_tb;
     peek(12'hB02);
     check_hex("minstret counts an issue", rdata, before_lo + 32'd1);
 
-    // An explicit write beats that cycle's increment (ADR-0005). Driven with
-    // instret high, which is the case that would otherwise land value+1.
+    // An explicit write beats that cycle's increment. Driven with instret high,
+    // which is the case that would otherwise land value+1.
     instret = 1'b1;
     poke(12'hB02, 32'h0000_0100);
     instret = 1'b0;
@@ -307,28 +289,17 @@ module csr_tb;
     check_read("an explicit mcycle write beats the increment", 12'hB00, 32'h0000_0000);
     check_read("...and does not disturb mcycleh", 12'hB80, before_hi);
 
-    // ...INCLUDING AT THE CARRY BOUNDARY, which is the only place that last
-    // claim can be false and the only place nothing else in this repo can
-    // reach.
+    // The same at the carry boundary, which is the only place that last claim
+    // can be false. "Any CSR write takes precedence over the automatic
+    // increment" (priv spec 20211203 §3.1.11) is about the 64-bit counter, not
+    // the half the address names, so with mcycle == 32'hffff_ffff a write to the
+    // low half must suppress a carry that would otherwise land in mcycleh.
     //
-    // "Any CSR write takes precedence over the automatic increment" (priv spec
-    // 20211203 §3.1.11, and ADR-0005's own wording) is about the 64-bit
-    // counter, not about the half the address happens to name: mcycle and
-    // mcycleh are two views of one register. With mcycle == 32'hffff_ffff, the
-    // increment's carry lands in the high half, and a write to the LOW half
-    // has to suppress it -- otherwise `csrw mcycle` silently advances mcycleh
-    // by one, exactly once every 2**32 cycles, and only if a write happens to
-    // fall on that cycle.
-    //
-    // Three oracles are structurally blind to it, which is why it is checked
-    // here and pinned by name. riscv-formal's rvfi_csrw_check.sv reads only
-    // the SELF-REPORTED rmask/wmask/rdata/wdata and never observes the
-    // register, so csrw_mcycle_ch0 cannot see it in any configuration; every
-    // ladder check is `mode bmc` from reset and could not reach 2**32 cycles
-    // if it could; and a `.S` program can only land a write on that one cycle
-    // by calibrating the instruction spacing first, which is a test that stops
-    // testing the moment the spacing changes. Driving the port directly is the
-    // one place this is deterministic.
+    // Nothing else in the tree can reach it: rvfi_csrw_check.sv reads only the
+    // self-reported masks and never observes the register, every ladder check is
+    // `mode bmc` from reset, and a `.S` program lands a write on that one cycle
+    // only by calibrating instruction spacing. Do not drop these vectors as
+    // duplicates of the two above (ADR-0048).
     poke(12'hB80, 32'h0000_0000);
     poke(12'hB00, 32'hffff_fffe);
     @(posedge clk);
@@ -351,13 +322,11 @@ module csr_tb;
     check_read("a write at the boundary still beats the increment", 12'hB02, 32'h0000_0000);
     check_read("...and its discarded carry does not reach minstreth", 12'hB82, 32'h0000_0000);
 
-    // ---- trap entry and mret (ADR-0005 / ADR-0028) -----------------------
-    // The privileged-spec sequence, driven directly. Nothing on the
-    // riscv-formal ladder can see any of it: rvfi_insn_check drops every value
-    // assertion under `spec_trap`, and mtvec/mepc/mcause/mstatus are
-    // deliberately off formal/checks.cfg's [csrs] list because
-    // rvfi_csrw_check.sv has no WARL model. This bench and test/asm/trap.S are
-    // the whole coverage.
+    // Trap entry and mret: the privileged-spec sequence, driven directly.
+    // Nothing on the riscv-formal ladder can see any of it -- rvfi_insn_check
+    // drops every value assertion under `spec_trap`, and mtvec/mepc/mcause/
+    // mstatus are off the [csrs] list because rvfi_csrw_check.sv has no WARL
+    // model. This bench and test/asm/trap.S are the whole coverage.
     poke(12'h305, 32'h0000_0100);   // mtvec = 0x100
     poke(12'h300, 32'h0000_0008);   // mstatus.MIE = 1, MPIE = 0
     check_hex("mtvec_value echoes mtvec for the decoder", mtvec_value, 32'h0000_0100);
@@ -382,11 +351,10 @@ module csr_tb;
     check_read("a trap with MIE clear pushes a clear MPIE", 12'h300, 32'h0000_1800);
     check_read("...and records the new cause", 12'h342, 32'd2);
 
-    // mepc's WARL mask applies to trap entry too, and it masks bit 0 ONLY:
-    // a compressed instruction faulting at pc % 4 == 2 must record an mepc
-    // with bit 1 SET, or the handler resumes two bytes early (ADR-0005).
-    // test/asm/trap.S faults a real `c.lw` at that alignment for the same
-    // reason; this is the same rule stated against the register itself.
+    // mepc's WARL mask applies to trap entry too, and masks bit 0 only: a
+    // compressed instruction faulting at pc % 4 == 2 must record an mepc with
+    // bit 1 set, or the handler resumes two bytes early. test/asm/trap.S faults
+    // a real `c.lw` at that alignment for the same reason.
     take_trap(32'd4, 32'h0000_0146);
     check_read("mepc preserves bit 1 on a 2-aligned faulting pc", 12'h341, 32'h0000_0146);
     take_trap(32'd4, 32'h0000_0147);

--- a/test/exec_tb.v
+++ b/test/exec_tb.v
@@ -2,67 +2,43 @@
 `default_nettype none
 `include "structs.v"
 
-// Standalone randomized differential bench for the executor's multiply/divide
-// datapath (ADR-0010): this is the *primary* guarantee for real mul/div
-// arithmetic, because riscv-formal runs under RISCV_FORMAL_ALTOPS and never
-// checks it. Drives `executor` directly (no decoder/pipeline involved) and
-// compares against SystemVerilog `*`, `/`, `%` with RISC-V divide-by-zero and
-// INT_MIN / -1 semantics. Exits non-zero (via $fatal) on any mismatch.
+// Standalone randomized differential bench for the executor's arithmetic. It
+// drives `executor` directly, with no decoder or pipeline involved, and compares
+// against SystemVerilog `*`, `/`, `%` and the three shift operators with RISC-V
+// divide-by-zero and INT_MIN / -1 semantics.
 //
-// It also covers the three shift arms -- SLL / SRL / SRA -- on the same
-// randomized differential footing. Those had no coverage here at all until
-// this bench grew it, despite SRA being the one arm in the executor whose
-// correctness depends on a signedness that IEEE 1800 will silently take away
-// from you; read the comment above the shift reference model below before
-// touching it.
+// For mul and div it is the *primary* guarantee (ADR-0010), because riscv-formal
+// runs under RISCV_FORMAL_ALTOPS and never checks that arithmetic at all. The
+// shifts and ADD/SUB do have ladder checks, but those are `mode bmc`, and an ADD
+// off-by-one was measured reaching `tohost` through the `.S` suite and the Sail
+// co-simulation while every unit bench stayed silent.
 //
-// ADD and SUB are covered the same way, added for a narrower reason: this is
-// the bench that exists specifically to grind the executor's arithmetic, and
-// it drove zero vectors through the simplest, most-used ALU operation in the
-// ISA. ADR-0010's *primary-guarantee* language is scoped to the ops
-// RISCV_FORMAL_ALTOPS hides from the riscv-formal ladder, which ADD/SUB are
-// not -- `insn_add_ch0`/`insn_sub_ch0` exercise real arithmetic on every PR.
-// But that ladder is `mode bmc`, not `mode prove` (see CLAUDE.md's milestone
-// caveats), and the randomized loop here is the fast, targeted leg for
-// exactly this datapath -- the same reasoning that put shifts here despite
-// `insn_sll_ch0`/`insn_srl_ch0`/`insn_sra_ch0` existing too. An ADD off-by-one
-// was measured reaching `tohost` via the `.S` suite and co-simulation while
-// every unit bench stayed silent; this closes that gap the cheap way, on the
-// same footing as everything else here.
+// ADR-0045 names this bench as M2's mul/div oracle, so it asserts its own shape
+// before it asserts anything about the core. Three mechanisms do that, each
+// because the bench could once stop checking and still print PASSED:
 //
-// ---- THIS BENCH ASSERTS ITS OWN SHAPE BEFORE IT ASSERTS ANYTHING ABOUT THE
-//      CORE, AND THAT IS DELIBERATE ------------------------------------------
-//
-// ADR-0045 closes M2's mul/div term by NAMING this bench as the oracle. This
-// repo's rule for a named gate (ADR-0033, ADR-0035) is that it must be unable
-// to stop checking without going red -- a check that quietly stopped running is
-// worse than no check, because it still reads as coverage. Three mechanisms
-// enforce that here, all of them running before or alongside the RTL vectors:
-//
-//   * `ref_selftest` pins every reference function -- mul, div AND shift --
-//     against literals computed BY HAND, never copied from a run of this bench.
-//     A literal derived from the thing it checks proves nothing. A degraded
-//     reference says ORACLE BROKEN and stops, instead of blaming the core.
+//   * `ref_selftest` pins every reference -- mul, div and shift -- against
+//     literals computed by hand. A literal captured from a run of this bench is
+//     derived from the function it is supposed to check, so it proves nothing;
+//     a degraded reference says ORACLE BROKEN and stops rather than blaming the
+//     core.
 //   * `check_vector_counts` pins the per-operation vector count against
-//     ADR-0010's contract written as its own literal, so a loop bound that
-//     drifted -- to 100 during a debugging session, or to zero -- fails here.
-//     Before this existed, RANDOM_VECTORS = 0 printed PASSED and exited 0.
-//   * `check_directed_manifest` pins that each REQUIRED directed corner vector
-//     actually ran, from a manifest that lives apart from the call sites. So
-//     deleting a call site fails; it does not merely shrink the run.
+//     ADR-0010's contract, written as its own literal, so a loop bound that
+//     drifted to zero fails here. It used to print PASSED and exit 0.
+//   * `check_directed_manifest` pins that each required directed corner vector
+//     actually ran, from a manifest kept apart from the call sites, so deleting
+//     a call site is red rather than a shorter run.
 module exec_tb;
   localparam int RANDOM_VECTORS = 10000;
   localparam logic [1:0] DIVIDE_STATE = 2'b10; // must match executor.v's `divide` state
 
-  // ADR-0010's contract is ">= 10,000 randomized operand pairs per operation".
-  // These two are that CONTRACT, written as literals of their own -- they are
-  // not a second copy of the loop bounds, and the whole point of them is that
-  // they do not move when a loop bound does. `MIN_DIRECTED_SHIFT_PER_OP` is
-  // 6 patterns x 32 shift amounts x {clean rs2, dirty rs2}.
+  // ADR-0010's contract (">= 10,000 randomized operand pairs per operation")
+  // written as literals of its own, deliberately not a second copy of the loop
+  // bounds: they must not move when a loop bound does.
+  // `MIN_DIRECTED_SHIFT_PER_OP` is 6 patterns x 32 amounts x {clean, dirty rs2}.
   //
-  // If a count check below goes red, the fix is to restore the loop, never to
-  // edit the number down to match it. Same rule as `formal/EXPECTED_FAIL` and
-  // `test/EXPECTED_FAIL`: re-derive it, never silence it.
+  // If a count check below goes red, restore the loop; never edit the number
+  // down to match it.
   localparam int MIN_RANDOM_PER_OP        = 10000;
   localparam int MIN_DIRECTED_SHIFT_PER_OP = 384;
 
@@ -73,8 +49,7 @@ module exec_tb;
   decoder_output in;
   executor_output out;
 
-  // No accessor in this standalone bench, so no reason for it to ever
-  // freeze — tie the input low.
+  // No accessor in this standalone bench, so nothing can ever freeze it.
   executor dut (
     .clk(clk),
     .reset(reset),
@@ -85,12 +60,9 @@ module exec_tb;
 
   int errors = 0;
 
-  // ---- the operation table -------------------------------------------------
-  //
-  // One table, one source of truth for the eleven op names. `run_op` resolves
-  // its `op_name` argument through it, which is also what makes a typo'd name
-  // fatal rather than silently comparing against whatever the executor left on
-  // rd_data.
+  // One source of truth for the op names: `run_op` resolves its `op_name`
+  // argument through this table, which is what makes a typo fatal rather than a
+  // silent comparison against whatever the executor left on rd_data.
   localparam int OP_MUL    = 0;
   localparam int OP_MULH   = 1;
   localparam int OP_MULHU  = 2;
@@ -109,31 +81,19 @@ module exec_tb;
   string op_names  [0:NUM_OPS-1];
   int    vec_count [0:NUM_OPS-1];
 
-  // ---- the directed-vector manifest ---------------------------------------
+  // The corner vectors this bench is required to run: ADR-0010's three
+  // sign-enable cases, then the six architecturally specified divide-by-zero and
+  // INT_MIN / -1 results. None is meaningfully reachable by the randomized
+  // sweep, since each names both operands exactly -- ten thousand `$random`
+  // pairs hit one with probability around 10^4 / 2^64 -- so deleting one is a
+  // real loss of coverage rather than a rounding error on a big number.
   //
-  // These are the corner vectors this bench is REQUIRED to run. The first three
-  // are ADR-0010's, verbatim: MULH(-1,-1) = 0, MULHSU(-1,1) = -1,
-  // MULHU(-1,-1) = 0xFFFFFFFE -- exactly the cases a swapped sign enable gets
-  // wrong. The remaining six are the RISC-V divide-by-zero and INT_MIN / -1
-  // results, which are architecturally specified values rather than computed
-  // ones.
-  //
-  // None of the nine is meaningfully reachable by the randomized sweep: each
-  // names both operands exactly, so ten thousand `$random` pairs hit one with
-  // probability around 10^4 / 2^64 (the divide-by-zero four fix rs2 = 0 and rs1
-  // too, so they are no better off). That is why they are written out by hand,
-  // and why deleting one is a real loss of coverage rather than a rounding
-  // error on a big number.
-  //
-  // The manifest is deliberately NOT the thing that issues them. `run_op`
-  // witnesses each (op, rs1, rs2) it actually drove into the DUT against this
-  // list, and `check_directed_manifest` fails on any entry never witnessed. So
-  // deleting a directed call site below is a red bench, not a shorter run --
-  // which is the whole difference between a gate and a claim.
-  //
-  // It also carries each vector's expected value and checks the CALL SITE
-  // against it, so a directed vector weakened in place (kept, but with its
-  // expectation edited to whatever the core happens to produce) is caught too.
+  // The manifest deliberately does not issue them. `run_op` witnesses each
+  // (op, rs1, rs2) it actually drove into the DUT against this list and
+  // `check_directed_manifest` fails on any entry never witnessed, so a deleted
+  // call site is red. Each entry also carries its expected value and is checked
+  // against the call site, which catches a directed vector kept but weakened in
+  // place.
   localparam int DIRECTED_N = 9;
   int          dir_op  [0:DIRECTED_N-1];
   logic [31:0] dir_rs1 [0:DIRECTED_N-1];
@@ -142,10 +102,9 @@ module exec_tb;
   logic        dir_ran [0:DIRECTED_N-1];
   string       dir_why [0:DIRECTED_N-1];
   // Witnessing is a linear scan per vector driven, and there are ~111,000 of
-  // them. This counts down to zero on the ninth directed call site -- all of
-  // which run before the sweeps -- after which `run_op` skips the scan. Purely
-  // a cost thing; `check_directed_manifest` still reads `dir_ran` itself, so a
-  // deleted call site leaves this above zero and is caught either way.
+  // them; this counts down to zero on the ninth directed call site, after which
+  // `run_op` skips the scan. Purely a cost thing -- `check_directed_manifest`
+  // reads `dir_ran` itself, so a deleted call site is caught either way.
   int          dir_pending;
 
   task automatic add_directed(input int slot, input int op, input logic [31:0] rs1_v,
@@ -203,17 +162,14 @@ module exec_tb;
     end
   endfunction
 
-  // ---- reference model: SystemVerilog *, /, % with RISC-V semantics ----
-  //
-  // The signed-reference rule stated at length above the shift references below
-  // governs these too, and `ref_div` / `ref_rem` are where it bites hardest:
-  // their RISC-V special cases are written as an if / else-if / else over
-  // separate STATEMENTS rather than as one `?:` chain, because a `?:` chain
-  // whose other arms are unsigned literals evaluates `$signed(a) / $signed(b)`
-  // unsigned. That is not hypothetical -- it is exactly ADR-0019's defect in
-  // the generated riscv-formal monitor, at exactly these two functions, where
-  // -7 / 2 scored 0x7ffffffc. `ref_selftest` pins both against hand-computed
-  // literals before any of them is trusted to judge the core.
+  // The reference model. The signed-arithmetic rule written out further down,
+  // above the shift references, governs these too, and `ref_div`/`ref_rem` are
+  // where it bites:
+  // their RISC-V special cases are an if / else-if / else over separate
+  // statements rather than one `?:` chain, because a chain whose other arms are
+  // unsigned literals evaluates `$signed(a) / $signed(b)` unsigned. That is
+  // ADR-0019's defect, at exactly these two functions, where -7 / 2 scored
+  // 0x7ffffffc.
   function automatic logic [31:0] ref_mul(input logic [31:0] a, input logic [31:0] b);
     logic [63:0] p;
     begin
@@ -276,13 +232,9 @@ module exec_tb;
     end
   endfunction
 
-  // ---- reference model: add / sub --------------------------------------
-  //
-  // Neither of these touches `$signed` or a conditional expression at all --
-  // two's-complement add/sub is signedness-independent bit for bit -- so the
-  // sign-context hazard above the shift references does not apply here.
-  // Direct one-line assignments, same as ref_divu/ref_remu above for the same
-  // reason: nothing here is a `?:` arm evaluating a signed operand.
+  // Two's-complement add and sub are signedness-independent bit for bit, so
+  // neither of these needs `$signed` and the sign-context hazard below does not
+  // apply to them.
   function automatic logic [31:0] ref_add(input logic [31:0] a, input logic [31:0] b);
     ref_add = a + b;
   endfunction
@@ -291,40 +243,22 @@ module exec_tb;
     ref_sub = a - b;
   endfunction
 
-  // ---- reference model: shifts ----------------------------------------
+  // Each shift below is computed in a statement of its own, into a local whose
+  // signedness is declared, and is never an arm of a `?:`. Keep them that way.
   //
-  // READ THIS BEFORE EDITING THE THREE FUNCTIONS BELOW.
+  // IEEE 1800 makes a conditional expression unsigned if any of its operands is
+  // unsigned, and pushes that unsignedness down into the context-determined
+  // operands, so a `$signed(a) >>> sh` in one arm of such a conditional
+  // evaluates as a LOGICAL shift -- with no warning, and only for negative
+  // operands, so every non-negative vector still agrees. The assignment target
+  // cannot rescue it: an expression's type does not depend on its left-hand
+  // side. This repo has been bitten twice, at ADR-0019's two monitor spec models
+  // and then here, where the natural one-line `ref_sra` written as a `?:` arm
+  // reported six mismatches against correct hardware.
   //
-  // Every shift here is computed in a STATEMENT OF ITS OWN, into a local whose
-  // signedness is declared, and is never an arm of a `?:` or any other
-  // conditional expression. That is not a style preference, it is the whole
-  // reason these functions are shaped the way they are.
-  //
-  // IEEE 1800 sign-context propagation makes a conditional expression unsigned
-  // if any of its operands is unsigned, and then pushes that unsignedness DOWN
-  // into the context-determined operands. A `$signed(a) >>> sh` sitting in one
-  // arm of such a conditional therefore evaluates as a LOGICAL shift -- with no
-  // warning, and only for negative operands, so every non-negative vector still
-  // agrees. The assignment target cannot rescue it: an expression's type does
-  // not depend on its left-hand side.
-  //
-  // This is not hypothetical, and it is not new here. ADR-0019 is the same
-  // defect at two sites in the generated riscv-formal monitor -- its DIV and
-  // REM spec models, where `-7 / 2` scored as `0x7ffffffc` and failed `div.S`
-  // and `rem.S` against a correct core, until the sanitizer made the
-  // arithmetic self-determined. It then happened AGAIN, here, while these very
-  // vectors were being written: the natural one-line `ref_sra` written as a
-  // `?:` arm reported six mismatches, and the thing that was wrong was the
-  // oracle. A bench whose oracle is broken is worse than no bench -- it blames
-  // the hardware and teaches the reader to distrust the bench. Keep each of
-  // these a standalone statement, and see `ref_selftest` below, which pins
-  // them against hand-computed literals that cannot degrade along with the
-  // expression.
-  //
-  // The `b[4:0]` masks are this reference's own model of the RV32I rule that
-  // the shift amount is rs2[4:0] and the upper 27 bits are ignored (spec Vol I
-  // 2.4.2, and rtl/executor.v's comment on the same). The vectors drive rs2
-  // values far above 31 so the RTL has to agree rather than merely coincide.
+  // The `b[4:0]` masks are this reference's own model of the RV32I rule that the
+  // shift amount is rs2[4:0] (spec Vol I 2.4.2). The vectors drive rs2 values
+  // far above 31 so the RTL has to agree rather than coincide.
   function automatic logic [31:0] ref_sll(input logic [31:0] a, input logic [31:0] b);
     logic [31:0] v;
     begin
@@ -358,18 +292,15 @@ module exec_tb;
     end
   endtask
 
-  // Checks the ORACLE, not the core -- no RTL is involved in any call to this.
-  // An SRA reference that had silently degraded to a logical shift (see the
-  // comment above the shift functions) agrees with a correct one on every
-  // non-negative operand, so it would pass thousands of randomized vectors and
-  // then report mismatches against correct hardware. The same is true of the
-  // signed divide and the signed multiply high halves.
+  // Checks the oracle, not the core -- no RTL is involved in any call to this. A
+  // reference that degraded to a logical shift (or an unsigned divide) agrees
+  // with a correct one on every non-negative operand, so it would pass thousands
+  // of randomized vectors and then report mismatches against correct hardware.
   //
-  // EVERY expected value passed to this task is computed BY HAND and written as
-  // a literal. That is the load-bearing property and it is easy to destroy: a
-  // literal captured from a run of this bench is derived from the very function
-  // it is supposed to check, which is the same defect one level down. If you add
-  // a case here, do the arithmetic on paper.
+  // Every expected value passed here is computed by hand and written as a
+  // literal. A literal captured from a run of this bench is derived from the
+  // function it is supposed to check, which is the same defect one level down;
+  // if you add a case, do the arithmetic on paper.
   task automatic ref_selftest(input string what, input logic [31:0] got,
                                input logic [31:0] want);
     begin
@@ -380,12 +311,9 @@ module exec_tb;
     end
   endtask
 
-  // Checks that the bench RAN what it says it runs. Before this existed a loop
-  // bound that had drifted to zero -- RANDOM_VECTORS = 0, an inner `for` edited
-  // during a debugging session and never put back -- printed PASSED and exited
-  // 0, and ADR-0045 names this bench as M2's mul/div oracle. The comparison is
-  // against MIN_RANDOM_PER_OP / MIN_DIRECTED_SHIFT_PER_OP, which are ADR-0010's
-  // contract written as literals rather than second copies of the loop bounds.
+  // Checks that the bench ran what it says it runs. A loop bound edited to zero
+  // during a debugging session and never put back used to print PASSED and exit
+  // 0.
   task automatic check_vector_counts;
     int k, want;
     begin
@@ -402,11 +330,9 @@ module exec_tb;
     end
   endtask
 
-  // Checks that every REQUIRED directed corner vector reached the DUT. The
-  // manifest lives apart from the call sites precisely so that deleting a call
-  // site is red rather than merely shorter; a randomized vector cannot cover
-  // for a deleted one, because these are the cases random operands do not
-  // reach (a specified divide-by-zero result) or reach only by accident.
+  // Checks that every required directed corner vector reached the DUT. A
+  // randomized vector cannot cover for a deleted one: these are the cases random
+  // operands do not reach, or reach only by accident.
   task automatic check_directed_manifest;
     int d;
     begin
@@ -431,14 +357,11 @@ module exec_tb;
     end
   endtask
 
-  // Multiply-family ops settle one cycle after issue (the executor never leaves
-  // `init` for them). Divide-family ops may enter the multi-cycle restoring
-  // divider (see criterion 4 below); the special-case (div-by-zero, INT_MIN/-1)
-  // paths finish within `init` like the multiply-family ops do. Either way, the
-  // executor is done exactly when it has returned to `init` after the issue
-  // edge, so poll for that instead of hardcoding a cycle count — that keeps this
-  // bench correct regardless of exactly how long the divider takes, and leaves
-  // criterion 4's specific cycle count to the dedicated timing monitor below.
+  // The executor is done exactly when it has returned to `init` after the issue
+  // edge -- immediately for the multiply family and the divide short-circuits,
+  // 33 cycles later for a real division. Polling for that rather than hardcoding
+  // a count keeps this task correct however long the divider takes; the cycle
+  // count itself is the timing monitor's job, at the bottom of this file.
   task automatic run_op(input string op_name, input logic [31:0] rs1_v, input logic [31:0] rs2_v,
                          input logic [31:0] expected);
     int guard;
@@ -471,9 +394,8 @@ module exec_tb;
         OP_SUB:    in.is_sub    = 1'b1;
       endcase
 
-      // Everything this bench claims about its own coverage is measured here,
-      // on the vectors it actually drove into the DUT -- never inferred from a
-      // loop bound or a localparam.
+      // Coverage is measured here, on the vectors actually driven into the DUT,
+      // rather than inferred from a loop bound.
       vec_count[id]++;
       if (dir_pending > 0) begin
         for (d = 0; d < DIRECTED_N; d++) begin
@@ -526,9 +448,10 @@ module exec_tb;
     #1;
     reset = 0;
 
-    // The oracle is checked before it is trusted to judge anything.
+    // The oracle is checked before it is trusted to judge anything. Every
+    // literal below is hand-computed, and the arithmetic behind it is written
+    // out so a reader can verify it without running anything.
     //
-    // ---- multiply references ------------------------------------------------
     // MUL: low 32 bits, signedness-independent. (-1)*(-1) = 1; 2^31 * 2 = 2^32,
     // whose low half is zero; 65535^2 = 0xfffe0001.
     ref_selftest("mul(ffffffff,ffffffff)",  ref_mul(32'hffffffff, 32'hffffffff), 32'h00000001);
@@ -559,11 +482,10 @@ module exec_tb;
     ref_selftest("mulhsu(ffffffff,00000001)", ref_mulhsu(32'hffffffff, 32'h00000001), 32'hffffffff);
     ref_selftest("mulhsu(00000002,80000000)", ref_mulhsu(32'h00000002, 32'h80000000), 32'h00000001);
     ref_selftest("mulhsu(ffffffff,80000000)", ref_mulhsu(32'hffffffff, 32'h80000000), 32'hffffffff);
-    // ---- divide references --------------------------------------------------
-    // These are ADR-0019's own case. -7 / 2 truncates toward zero to -3
-    // (0xfffffffd); a reference that had degraded to an unsigned divide scores
-    // 0x7ffffffc -- which is what `divu(fffffff9,00000002)` legitimately is, and
-    // it is written out just below so the two are visibly different numbers.
+    // ADR-0019's own case. -7 / 2 truncates toward zero to -3 (0xfffffffd); a
+    // reference degraded to an unsigned divide scores 0x7ffffffc, which is what
+    // `divu(fffffff9,00000002)` legitimately is -- written out just below so the
+    // two are visibly different numbers.
     ref_selftest("div(fffffff9,00000002)",  ref_div(32'hfffffff9, 32'h00000002), 32'hfffffffd);
     ref_selftest("div(00000007,fffffffe)",  ref_div(32'h00000007, 32'hfffffffe), 32'hfffffffd);
     ref_selftest("div(fffffff9,fffffffe)",  ref_div(32'hfffffff9, 32'hfffffffe), 32'h00000003);
@@ -579,7 +501,6 @@ module exec_tb;
     ref_selftest("rem(80000000,ffffffff)",  ref_rem(32'h80000000, 32'hffffffff), 32'h00000000);
     ref_selftest("remu(fffffff9,00000002)", ref_remu(32'hfffffff9, 32'h00000002), 32'h00000001);
     ref_selftest("remu(00000064,00000000)", ref_remu(32'h00000064, 32'h00000000), 32'h00000064);
-    // ---- shift references ---------------------------------------------------
     ref_selftest("sra(80000000,4)",  ref_sra(32'h80000000, 32'd4),  32'hf8000000);
     ref_selftest("sra(80000000,31)", ref_sra(32'h80000000, 32'd31), 32'hffffffff);
     ref_selftest("sra(deadbeef,8)",  ref_sra(32'hdeadbeef, 32'd8),  32'hffdeadbe);
@@ -591,7 +512,6 @@ module exec_tb;
     // ...including the reference's own rs2[4:0] masking, on both sides of 32.
     ref_selftest("sra(80000000,36)", ref_sra(32'h80000000, 32'd36), 32'hf8000000);
     ref_selftest("sll(00000001,32)", ref_sll(32'h00000001, 32'd32), 32'h00000001);
-    // ---- add / sub references ------------------------------------------
     // Two's complement wraps: -1 + 1 = 0; INT_MAX + 1 overflows into the sign
     // bit; 0 - 1 wraps to all-ones; INT_MIN - 1 wraps to INT_MAX.
     ref_selftest("add(ffffffff,00000001)", ref_add(32'hffffffff, 32'h00000001), 32'h00000000);
@@ -603,8 +523,8 @@ module exec_tb;
       $fatal(1);
     end
 
-    // Required directed vectors (ADR-0010): exactly the cases the swapped sign
-    // enables get wrong.
+    // ADR-0010's required directed vectors: the cases a swapped sign enable gets
+    // wrong.
     run_op("mulh",   32'hffffffff, 32'hffffffff, 32'h00000000);
     run_op("mulhsu", 32'hffffffff, 32'h00000001, 32'hffffffff);
     run_op("mulhu",  32'hffffffff, 32'hffffffff, 32'hfffffffe);
@@ -617,13 +537,11 @@ module exec_tb;
     run_op("div",  32'h80000000, 32'hffffffff, 32'h80000000);
     run_op("rem",  32'h80000000, 32'hffffffff, 32'h00000000);
 
-    // Directed shift sweep: every shift amount 0..31 against each pattern,
-    // driven TWICE -- once with a clean rs2 and once with all 27 upper bits
-    // set. $random alone reaches every amount with overwhelming probability but
-    // does not guarantee it, and the two forms together are what turns "the
-    // masking happens to work on random inputs" into "the same amount with and
-    // without garbage above bit 4 gives the same answer", which is the actual
-    // rs2[4:0] rule (rtl/executor.v).
+    // Every shift amount 0..31 against each pattern, driven twice: once with a
+    // clean rs2 and once with all 27 upper bits set. `$random` reaches every
+    // amount with overwhelming probability but does not guarantee it, and the
+    // pair is what states the rs2[4:0] rule -- the same amount with and without
+    // garbage above bit 4 must give the same answer.
     pattern[0] = 32'h80000000;
     pattern[1] = 32'hffffffff;
     pattern[2] = 32'h7fffffff;
@@ -643,9 +561,8 @@ module exec_tb;
       end
     end
 
-    // Randomized differential coverage: >=10,000 vectors per operation.
-    // $random's rs2 is a full 32-bit word, so the great majority of shift
-    // vectors here also carry a shift amount above 31.
+    // `$random`'s rs2 is a full 32-bit word, so most shift vectors here also
+    // carry a shift amount above 31.
     for (i = 0; i < RANDOM_VECTORS; i++) begin
       a = $random;
       b = $random;
@@ -664,9 +581,8 @@ module exec_tb;
       run_op("sub",    a, b, ref_sub(a, b));
     end
 
-    // The bench grades its own shape LAST and reports it FIRST: everything
-    // above is a claim about the core, and these two are the claim that the
-    // above happened at all.
+    // Everything above is a claim about the core; these two are the claim that
+    // it happened at all.
     check_vector_counts();
     check_directed_manifest();
 
@@ -684,9 +600,9 @@ module exec_tb;
     end
   end
 
-  // Criterion 4: the divider produces its result exactly 33 cycles after issue
-  // (32 restoring-division iterations plus one capture cycle), not 66. Checked
-  // against every real division performed during the run above, not just once.
+  // The divider produces its result exactly 33 cycles after issue -- 32
+  // restoring-division iterations plus one capture cycle -- checked against
+  // every real division performed in the run above.
   int cycle_count;
   logic prev_divide;
 

--- a/test/mem_tb.v
+++ b/test/mem_tb.v
@@ -1,11 +1,9 @@
 `timescale 1 ns / 1 ps
 `default_nettype none
 
-// Standalone bench for rtl/memory.v (see `eb18320`). Since ADR-0054 the module
-// is also the data RAM `test/testbench.v` instantiates, so the whole `.S` suite
-// and the Sail co-simulation run against it too -- this bench is no longer the
-// only thing that touches it. What it still does, and they cannot, is drive the
-// corners: an out-of-range access, and the no-change read behaviour below.
+// Standalone bench for rtl/memory.v. The `.S` suite and the Sail co-simulation
+// also run against this module (test/testbench.v instantiates it), but only this
+// bench drives the corners: an out-of-range access, and the no-change read.
 module mem_tb;
   localparam int RAM_WORDS = 16;
 
@@ -17,10 +15,10 @@ module mem_tb;
   logic [3:0]  mem_wstrb;
   logic [31:0] mem_rdata;
 
-  // BASE = 0 so the vectors below can address the array directly. The shipping
-  // instances use ADR-0008's non-zero RAM base (rtl/littlesoc.v,
-  // test/testbench.v), and the out-of-range vectors here cover the decode
-  // either way -- an unmapped address must read zero, not alias a mapped word.
+  // BASE = 0 so the vectors below can address the array directly; the shipping
+  // instances use ADR-0008's non-zero RAM base. The property the out-of-range
+  // vectors check holds either way: an unmapped address must not alias a mapped
+  // word.
   memory #(.BASE(32'h0), .RAM_WORDS(RAM_WORDS)) dut (
     .clk(clk),
     .mem_addr(mem_addr),
@@ -63,9 +61,8 @@ module mem_tb;
   task automatic do_read(input logic [31:0] addr, output logic [31:0] data);
     begin
       mem_addr = addr;
-      // A decoy write-data value, distinct from anything ever written, so a read
-      // that accidentally echoes mem_wdata (rtl/memory.v's deleted bug) is caught
-      // instead of coincidentally matching.
+      // A decoy distinct from anything ever written, so a read that echoes
+      // mem_wdata instead of the array is caught rather than coinciding.
       mem_wdata = 32'hdeadbeef;
       mem_wstrb = 4'b0000;
       @(posedge clk);
@@ -83,18 +80,14 @@ module mem_tb;
     @(posedge clk);
     #1;
 
-    // Criterion 5a: a wstrb == 0 read following a write to the same address
-    // returns ram[addr>>2], not a stale echo of the bus's mem_wdata.
     do_write(32'h00000004, 32'hcafef00d);
     do_read(32'h00000004, got);
     check("write-then-read same address", got, 32'hcafef00d);
 
-    // A second pair at a different address, to rule out a fluke.
     do_write(32'h0000000c, 32'h01234567);
     do_read(32'h0000000c, got);
     check("write-then-read second address", got, 32'h01234567);
 
-    // Criterion 5b: an out-of-range read must not alias an in-range ram word.
     do_write(32'h00000000, 32'ha5a5a5a5);
     do_read(32'h00000000, got);
     check("in-range sanity read", got, 32'ha5a5a5a5);
@@ -105,15 +98,12 @@ module mem_tb;
     do_read(32'hfffffffc, got); // far out of range
     check_ne("out-of-range read does not alias ram[0] (far)", got, 32'ha5a5a5a5);
 
-    // ADR-0054: the read port HOLDS on a write cycle. This is not a taste
-    // question and it is not free to change: yosys infers `SB_SPRAM256KA` only
-    // from a no-change read port (`ice40/spram.txt` declares `rdwr no_change`),
-    // and the read-first spelling silently maps the same array to 128
-    // `SB_RAM40_4K` -- four times the part's entire block RAM, reported as a
-    // normal synthesis run. Nothing in the pipeline observes the difference
-    // (rtl/accessor.v reads mem_rdata only on a load's response cycle, when
-    // decode is bubbled), so nothing but this vector would notice it being
-    // "fixed" back.
+    // The read port holds on a write cycle. yosys infers `SB_SPRAM256KA` only
+    // from a no-change read port, and the read-first spelling maps the same
+    // array to 128 `SB_RAM40_4K` -- four times the part's block RAM -- with no
+    // diagnostic. Nothing in the pipeline observes the difference (rtl/accessor.v
+    // reads mem_rdata only on a load's response cycle), so nothing but this
+    // vector would notice it being "fixed" back (ADR-0054).
     do_read(32'h00000004, got);
     check("read-port setup for the hold check", got, 32'hcafef00d);
     do_write(32'h00000008, 32'h0f0f0f0f);

--- a/test/monitor_tb.v
+++ b/test/monitor_tb.v
@@ -1,44 +1,10 @@
-// Unit bench for the generated RVFI monitor itself -- not for the core.
+// Unit bench for the generated RVFI monitor itself -- not for the core. The
+// monitor is an oracle both sim legs read, so a defect in it is a defect in
+// every `make test` result (ADR-0019). Each vector below is a hand-built RVFI
+// retire whose correct verdict is known by construction.
 //
-// The monitor is an oracle both sim legs read (ADR-0019), so a defect in it is
-// a defect in every `make test` result. This bench drives the `monitor` module
-// directly with hand-built RVFI retires whose correct verdict is known by
-// construction, which is the technique that pinned the DIV/REM signedness
-// defect ADR-0019 records. It is compiled against test/monitor.sim.v -- the
-// sanitized derivative, i.e. the file that actually does the checking.
-//
-// What it pins:
-//
-//   * a correct non-trapping retire is accepted (vectors 1, 3);
-//   * a correct TRAPPING retire is accepted (vectors 2, 5) -- this is the
-//     !spec_trap gate the generator omits and test/sanitize_monitor.py adds.
-//     On a misaligned `lw` the spec model still reports spec_rd_addr = the
-//     destination register, spec_rd_wdata = the loaded value, spec_pc_wdata =
-//     pc+4 and spec_mem_rmask = the byte mask, while a correct core writes no
-//     register, strobes no memory and redirects to mtvec (ADR-0028). Without
-//     the gate these vectors report errors 104/105/106/111-113 (load) and
-//     108 (store) against hardware that is behaving correctly. Run this bench
-//     against an unsanitized monitor -- or with the gate line mutated to
-//     `if (1'b1)` -- and it $fatal(1)s;
-//   * a genuinely wrong non-trapping retire is still REJECTED (vector 4).
-//     Without this the bench could pass by checking nothing, and a gate that
-//     accidentally disabled all spec checking would look identical to a
-//     correct one;
-//   * a retire that FAILS TO TRAP when the spec model says it must is still
-//     REJECTED (vector 7, error 101). Vector 4 does not cover this: its wrong
-//     retire is non-trapping, so it passes just as happily with the trap
-//     comparison switched off. Error 101 is the one check upstream's
-//     checks/rvfi_insn_check.sv keeps live under spec_trap, which makes it the
-//     one the sanitizer's gate could swallow without changing a site count --
-//     see test/sanitize_monitor.py's rule 3;
-//   * an M3 instruction with no spec model (`ecall`, vector 6) is accepted
-//     silently, because spec_valid never asserts for it. That is not the gate
-//     working, it is the monitor having nothing to say -- the reason the trap
-//     and CSR `.S` tests carry their own in-band assertions rather than
-//     leaning on the per-retire oracle. See test/asm/riscv_test.h.
-//
-// Pass/fail is vvp's exit code, like the other benches in `make test-units`:
-// $fatal(1) on a mismatch, $finish on success.
+// It compiles against test/monitor.sim.v, the sanitized derivative that
+// actually does the checking, so it also covers what the sanitizer inserts.
 `timescale 1ns / 1ps
 
 module monitor_tb;
@@ -103,7 +69,7 @@ module monitor_tb;
 
   // `errcode` is a one-cycle pulse two clocks behind the retire that caused it
   // (the per-channel code is registered, then the top-level mux registers it
-  // again), so latch it rather than sampling on a guessed cycle.
+  // again), so latch it rather than sample on a guessed cycle.
   reg [15:0] latched = 0;
   reg        clear_latched = 0;
 
@@ -180,6 +146,7 @@ module monitor_tb;
 
     // 1. add x3, x1, x2 with x1=5, x2=7 -- correct, non-trapping. Establishes
     //    the shadow PC at 4 and shadow x3 = 12 for the vectors that follow.
+    //    A correct non-trapping retire must be accepted.
     drive_retire(32'h0020_81b3, 1'b0,
                  5'd1, 5'd2, 32'd5, 32'd7,
                  5'd3, 32'd12,
@@ -190,9 +157,10 @@ module monitor_tb;
     // 2. lw x5, 1(x1) with x1 = RAM base -- address 0x00010001, misaligned, so
     //    spec_trap holds. A correct core reports the ADR-0028 convention:
     //    rd_addr/rd_wdata/mem masks all zero, pc_wdata = mtvec. The spec model
-    //    meanwhile reports rd = x5, rd_wdata = the loaded word and
-    //    pc_wdata = pc+4, so every one of those comparisons disagrees. Only
-    //    the !spec_trap gate keeps this clean.
+    //    reports rd = x5, rd_wdata = the loaded word and pc_wdata = pc+4, so
+    //    every one of those comparisons disagrees and only the `!spec_trap` gate
+    //    test/sanitize_monitor.py inserts keeps this clean. Against an
+    //    unsanitized monitor it reports errors 104/105/106/111-113.
     drive_retire(32'h0010_a283, 1'b1,
                  5'd1, 5'd0, RAM, 32'd0,
                  5'd0, 32'd0,
@@ -210,8 +178,8 @@ module monitor_tb;
     expect_errcode(16'd0, "correct addi retire after the trap");
 
     // 4. Positive control: the same add as vector 1, but reporting 13 instead
-    //    of 12. The monitor must still reject this -- a gate that switched off
-    //    spec checking altogether would pass every vector above.
+    //    of 12. Without a vector the monitor must reject, a gate that switched
+    //    off spec checking altogether would pass everything above.
     $display("monitor_tb: the monitor error banner below is EXPECTED (positive control)");
     drive_retire(32'h0020_81b3, 1'b0,
                  5'd1, 5'd2, 32'd5, 32'd7,
@@ -232,8 +200,8 @@ module monitor_tb;
 
     // 6. ecall. riscv-formal ships no spec model for it at the pinned SHA, so
     //    spec_valid is 0 and the whole semantic block is skipped -- the monitor
-    //    is not checking this instruction at all. Recorded here so that nobody
-    //    reads a green run as evidence that M3's new instructions are covered.
+    //    is not checking this instruction at all, which is why the trap and CSR
+    //    `.S` tests carry their own in-band assertions.
     drive_retire(32'h0000_0073, 1'b1,
                  5'd0, 5'd0, 32'd0, 32'd0,
                  5'd0, 32'd0,
@@ -241,28 +209,22 @@ module monitor_tb;
                  32'd0, 4'b0000, 4'b0000, 32'd0, 32'd0);
     expect_errcode(16'd0, "ecall retire (no spec model exists -- unchecked)");
 
-    // 7. Positive control for the trap comparison ITSELF (error 101) -- the one
-    //    check riscv-formal's checks/rvfi_insn_check.sv deliberately keeps live
-    //    under spec_trap, and that test/sanitize_monitor.py's third rule must
-    //    therefore leave OUTSIDE the `!spec_trap` gate it inserts.
+    // 7. Positive control for the trap comparison itself (error 101), which is
+    //    the one check checks/rvfi_insn_check.sv keeps live under spec_trap and
+    //    that test/sanitize_monitor.py's third rule must therefore leave outside
+    //    the gate it inserts. Vector 4 does not cover it: its wrong retire is
+    //    non-trapping, so it stays green with the trap comparison disabled, and
+    //    a sanitizer that swallowed 101 into its own gate would go unnoticed.
     //
-    //    Vector 4's wrong retire is non-trapping, so it stays green even if the
-    //    trap comparison is disabled: nothing above would notice a sanitizer
-    //    that swallowed error 101 into its own gate. That is the silent failure
-    //    the span-contents assertions in test/sanitize_monitor.py exist to
-    //    prevent, and this vector is the simulation-side half of the same
-    //    check. It is the misaligned `lw` of vector 2 again, except the core
-    //    claims it completed normally -- rvfi_trap = 0, x5 written, pc_wdata =
-    //    pc+4, read mask strobed -- while the spec model reports spec_trap = 1.
-    //    A core that failed to trap on a misaligned load looks exactly like
-    //    this. Only 101 may fire: every other comparison sits inside the gate
-    //    and spec_trap holds, so they are switched off.
+    //    It is vector 2's misaligned `lw` again, except the core claims it
+    //    completed normally -- rvfi_trap = 0, x5 written, pc_wdata = pc+4, read
+    //    mask strobed -- while the spec model says spec_trap. Only 101 may fire;
+    //    every other comparison sits inside the gate.
     //
-    //    Deliberately last. It is the only vector reporting trap = 0 on a
-    //    trapping instruction, so it leaves the shadow PC valid and pointing at
-    //    an address no handler would resume from; anything appended after it
-    //    would report error 130 for reasons that have nothing to do with what
-    //    it is testing.
+    //    Keep this last. It is the only vector reporting trap = 0 on a trapping
+    //    instruction, so it leaves the shadow PC pointing at an address no
+    //    handler would resume from and anything appended after it reports error
+    //    130 for unrelated reasons.
     $display("monitor_tb: the monitor error banner below is EXPECTED (positive control)");
     drive_retire(32'h0010_a283, 1'b0,
                  5'd1, 5'd0, RAM, 32'd0,

--- a/test/regfile_tb.v
+++ b/test/regfile_tb.v
@@ -1,27 +1,20 @@
 `timescale 1 ns / 1 ps
 `default_nettype none
 
-// rtl/regfile.v's contract (CLAUDE.md invariants 6 and 9, ADR-0004, ADR-0042).
-//
-// The read is REGISTERED, so an operand takes two cycles to obtain and the two
-// cycles are not interchangeable:
+// rtl/regfile.v's contract (CLAUDE.md invariants 6 and 9, ADR-0042). The read
+// is registered, so an operand takes two cycles to obtain and the two are not
+// interchangeable:
 //
 //   FETCH cycle  -- rs1/rs2 are presented. The posedge that ends it captures
 //                   the array contents at those addresses, write-first, so a
 //                   write presented in THIS cycle is captured too.
-//   USE cycle    -- rs1/rs2 are held UNCHANGED. reg_rs1/reg_rs2 are valid, and
+//   USE cycle    -- rs1/rs2 are held unchanged. reg_rs1/reg_rs2 are valid, and
 //                   the write-through bypass covers a write presented now.
 //
-// Between them those two forwarding points make the operand the cycle-N
-// architectural value including a cycle-N writeback, which is the whole
-// observable content of invariant 6. rtl/decoder.v's `operand_stall` is what
-// supplies the fetch cycle, and it holds the PC so the addresses cannot move.
-//
-// THIS BENCH WAS REWRITTEN, NOT EXTENDED (ADR-0042). Its predecessor sampled
-// `#1` after a posedge with no notion of a fetch cycle at all -- correct
-// against a combinational read, meaningless against this one, and three of its
-// checks failed on timing alone. What follows samples where a real consumer
-// does and nowhere else.
+// Those two forwarding points together make the operand the cycle-N
+// architectural value including a cycle-N writeback. rtl/decoder.v's
+// `operand_stall` supplies the fetch cycle and holds the PC so the addresses
+// cannot move; every vector below samples where a real consumer does.
 module regfile_tb;
   logic clk = 0;
   always #5 clk = ~clk;
@@ -63,12 +56,10 @@ module regfile_tb;
     end
   endtask
 
-  // ADR-0042: the two arrays exist only because an ice40 EBR has one read port,
-  // so a second read port means a second copy. One `always_ff` writes both from
-  // one address and one data word -- but nothing downstream would notice them
-  // drifting: test/cosim.cc reads `regs_a` alone, and `reg_rs2` is the only
-  // consumer of `regs_b`. Assert the duplication directly rather than trusting
-  // the write block by inspection.
+  // Nothing downstream would notice the two arrays drifting apart: test/cosim.cc
+  // reads `regs_a` alone, and `reg_rs2` is the only consumer of `regs_b`. So
+  // assert the duplication directly rather than trusting the write block by
+  // inspection (ADR-0042).
   task automatic check_mirrors(input string what);
     begin
       for (int i = 0; i < 32; i++) begin
@@ -81,8 +72,8 @@ module regfile_tb;
     end
   endtask
 
-  // Open a cycle and drive it. Signals settle just after the posedge, the way
-  // decode's combinational outputs do.
+  // Open a cycle and drive it, settling just after the posedge the way decode's
+  // combinational outputs do.
   task automatic drive(input logic [4:0] a1, input logic [4:0] a2,
                        input logic we, input logic [4:0] wa, input logic [31:0] wd);
     begin
@@ -93,15 +84,15 @@ module regfile_tb;
       wen   = we;
       waddr = wa;
       wdata = wd;
-      // Let the read mux settle before the caller samples. Without it the
+      // Let the read mux settle before the caller samples. Without this the
       // check races the `always_comb` and reads the previous cycle's operand,
       // which looks exactly like a broken bypass.
       #1;
     end
   endtask
 
-  // A plain write cycle: no read is being fetched, so the addresses park on x0,
-  // which reads 0 unconditionally and can never be written.
+  // A plain write cycle. The addresses park on x0, which reads 0
+  // unconditionally and can never be written, so no read is in flight.
   task automatic write_cycle(input logic [4:0] wa, input logic [31:0] wd);
     begin
       drive(5'd0, 5'd0, 1'b1, wa, wd);
@@ -116,60 +107,55 @@ module regfile_tb;
     wdata = 32'b0;
 
     // Seed three registers, one write per cycle, so the reads below have known
-    // array contents that did NOT arrive through either forwarding path.
+    // array contents that did not arrive through either forwarding path.
     write_cycle(5'd5, 32'hcafef00d);
     write_cycle(5'd6, 32'h22222222);
     write_cycle(5'd7, 32'h33333333);
 
-    // ---- the plain case: fetch, then use, nothing being written ----
+    // The plain case: fetch, then use, nothing being written.
     drive(5'd5, 5'd6, 1'b0, 5'd0, 32'h0);   // fetch
     drive(5'd5, 5'd6, 1'b0, 5'd0, 32'h0);   // use, addresses held
     check_hex("registered read of the array (rs1)", reg_rs1, 32'hcafef00d);
     check_hex("registered read of the array (rs2)", reg_rs2, 32'h22222222);
     check_mirrors("arrays agree after the seed writes");
 
-    // ---- WRITE-FIRST: the write lands in the FETCH cycle ----
-    // The posedge that captures the read is the same posedge that commits this
-    // write. Without the write-first term in rtl/regfile.v the captured word
-    // would be the pre-write contents, and the operand would be exactly one
-    // writeback stale -- the ADR-0004 defect, moved a cycle earlier where the
-    // scoreboard cannot see it.
+    // Write-first: the write lands in the FETCH cycle, on the same posedge that
+    // captures the read. Without the write-first term in rtl/regfile.v the
+    // captured word is the pre-write contents and the operand is exactly one
+    // writeback stale -- the ADR-0004 defect, a cycle earlier than the
+    // scoreboard can see.
     drive(5'd5, 5'd5, 1'b1, 5'd5, 32'h44444444);   // fetch, writing x5
     drive(5'd5, 5'd5, 1'b0, 5'd0, 32'h0);          // use, no write
     check_hex("write-first capture in the fetch cycle (rs1)", reg_rs1, 32'h44444444);
     check_hex("write-first capture in the fetch cycle (rs2)", reg_rs2, 32'h44444444);
 
-    // ---- WRITE-THROUGH BYPASS: the write lands in the USE cycle ----
-    // Nothing has reached the arrays yet, so the bypass mux is the only path
-    // that can produce this value.
+    // Write-through bypass: the write lands in the USE cycle. Nothing has
+    // reached the arrays yet, so the bypass mux is the only path that can
+    // produce this value.
     drive(5'd6, 5'd6, 1'b0, 5'd0, 32'h0);          // fetch, no write
     drive(5'd6, 5'd6, 1'b1, 5'd6, 32'h55555555);   // use, writing x6
     check_hex("write-through bypass in the use cycle (rs1)", reg_rs1, 32'h55555555);
     check_hex("write-through bypass in the use cycle (rs2)", reg_rs2, 32'h55555555);
 
     // And it really did land, one cycle later, through the array rather than
-    // through either forwarding path.
+    // through a forwarding path.
     drive(5'd6, 5'd6, 1'b0, 5'd0, 32'h0);
     drive(5'd6, 5'd6, 1'b0, 5'd0, 32'h0);
     check_hex("the bypassed write reached the array (rs1)", reg_rs1, 32'h55555555);
     check_mirrors("arrays agree after the forwarded writes");
 
-    // ---- THE RULE INVARIANT 9 IS ABOUT ----
-    // The read register is keyed to the address presented in the FETCH cycle,
-    // not to whatever rs1 happens to be during the use cycle. Point rs1
-    // somewhere else in the use cycle and the previously fetched operand is
-    // what comes back. This is not a behaviour to rely on -- it is the reason
-    // rtl/decoder.v must hold the PC across the pair, and it is what would
-    // break loudly if the read were made combinational again without removing
-    // `operand_stall`.
+    // Invariant 9: the read register is keyed to the address presented in the
+    // FETCH cycle, not to whatever rs1 holds during the use cycle. This is not a
+    // behaviour to rely on -- it is why rtl/decoder.v must hold the PC across
+    // the pair, and it is what breaks loudly if the read is made combinational
+    // again without removing `operand_stall`.
     drive(5'd5, 5'd0, 1'b0, 5'd0, 32'h0);          // fetch x5
     drive(5'd6, 5'd0, 1'b0, 5'd0, 32'h0);          // use, but rs1 now points at x6
     check_hex("the read is keyed to the fetched address, not the current one",
               reg_rs1, 32'h44444444);
     check_ne("...and specifically is NOT x6's value", reg_rs1, 32'h55555555);
 
-    // ---- x0 ----
-    // Reads 0 on both ports in both cycles, even with waddr == 0 and wen == 1
+    // x0 reads 0 on both ports in both cycles, even with waddr == 0 and wen == 1
     // aimed straight at it. The read mux forces this unconditionally; the write
     // suppression is a separate claim, checked next.
     drive(5'd0, 5'd0, 1'b1, 5'd0, 32'hdeadbeef);
@@ -178,20 +164,18 @@ module regfile_tb;
     check_hex("x0 reads 0 in the use cycle (rs1)", reg_rs1, 32'h00000000);
     check_hex("x0 reads 0 in the use cycle (rs2)", reg_rs2, 32'h00000000);
 
-    // White box, repointed from the single `regs` array to both copies
-    // (ADR-0042): the suppressed write must have reached neither backing array.
-    // The read mux would hide a missing guard completely.
+    // White box, because the read mux would hide a missing write guard
+    // completely: the suppressed write must have reached neither array.
     drive(5'd0, 5'd0, 1'b0, 5'd0, 32'h0);
     check_ne("x0 write never reaches regs_a", dut.regs_a[0], 32'hdeadbeef);
     check_ne("x0 write never reaches regs_b", dut.regs_b[0], 32'hdeadbeef);
 
-    // ---- the bypass fires only on an address match ----
+    // The bypass fires only on an address match.
     drive(5'd7, 5'd7, 1'b0, 5'd0, 32'h0);          // fetch x7
     drive(5'd7, 5'd7, 1'b1, 5'd5, 32'h66666666);   // use, writing an unrelated x5
     check_hex("bypass does not leak into an unrelated address (rs1)", reg_rs1, 32'h33333333);
     check_hex("bypass does not leak into an unrelated address (rs2)", reg_rs2, 32'h33333333);
 
-    // ---- the two ports are independent ----
     // Different addresses, one answered from its array and one from the bypass,
     // then the same with the roles swapped -- so a bypass wired to the wrong
     // array cannot pass both directions.


### PR DESCRIPTION
Closes JEF-719.

Batch 2 of the comment rewrite, following #97. Nine files, comments only.

```
$ git diff -U0 origin/main | grep '^[+-]' | grep -v '^[+-][+-]' | grep -vE '^[+-]\s*(//|$)'
$
```

Zero non-comment, non-blank lines. Every line of SystemVerilog is byte-identical.

## Per-file line-count deltas

| File | Comment lines before | after | delta |
|---|---:|---:|---:|
| `rtl/executor.v` | 369 | 231 | -138 |
| `test/exec_tb.v` | 242 | 158 | -84 |
| `rtl/csrs.v` | 176 | 122 | -54 |
| `test/csr_tb.v` | 108 | 76 | -32 |
| `test/monitor_tb.v` | 87 | 49 | -38 |
| `rtl/writeback.v` | 75 | 37 | -38 |
| `test/regfile_tb.v` | 68 | 52 | -16 |
| `rtl/regfile.v` | 38 | 26 | -12 |
| `test/mem_tb.v` | 25 | 15 | -10 |
| **total** | **1188** | **766** | **-422** |

(`grep -cE '^[[:space:]]*//'`.)

## Five before/after pairs

### 1. Outright deletion — `rtl/writeback.v`, the port-list block

Deleted with nothing in its place. The invariant-3 sentence is already stated at
the `wen` assignment forty lines down, where it applies; the second half is
history.

```diff
   output logic [31:0] wdata
-  // ADR-0006 / CLAUDE.md invariant 3: "retire is `valid` reaching
-  // writeback, which gates wen and drives rvfi_valid" — this is that spot.
-  // `rvfi_trap` is no longer hardwired either: rtl/decoder.v computes it where
-  // every trap is detected and committed (invariant 2) and it rides the shadow
-  // down here like the CSR fields and everything else per-retire.
  `ifdef RISCV_FORMAL
```

Also deleted outright, same rule: `rtl/executor.v`'s two `// state machine`
banners, `rtl/csrs.v`'s `// ---- read mux ----` and `// ---- state ----`
banners, `rtl/csrs.v`'s "named rather than spelled as hex" justification for
naming its localparams, and `test/mem_tb.v`'s `// Criterion 5a` / `// Criterion
5b` labels, which pointed at a numbered list that lives in no file in the repo.

### 2. `rtl/executor.v` — ADR-0049's label blocks become prose

ADR-0049 requires every `assume` to name the fact it models, where that fact is
discharged, and its scope. All three survive at all five assumes; the
three-column layout does not. This is the shape #97 already gave
`formal/complete.sv`.

```diff
-  // FACT       reset never returns after the first cycle.
-  // DISCHARGED NOWHERE. True of every harness in the tree; asserted by none.
-  // SCOPE      the whole task -- LARGER than what it was written for. The
-  //            paragraph above is about the divide-family assertions, but this
-  //            is an unguarded `always_comb assume`, so it equally excuses the
-  //            whole multiply section and the ADR-0015 freeze block from
-  //            ever seeing a mid-trace reset. That is harmless here (a
-  //            re-asserted reset is not a real environment) and is written
-  //            down because ADR-0049 clause 3 requires the reader to be told
-  //            the scope rather than left to infer it from proximity.
+  // Assumed: reset never returns after the first cycle. True of every harness in
+  // the tree and asserted by none, so again discharged nowhere. It was written
+  // for the divide-family assertions, which span many cycles and where a
+  // re-asserted reset would jump from `divide` to `init` with out.rd_data zeroed
+  // by the reset branch rather than computed by the divider. Being unguarded its
+  // scope is larger than that: it equally excuses the multiply section and the
+  // freeze block from ever seeing a mid-trace reset, which is harmless because a
+  // re-asserted reset is not a real environment.
   always_comb if (clocked) assume(!reset);
```

The last clause of the original — that it is written down because clause 3 says
to — is meta-commentary about the comment and is gone; the scope itself stays.

### 3. `rtl/regfile.v` — history out, tripwire in

```diff
-  // Write-through bypass (ADR-0004, CLAUDE.md invariant 6), unchanged in intent
-  // from the flip-flop regfile: a write presented in the cycle the operand is
-  // USED forwards wdata directly instead of the value captured a cycle ago.
-  //
-  // The two forwarding points together -- write-first above, this bypass here
-  // -- are what make the operand the cycle-N architectural value *including* a
-  // cycle-N writeback, which is the whole observable content of invariant 6 and
-  // the reason ADR-0004's stall-only scoreboard needs no forwarding path for
-  // the writeback slot. Deleting either one is a direct invariant-6 violation;
-  // deleting the rs2 half of this one is the ladder's liveness probe (ADR-0040).
-  // x0 always reads 0, regardless of wen/waddr.
+  // Write-through bypass: a write presented in the cycle the operand is used
+  // forwards wdata directly instead of the value captured a cycle ago. Together
+  // with the write-first term above it makes the operand the cycle-N
+  // architectural value including a cycle-N writeback, which is the whole
+  // observable content of CLAUDE.md invariant 6 and the reason ADR-0004's
+  // stall-only scoreboard needs no forwarding path for the writeback slot.
+  // Deleting either point violates invariant 6; deleting the rs2 half of this
+  // one is the ladder's liveness probe for reg_ch0 (ADR-0040).
+  // x0 always reads 0, regardless of wen/waddr.
```

"unchanged in intent from the flip-flop regfile" is history. The probe sentence
gains `for reg_ch0`, because a probe with no named check is not actionable.

### 4. `rtl/csrs.v` — the carry-boundary defect story becomes the rule

The defect is fixed and guarded by `test/csr_tb.v`, so the story is history. The
rule is not, and neither is the fact that no other oracle can see it — that half
moves to `test/csr_tb.v`, at the vectors, where someone might otherwise delete
them as duplicates. 21 lines to 11.

```diff
-  // ADR-0005's "an explicit write to a counter takes precedence over that
-  // cycle's increment" -- and the privileged spec's own "any CSR write takes
-  // precedence over the automatic increment" (20211203 §3.1.11) -- are
-  // statements about the 64-BIT COUNTER, not about the half whose address the
-  // instruction happens to name. mcycle and mcycleh are two views of one
-  // register, so a write to either half suppresses that cycle's increment of
-  // the whole thing. Hence a `_tick` term per counter rather than the two
-  // per-half overrides below doing the job on their own.
-  //
-  // Suppressing per half instead is wrong only at the carry boundary, and
-  // wrong there in a way that nothing else in this repo can see. With
-  // mcycle == 32'hffff_ffff the increment's carry lands in the HIGH half while
-  // the explicit write replaces the low one, so `csrw mcycle` advances mcycleh
-  // by one -- contradicting the invariant the RVFI report at the bottom of this
-  // file is built to satisfy, and doing it once every 2**32 cycles and only if
-  // a write falls on that exact cycle. checks/rvfi_csrw_check.sv reads the
-  // SELF-REPORTED masks and never observes the register; every ladder check is
-  // `mode bmc` from reset; and a `.S` program can land a write on that cycle
-  // only by calibrating instruction spacing first, which is a test that stops
-  // testing the moment the spacing changes. test/csr_tb.v drives this port
-  // directly and is the one place it is deterministic (ADR-0048).
+  // "Any CSR write takes precedence over the automatic increment" (priv spec
+  // 20211203 §3.1.11) is a statement about the 64-bit COUNTER, not about the
+  // half whose address the instruction names: mcycle and mcycleh are two views
+  // of one register, so a write to either half suppresses that cycle's increment
+  // of the whole thing. Hence a `_tick` term per counter rather than the two
+  // per-half overrides below doing the job alone.
+  //
+  // Suppressing per half instead differs only at the carry boundary, where the
+  // increment's carry lands in the high half while the write replaces the low
+  // one -- so `csrw mcycle` advances mcycleh. test/csr_tb.v is the only thing
+  // that can see it (ADR-0048).
```

### 5. `test/exec_tb.v` — the signed-arithmetic tripwire, 34 lines to 16

The one the ticket names as having caught real bugs twice. The mechanism, the
invisibility (negative operands only), the two occurrences and the instruction
all stay. The rhetorical setup and the argument with a hypothetical reader go.

```diff
-  // ---- reference model: shifts ----------------------------------------
-  //
-  // READ THIS BEFORE EDITING THE THREE FUNCTIONS BELOW.
-  //
-  // Every shift here is computed in a STATEMENT OF ITS OWN, into a local whose
-  // signedness is declared, and is never an arm of a `?:` or any other
-  // conditional expression. That is not a style preference, it is the whole
-  // reason these functions are shaped the way they are.
-  //
-  // IEEE 1800 sign-context propagation makes a conditional expression unsigned
+  // Each shift below is computed in a statement of its own, into a local whose
+  // signedness is declared, and is never an arm of a `?:`. Keep them that way.
+  //
+  // IEEE 1800 makes a conditional expression unsigned if any of its operands is
...
-  // This is not hypothetical, and it is not new here. ADR-0019 is the same
-  // defect at two sites in the generated riscv-formal monitor -- its DIV and
-  // REM spec models, where `-7 / 2` scored as `0x7ffffffc` and failed `div.S`
-  // and `rem.S` against a correct core, until the sanitizer made the
-  // arithmetic self-determined. It then happened AGAIN, here, while these very
-  // vectors were being written: the natural one-line `ref_sra` written as a
-  // `?:` arm reported six mismatches, and the thing that was wrong was the
-  // oracle. A bench whose oracle is broken is worse than no bench -- it blames
-  // the hardware and teaches the reader to distrust the bench. Keep each of
-  // these a standalone statement, and see `ref_selftest` below, which pins
-  // them against hand-computed literals that cannot degrade along with the
-  // expression.
+  // side. This repo has been bitten twice, at ADR-0019's two monitor spec models
+  // and then here, where the natural one-line `ref_sra` written as a `?:` arm
+  // reported six mismatches against correct hardware.
```

## Tripwires

None dropped. Kept, all shorter: `rtl/regfile.v`'s write-through bypass,
`rtl/writeback.v`'s `sorry:` sensitivity reasoning and its 20-note cap,
`test/mem_tb.v`'s no-change read port (SPRAM vs. 128 EBRs), `rtl/csrs.v`'s
per-counter increment suppression and its `mepc` bit-1 mask, `test/exec_tb.v`'s
`ref_selftest` / `check_vector_counts` / `check_directed_manifest` and the
signed-reference rule, `rtl/executor.v`'s divide cap (both measured properties:
why `|| state == divide` is required and why it must bound `div_x`/`div_y`
rather than `in.rs1`/`in.rs2`), the `UNKNOWN rc=4` detection signal for the
completion assertions, the `$onehot0` list's coupling to `rtl/structs.v`, and
`test/monitor_tb.v`'s vector 7 (why it must be last, and why vector 4 does not
cover it).

## Gates

| Gate | Result |
|---|---|
| `make -C formal check JOBS=4` | **85 checks: 85 pass, 0 fail**; `EXPECTED_FAIL` and `EXPECTED_CHECKS` both match exactly, both directions. 5m45s wall at load ~8.5 (a sibling agent was running synthesis; 345% CPU) |
| `make test` | **56/56 passed**, failure list matches `test/EXPECTED_FAIL` exactly |
| `make test-units` | 7 benches, all PASSED, matching `test/*_tb.v` exactly |
| `make probe-gates` | 125 graded comparisons, every failure path executed |
| `make lint` | svlint clean in both passes |

One note on ordering, stated rather than implied: the ladder ran on the
substantive tree. After it, a `/simplify` pass made six single-word edits inside
`//` text (lowercasing `TRAPPING`, `STATEMENTS`, `START`, `LOADS`, `BY HAND`,
`REJECT`) and reworded one cross-reference in `test/exec_tb.v`. `make lint` and
`make test` (56/56) were re-run green after those; the ladder was not re-run for
six lowercase letters inside comments, per the run-once concurrency budget.

`/soundcheck:pr-review`: no Critical or High findings — the diff adds no
executable lines and no credential-shaped strings.

Out of scope and untouched, per the ticket: `rtl/decoder.v`, `rtl/imemory.v`,
`rtl/memory.v`, `rtl/littlesoc.v`, `rtl/accessor.v`, `rtl/structs.v`,
`rtl/fetcher.v`, `test/testbench.v`, `test/decoder_tb.v`, `test/imem_tb.v`,
`formal/`, `Makefile`, `.github/`. `CLAUDE.md` and `docs/adr/` are deliberately
running logs and are exempt from the rule. `test/monitor.v` is generated and was
not hand-edited (invariant 7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
