### PR TITLE
Text is writable: imemory gains the write port, the data read and the steal (JEF-722)

### DIFF
--- a/docs/adr/0059-text-is-writable-and-the-arbiter-lives-in-the-memory.md
+++ b/docs/adr/0059-text-is-writable-and-the-arbiter-lives-in-the-memory.md
@@ -1,0 +1,136 @@
+# ADR-0059: Text is writable, and the arbiter lives in the memory
+
+**Status:** Accepted · 2026-08-02 · *Builds step 2 of
+[`docs/ideas/one-address-space-over-two-memories.md`](../ideas/one-address-space-over-two-memories.md).
+Re-measures [ADR-0057](0057-what-writable-text-costs-in-ladder-depth-and-in-nanoseconds.md)'s
+synthesis half against the real steal select, which is that ADR's condition 2, and answers its
+condition 3. Reads its logic levels through
+[ADR-0058](0058-the-fetch-loop-is-not-two-levels-too-deep.md)'s model.*
+
+## Context
+
+`rtl/imemory.v` was a ROM with an idle write port. `rtl/littlesoc.v` and `test/testbench.v` decoded
+two disjoint buses, so nothing on the data bus could reach the text region: no program could be
+loaded at runtime, no trap handler could read the instruction that faulted, and ADR-0054's `.data`
+gap had no path to close.
+
+ADR-0057 built scratch RTL for the two unknowns, measured them and threw it away. This change is the
+first of the sprint's shipping steps: the write port, the data read and the steal, with the core
+still untouched.
+
+## Decision 1 — the range decode and the steal live inside `rtl/imemory.v`
+
+There is one implementation of both, and both consumers get it by instantiating the module.
+
+The alternative — a separate arbiter module, or the decode written into each consumer — was
+declined on the parameter. `test/testbench.v` runs `ROM_WORDS = 4096` against the SoC's 2048, so a
+range test written outside the module would have to be given the size twice and would put the two
+sim legs on different maps the first time one of them changed. A separate module would need the
+same parameter and would add a second file to keep in step, for no coverage `test/imem_tb.v` does
+not already give.
+
+## Decision 2 — the two buses join with an OR, and it is verified across a write
+
+`rtl/memory.v` answers zero outside its range and `rtl/imemory.v` answers zero outside the text
+range, so `mem_rdata` is `imem_mem_rdata | dmem_mem_rdata` — a wired join rather than a select, one
+less level, and it sits on the data path rather than the fetch loop.
+
+The case worth checking is the one ADR-0054 decision 4 creates: `rtl/memory.v`'s read port is
+**no-change on a write cycle**, so on a store its registered output holds whatever the last load
+left there. Two live values on the wire would corrupt a text load. They cannot meet:
+
+- On a **text load**, `mem_addr` is outside the RAM's range and `mem_wstrb` is zero, so
+  `rtl/memory.v` takes its read arm and drives zero on exactly that cycle. The OR sees the text
+  word and a zero.
+- On a **store**, `rtl/imemory.v` answers zero — `data_hit` gates on `mem_ren`, not on the write —
+  and the RAM holds its stale value. The OR sees a stale value and a zero, on a cycle no load reads
+  `mem_rdata` (ADR-0015).
+
+## Decision 3 — `mem_ren` is a port and both consumers tie it low
+
+The idle bus presents `mem_addr = 0`, which is inside the text range, so without a read enable every
+idle cycle would steal a fetch and the core would never run. The port lands here so the next change
+drives it; `fetch_stall` lands unconnected for the same reason. `test/imem_tb.v` drives both, so
+neither is untested — it is untested *by the suite*, which is a different thing and is why the bench
+grew rather than the suite.
+
+While `mem_ren` is low, a store to text still writes and still steals, with nothing consuming the
+steal. No program in `test/asm` does that. One thing did: `test/testbench.v`'s baked-in `make waves`
+program counted at address 1020, inside the text range. It counts at `0x10000` now, which is where
+the comment above it always said the data was. Retires and writes are unchanged at 79 and 20.
+
+## The measurement
+
+**Toolchain, quoted with the number:** Homebrew Yosys 0.67+post (`b8e7da6f`),
+nextpnr-0.10-108-g68c1acd8, `icetime` from the same install — the same box and build ADR-0057 and
+ADR-0058 measured on. Machine load 8–26 throughout, with a sibling build live; `icetime` is a static
+analysis, so load moves the wall time and not the numbers. `SOC_PROG=add.S`.
+
+| design | LC | `icetime` ns, four placements (default, seeds 1–3) | MHz |
+|---|---|---|---|
+| baseline (`85e7113`) | 4041 | 88.51 · 87.94 · 87.55 · 87.43 | 11.30 – 11.44 |
+| **this change** | **4304** | **98.08 · 97.75 · 98.19 · 96.92** | **10.18 – 10.32** |
+
+**+263 logic cells and about +10.5% on the critical path.** The distributions do not overlap and the
+gap is outside both bands that could explain it — 1–2% across placements of one netlist and
+ADR-0054's 3.6% across edits — so it is the change, not churn. ADR-0057 predicted 4336 cells and
+94.89–96.77 ns with a free pad driving the mux select; the real select is a combinational cone off
+the accessor, and its condition 2 said the spike's figure was therefore a lower bound. It was, by
+about two points.
+
+**The cell census does not move: 20 `SB_RAM40_4K`, 2 `SB_SPRAM256KA`, 4 `SB_IO`.** Adding a
+byte-enabled write port to the initialised banks does not degrade block-RAM inference, which is what
+ADR-0057 measured structurally and `make soc-timing`'s declared census now re-checks on every run.
+
+### Read the levels apart, or this change looks like an improvement
+
+| | levels | LUT/setup | carry | per LUT | per carry | path |
+|---|---|---|---|---|---|---|
+| baseline | 41 | 25 | 17 | 3.31 ns | 0.34 ns | `imem.in_range → imem.in_range2` |
+| this change | **30** | **29** | **1** | 3.35 ns | 0.83 ns | `imem.rom_odd…RDATA → imem.rom_even…RDATA` |
+
+It is the same loop — bank read data, fetch window, decode, next PC, back into the banks — and it
+still fits in one cycle with no flush (invariant 1). What moved is where it ends: it used to end at
+the registered range flag, and it now ends at the bank read address, with the steal mux in front of
+it. That trades **16 carry hops for 4 LUT levels**, so `icetime`'s single level count falls by
+eleven while the path gets 10.8% slower. ADR-0058 wrote that hazard down as a warning; this is it
+happening on a real change, and the reason `make soc-timing` prints the two counts separately.
+
+### The ruling on ADR-0038's 12 MHz intent (ADR-0057 condition 3)
+
+The design was 6% short of the declared 12 MHz. It is now about 15% short. **The declaration is not
+moved, and this is the reasoning rather than a shrug:**
+
+- The gate is `SOC_MIN_MHZ`, and it holds at every placement measured — 10.18 MHz worst against a
+  10.0 floor.
+- The alternatives are priced and none of them is cheap. ADR-0057 measured the read mux as free in
+  area and the write port as all of it, so dropping text loads does not buy the time back. ADR-0058
+  measured a second path within 1.7% of the fetch loop, which caps fetch-loop tuning near 11.5 MHz.
+- What would buy it back is ADR-0057's own fallback — decode the steal from the accessor's
+  registered inputs a cycle early, taking the select's cone off the mux. It costs a register and
+  changes the shape of everything downstream, so it is a change of its own, not a tweak to this one.
+
+The number to reconcile the intent against is now 10.2 MHz rather than 11.3.
+
+## Consequences
+
+- **`SOC_MIN_MHZ`'s margin is thin: 1.8% at the worst placement, against a 3.6% edit-churn band.**
+  It is left at 10.0 deliberately — lowering a ratchet in the same change that consumed its headroom
+  is how a floor stops meaning anything — but the next change to this design either buys time back
+  or moves the floor with a reason. This is the first time the floor has been within the churn band
+  of the measurement, and it should not be discovered by a red gate on an unrelated edit.
+- **Nothing in `formal/` builds `rtl/imemory.v`**, so the ladder is out of contact with this change.
+  It was run rather than assumed: 85 checks, 85 pass, both set equalities exact.
+- **`mem_ren` and `fetch_stall` are dark**, so the suite's retire counts do not move — measured
+  identical program by program, not merely above `test/OBSERVED_FLOOR`. The next change drives them
+  and lands ADR-0057's three `[depth]` lines with them; the F and G that justify those were measured
+  against a modelled arbiter, and this is the arbiter they modelled.
+- **The bus stays non-faulting.** Out-of-range loads read zero, out-of-range writes are dropped
+  without aliasing a mapped word, out-of-range fetch reads zero. Nothing here can refuse a
+  transaction, so nothing faults after decode and invariant 2 is untouched. That is ADR-0044
+  option 1, adopted for the text region as the brief proposes.
+- **`test/imem_tb.v` covers the data port against a flat reference**, per ADR-0054 decision 5's
+  rule: the reference is a word array updated byte by byte from the strobe, never derived from the
+  bank split. Seven mutations of `rtl/imemory.v` were run against it — swapped write bank, no steal,
+  strobes ignored, range test open, `fetch_stall` stuck low, read answer unmasked, and the steal
+  ungated by `mem_ren` — and each is red with a diagnostic naming its own defect.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -63,6 +63,7 @@ and what it costs. Reversing one is fine — write a new ADR that supersedes it.
 | [0056](0056-the-makefile-embedded-ratchets-get-probes-and-soc-timing-gets-a-job.md) | The Makefile-embedded ratchets get probes, and `soc-timing` gets a job | Accepted · extends 0053, follows 0052 |
 | [0057](0057-what-writable-text-costs-in-ladder-depth-and-in-nanoseconds.md) | What writable text costs, in ladder depth and in nanoseconds | Accepted · re-runs 0046's derivation and 0054's timing; corrects 0054's `SOC_MIN_MHZ` |
 | [0058](0058-the-fetch-loop-is-not-two-levels-too-deep.md) | The fetch loop is not two levels too deep | Accepted · a measured null; corrects how 0054's logic-level count reads |
+| [0059](0059-text-is-writable-and-the-arbiter-lives-in-the-memory.md) | Text is writable, and the arbiter lives in the memory | Accepted · builds 0057's step 2; answers its condition 3 |
 
 0001–0007 came from the design brief
 ([`docs/ideas/finish-the-rewrite.md`](../ideas/finish-the-rewrite.md)). 0008–0011 came out of

--- a/rtl/imemory.v
+++ b/rtl/imemory.v
@@ -1,7 +1,9 @@
 `timescale 1 ns / 1 ps
 `default_nettype none
-// The instruction ROM: two interleaved banks of 32-bit words, read
+// The instruction memory: two interleaved banks of 32-bit words, read
 // synchronously off the fetch address published one cycle early (ADR-0054).
+// The data bus reaches it too, through the banks' own write port and by
+// borrowing their read port for a cycle.
 //
 // It is a ROM in BLOCK RAM, and both halves of that are decisions
 // (ADR-0054 §"ROM in BRAM"). `SB_SPRAM256KA` is the only large memory on this
@@ -65,7 +67,25 @@ module imemory #(
   // the NEXT edge. This module latches it, so its outputs answer that cycle.
   input  logic [31:0] imem_addr_next,
   output logic [31:0] imem_data,
-  output logic [31:0] imem_data2
+  output logic [31:0] imem_data2,
+  // The data bus, so text is readable and writable from a store or a load.
+  // The range decode and the arbitration between the two buses live here
+  // rather than in each consumer: rtl/littlesoc.v and test/testbench.v run
+  // different `ROM_WORDS`, so a range test written outside this module would
+  // put the two legs on different maps.
+  input  logic [31:0] mem_addr,
+  input  logic [31:0] mem_wdata,
+  input  logic [3:0]  mem_wstrb,
+  // High on the cycle a load's request is on the bus. The idle bus presents
+  // address 0, which is inside the text range, so without it every idle cycle
+  // would steal a fetch.
+  input  logic        mem_ren,
+  // Zero unless the previous cycle was a text-range load, so a consumer can
+  // OR this with the data RAM's answer.
+  output logic [31:0] mem_rdata,
+  // High for the cycle whose fetch window was taken by a data access. The
+  // fetch that lost the read port has to be repeated.
+  output logic        fetch_stall
 );
   localparam int BANK_WORDS = ROM_WORDS / 2;
   localparam int BANK_BITS  = $clog2(BANK_WORDS);
@@ -93,6 +113,35 @@ module imemory #(
   assign odd_index  = word_index[BANK_BITS:1];
   assign even_index = odd_index + {{(BANK_BITS-1){1'b0}}, word_index[0]};
 
+  // The data side. One word, so it needs one bank -- the one its word parity
+  // names -- at the index that parity strips off.
+  //
+  // The range test is the same shape as the fetch one below: a word index
+  // against a constant, with no adder in front of it. `mem_addr` is
+  // word-aligned for every load and store (rtl/accessor.v), so the low two
+  // bits carry nothing the byte strobes do not.
+  logic [29:0]          data_word;
+  logic [BANK_BITS-1:0] data_index;
+  logic                 data_odd, text_range;
+  assign data_word  = mem_addr[31:2];
+  assign data_index = data_word[BANK_BITS:1];
+  assign data_odd   = data_word[0];
+  assign text_range = data_word < 30'(ROM_WORDS);
+
+  // The steal. A text access takes the banks' single read port for the edge,
+  // so the fetch presented that cycle is answered with the data word instead
+  // and has to be repeated -- `fetch_stall` below says so. A store steals too:
+  // it holds the write port, and a fetch read of the word being written is a
+  // collision the part does not define.
+  logic text_access, text_write_even, text_write_odd;
+  assign text_access     = (mem_ren || |mem_wstrb) && text_range;
+  assign text_write_even = |mem_wstrb && text_range && !data_odd;
+  assign text_write_odd  = |mem_wstrb && text_range &&  data_odd;
+
+  logic [BANK_BITS-1:0] even_raddr, odd_raddr;
+  assign even_raddr = text_access ? data_index : even_index;
+  assign odd_raddr  = text_access ? data_index : odd_index;
+
   // Out of range reads as zero, which decodes to an illegal instruction, so a
   // wild PC faults instead of silently aliasing back into the ROM through bit
   // truncation. Both words are tested: the last word of ROM is in range while
@@ -110,14 +159,37 @@ module imemory #(
   // It also removes a corner: `word + 1` wraps at the top of the address space,
   // so the old form called the second word of a fetch at 0xfffffffc "in range"
   // and answered it from word 0. This form faults both words there.
+  //
+  // The read below is unconditional and the write is a second, separately
+  // addressed port: that is the shape yosys maps to an EBR's own read and write
+  // ports. Both buses are answered from these registers, so a data read arrives
+  // a cycle after its address the same way a fetch does.
   logic [31:0] even_data, odd_data;
   logic        odd_first, in_range, in_range2;
+  logic        data_hit, data_hit_odd;
   always_ff @(posedge clk) begin
-    even_data <= rom_even[even_index];
-    odd_data  <= rom_odd[odd_index];
+    even_data <= rom_even[even_raddr];
+    odd_data  <= rom_odd[odd_raddr];
     odd_first <= word_index[0];
     in_range  <= next_word < 30'(ROM_WORDS);
     in_range2 <= next_word < 30'(ROM_WORDS) - 30'd1;
+
+    fetch_stall  <= text_access;
+    data_hit     <= mem_ren && text_range;
+    data_hit_odd <= data_odd;
+
+    if (text_write_even) begin
+      if (mem_wstrb[0]) rom_even[data_index][7:0]   <= mem_wdata[7:0];
+      if (mem_wstrb[1]) rom_even[data_index][15:8]  <= mem_wdata[15:8];
+      if (mem_wstrb[2]) rom_even[data_index][23:16] <= mem_wdata[23:16];
+      if (mem_wstrb[3]) rom_even[data_index][31:24] <= mem_wdata[31:24];
+    end
+    if (text_write_odd) begin
+      if (mem_wstrb[0]) rom_odd[data_index][7:0]   <= mem_wdata[7:0];
+      if (mem_wstrb[1]) rom_odd[data_index][15:8]  <= mem_wdata[15:8];
+      if (mem_wstrb[2]) rom_odd[data_index][23:16] <= mem_wdata[23:16];
+      if (mem_wstrb[3]) rom_odd[data_index][31:24] <= mem_wdata[31:24];
+    end
   end
 
   logic [31:0] window_lo, window_hi;
@@ -125,4 +197,8 @@ module imemory #(
   assign window_hi = odd_first ? even_data : odd_data;
   assign imem_data  = in_range  ? window_lo : 32'b0;
   assign imem_data2 = in_range2 ? window_hi : 32'b0;
+
+  // Zero out of range, and zero on the cycle after a store, so a consumer can
+  // OR this with the data RAM's `mem_rdata` instead of decoding the map twice.
+  assign mem_rdata = data_hit ? (data_hit_odd ? odd_data : even_data) : 32'b0;
 endmodule

--- a/rtl/littlesoc.v
+++ b/rtl/littlesoc.v
@@ -13,9 +13,13 @@
 //
 // ---- the memory map --------------------------------------------------------
 //
-// ADR-0008's, unchanged, and Harvard: the instruction bus indexes ROM from 0
-// and the data bus indexes RAM from RAM_BASE, and they are not two windows on
-// one address space. Everything out of range on either bus reads as zero.
+// ADR-0008's addresses, unchanged: text from 0, RAM from RAM_BASE. The data
+// bus now reaches both -- a store into the text range writes it and a load
+// from it is answered by `imemory` -- so the two memories are one address
+// space, and `mem_rdata` is the OR of their two answers. Fetch still reaches
+// text only. Everything out of range on either bus reads as zero and no
+// access is ever refused, which is what keeps every trap in decode
+// (CLAUDE.md invariant 2).
 //
 // ---- what this cannot do yet, stated rather than discovered -----------------
 //
@@ -71,6 +75,7 @@ module littlesoc (
   // ---- the core ------------------------------------------------------------
   logic        trap;
   logic [31:0] mem_addr, mem_wdata, mem_rdata;
+  logic [31:0] imem_mem_rdata, dmem_mem_rdata;
   logic [3:0]  mem_wstrb;
   logic [31:0] imem_addr, imem_addr2, imem_addr_next;
   logic [31:0] imem_data, imem_data2;
@@ -111,7 +116,16 @@ module littlesoc (
     .clk(clk),
     .imem_addr_next(imem_addr_next),
     .imem_data(imem_data),
-    .imem_data2(imem_data2)
+    .imem_data2(imem_data2),
+    .mem_addr(mem_addr),
+    .mem_wdata(mem_wdata),
+    .mem_wstrb(mem_wstrb),
+    // The core has no read enable yet, so no load reaches the text region and
+    // no idle cycle steals a fetch. Stores do reach it.
+    .mem_ren(1'b0),
+    .mem_rdata(imem_mem_rdata),
+    // Nothing consumes the steal yet: the core has no stall input for it.
+    .fetch_stall()
   );
 
   // ---- data RAM ------------------------------------------------------------
@@ -121,8 +135,15 @@ module littlesoc (
     .mem_addr(mem_addr),
     .mem_wdata(mem_wdata),
     .mem_wstrb(mem_wstrb),
-    .mem_rdata(mem_rdata)
+    .mem_rdata(dmem_mem_rdata)
   );
+
+  // Both memories answer zero outside their own range, so the two buses join
+  // with an OR rather than a select -- one less level on the data path. The
+  // ranges do not overlap, and a store leaves the RAM's registered read data
+  // unchanged (rtl/memory.v) while the ROM answers zero, so the OR can never
+  // mix two live values.
+  assign mem_rdata = imem_mem_rdata | dmem_mem_rdata;
 
   // ---- the two observable bits --------------------------------------------
   // A tap on the store bus and a sticky trap flag. Between them they keep every

--- a/test/imem_tb.v
+++ b/test/imem_tb.v
@@ -20,9 +20,14 @@
 //     `imem_data2`. Getting that wrong aliases the top of ROM back to the
 //     bottom, which reads as a plausible instruction rather than as a fault.
 //
-// The reference is a flat, independently-filled array indexed by word number.
-// It is not built from the bank images: the bank split is the thing under test,
-// so a reference derived from it would agree with any split at all.
+//   * The data port. The `.S` suite cannot reach it at all: no program stores
+//     into the text region, and both consumers tie `mem_ren` low. So the write
+//     port, the borrowed read port and the steal are checked here or nowhere.
+//
+// The reference is a flat, independently-filled array indexed by word number,
+// and every write is applied to it byte by byte from the strobe. It is not
+// built from the bank images: the bank split is the thing under test, so a
+// reference derived from it would agree with any split at all.
 module imem_tb;
   localparam int ROM_WORDS = 16;
 
@@ -31,12 +36,21 @@ module imem_tb;
 
   logic [31:0] imem_addr_next;
   logic [31:0] imem_data, imem_data2;
+  logic [31:0] mem_addr, mem_wdata, mem_rdata;
+  logic [3:0]  mem_wstrb;
+  logic        mem_ren, fetch_stall;
 
   imemory #(.ROM_WORDS(ROM_WORDS)) dut (
     .clk(clk),
     .imem_addr_next(imem_addr_next),
     .imem_data(imem_data),
-    .imem_data2(imem_data2)
+    .imem_data2(imem_data2),
+    .mem_addr(mem_addr),
+    .mem_wdata(mem_wdata),
+    .mem_wstrb(mem_wstrb),
+    .mem_ren(mem_ren),
+    .mem_rdata(mem_rdata),
+    .fetch_stall(fetch_stall)
   );
 
   // The flat reference. Word i holds a value that is unique in both halves, so
@@ -54,15 +68,69 @@ module imem_tb;
     end
   endtask
 
-  // Present a word address and take the edge that latches it; the outputs are
-  // valid for the whole of the cycle after, which is where they are read.
-  // That IS the contract (ADR-0054): the address is presented one cycle before
-  // the data is needed.
-  task automatic fetch(input logic [31:0] addr);
+  // One cycle, with every input named. Presenting an address and taking the
+  // edge that latches it IS the contract (ADR-0054): the outputs are valid for
+  // the whole of the cycle after, which is where they are read.
+  task automatic step(input logic [31:0] fetch_addr,
+                      input logic [31:0] data_addr,
+                      input logic        ren,
+                      input logic [3:0]  strb,
+                      input logic [31:0] wdata);
     begin
-      imem_addr_next = addr;
+      imem_addr_next = fetch_addr;
+      mem_addr       = data_addr;
+      mem_ren        = ren;
+      mem_wstrb      = strb;
+      mem_wdata      = wdata;
       @(posedge clk);
       #1;
+    end
+  endtask
+
+  // A fetch with the data bus idle. The idle bus presents address 0, which is
+  // inside the text range, so `mem_ren` low is the only thing keeping it from
+  // stealing every cycle.
+  task automatic fetch(input logic [31:0] addr);
+    step(addr, 32'b0, 1'b0, 4'b0000, 32'b0);
+  endtask
+
+  // A data access. The fetch address is parked at word 0, so an answer that
+  // came off the fetch side rather than the data side reads as word 0.
+  task automatic dread(input logic [31:0] addr);
+    step(32'b0, addr, 1'b1, 4'b0000, 32'b0);
+  endtask
+
+  task automatic check_stall(input string what, input logic expected);
+    check(what, {31'b0, fetch_stall}, {31'b0, expected});
+  endtask
+
+  // A write, and the same write applied to the reference. One task so the two
+  // take the same arguments by construction. Out of range the reference does
+  // nothing, which is what makes the walk below a test that a dropped write
+  // really was dropped.
+  task automatic write_word(input logic [31:0] addr, input logic [3:0] strb,
+                            input logic [31:0] data);
+    int word;
+    begin
+      step(32'b0, addr, 1'b0, strb, data);
+      word = int'(addr >> 2);
+      if (word < ROM_WORDS) begin
+        if (strb[0]) ref_rom[word][7:0]   = data[7:0];
+        if (strb[1]) ref_rom[word][15:8]  = data[15:8];
+        if (strb[2]) ref_rom[word][23:16] = data[23:16];
+        if (strb[3]) ref_rom[word][31:24] = data[31:24];
+      end
+    end
+  endtask
+
+  // Every word of the ROM, through the fetch path, against the reference. A
+  // write that landed in the wrong bank, at the wrong index, or on the wrong
+  // bytes shows up here even when the word it was aimed at reads correctly.
+  task automatic check_all(input string what);
+    int j;
+    for (j = 0; j < ROM_WORDS; j++) begin
+      fetch(32'(j) * 4);
+      check($sformatf("%s: word %0d", what, j), imem_data, ref_rom[j]);
     end
   endtask
 
@@ -77,9 +145,7 @@ module imem_tb;
       else            dut.rom_odd[i/2]  = ref_rom[i];
     end
 
-    imem_addr_next = 32'b0;
-    @(posedge clk);
-    #1;
+    fetch(32'b0);
 
     // Every word index, both parities, both window words.
     for (i = 0; i < ROM_WORDS - 1; i++) begin
@@ -122,12 +188,99 @@ module imem_tb;
     // is what makes a stalled cycle free (rtl/decoder.v holds `next_pc = pc`).
     fetch(32'h0000_0008);
     check("a held address re-presents the same word", imem_data, ref_rom[2]);
+    check_stall("an idle data bus does not steal a fetch", 1'b0);
+
+    // ---- the data read path ------------------------------------------------
+    // Every word, both parities, out of the borrowed read port. The fetch
+    // address sits at word 0 throughout, so an answer that came from the fetch
+    // side instead of the data side would read as word 0's value.
+    for (i = 0; i < ROM_WORDS; i++) begin
+      dread(32'(i) * 4);
+      check($sformatf("data read of word %0d", i), mem_rdata, ref_rom[i]);
+      check_stall($sformatf("word %0d: a data read steals the fetch", i), 1'b1);
+    end
+
+    // Out of range in both directions: zero, no alias, and no steal -- the
+    // fetch keeps the read port because the access was never ours.
+    dread(32'(ROM_WORDS) * 4);
+    check("data read one past the end", mem_rdata, 32'b0);
+    check_stall("an out-of-range read steals nothing", 1'b0);
+    dread(32'h0000_1004);
+    check("far out-of-range data read does not alias", mem_rdata, 32'b0);
+
+    // A read and a fetch of the same word on adjacent cycles, at both
+    // parities. The read answers from the bank the word lives in and the fetch
+    // that follows is unaffected by having lost the port the cycle before.
+    dread(32'h0000_0010);
+    check("read word 4 (even bank)", mem_rdata, ref_rom[4]);
+    fetch(32'h0000_0010);
+    check("fetch word 4 the cycle after reading it", imem_data, ref_rom[4]);
+    check("...and its second word", imem_data2, ref_rom[5]);
+    check_stall("the fetch after a steal is not itself stolen", 1'b0);
+
+    dread(32'h0000_0014);
+    check("read word 5 (odd bank)", mem_rdata, ref_rom[5]);
+    fetch(32'h0000_0014);
+    check("fetch word 5 the cycle after reading it", imem_data, ref_rom[5]);
+    check("...and its second word", imem_data2, ref_rom[6]);
+
+    // The other order: a fetch, then a read of the word it just returned.
+    fetch(32'h0000_0018);
+    check("fetch word 6", imem_data, ref_rom[6]);
+    dread(32'h0000_0018);
+    check("read word 6 the cycle after fetching it", mem_rdata, ref_rom[6]);
+
+    // ---- the write port ----------------------------------------------------
+    // A whole word into each bank, then read back through both paths.
+    write_word(32'h0000_0008, 4'b1111, 32'h1122_3344);
+    check_stall("a write steals the fetch", 1'b1);
+    fetch(32'h0000_0008);
+    check("a written even-bank word fetches back", imem_data, ref_rom[2]);
+    dread(32'h0000_0008);
+    check("...and reads back", mem_rdata, ref_rom[2]);
+
+    write_word(32'h0000_000c, 4'b1111, 32'h5566_7788);
+    fetch(32'h0000_000c);
+    check("a written odd-bank word fetches back", imem_data, ref_rom[3]);
+    check_all("after two word writes");
+
+    // Byte strobes, one lane at a time over a word that already holds data, at
+    // both parities. A strobe applied to the wrong lane, or a write that put
+    // the whole word down regardless of the strobe, changes bytes the
+    // reference keeps.
+    for (i = 0; i < 4; i++) begin
+      write_word(32'h0000_0010, 4'b0001 << i, 32'hdead_beef);
+      check_all($sformatf("after sb into byte %0d of word 4", i));
+      write_word(32'h0000_0014, 4'b0001 << i, 32'h0f1e_2d3c);
+      check_all($sformatf("after sb into byte %0d of word 5", i));
+    end
+
+    // Halfword strobes, low and high, at both parities.
+    write_word(32'h0000_0018, 4'b0011, 32'ha5a5_5a5a);
+    write_word(32'h0000_0018, 4'b1100, 32'h1234_5678);
+    write_word(32'h0000_001c, 4'b0011, 32'hbeef_cafe);
+    write_word(32'h0000_001c, 4'b1100, 32'h9876_5432);
+    check_all("after four sh writes");
+
+    // ---- the range boundary, on the write side -----------------------------
+    // The last word is in range and takes a write.
+    write_word(32'(ROM_WORDS - 1) * 4, 4'b1111, 32'h0bad_f00d);
+    check_all("after writing the last word");
+
+    // One past the end, and far past it at an address whose low bits index a
+    // real bank word. Both are dropped, and `check_all` is what says they did
+    // not land somewhere else instead.
+    write_word(32'(ROM_WORDS) * 4, 4'b1111, 32'hffff_ffff);
+    check_stall("a write past the end steals nothing", 1'b0);
+    write_word(32'h0000_1004, 4'b1111, 32'hffff_ffff);
+    write_word(32'hffff_fffc, 4'b1111, 32'hffff_ffff);
+    check_all("after three out-of-range writes");
 
     if (errors != 0) begin
       $display("FAILED: %0d mismatches", errors);
       $fatal(1);
     end else begin
-      $display("PASSED: imemory.v bank select, dual-word window, range decode");
+      $display("PASSED: imemory.v bank select, dual-word window, range decode, data port");
       $finish;
     end
   end

--- a/test/testbench.v
+++ b/test/testbench.v
@@ -51,6 +51,12 @@ module testbench(
   logic [31:0] mem_wdata;
   logic [3:0]  mem_wstrb;
   logic [31:0] mem_rdata;
+  // Both memories answer zero outside their own range, so the two buses join
+  // with an OR. Same wiring as rtl/littlesoc.v, which is the point: the range
+  // decode and the steal live in rtl/imemory.v, so the two legs cannot end up
+  // on different maps.
+  logic [31:0] imem_mem_rdata, dmem_mem_rdata;
+  assign mem_rdata = imem_mem_rdata | dmem_mem_rdata;
   logic        trap;
  `ifdef RISCV_FORMAL
   logic        rvfi_valid;
@@ -89,7 +95,7 @@ module testbench(
     .mem_addr(mem_addr),
     .mem_wdata(mem_wdata),
     .mem_wstrb(mem_wstrb),
-    .mem_rdata(mem_rdata)
+    .mem_rdata(dmem_mem_rdata)
   );
 
   // No init files: every consumer of this bench fills the banks itself. The
@@ -99,7 +105,15 @@ module testbench(
     .clk(clk),
     .imem_addr_next(imem_addr_next),
     .imem_data(imem_data),
-    .imem_data2(imem_data2)
+    .imem_data2(imem_data2),
+    .mem_addr(mem_addr),
+    .mem_wdata(mem_wdata),
+    .mem_wstrb(mem_wstrb),
+    // Tied off and unconnected exactly as rtl/littlesoc.v ties them: the core
+    // has no read enable to drive and no stall input to take the steal.
+    .mem_ren(1'b0),
+    .mem_rdata(imem_mem_rdata),
+    .fetch_stall()
   );
 
   littlecpu uut (
@@ -354,8 +368,11 @@ module testbench(
   // carry in an `initial rom[...]` block, written straight into rtl/imemory.v's
   // two banks (ADR-0054 -- word 2i is even, word 2i+1 is odd). It exercises
   // fetch, a load, a store and a backward jump, which is what the waveform is
-  // for; the store address is outside ADR-0008's RAM region, so the loads read
-  // zero, and that was already true before this change.
+  // for.
+  //
+  // It counts in RAM. An address in the text range would take the banks' write
+  // port and steal the fetch behind it, and nothing here drives the core's
+  // stall for that yet.
   //
   // A HIERARCHICAL REFERENCE, hence `ifdef ICARUS` -- the same guard the clock
   // and reset generation above carries. yosys does not RESOLVE one of these: it
@@ -363,7 +380,7 @@ module testbench(
   // which CLAUDE.md records as a real hazard. The cxxrtl legs never take this
   // path; they load their ROM through `debug_items`.
   initial begin
-    imem.rom_even[0] = 32'h3fc00093; //       li      x1, 1020
+    imem.rom_even[0] = 32'h000100b7; //       lui     x1, 0x10
     imem.rom_odd [0] = 32'h0000a023; //       sw      x0, 0(x1)
     imem.rom_even[1] = 32'h0000a103; // loop: lw      x2, 0(x1)
     imem.rom_odd [1] = 32'h00110113; //       addi    x2, x2, 1


### PR DESCRIPTION
Closes JEF-722.

Step 2 of `docs/ideas/one-address-space-over-two-memories.md`: `rtl/imemory.v` takes the data bus, the two consumers wire it, and `test/imem_tb.v` grows the coverage. **No `rtl/` file outside `imemory.v` and `littlesoc.v` changed, and the core is untouched** — `mem_ren` is tied low and `fetch_stall` is unconnected, so the ports ship dark and the next ticket drives them.

## What landed

- **`rtl/imemory.v`** gains `mem_addr`/`mem_wdata`/`mem_wstrb`/`mem_ren` in and `mem_rdata`/`fetch_stall` out. A text-range store writes the bank its word parity names, byte by byte from the strobe; a text-range load borrows the banks' read port; either raises `fetch_stall` for the fetch it displaced. The range decode derives from the module's own `ROM_WORDS`.
- **One implementation, two consumers** (acceptance 2). The decode and the steal are inside the module both `rtl/littlesoc.v` and `test/testbench.v` instantiate. The alternative was declined on the parameter: the SoC runs 2048 words against the bench's 4096, so a range test written outside would put the two legs on different maps the first time one changed.
- **The `mem_rdata` join is an OR**, and the write case the ticket asked to verify rather than assume holds: on a text load, `rtl/memory.v` takes its read arm (`wstrb == 0`) and drives zero because the address is outside its range; on a store, `rtl/imemory.v` drives zero because `data_hit` gates on `mem_ren`. Two live values never meet. Written out in ADR-0059 decision 2.
- **`test/testbench.v`'s baked-in `make waves` program moved its counter from address 1020 to `0x10000`.** 1020 is inside the text range, so with this change every store would have taken the write port and stolen the fetch behind it with nothing to absorb the steal. Retires and writes are unchanged at 79 and 20.
- **ADR-0059** records the arbiter's placement, the measurement, and the ruling ADR-0057 condition 3 asked for.

## The measurement (acceptance 6)

Toolchain quoted with the number: **Homebrew Yosys 0.67+post (`b8e7da6f`), nextpnr-0.10-108-g68c1acd8, icetime from the same install** — the box ADR-0057 and ADR-0058 measured on. **Machine load 8–26** throughout (a sibling agent was building); `icetime` is a static analysis, so load moves wall time and not the numbers. `SOC_PROG=add.S`.

| design | LC | icetime ns, four placements (default, seeds 1–3) | MHz |
|---|---|---|---|
| baseline (`85e7113`) | 4041 | 88.51 · 87.94 · 87.55 · 87.43 | 11.30 – 11.44 |
| **this PR** | **4304** | **98.08 · 97.75 · 98.19 · 96.92** | **10.18 – 10.32** |

+263 cells, about +10.5% on the path. The distributions do not overlap and the gap clears both bands (1–2% across placements, 3.6% across edits), so it is the change. ADR-0057 predicted 4336 cells and 94.9–96.8 ns with a free pad driving the mux select and said that was a lower bound because the real select is a cone off the accessor; it was, by about two points.

**Cell census unchanged: 20 `SB_RAM40_4K`, 2 `SB_SPRAM256KA`, 4 `SB_IO`.**

**Read the levels apart or this looks like an improvement** (ADR-0058): baseline 41 levels = 25 LUT + 17 carry, `imem.in_range → imem.in_range2`; this PR 30 levels = 29 LUT + 1 carry, bank read data → bank read address. Same loop, ending deeper — it trades 16 nearly-free carry hops for 4 LUT levels, so icetime's single count falls by eleven while the path gets 10.8% slower.

## Gates — run, not asserted

| gate | result |
|---|---|
| `make test` | **56/56**, `EXPECTED_FAIL` matched; per-program retire and spec-checked counts **byte-identical to main** (diffed, not just above `OBSERVED_FLOOR`) |
| `make cosim-suite` | **56/56 agreed**, `COSIM_EXPECTED_FAIL` matched |
| `make test-units` | **7/7**, list matches `test/*_tb.v` both ways |
| `make -C formal check JOBS=4` | **85 checks, 85 pass**; failure list and generated set both match exactly |
| `make fit` | 3875 of 4100 — unchanged (`fit` synthesises `littlecpu` with memories external) |
| `make soc-timing` | 10.20 MHz at the default placement against a 10.00 floor — OK |
| `make lint` | clean in both passes |
| `make waves` / `testbench.vvp` | green, `RETIRES 79 SPEC-CHECKED 79 WRITES 20` |
| `make elaborate-strict` | zero warnings; iverilog's `sorry:` count holds at 20, all `in[952:0]` |

## Red directions demonstrated

Seven mutations of `rtl/imemory.v`, each red in `test/imem_tb.v` with a diagnostic naming its own defect: swapped write bank, no steal on the read address, strobes ignored, range test open, `fetch_stall` stuck low, read answer unmasked out of range, and the steal ungated by `mem_ren`.

## Decisions and flags for review

- **DECISION NEEDED — `SOC_MIN_MHZ`'s margin is now 1.8% against a 3.6% edit-churn band.** I left it at 10.0: lowering a ratchet in the same change that consumed its headroom is how a floor stops meaning anything. But the next change to this design either buys time back (ADR-0057's fallback: decode the steal from the accessor's registered inputs a cycle early) or moves the floor with a recorded reason. This is the first time the floor has sat inside the churn band of the measurement, and it should not be found by a red gate on an unrelated edit.
- **ADR number 0059** was free on `main` and against every open PR at the time of writing. If a sibling PR takes it first, this one renumbers.
- **The arbiter stayed inside `rtl/imemory.v`** rather than becoming an eighth unit bench. `UNIT_BENCHES` stays at 7. Acceptance is coverage, and a separate module would need the same `ROM_WORDS` parameter and a second file to keep in step.
- **`make -C formal check` was run** even though nothing in `formal/` builds `rtl/imemory.v` — the ladder is structurally out of contact with this change, which is why it is green and why that greenness says nothing about the new hardware. `test/imem_tb.v` is what covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
