### PR TITLE
Take the OSS CAD Suite from the runner image

### DIFF
--- a/.github/actions/setup-oss-cad-suite/action.yml
+++ b/.github/actions/setup-oss-cad-suite/action.yml
@@ -1,56 +1,85 @@
 name: Set up OSS CAD Suite
 description: >-
-  Restore the pinned OSS CAD Suite release (yosys, iverilog, sby, ...) from
-  cache, downloading and checksum-verifying it on a cache miss, and add it
-  to PATH. Used by every ci.yml job that needs the open toolchain; the pin
-  itself stays in ci.yml's env: block, passed in as
-  inputs, so it stays visible in the workflow and this action has no pin of
-  its own to drift.
-inputs:
-  tag:
-    description: OSS CAD Suite release tag (e.g. 2026-06-29)
-    required: true
-  file:
-    description: Release asset filename (e.g. oss-cad-suite-linux-x64-20260629.tgz)
-    required: true
-  sha256:
-    description: Expected SHA-256 of the release asset
-    required: true
+  Put the OSS CAD Suite (yosys, iverilog, sby, nextpnr-ice40, icetime, the
+  solvers) on PATH. Uses the copy in the runner image when there is one,
+  otherwise downloads the latest release and verifies it against the digest
+  GitHub publishes for the asset.
 runs:
   using: composite
   steps:
+    # Seven jobs each restored 607 MB from the cache service every run, measured
+    # at a 129s mean and up to 222s once they contend for bandwidth. The runner
+    # image carries the suite, so on those runners this is a local path.
+    - name: Use the runner image's OSS CAD Suite if it has one
+      id: image
+      shell: bash
+      run: |
+        set -euo pipefail
+        if [ -x /opt/oss-cad-suite/bin/yosys ]; then
+          echo "found=true" >> "$GITHUB_OUTPUT"
+          echo "using the runner image's copy: $(/opt/oss-cad-suite/bin/yosys -V)"
+        else
+          echo "found=false" >> "$GITHUB_OUTPUT"
+          echo "no copy in the runner image -- downloading the latest release"
+        fi
+
+    # Latest, not a pin. A toolchain bump that changes the hardware shows up in
+    # `make fit` and `make soc-timing`, both of which ratchet: ADR-0052 measured
+    # 21 cells between two yosys builds on identical RTL. formal/pin.mk is a
+    # different question and stays pinned -- test/monitor.v is generated from it
+    # and tracked, so bumping that one means regenerating the monitor.
+    - name: Resolve the latest OSS CAD Suite release
+      id: release
+      if: steps.image.outputs.found != 'true'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        set -euo pipefail
+        release=$(curl -fsSL -H "Authorization: Bearer $GH_TOKEN" \
+          https://api.github.com/repos/YosysHQ/oss-cad-suite-build/releases/latest)
+        tag=$(jq -r .tag_name <<<"$release")
+        # The asset name carries the date without dashes: 2026-06-29 -> ...-20260629.tgz
+        asset="oss-cad-suite-linux-x64-${tag//-/}.tgz"
+        digest=$(jq -r --arg a "$asset" '.assets[] | select(.name == $a) | .digest' <<<"$release" | cut -d: -f2)
+        test -n "$digest"
+        echo "tag=$tag" >> "$GITHUB_OUTPUT"
+        echo "asset=$asset" >> "$GITHUB_OUTPUT"
+        echo "digest=$digest" >> "$GITHUB_OUTPUT"
+        echo "latest is $tag"
+
     - name: Restore OSS CAD Suite from cache
       id: cache
+      if: steps.image.outputs.found != 'true'
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: oss-cad-suite
-        # Keyed on the SHA-256, not the tag: the verification step below is
-        # skipped on a cache hit, so a tag-keyed entry would let a poisoned
-        # cache be restored without ever meeting the checksum. Content-
-        # addressing the key means a restored entry is one that was verified
-        # against this exact digest when it was written.
-        key: oss-cad-suite-linux-x64-${{ inputs.sha256 }}
+        # Keyed on the digest, not the tag: the verification below is skipped on
+        # a cache hit, so a tag-keyed entry would let a poisoned cache be
+        # restored without ever meeting a checksum.
+        key: oss-cad-suite-linux-x64-${{ steps.release.outputs.digest }}
 
     - name: Download OSS CAD Suite (cache miss)
-      if: steps.cache.outputs.cache-hit != 'true'
+      if: steps.image.outputs.found != 'true' && steps.cache.outputs.cache-hit != 'true'
       shell: bash
       run: |
         set -euo pipefail
         curl -fsSL -o oss-cad-suite.tgz \
-          "https://github.com/YosysHQ/oss-cad-suite-build/releases/download/${{ inputs.tag }}/${{ inputs.file }}"
-        # Upstream does not publish a checksum asset for this release, so
-        # this is this repo's own pin -- same "don't trust the dependency,
-        # pin what you got" posture as formal/pin.mk (ADR-0013).
-        echo "${{ inputs.sha256 }}  oss-cad-suite.tgz" | sha256sum -c -
+          "https://github.com/YosysHQ/oss-cad-suite-build/releases/download/${{ steps.release.outputs.tag }}/${{ steps.release.outputs.asset }}"
+        echo "${{ steps.release.outputs.digest }}  oss-cad-suite.tgz" | sha256sum -c -
         tar -xzf oss-cad-suite.tgz
         rm oss-cad-suite.tgz
-
-    - name: Report cache status
-      shell: bash
-      run: echo "oss-cad-suite cache-hit=${{ steps.cache.outputs.cache-hit }}"
 
     - name: Add OSS CAD Suite to PATH
       shell: bash
       run: |
-        echo "$GITHUB_WORKSPACE/oss-cad-suite/bin" >> "$GITHUB_PATH"
-        echo "$GITHUB_WORKSPACE/oss-cad-suite/py3bin" >> "$GITHUB_PATH"
+        set -euo pipefail
+        if [ "${{ steps.image.outputs.found }}" = "true" ]; then
+          root=/opt/oss-cad-suite
+        else
+          root="$GITHUB_WORKSPACE/oss-cad-suite"
+        fi
+        echo "$root/bin" >> "$GITHUB_PATH"
+        echo "$root/py3bin" >> "$GITHUB_PATH"
+        # Fail here rather than in whichever job first reaches for yosys.
+        test -x "$root/bin/yosys"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,15 +15,6 @@ permissions:
 
 # The tag and the filename must name the same oss-cad-suite release
 # (https://github.com/YosysHQ/oss-cad-suite-build/releases); bump them together.
-env:
-  OSS_CAD_SUITE_TAG: "2026-06-29"
-  OSS_CAD_SUITE_FILE: "oss-cad-suite-linux-x64-20260629.tgz"
-  # Upstream publishes no checksum asset for this release, so this digest is
-  # this repo's own pin, computed locally from the tarball it fetched -- the
-  # same posture as formal/pin.mk. The composite action verifies it before
-  # extracting anything.
-  OSS_CAD_SUITE_SHA256: "dfb5df3c28599081d2baca13884c069c025b1990c86e90f4a4d84aadcd255cc5"
-
 jobs:
   # Both elaboration frontends: yosys write_cxxrtl, then iverilog over
   # test/testbench.v + rtl/ + test/monitor.v.
@@ -39,10 +30,6 @@ jobs:
 
       - name: Set up OSS CAD Suite
         uses: ./.github/actions/setup-oss-cad-suite
-        with:
-          tag: ${{ env.OSS_CAD_SUITE_TAG }}
-          file: ${{ env.OSS_CAD_SUITE_FILE }}
-          sha256: ${{ env.OSS_CAD_SUITE_SHA256 }}
 
       - name: yosys write_cxxrtl, warnings promoted
         # `make elaborate-strict` runs `proc; opt_clean; check` ahead of
@@ -137,10 +124,6 @@ jobs:
 
       - name: Set up OSS CAD Suite
         uses: ./.github/actions/setup-oss-cad-suite
-        with:
-          tag: ${{ env.OSS_CAD_SUITE_TAG }}
-          file: ${{ env.OSS_CAD_SUITE_FILE }}
-          sha256: ${{ env.OSS_CAD_SUITE_SHA256 }}
 
       - name: make test
         run: make test
@@ -175,10 +158,6 @@ jobs:
 
       - name: Set up OSS CAD Suite
         uses: ./.github/actions/setup-oss-cad-suite
-        with:
-          tag: ${{ env.OSS_CAD_SUITE_TAG }}
-          file: ${{ env.OSS_CAD_SUITE_FILE }}
-          sha256: ${{ env.OSS_CAD_SUITE_SHA256 }}
 
       - name: Executor arithmetic BMC
         run: make -C formal components_executor
@@ -257,10 +236,6 @@ jobs:
 
       - name: Set up OSS CAD Suite
         uses: ./.github/actions/setup-oss-cad-suite
-        with:
-          tag: ${{ env.OSS_CAD_SUITE_TAG }}
-          file: ${{ env.OSS_CAD_SUITE_FILE }}
-          sha256: ${{ env.OSS_CAD_SUITE_SHA256 }}
 
       - name: make fit
         # Never pipe a graded command in a `run:` block. Without an explicit
@@ -328,10 +303,6 @@ jobs:
 
       - name: Set up OSS CAD Suite
         uses: ./.github/actions/setup-oss-cad-suite
-        with:
-          tag: ${{ env.OSS_CAD_SUITE_TAG }}
-          file: ${{ env.OSS_CAD_SUITE_FILE }}
-          sha256: ${{ env.OSS_CAD_SUITE_SHA256 }}
 
       - name: make soc-timing
         # Redirected rather than piped -- see the `fit` job's step for why. The
@@ -393,10 +364,6 @@ jobs:
 
       - name: Set up OSS CAD Suite
         uses: ./.github/actions/setup-oss-cad-suite
-        with:
-          tag: ${{ env.OSS_CAD_SUITE_TAG }}
-          file: ${{ env.OSS_CAD_SUITE_FILE }}
-          sha256: ${{ env.OSS_CAD_SUITE_SHA256 }}
 
       - name: make -C formal nonperturbation
         # Redirected rather than piped -- see the `fit` job's step for why.
@@ -500,10 +467,6 @@ jobs:
 
       - name: Set up OSS CAD Suite
         uses: ./.github/actions/setup-oss-cad-suite
-        with:
-          tag: ${{ env.OSS_CAD_SUITE_TAG }}
-          file: ${{ env.OSS_CAD_SUITE_FILE }}
-          sha256: ${{ env.OSS_CAD_SUITE_SHA256 }}
 
       # sby's btor engine replays a counterexample with btorsim, so btorsim is
       # reached only by a check that found one -- on a box without it, every red


### PR DESCRIPTION
Seven of the nine CI jobs restored the OSS CAD Suite from the GitHub cache service on every run — **607,515,233 bytes each, ~4.25 GB per run** of a file that never changes.

**The cache was hitting.** This was never a miss problem; the cost is bandwidth contention between jobs that start together. Measured across three runs, twenty setups: **129s mean, 12s to 222s**. `formal` starts first and pulls at 46 MB/s while `test` and `elaborate` log `Received 0 of 607515233 (0.0%), 0.0 MBs/sec`. Roughly 15 minutes of runner time per run.

## Change

The runner image now carries the suite (thejefflarson/runner#36), so on `little-cpu-runners` this is a local path. A runner without it resolves the latest release from the GitHub API and verifies the download against the digest GitHub publishes for the asset.

**No pin.** A toolchain change that alters the hardware surfaces in `make fit` and `make soc-timing`, both ratchets — 21 cells sit between two yosys builds on identical RTL (ADR-0052).

`formal/pin.mk` is untouched and stays pinned. Different problem: `test/monitor.v` is generated from riscv-formal and tracked, and the repo executes Python straight out of that clone. Staying current with *that* is the freshness workflow from #96.

## Why this replaces #91

#91 held for a real reason: measured on its own run, `components` hit its 5-minute timeout with the setup step alone at 3m14s, because removing the pin moved the cache key to follow latest and every job cold-downloaded. **The image had to exist first.** It does now — published 2026-08-02T20:10:53Z, the first successful publish since July 31.

Getting there also meant fixing the image build, which had been failing on `archive.ubuntu.com` since July 31 (thejefflarson/runner#36 and #37).

#91 itself went stale when #97 rewrote this workflow's comments; this is the same change re-applied cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJ77ZZJ6pDiL3vj3Qw9hKs