### PR TITLE
The sixth stall reason: mem_ren out, fetch_stall in, and fence.i serializes (JEF-723)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -239,6 +239,28 @@ de-interleave the `--rom` image across the two banks. `test/imem_tb.v` joins `ma
 (**seven** benches) and walks every word index at both parities against a **flat** reference, kept
 deliberately independent of the bank split.
 
+**Text is writable, the steal reaches decode, and `fence.i` stopped being free** (ADR-0059,
+ADR-0060, ADR-0061). `rtl/imemory.v` owns the range decode, the write port and the arbitration;
+`rtl/accessor.v` exports `mem_ren` (`!reset && in_valid && is_load`) and `rtl/decoder.v` takes
+`fetch_stall` as the **sixth stall reason** on the existing bubble mechanism — `pc` holds, `out <=
+'0`, no flush, nothing issued. `mem_ren` is not cosmetic: the idle bus presents address 0, which is
+inside the text range, so without it every idle cycle would steal a fetch and the core would never
+run. **`fence.i` now serializes** on invariant 5's drain predicate, because the fetch address is
+published a cycle early (ADR-0054) — a store at cycle D writes the array at edge D+2 while the
+instruction after a `fence.i` at D+1 was fetched at edge D+1, so it would execute stale text after
+`fence.i` retired. All four in-flight slots have to be empty for that argument to hold, and
+`accessor_out.valid` is the slot that carries a store (ADR-0026). **Three ladder depths moved with
+it** — `insn 19`, `ill 19`, `reg 15 22` — off a re-measured **F = 6, G = 4 → 6**, and the ladder's
+wall time roughly doubled. Two things about the change are worth knowing before touching it. The
+**coincidence of `fetch_stall` with a divider or accessor freeze is a ruling, not statement order**:
+holding wins, and it is asserted in two places because reordering two `else if` arms is otherwise
+silent. And **the suite does not exercise any of this end to end**: no program in `test/asm` does a
+text-region data access (`.data` is at `0x10000`, the bench's text ends at `0x4000`), so retire
+counts are identical program by program and the steal never fires there. `formal/wrapper.v` models
+the arbiter and is where the ladder meets it; `imemcheck`/`dmemcheck`/`cover`/`complete` tie
+`fetch_stall` low and say so. `selfmod.S` and `textload.S` are the programs that would close this,
+and they are not written yet.
+
 **Every graded comparison in the grading layer now has a probe of its own red direction, and two of
 them had never been executed** (ADR-0053). Five of this repo's recorded defects were in that layer
 and every one was in a *script*; the class is the comparison whose failure path was never run, and
@@ -581,7 +603,7 @@ signal and is the single entry on the `elaborate` gate's allowlist; everything e
 `Warning:` is promoted to an error there (`.github/workflows/ci.yml`, which cross-references this
 note). It is not zero, and this line said zero until ADR-0037. The
 cxxrtl binary builds and runs, the whole `.S` suite passes under it with `test/EXPECTED_FAIL`
-empty, `make test-units` passes (**seven** benches since ADR-0054 added `imem_tb`: `exec_tb` —
+empty, `make test-units` passes (**eight** benches since ADR-0060 added `accessor_tb`: `exec_tb` —
 10,000 randomized differential vectors
 per op across `mul`/`mulh`/`mulhu`/`mulhsu`/`div`/`divu`/`rem`/`remu`/`sll`/`srl`/`sra` **and**
 `add`/`sub` — the latter pair closing the bench's own blind spot on the simplest ALU op — plus 384
@@ -599,7 +621,9 @@ where the first two used to print `PASSED` and exit 0 — `mem_tb`,
 `regfile_tb` — which covers the write-through bypass and x0 semantics — `csr_tb`, which covers
 `rtl/csrs.v`'s read mux, its `implemented` address set, its WARL masks and its trap-entry/`mret`
 port, `imem_tb`, which walks rtl/imemory.v's bank select at every word index and both parities
-against a flat reference plus its range decode (ADR-0054), and `monitor_tb`, which checks the oracle
+against a flat reference plus its range decode (ADR-0054), `accessor_tb`, which exists for the one
+signal nothing else can see stuck low — `mem_ren`, the read enable the memory's arbiter keys on
+(ADR-0060) — and `monitor_tb`, which checks the oracle
 itself rather than the core), and **all three**
 component proofs — decoder, executor and `pcloop` — pass by k-induction (`mode prove`; re-run and
 read off each `sby` summary, not inferred from a green job. See ADR-0017 for what the decoder proof
@@ -712,7 +736,12 @@ These are the design. Violating one is a bug even if tests pass.
    reaching writeback, which gates `wen` and drives `rvfi_valid`.
 4. **Hazards are handled by stall-only interlock in decode.** No forwarding network. Adding one is
    a CPI-only optimization and requires a new ADR.
-5. **CSR instructions and `mret` serialize** — held in decode until execute/access/writeback drain.
+5. **CSR instructions, `mret` and `fence.i` serialize** — held in decode until execute/access/
+   writeback drain. The first two serialize so a one-cycle-wide architectural update cannot
+   interleave with instructions that issued before it. `fence.i` serializes for a different reason
+   (ADR-0061): text is writable and the fetch address is published a cycle early, so ordering a
+   store against the fetches behind it needs the older store's write edge to have passed before
+   `fence.i` issues. Same mechanism, two reasons; do not collapse them.
 6. **The regfile read is synchronous and takes one cycle** (ADR-0042). Decode observes, in the
    cycle it issues, the architectural value of rs1/rs2 **including a writeback committed in that
    same cycle** — two forwarding points in fabric (write-first into the read register, then the
@@ -721,16 +750,22 @@ These are the design. Violating one is a bug even if tests pass.
    forwarding path for the writeback slot. The flip-flop array that used to make the read
    combinational was one implementation of that contract, not the contract.
 7. **`test/monitor.v` is generated but tracked.** Regenerate it; never hand-edit it.
-8. **Stalls are a single global broadcast: five reasons over two mechanisms** (ADR-0026 amending
-   ADR-0009; ADR-0042 adding the fifth). The reasons are the decode scoreboard, the divider, the
-   accessor's one-cycle load-response turnaround (ADR-0015), CSR serialization (invariant 5), and
-   the operand-fetch cycle (invariant 9) — which bubbles, exactly like a RAW hazard, and adds no
+8. **Stalls are a single global broadcast: six reasons over two mechanisms** (ADR-0026 amending
+   ADR-0009; ADR-0042 adding the fifth, ADR-0060 the sixth). The reasons are the decode scoreboard,
+   the divider, the accessor's one-cycle load-response turnaround (ADR-0015), serialization
+   (invariant 5), the operand-fetch cycle (invariant 9), and the instruction memory's stolen fetch
+   window (`fetch_stall`, ADR-0059) — the last two bubble, exactly like a RAW hazard, and add no
    third mechanism. The **mechanisms** are
    what actually matters, and three non-local rules hold them together, each breakable silently:
    (a) while `divider_stall` or `accessor_stall` is asserted, decode **holds** `decoder_out`
    unchanged rather than bubbling it, and nothing downstream may consume it that cycle; a RAW
-   hazard **bubbles** instead, and so does CSR serialization — the CSR instruction has not issued
-   yet, so it folds into the existing `hazard` term rather than becoming new machinery. (b) Every
+   hazard **bubbles** instead, and so do serialization and `fetch_stall` — neither instruction has
+   issued, so they fold into the existing `hazard`/bubble arm rather than becoming new machinery.
+   **A `fetch_stall` coinciding with either freeze HOLDS**: the freeze is about an instruction
+   already in `decoder_out` that nothing has consumed, and bubbling would drop it. That is a ruling
+   (ADR-0060), enforced only by the publish block's arm order, so it is asserted in
+   `rtl/decoder.v`'s `FORMAL` block and driven as a vector in `test/decoder_tb.v` — reordering two
+   `else if` arms is otherwise silent. (b) Every
    in-flight non-`x0` `rd` is visible to the scoreboard on every cycle between issue and the
    regfile write-through, with no gap: `decoder_out` → `executor_out` → `accessor_pending` (loads
    only) → write-through. (c) The serialization drain predicate reads **four** slots, not the
@@ -749,11 +784,15 @@ These are the design. Violating one is a bug even if tests pass.
 ## ISA target
 
 RV32IMC_Zicsr_Zifencei, M-mode only. `misa = 0x4000_1104` — neither Zicsr nor Zifencei has a
-`misa` bit, so the ISA string is the only place either is claimed. Zifencei is claimed because the
-core already implements it correctly and for free: one hart, no icache, so a conformant `fence.i`
-is a NOP, which is what `rtl/decoder.v` already does. Before ADR-0002 was amended the string did
-NOT claim it while the decoder accepted it anyway — silently permissive, and the one combination
-that was wrong.
+`misa` bit, so the ISA string is the only place either is claimed. **Zifencei costs a pipeline
+drain** (ADR-0061): `fence.i` serializes on invariant 5's predicate, because text is writable
+(ADR-0059) and the fetch address is published a cycle early (ADR-0054), so a store at cycle D writes
+the array at edge D+2 while the instruction after a `fence.i` at D+1 was fetched at edge D+1. This
+section said it was correct **and free** — one hart, no icache, so a conformant `fence.i` is a NOP —
+and that was a property of ADR-0008's split buses rather than of the core. The cache half is still
+free; the ordering half never was, it was merely unreachable. Before ADR-0002 was amended the string
+did NOT claim Zifencei while the decoder accepted it anyway — silently permissive, and the one
+combination that was wrong.
 
 **Conformance is not negotiable against minimality.** Every CSR the privileged spec lists
 unconditionally for RV32 machine mode is implemented; a core that traps on a mandatory register is
@@ -1010,11 +1049,13 @@ term 6 is open.** Read each term's own text, not this sentence:
    closed it again**, which is the more useful thing to know about it: the depths those 82 checks run
    at were derived against a pipeline two changes old, and a depth below its floor goes green having
    stopped asking. They are re-derived now, and the derivation is *measured* — `hang` gives the
-   worst-case first retire (F = 6), `liveness` the worst-case retire gap (G = 4), both in seconds,
-   both re-runnable. No depth moved. `insn 15` and `reg 15 20` clear their floors by **one cycle**,
-   so **any change that adds a stall reason, lengthens a stage, or widens the scoreboard past its
-   three fixed slots must re-measure F and G before it lands.** Two of the last three such changes
-   did not.
+   worst-case first retire (F = 6), `liveness` the worst-case retire gap (G = 6 since ADR-0060; it
+   was 4), both in seconds, both re-runnable. **Three depths moved with the sixth stall reason** —
+   `insn 15 → 19`, `ill 15 → 19`, `reg 15 20 → 15 22` (ADR-0057 predicted them, ADR-0060 re-measured
+   them against the shipping RTL) — and `insn 19` and `reg 15 22` still clear their floors by
+   **one cycle**, so **any change that adds a stall reason, lengthens a stage, or widens the
+   scoreboard past its three fixed slots must re-measure F and G before it lands.** Two of the last
+   four such changes did not; the ladder's wall time roughly doubled paying for this one.
 2. **The mul/div checks run without `RISCV_FORMAL_ALTOPS`**, or ADR-0010's gap is closed by a named
    oracle that does. `insn_mul`/`insn_div`/`insn_rem` passing still says nothing whatever about the
    real multiplier or divider. **ADR-0045 closed this on the "or" clause by naming

--- a/Makefile
+++ b/Makefile
@@ -551,17 +551,18 @@ lint-setup:
 # `check-unit-benches` compares it against `ls test/*_tb.v` in BOTH directions,
 # and the recipe below is DRIVEN by it — so the list cannot be satisfied by
 # adding a name without also giving the bench its sources.
-UNIT_BENCHES := exec_tb mem_tb imem_tb decoder_tb regfile_tb csr_tb monitor_tb
+UNIT_BENCHES := exec_tb mem_tb imem_tb decoder_tb regfile_tb csr_tb accessor_tb monitor_tb
 
 # Per-bench RTL. monitor_tb is not an RTL bench at all: its source is the
 # sanitized monitor, which is why it names a file under test/ rather than rtl/.
-UNIT_BENCH_SRC_exec_tb    := rtl/structs.v rtl/executor.v
-UNIT_BENCH_SRC_mem_tb     := rtl/memory.v
-UNIT_BENCH_SRC_imem_tb    := rtl/imemory.v
-UNIT_BENCH_SRC_decoder_tb := rtl/structs.v rtl/decoder.v
-UNIT_BENCH_SRC_regfile_tb := rtl/regfile.v
-UNIT_BENCH_SRC_csr_tb     := rtl/structs.v rtl/csrs.v
-UNIT_BENCH_SRC_monitor_tb := test/monitor.sim.v
+UNIT_BENCH_SRC_exec_tb     := rtl/structs.v rtl/executor.v
+UNIT_BENCH_SRC_mem_tb      := rtl/memory.v
+UNIT_BENCH_SRC_imem_tb     := rtl/imemory.v
+UNIT_BENCH_SRC_decoder_tb  := rtl/structs.v rtl/decoder.v
+UNIT_BENCH_SRC_regfile_tb  := rtl/regfile.v
+UNIT_BENCH_SRC_csr_tb      := rtl/structs.v rtl/csrs.v
+UNIT_BENCH_SRC_accessor_tb := rtl/structs.v rtl/accessor.v
+UNIT_BENCH_SRC_monitor_tb  := test/monitor.sim.v
 
 # `present` is derived from the tree inside the recipe rather than from a
 # $(wildcard) at parse time: make caches directory contents, and a check whose

--- a/docs/adr/0060-the-steal-reaches-decode-as-the-sixth-stall-reason.md
+++ b/docs/adr/0060-the-steal-reaches-decode-as-the-sixth-stall-reason.md
@@ -1,0 +1,146 @@
+# ADR-0060: The steal reaches decode, as the sixth stall reason
+
+**Status:** Accepted · 2026-08-02 · *Builds step 3 of
+[`docs/ideas/one-address-space-over-two-memories.md`](../ideas/one-address-space-over-two-memories.md)
+on top of [ADR-0059](0059-text-is-writable-and-the-arbiter-lives-in-the-memory.md). Lands
+[ADR-0057](0057-what-writable-text-costs-in-ladder-depth-and-in-nanoseconds.md) condition 1 — the
+three `[depth]` lines — with F and G re-measured against the shipping RTL rather than inherited.
+Amends [ADR-0026](0026-stalls-are-four-reasons-over-two-mechanisms.md) and
+[ADR-0009](0009-stall-protocol-semantics.md).
+[ADR-0061](0061-fence-i-has-to-serialize.md) is the other half of this change and is separate
+because its finding outlives it.*
+
+## Context
+
+ADR-0059 gave `rtl/imemory.v` the write port, the data read and the steal, and left both ends dark:
+`mem_ren` was tied low at both instantiation sites and `fetch_stall` was unconnected. In that state
+text is writable but not readable, and a store to text corrupts a fetch nobody stalls for.
+
+Turning them on is two wires and one ruling.
+
+## Decision 1 — `mem_ren` is `!reset && in_valid && is_load`, and it is load-bearing
+
+`rtl/accessor.v` already computes that predicate for its load-response stall; the read enable is the
+same expression with the reset term the request block applies. The idle bus presents `mem_addr = 0`,
+which is inside the text range, so without it the memory would answer every idle cycle as a text
+read, steal the fetch window and the core would never run. It is not an optimisation and it is not
+cosmetic.
+
+`test/accessor_tb.v` is new and exists for one signal. Stuck *high* is caught elsewhere — the
+ladder's environment would steal every cycle and `hang` would go red — but stuck *low* is invisible
+to everything else in the tree until a program does a text-region load, and none does yet. The bench
+covers the request cycle, the response cycle, a store, an ALU op, a bubble, reset and all five load
+widths. `UNIT_BENCHES` goes 7 → 8.
+
+## Decision 2 — the steal bubbles, and a coincident freeze outranks it
+
+`fetch_stall` is the sixth stall *reason* on ADR-0009's existing two mechanisms. It bubbles, exactly
+like a RAW hazard and the operand-fetch cycle: `pc` holds and `out <= '0`. There is no flush and
+nothing to flush — nothing issued, because `issuing = !reset && !stall` gates trap commit, the CSR
+write and `minstret`, and `stall` sits second in `next_pc`'s priority chain above every redirect.
+
+The coincidence with `divider_stall`/`accessor_stall` is the part worth ruling on:
+
+- A **freeze** holds `decoder_out` because the instruction sitting in it has not been consumed yet.
+- A **steal** bubbles because the window presented this cycle is a data word, so there is nothing to
+  publish.
+- On a cycle with **both**, holding wins. Bubbling would drop the held instruction, which nothing
+  downstream would notice.
+
+The publish block's arm order already gives that, which is exactly why it is stated rather than
+left implied: reordering two `else if` arms is a silent change with no elaboration error and no
+failing `.S` program. Both directions are asserted in `rtl/decoder.v`'s own `FORMAL` block and driven
+as vectors in `test/decoder_tb.v`. This extends invariant 8's rule (a) rather than adding a
+mechanism.
+
+`formal/pcloop.sv` gains `fetch_stall` in `f_may_stall` and an assertion that the steal holds the
+pc. That is ADR-0046's trap, avoided deliberately: a new stall reason plus a stale `f_may_stall`
+makes the sequential-advance assertion cover a cycle on which the decoder legitimately holds the pc,
+and the task goes red on correct RTL. It stayed red on `main` for eight commits the last time.
+
+## Decision 3 — `formal/wrapper.v` models the arbiter; the four hand-authored tasks tie it low
+
+The ladder drives `fetch_stall` from a transcription of `rtl/imemory.v`'s equation,
+`(mem_ren || |mem_wstrb) && mem_addr < 0x2000`, registered. Left free it would be an input an
+adversarial environment could hold forever, which starves `hang` and `liveness_ch0` — the failure
+ADR-0042 found with `imem_data`.
+
+The same-address stability assumption is weakened in the two places ADR-0057 identified: the compare
+is dropped on the cycle after any text access (the read port was borrowed, so the window is the data
+word) and, after a text *store*, on the cycle after that as well (the array changed, and the fetch
+address is published a cycle early). Both are dropped compares rather than modelled values, which is
+the wide side — an assumption can only make checks easier, so a depth floor derived under it is the
+safe one.
+
+`imemcheck`, `dmemcheck`, `cover` and `complete` tie `fetch_stall` low, and each says so at the
+site. They model no memory at all — `imem_data` is free or `rand_const` and answered in the same
+cycle — so a steal there would add stall cycles without adding coverage, and would push `cover`'s
+five goals and `complete`'s depth-50 walk further out for nothing. The ladder is where a stealing
+memory is modelled. What that leaves open is named in the consequences below.
+
+## The measurement: F and G, re-derived here rather than quoted
+
+ADR-0025 requires empirical evidence in either direction before a `[depth]` line moves, and ADR-0057
+supplied it from scratch RTL. That RTL is not what shipped, so both sweeps were re-run against this
+change, by the recipe in `formal/checks.cfg`.
+
+| sweep | result | ADR-0057's spike |
+|---|---|---|
+| `hang`, check cycle 6 | `bad state property 0 reachable at bound k = 6` | red |
+| `hang`, check cycle 7 | PASS | PASS |
+| `liveness`, trig 10, gap 4 | red at k = 14 | red |
+| `liveness`, trig 10, gap 5 | red at k = 15 | red |
+| `liveness`, trig 10, gap 6 | PASS | PASS |
+| `liveness`, trig 15, gap 5 | red at k = 20 | red |
+| `liveness`, trig 15, gap 6 | PASS | PASS |
+
+**F = 6, unchanged. G = 6, from 4.** Two triggers rather than one, so the gap figure is not an
+artefact of where the trigger was placed, and the gap-5 counterexample is the non-vacuity witness
+ADR-0046 describes: `rvfi_liveness_check.sv` opens with `assume(rvfi_valid)` at its trig cycle, so an
+unreachable trigger would PASS at every gap instead of failing below 6.
+
+F + G goes 10 → 12 and F + 2G goes 14 → 18, so three lines move: **`insn 15 → 19`**, **`ill 15 → 19`**
+and **`reg 15 20 → 15 22`**. Each is its floor plus the one cycle of margin this table already
+carries on those two families. Every other line clears 18 with room. The `csrc_*` pair is the one
+family F and G do not bound; ADR-0057 re-measured its floor under this environment at 9, unchanged,
+and 15 still clears it.
+
+**A green ladder at the old depths would have proved nothing**, which is the reason the depths land
+in this change rather than after it: ADR-0057 ran the full ladder at `insn 15` under the proposal's
+environment and got 85/85, with three checks green having stopped asking.
+
+## Consequences
+
+- **CLAUDE.md invariant 8 is six reasons over two mechanisms**, and invariant 5 names `fence.i`
+  alongside the CSR instructions and `mret` (ADR-0061).
+- **The ladder costs about twice the wall time.** ADR-0057 measured 7m14s → 13m42s at `JOBS=4`
+  locally; CI's `formal` job was 4m22s against `timeout-minutes: 20`, so the margin narrows from
+  about 5× to about 2×. Worth knowing before the next depth increase, which has nowhere left to go
+  without a budget conversation.
+- **`insn` and `reg` still clear their floors by exactly one cycle.** ADR-0046 called that thin at
+  F + 2G = 14 and it is no less thin at 18. A seventh stall reason re-opens all of this.
+- **The suite's retire counts did not move**, measured program by program against
+  `test/OBSERVED_FLOOR` rather than merely graded against it as a floor. No program in `test/asm`
+  does a text-region data access — `.data` is based at `0x10000` and the bench's text ends at
+  `0x4000` — so the steal never fires there. The brief predicted zero cost on the current suite and
+  that is what was measured; it also means **the suite does not yet exercise this change end to
+  end.** The programs that would (`selfmod.S`, `textload.S`, a contention test) are the brief's step
+  5 and are not in this change.
+- **Four formal tasks now assume no data access ever takes the fetch window.** That is a real
+  assumption, recorded at each site in ADR-0049's form. `imemcheck` is the one where it will have to
+  be paid off: the brief's step 4 gives it the write path so it can observe a text store, and the
+  same change is where a stealing memory belongs in that task.
+- **The core side costs no measurable time.** `make soc-timing` at Homebrew Yosys 0.67+post
+  (`b8e7da6f`), machine load 9-15: **95.74 / 96.67 / 98.06 ns across three placements = 10.20-10.44
+  MHz**, 35.9% logic / 64.1% routing, 34 logic levels (28 LUT + 7 carry), on
+  `imem.in_range → imem.rom_even.0.0_RDATA[1]`. ADR-0059 measured 10.18-10.32 MHz for the memory
+  half alone, so the two distributions overlap and turning the ports on sits inside the placement
+  band. `SOC_MIN_MHZ` holds at every placement, with the same thin margin ADR-0059 recorded.
+  `make fit` is **3899 cells** against 3875 before — 24, inside the ±50 churn floor — and under
+  `FIT_MAX_LC` 4100. The ruling on ADR-0038's 12 MHz intent was made in ADR-0059 and is not
+  re-opened here.
+- **Four mutations, each red for its own reason.** Dropping `fetch_stall` from `stall` fails
+  `components_pcloop` (`pcloop.sv:379`, the new hold assertion) and `decoder_tb`; making the bubble
+  arm win the coincidence fails `components_decoder` (`decoder.v:1199`) and `decoder_tb`; dropping
+  `instr_fencei` from the serialization term fails `decoder_tb`; tying `mem_ren` low fails
+  `accessor_tb` on all five load widths.

--- a/docs/adr/0061-fence-i-has-to-serialize.md
+++ b/docs/adr/0061-fence-i-has-to-serialize.md
@@ -1,0 +1,76 @@
+# ADR-0061: `fence.i` has to serialize
+
+**Status:** Accepted · 2026-08-02 · *Amends
+[ADR-0002](0002-isa-target-rv32imc-zicsr.md), which claims Zifencei on the grounds that a conformant
+`fence.i` is free here. Lands with
+[ADR-0060](0060-the-steal-reaches-decode-as-the-sixth-stall-reason.md) and is separate from it on
+purpose.*
+
+## Context
+
+ADR-0002 claims Zifencei in `misa`'s ISA string, and CLAUDE.md's ISA-target section gives the
+reason: one hart, no icache, so a conformant `fence.i` is a NOP, which is what `rtl/decoder.v`
+already does.
+
+That reasoning has a premise it does not state. A `fence.i` orders *stores to instruction memory*
+against *fetches on the same hart*. It was free here because no store could reach instruction
+memory — ADR-0008's separate address spaces made the ordering vacuous. ADR-0059 removed that
+premise. **"Correct and for free" was a property of the split, not of the core.**
+
+## The defect, in cycles
+
+The fetch address is published one cycle early (ADR-0054), so a store's write and the fetch of the
+instruction that should observe it land two edges apart:
+
+| cycle | store | the instruction after `fence.i` |
+|---|---|---|
+| D | the store is on the bus | |
+| D+1 | | `fence.i` issues; its successor's fetch address is latched at this edge |
+| D+2 | the array is written at this edge | |
+| D+3 | | the successor executes, from the word fetched at D+1 |
+
+The successor executes stale text after `fence.i` retired. That is a Zifencei violation, and it is
+reachable the moment `mem_ren` and `fetch_stall` are live.
+
+Nothing else in the machine covers it. The steal (ADR-0059) forbids a fetch read and a store write
+meeting on one edge, so a *torn* word is impossible — but it says nothing about a fetch that
+happened before the write and is therefore cleanly stale.
+
+## Decision
+
+**`fence.i` joins the serialization drain that Zicsr instructions and `mret` already use.** One OR
+term on the existing predicate in `rtl/decoder.v`; no new mechanism, no new stall reason.
+
+`pipe_drained` requires all four in-flight slots empty — `decoder_out`, `executor_out`,
+`accessor_pending_valid` and `accessor_out.valid` — and the fourth is the one that makes this work.
+A store is in `accessor_out` for the cycle *after* its write edge and appears in none of the other
+three (ADR-0026), so a drained pipe means the write edge has already passed. The address published
+on `fence.i`'s own issue edge is therefore latched against the written array, and everything after
+it is fetched from post-write text.
+
+It costs 3-4 cycles when executed and nothing otherwise. `fence` (the data-ordering one) is
+untouched and stays a plain NOP: one hart, one bus, one access in flight, nothing to order.
+
+Instructions *between* a text store and the `fence.i` may see old or new text. That is legal — the
+spec only requires ordering across the fence — and they cannot see a torn value, because the steal
+forbids the same-edge read and write.
+
+## Consequences
+
+- **CLAUDE.md invariant 5 names three things now**: CSR instructions, `mret` and `fence.i`. The
+  first two serialize to keep a one-cycle-wide architectural update from interleaving; this one
+  serializes to order a memory write against a fetch. Same mechanism, different reason, and the
+  invariant says so rather than implying one reason covers both.
+- **The ISA-target section stops saying Zifencei is free.** It is claimed and implemented, and it
+  costs a drain.
+- **No oracle here checks it.** riscv-formal ships no spec model for `fence.i` at the pin — it is on
+  `formal/COMPLETE_EXCLUSIONS` for exactly that — so `spec_valid` is 0 for it and the ladder's
+  semantic block is skipped. What covers the decision is `test/decoder_tb.v` (the drain predicate,
+  driven directly) and `formal/pcloop.sv` (the pc holds while it waits). What would cover the
+  *behaviour* is a program that stores to text, fences and executes the result: `selfmod.S`, in the
+  brief's step 5, not in this change. Until it exists this is an argued fix with a unit test, and
+  that is the honest description of it.
+- **The general lesson is the one to keep.** A conformance claim that is free because of a
+  structural accident is a claim with an unstated premise, and the premise outlives the memory of
+  it. `misa`'s C bit was in the same position once (CLAUDE.md: "no longer an untested claim"). The
+  place to look for the next one is any line in this repo saying something is correct *and* free.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -64,6 +64,8 @@ and what it costs. Reversing one is fine — write a new ADR that supersedes it.
 | [0057](0057-what-writable-text-costs-in-ladder-depth-and-in-nanoseconds.md) | What writable text costs, in ladder depth and in nanoseconds | Accepted · re-runs 0046's derivation and 0054's timing; corrects 0054's `SOC_MIN_MHZ` |
 | [0058](0058-the-fetch-loop-is-not-two-levels-too-deep.md) | The fetch loop is not two levels too deep | Accepted · a measured null; corrects how 0054's logic-level count reads |
 | [0059](0059-text-is-writable-and-the-arbiter-lives-in-the-memory.md) | Text is writable, and the arbiter lives in the memory | Accepted · builds 0057's step 2; answers its condition 3 |
+| [0060](0060-the-steal-reaches-decode-as-the-sixth-stall-reason.md) | The steal reaches decode, as the sixth stall reason | Accepted · builds 0057's step 3 and lands its condition 1; amends 0026, 0009 |
+| [0061](0061-fence-i-has-to-serialize.md) | `fence.i` has to serialize | Accepted · amends 0002; lands with 0060 |
 
 0001–0007 came from the design brief
 ([`docs/ideas/finish-the-rewrite.md`](../ideas/finish-the-rewrite.md)). 0008–0011 came out of

--- a/formal/checks.cfg
+++ b/formal/checks.cfg
@@ -104,24 +104,30 @@ mscratch any
 #   F = 6   worst-case first retire. Sweep `hang`'s check cycle: red at 6, PASS
 #           at 7 -- rvfi_hang_check.sv asserts on a registered flag, so the flip
 #           point is F + 1.
-#   G = 4   worst-case gap between two retires. Sweep `liveness`'s trig-to-check
-#           distance: red at 3, PASS at 4. The gap-3 counterexample is also this
-#           measurement's non-vacuity witness, since rvfi_liveness_check.sv
-#           opens with `assume(rvfi_valid)` at its trig cycle.
+#   G = 6   worst-case gap between two retires. Sweep `liveness`'s trig-to-check
+#           distance: red at 5, PASS at 6, at trig 10 and again at trig 15. The
+#           gap-5 counterexample is also this measurement's non-vacuity witness,
+#           since rvfi_liveness_check.sv opens with `assume(rvfi_valid)` at its
+#           trig cycle.
+#
+# G was 4 until the sixth stall reason landed (ADR-0060), and the two cycles are
+# not what the reason itself costs: one is the steal bubble and the other is the
+# refetch the weakened imem-stability assumption in formal/wrapper.v allows.
+# ADR-0057 measured them apart, one configuration at a time.
 #
 # To re-measure: copy this file with only the `hang` (or `liveness`) line in
 # [depth], run `python3 genchecks-local.py <copy>`, and sweep the last column.
 # Any change that adds a stall reason, lengthens a stage or widens the
 # scoreboard past its three fixed slots has to do that before it lands. The
-# figures the table is checked against are the single hop F + G = 10 and the two
-# hops F + 2G = 14, and `insn 15` and `reg 15 20` clear 14 by one cycle -- the
+# figures the table is checked against are the single hop F + G = 12 and the two
+# hops F + 2G = 18, and `insn 19` and `reg 15 22` clear 18 by one cycle -- the
 # thinnest margin here.
 #
 # The first column of a [depth] line is RISCV_FORMAL_RESET_CYCLES, which
 # checks/rvfi_testbench.sv wires to the CHECKER's shadow state only; the DUT is
 # held in reset for cycle 0 regardless. So a two-column check has to clear G
-# over its depth-minus-start window, not F + G, and `reg 15 20` is a window of 5
-# against G = 4 rather than something vacuous.
+# over its depth-minus-start window, not F + G, and `reg 15 22` is a window of 7
+# against G = 6 rather than something vacuous.
 #
 # csrc_upcnt and csrc_any are the only two-retire checks here, and F and G do
 # not bound them: they shadow a value from one retire of a CSR instruction
@@ -148,8 +154,8 @@ mscratch any
 # All of the above assumes RISCV_FORMAL_ALTOPS (see [defines]). Without it the
 # real divider holds executor_out.valid for 32 cycles, F becomes ~37 and G ~36,
 # and every number here must be re-derived.
-insn           15
-reg      15    20
+insn           19
+reg      15    22
 pc_fwd   10    30
 pc_bwd   10    30
 liveness 1  10 30
@@ -157,7 +163,7 @@ unique   1  10 30
 causal   10    20
 causal_mem 10  20
 hang     1     30
-ill            15
+ill            19
 csrw           30
 csrc_upcnt 1   15
 csrc_any   1   15

--- a/formal/complete.sv
+++ b/formal/complete.sv
@@ -64,6 +64,12 @@ module rvfi_testbench (
   // Unread here, since this environment answers imem_data in the same cycle,
   // but connected rather than left dangling.
   logic [31:0] imem_addr_next;
+  // ADR-0059's steal, tied low: this task walks the ISA against the spec model
+  // and answers `imem_data` in the same cycle from a memory it does not model,
+  // so a steal would only cost retires inside the depth-50 window.
+  // formal/wrapper.v is where the arbiter is transcribed and driven.
+  logic        mem_ren;
+  logic        fetch_stall = 1'b0;
 
   littlecpu wrapper (
     .clk(clk),
@@ -76,7 +82,9 @@ module rvfi_testbench (
     .mem_addr(mem_addr),
     .mem_wdata(mem_wdata),
     .mem_wstrb(mem_wstrb),
+    .mem_ren(mem_ren),
     .mem_rdata(mem_rdata),
+    .fetch_stall(fetch_stall),
     .trap(trap),
     `RVFI_CONN
   );

--- a/formal/cover.sv
+++ b/formal/cover.sv
@@ -20,6 +20,12 @@ module testbench (
   // `imem_addr` in the same cycle -- but connected rather than left dangling,
   // so every instantiation of the core names every port.
   logic [31:0] imem_addr_next;
+  // ADR-0059's steal, tied low: this environment answers `imem_data` freely
+  // against `imem_addr` in the same cycle and models no memory, so a steal
+  // would only push the five goals further out. formal/wrapper.v is where the
+  // arbiter is transcribed and driven.
+  logic        mem_ren;
+  logic        fetch_stall = 1'b0;
 
   littlecpu uut (
     .clk(clk),
@@ -32,7 +38,9 @@ module testbench (
     .mem_addr(mem_addr),
     .mem_wdata(mem_wdata),
     .mem_wstrb(mem_wstrb),
+    .mem_ren(mem_ren),
     .mem_rdata(mem_rdata),
+    .fetch_stall(fetch_stall),
     .trap(trap),
     `RVFI_CONN
   );

--- a/formal/dmemcheck.sv
+++ b/formal/dmemcheck.sv
@@ -43,7 +43,14 @@ module testbench (
   logic [31:0] mem_addr;
   logic [31:0] mem_wdata;
   logic [3:0]  mem_wstrb;
+  logic        mem_ren;
   logic [31:0] mem_rdata;
+
+  // ADR-0059's steal, tied low: this task is about the data bus, and its fetch
+  // side is free every cycle from a memory it does not model, so a steal would
+  // add stall cycles and no coverage. formal/wrapper.v is where the arbiter is
+  // transcribed and driven.
+  logic        fetch_stall = 1'b0;
 
   // rvfi_dmem_check (riscv-formal, unmodified) already builds its own
   // load-after-store shadow purely from rvfi_mem_*, so it needs no
@@ -126,7 +133,9 @@ module testbench (
     .mem_addr(mem_addr),
     .mem_wdata(mem_wdata),
     .mem_wstrb(mem_wstrb),
+    .mem_ren(mem_ren),
     .mem_rdata(mem_rdata),
+    .fetch_stall(fetch_stall),
     .trap(trap),
     `RVFI_CONN
   );

--- a/formal/imemcheck.sv
+++ b/formal/imemcheck.sv
@@ -50,7 +50,20 @@ module testbench (
   logic [31:0] mem_addr;
   logic [31:0] mem_wdata;
   logic [3:0]  mem_wstrb;
+  logic        mem_ren;
   logic [31:0] mem_rdata;
+
+  // FACT       no data access ever takes the fetch window (ADR-0059's steal).
+  // DISCHARGED formal/wrapper.v, which transcribes rtl/imemory.v's arbiter and
+  //            drives `fetch_stall` from it, so all 85 ladder checks run
+  //            against a stealing memory.
+  // SCOPE      this whole task. It is the same fiction the four assumes below
+  //            already rest on -- a fetch bus that answers combinationally,
+  //            from a memory this task does not model -- and a steal against an
+  //            unmodelled memory would add stall cycles without adding
+  //            coverage. The write path this task needs to observe a text store
+  //            is a separate obligation and is not built yet.
+  logic        fetch_stall = 1'b0;
 
   // FACT       the fetch bus answers from memory: whenever either of the two
   //            fetch ports covers the halfword `checker_inst` has pinned, the
@@ -100,7 +113,9 @@ module testbench (
     .mem_addr(mem_addr),
     .mem_wdata(mem_wdata),
     .mem_wstrb(mem_wstrb),
+    .mem_ren(mem_ren),
     .mem_rdata(mem_rdata),
+    .fetch_stall(fetch_stall),
     .trap(trap),
     `RVFI_CONN
   );

--- a/formal/pcloop.sv
+++ b/formal/pcloop.sv
@@ -39,6 +39,10 @@ module pcloop (
     input executor_output executor_out,
     input logic divider_stall,
     input logic accessor_stall,
+    // ADR-0059's steal. Free here, like the other two stall inputs: this task
+    // instantiates no memory, so the solver may assert it on any cycle, which
+    // is the stronger environment for the assertions below.
+    input logic fetch_stall,
     input logic accessor_pending_valid,
     input logic [4:0] accessor_pending_rd,
     // ADR-0026's drain slot and the CSR file's read side. rtl/csrs.v is not
@@ -99,6 +103,7 @@ module pcloop (
     .executor_out(executor_out),
     .divider_stall(divider_stall),
     .accessor_stall(accessor_stall),
+    .fetch_stall(fetch_stall),
     .accessor_pending_valid(accessor_pending_valid),
     .accessor_pending_rd(accessor_pending_rd),
     .accessor_out_valid(accessor_out_valid),
@@ -255,8 +260,21 @@ module pcloop (
   end
   assign f_operand_fetch = !f_read_taken || f_prev_rs1 != rs1 || f_prev_rs2 != rs2;
 
-  assign f_may_stall = divider_stall || accessor_stall || f_live_rs1 || f_live_rs2 ||
-      f_system || f_operand_fetch;
+  // ADR-0059's steal is the sixth stall reason, and it is a direct input here,
+  // so it needs no transcription -- only inclusion. Leaving it out is the trap
+  // ADR-0046 walked into: a new stall reason plus a stale `f_may_stall` makes
+  // the sequential-advance assertion cover a cycle on which the decoder
+  // legitimately holds the pc, and the task goes red on correct RTL.
+  //
+  // `fence.i` joins the serialization drain too (ADR-0061), and `f_system`
+  // does not reach it -- that term is the SYSTEM opcode and this is MISC-MEM.
+  // Widened to the whole opcode for the same reason `f_system` is: `fence`
+  // comes along, is never held, and being excused costs nothing.
+  logic f_fencei;
+  assign f_fencei = f_uncompressed && f_instr[6:2] == 5'b00011;
+
+  assign f_may_stall = divider_stall || accessor_stall || fetch_stall ||
+      f_live_rs1 || f_live_rs2 || f_system || f_fencei || f_operand_fetch;
 
   // Trap entry and `mret` also write a non-sequential pc (ADR-0028: a trap is
   // a branch), so the sequential-advance assertion must not cover those
@@ -288,12 +306,13 @@ module pcloop (
   // every assertion below excludes.
   logic [31:0] past_pc, prev_mtvec, prev_mepc;
   logic prev_reset, prev_may_stall, prev_hard_stall, prev_jump_branch, prev_uncompressed;
-  logic prev_trap_entry, prev_mret_entry;
+  logic prev_trap_entry, prev_mret_entry, prev_fetch_stall;
   always_ff @(posedge clk) begin
     past_pc           <= pc;
     prev_reset        <= reset;
     prev_may_stall    <= f_may_stall;
     prev_hard_stall   <= divider_stall || accessor_stall;
+    prev_fetch_stall  <= fetch_stall;
     prev_jump_branch  <= f_jump_branch || f_redirect;
     prev_uncompressed <= f_uncompressed;
     prev_trap_entry   <= trap_entry;
@@ -350,6 +369,14 @@ module pcloop (
   // task's assertion, as above.
   always_ff @(posedge clk)
     if (clocked && prev_hard_stall && !prev_reset) assert(pc == past_pc);
+
+  // The steal holds the pc too, which is what makes it a bubble rather than
+  // something needing a kill signal (ADR-0059, CLAUDE.md invariant 1): the same
+  // instruction is presented again next cycle, so nothing was issued and there
+  // is nothing to undo. Stated separately from the freeze above because the two
+  // reach the pc through different arms of the publish block.
+  always_ff @(posedge clk)
+    if (clocked && prev_fetch_stall && !prev_reset) assert(pc == past_pc);
 
   // The redirect cycles the increment assertion above steps around, covered
   // here instead of merely excused. A trap goes to mtvec and an mret goes to

--- a/formal/wrapper.v
+++ b/formal/wrapper.v
@@ -38,18 +38,47 @@ module rvfi_wrapper (
   (* keep *) logic [31:0] mem_addr;
   (* keep *) logic [31:0] mem_wdata;
   (* keep *) logic [3:0]  mem_wstrb;
+  (* keep *) logic        mem_ren;
   (* keep *) logic        trap;
+
+  // rtl/imemory.v's arbiter, transcribed: a data access inside the text range
+  // takes the banks' read port for that edge, and the memory reports it as
+  // `fetch_stall` on the cycle whose fetch window it cost (ADR-0059).
+  //
+  // Driven from the core's own bus rather than left free. A free stall input
+  // lets the environment hold the core forever, which is what `hang` and
+  // `liveness_ch0` measure -- the same failure ADR-0042 found when `imem_data`
+  // was left unconstrained.
+  //
+  // The 8 KB bound is rtl/littlesoc.v's `ROM_WORDS = 2048`. Nothing here
+  // depends on the exact size: it decides how often a steal is reachable, not
+  // whether it is.
+  localparam logic [31:0] TEXT_BYTES = 32'h0000_2000;
+  logic text_range, text_access, text_write;
+  assign text_range  = mem_addr < TEXT_BYTES;
+  assign text_access = (mem_ren || |mem_wstrb) && text_range;
+  assign text_write  = |mem_wstrb && text_range;
+
+  (* keep *) logic fetch_stall = 0;
+  logic [1:0] text_write_age = 0;
+  always @(posedge clock) begin
+    fetch_stall    <= !reset && text_access;
+    text_write_age <= {text_write_age[0], !reset && text_write};
+  end
 
   // INSTRUCTION MEMORY IS A FUNCTION OF ITS ADDRESS (ADR-0042, ADR-0017).
   //
   // FACT       instruction memory is a function of its address, across two
-  //            consecutive cycles.
+  //            consecutive cycles, except on the cycle whose fetch window a
+  //            data access took and, after a text store, on the cycle after
+  //            that.
   // DISCHARGED NOWHERE. There is no check anywhere in this repo that asserts
-  //            it. The backing is structural: rtl/imemory.v is a $readmemh ROM
-  //            with no write port, and ADR-0044 keeps the instruction side
-  //            read-only. Believed, not proved -- which is the honest answer
-  //            and, per ADR-0049, an acceptable one.
-  // SCOPE      ALL 82 GENERATED CHECKS. This is an unguarded `assume` in the
+  //            it. The backing is structural: rtl/imemory.v answers both fetch
+  //            ports from one array, and the two exceptions are that array's
+  //            read port being borrowed and its contents changing (ADR-0059).
+  //            Believed, not proved -- which is the honest answer and, per
+  //            ADR-0049, an acceptable one.
+  // SCOPE      ALL 85 GENERATED CHECKS. This is an unguarded `assume` in the
   //            harness every check instantiates, so it is in force over every
   //            insn_*, reg, pc_fwd/pc_bwd, causal*, unique and cover check --
   //            not only the two it was written for (`hang` and `liveness_ch0`,
@@ -89,6 +118,16 @@ module rvfi_wrapper (
   // unbounded array; consecutive-cycle stability is implied by it, is all the
   // operand-fetch cycle actually needs, and leaves the environment free to
   // answer differently for an address revisited later.
+  //
+  // The two exceptions are what writable text costs here (ADR-0057 measured
+  // them at two cycles of ladder depth, which is most of the move from G = 4 to
+  // G = 6). A text access of either kind takes the read port, so the window
+  // presented the next cycle is the data word rather than the ROM's answer; a
+  // text store additionally changes what the ROM answers from the cycle after
+  // that onward, because the array is written on the same edge and the fetch
+  // address is published a cycle early (ADR-0054). Both are dropped compares
+  // rather than modelled values, which is the wide side: an assumption can only
+  // make checks easier, so a depth floor derived under it is the safe one.
   logic [31:0] past_imem_addr, past_imem_data;
   logic [31:0] past_imem_addr2, past_imem_data2;
   logic        past_imem_valid = 0;
@@ -102,7 +141,7 @@ module rvfi_wrapper (
   end
 
   always @* begin
-    if (past_imem_valid && !reset) begin
+    if (past_imem_valid && !reset && !fetch_stall && !text_write_age[1]) begin
       if (imem_addr  == past_imem_addr)  assume (imem_data  == past_imem_data);
       if (imem_addr2 == past_imem_addr2) assume (imem_data2 == past_imem_data2);
     end
@@ -119,7 +158,9 @@ module rvfi_wrapper (
     .mem_addr(mem_addr),
     .mem_wdata(mem_wdata),
     .mem_wstrb(mem_wstrb),
+    .mem_ren(mem_ren),
     .mem_rdata(mem_rdata),
+    .fetch_stall(fetch_stall),
     .trap(trap),
     `RVFI_CONN
   );
@@ -140,6 +181,10 @@ module rvfi_wrapper (
   //     exactly the one cycle after a load's request (ADR-0015 invariant
   //     I3 -- the following cycle `in.valid` is guaranteed 0, so `stalled`
   //     falls unconditionally).
+  //   - the instruction memory's steal: `fetch_stall` is a port, but this
+  //     harness computes it from the core's own bus (above) rather than
+  //     letting the environment choose it, so it lasts one cycle per data
+  //     access and cannot be held.
   // There is nothing for this block to assume: littlecpu has no port an
   // adversarial environment could hold to defeat forward progress, so
   // RISCV_FAIRNESS's usual job (bound the stall) has no signal to act on

--- a/rtl/accessor.v
+++ b/rtl/accessor.v
@@ -30,6 +30,12 @@ module accessor(
     // fresh instruction would collide over this stage's single output
     // register and the single-port memory bus.
     output logic stalled,
+    // High for the cycle a load's request is on the bus. rtl/imemory.v needs
+    // it to tell a real read from the idle bus, which presents address 0 --
+    // inside the text range, so an unqualified address would steal a fetch
+    // every idle cycle and the core would never run (ADR-0059). Same predicate
+    // as `stalled` above plus the reset term the request block below applies.
+    output logic mem_ren,
     // ADR-0004 hazard scoreboard (ADR-0004): a load's result is a live
     // producer from the moment its request is issued here until write-through
     // makes it visible, which is one cycle later than decoder_out/executor_out
@@ -85,6 +91,7 @@ module accessor(
   logic is_load;
   assign is_load = in_is_lw || in_is_lh || in_is_lhu || in_is_lb || in_is_lbu;
   assign stalled = in_valid && is_load;
+  assign mem_ren = !reset && in_valid && is_load;
   logic is_store;
   assign is_store = in_is_sw || in_is_sh || in_is_sb;
 

--- a/rtl/decoder.v
+++ b/rtl/decoder.v
@@ -25,6 +25,13 @@ module decoder (
   // instruction sitting in decoder_out. Decode must hold it unchanged
   // instead, for exactly the one cycle this is asserted.
   input  logic accessor_stall,
+  // ADR-0059: the instruction memory took its read port for a data access this
+  // cycle, so the fetch window presented now holds the data word instead of the
+  // instruction at `pc`. Bubble-shaped like a RAW hazard -- nothing issued, so
+  // the PC holds and the same instruction is presented again next cycle. A
+  // divider or accessor freeze on the same cycle outranks it; see the publish
+  // block below for why the order is that way round.
+  input  logic fetch_stall,
   // ADR-0004 hazard scoreboard, third producer: a load in the accessor's
   // one-cycle turnaround (see accessor_stall and rtl/accessor.v) is a live
   // producer for that one extra cycle neither decoder_out nor executor_out
@@ -393,13 +400,14 @@ module decoder (
   // "continue" are the same instruction on this core.
   assign instr_wfi = instr_error && instr[31:20] == 12'h105;
 
-  // MISC-MEM: `fence` and `fence.i` are NOPs (ADR-0005). One hart, no caches,
-  // and a Harvard ROM no store can reach (ADR-0008), so there is nothing for
-  // either to order or to invalidate. Same story as `wfi` above: merely
-  // unrecognised until trap entry landed, at which point a legal `fence` would
-  // have faulted. Only funct3 is tested -- `fence`'s fm/pred/succ fields and
-  // `fence.i`'s reserved immediate are legal-value fields with nothing to act
-  // on here.
+  // MISC-MEM. `fence` is a NOP: one hart, one bus, and one access in flight at
+  // a time, so there is nothing to order. `fence.i` is a NOP in its cache half
+  // for the same reason -- no icache -- but it also has to wait, which is the
+  // serialization term below rather than anything here. Same story as `wfi`
+  // above: merely unrecognised until trap entry landed, at which point a legal
+  // `fence` would have faulted. Only funct3 is tested -- `fence`'s fm/pred/succ
+  // fields and `fence.i`'s reserved immediate are legal-value fields with
+  // nothing to act on here.
   logic instr_miscmem, instr_fence, instr_fencei;
   assign instr_miscmem = opcode == 5'b00011 && uncompressed;
   assign instr_fence  = instr_miscmem && funct3 == 3'b000;
@@ -620,15 +628,25 @@ module decoder (
   // decode, the same one-cycle-wide architectural update a CSR instruction
   // makes, and holding it until the pipe drains keeps that update from being
   // interleaved with instructions that issued before it.
-  logic pipe_drained, csr_serialize;
+  //
+  // `fence.i` joins them because text is writable (ADR-0059) and the fetch
+  // address is published a cycle early (ADR-0054). Waiting for all four slots
+  // is what makes the ordering it promises true: an older store is still in
+  // `accessor_out` for the cycle after its write edge, so a drained pipe means
+  // that edge has passed, and the address published on `fence.i`'s own issue
+  // edge is therefore latched against the written array. Without the wait,
+  // `fence.i` at cycle D+1 after a store at D issues while the fetch of its
+  // successor happened at edge D+1 -- before the write at edge D+2 -- and the
+  // successor executes stale text (ADR-0061).
+  logic pipe_drained, serialize;
   assign pipe_drained = !out.valid && !executor_out.valid && !accessor_out_valid &&
     !accessor_pending_valid;
-  assign csr_serialize = (instr_csr_access || instr_mret) && !pipe_drained;
+  assign serialize = (instr_csr_access || instr_mret || instr_fencei) && !pipe_drained;
 
   logic hazard_rs1, hazard_rs2, hazard, stall;
   assign hazard_rs1 = uses_rs1 && rs1 != 0 && live_rs1;
   assign hazard_rs2 = uses_rs2 && rs2 != 0 && live_rs2;
-  assign hazard = hazard_rs1 || hazard_rs2 || csr_serialize;
+  assign hazard = hazard_rs1 || hazard_rs2 || serialize;
 
  `ifdef RISCV_FORMAL
   // ADR-0006: rs1_valid/rs2_valid decide whether rvfi_rs{1,2}_addr
@@ -724,10 +742,11 @@ module decoder (
                                         (uses_rs2 && prev_rs2 != rs2);
 
   // ADR-0009: a single global stall, combining the local RAW hazard and the
-  // operand-fetch cycle with whatever's busy downstream (the divider, or the
-  // accessor's one-cycle load turnaround). Any reason freezes the PC; see below
-  // for why the two downstream reasons freeze decoder_out differently.
-  assign stall = hazard || operand_stall || divider_stall || accessor_stall;
+  // operand-fetch cycle with whatever's busy downstream (the divider, the
+  // accessor's one-cycle load turnaround, or the instruction memory's stolen
+  // fetch window). Any reason freezes the PC; see below for why the two
+  // downstream reasons freeze decoder_out differently.
+  assign stall = hazard || operand_stall || divider_stall || accessor_stall || fetch_stall;
 
   // ---- the next PC (ADR-0054) ---------------------------------------------
   //
@@ -857,8 +876,17 @@ module decoder (
       // Takes priority over a same-cycle hazard for the same reason — that
       // hazard is about the *next* instruction, which isn't decode's problem
       // yet since decoder_out hasn't advanced.
+      //
+      // It takes priority over a same-cycle `fetch_stall` too, and that is a
+      // ruling rather than a consequence of the arm order (ADR-0060). A steal
+      // says the window presented this cycle is not an instruction, so there is
+      // nothing to publish; a freeze says the instruction already sitting in
+      // decoder_out has not been consumed yet. Bubbling on the coincidence
+      // would drop that instruction, so holding wins. The `ifdef FORMAL` block
+      // at the bottom asserts it: the arm order is the only thing enforcing it,
+      // and reordering these two arms would otherwise be silent.
       out <= out;
-    end else if (hazard || operand_stall) begin
+    end else if (hazard || operand_stall || fetch_stall) begin
       // ADR-0009: upstream of the stalling stage freezes — the PC (and so
       // the fetch window) holds, so the stalled instruction re-presents next
       // cycle. ADR-0042's operand-fetch cycle shares this arm exactly: holding
@@ -1154,6 +1182,22 @@ module decoder (
 
   // ADR-0009: a stalled cycle never advances pc.
   always_ff @(posedge clk) if (clocked && prev_stall && !prev_reset) assert(pc == past_pc);
+
+  // ADR-0060: a steal and a divider/accessor freeze on the same cycle hold
+  // decoder_out; a steal on its own bubbles it. Both directions are asserted,
+  // because the publish block's arm order is all that decides which happens and
+  // each failure is silent -- bubbling on the coincidence drops an instruction
+  // nothing downstream has consumed, and holding on a plain steal republishes
+  // one the executor reads every cycle.
+  decoder_output past_out;
+  logic prev_hold_and_steal, prev_steal_only;
+  always_ff @(posedge clk) begin
+    past_out            <= out;
+    prev_hold_and_steal <= fetch_stall && (divider_stall || accessor_stall);
+    prev_steal_only     <= fetch_stall && !divider_stall && !accessor_stall;
+  end
+  always_comb if (clocked && !prev_reset && prev_hold_and_steal) assert(out == past_out);
+  always_comb if (clocked && !prev_reset && prev_steal_only)     assert(out == '0);
 
   // ADR-0054: the contract the instruction memory rests on -- what this module
   // publishes as `next_pc` in cycle N is what `pc` holds in cycle N+1. One

--- a/rtl/littlecpu.v
+++ b/rtl/littlecpu.v
@@ -24,10 +24,22 @@ module littlecpu(
   // directly -- which is exactly what formal/wrapper.v does, so the riscv-formal
   // ladder sees this change as one extra, unread output port.
   output logic [31:0] imem_addr_next,
+  // ADR-0059: the fetch and data buses share one address space and the
+  // instruction memory owns the arbitration between them. `mem_ren` is what
+  // tells a real load from the idle bus, which presents address 0 -- inside the
+  // text range, so without it every idle cycle would steal a fetch.
+  // `fetch_stall` comes back high for the cycle whose fetch window a data
+  // access took, and is the sixth stall reason (CLAUDE.md invariant 8).
+  //
+  // A memory that cannot steal -- the formal environments answer `imem_data`
+  // freely, and any Harvard consumer -- ties `fetch_stall` low and leaves
+  // `mem_ren` unread.
   output logic [31:0] mem_addr,
   output logic [31:0] mem_wdata,
   output logic [3:0]  mem_wstrb,
+  output logic        mem_ren,
   input  logic [31:0] mem_rdata,
+  input  logic        fetch_stall,
   output logic trap
   `ifdef RISCV_FORMAL
   ,
@@ -167,6 +179,7 @@ module littlecpu(
     .executor_out(executor_out),
     .divider_stall(divider_stalled),
     .accessor_stall(accessor_stalled),
+    .fetch_stall(fetch_stall),
     .accessor_pending_valid(accessor_pending_valid),
     .accessor_pending_rd(accessor_pending_rd),
     .accessor_out_valid(accessor_out_valid),
@@ -244,6 +257,7 @@ module littlecpu(
     .mem_addr(mem_addr),
     .mem_wstrb(mem_wstrb),
     .mem_wdata(mem_wdata),
+    .mem_ren(mem_ren),
     .mem_rdata(mem_rdata),
     .stalled(accessor_stalled),
     .pending_valid(accessor_pending_valid),

--- a/rtl/littlesoc.v
+++ b/rtl/littlesoc.v
@@ -77,6 +77,7 @@ module littlesoc (
   logic [31:0] mem_addr, mem_wdata, mem_rdata;
   logic [31:0] imem_mem_rdata, dmem_mem_rdata;
   logic [3:0]  mem_wstrb;
+  logic        mem_ren, fetch_stall;
   logic [31:0] imem_addr, imem_addr2, imem_addr_next;
   logic [31:0] imem_data, imem_data2;
 
@@ -91,7 +92,9 @@ module littlesoc (
     .mem_addr(mem_addr),
     .mem_wdata(mem_wdata),
     .mem_wstrb(mem_wstrb),
+    .mem_ren(mem_ren),
     .mem_rdata(mem_rdata),
+    .fetch_stall(fetch_stall),
     .trap(trap)
   );
 
@@ -120,12 +123,9 @@ module littlesoc (
     .mem_addr(mem_addr),
     .mem_wdata(mem_wdata),
     .mem_wstrb(mem_wstrb),
-    // The core has no read enable yet, so no load reaches the text region and
-    // no idle cycle steals a fetch. Stores do reach it.
-    .mem_ren(1'b0),
+    .mem_ren(mem_ren),
     .mem_rdata(imem_mem_rdata),
-    // Nothing consumes the steal yet: the core has no stall input for it.
-    .fetch_stall()
+    .fetch_stall(fetch_stall)
   );
 
   // ---- data RAM ------------------------------------------------------------

--- a/test/accessor_tb.v
+++ b/test/accessor_tb.v
@@ -1,0 +1,160 @@
+`timescale 1 ns / 1 ps
+`default_nettype none
+`include "structs.v"
+
+// The read enable rtl/imemory.v arbitrates on (ADR-0059/ADR-0060).
+//
+// The idle bus presents address 0, which is inside the text range, so the
+// memory cannot tell a real load from an idle cycle by address alone. This
+// bench is what says `mem_ren` draws that line: it is high for the one cycle a
+// load's request is on the bus and low for every other cycle, including the
+// response cycle, a store, an ALU op, a bubble and reset.
+//
+// Stuck high is caught elsewhere -- the ladder's environment would steal every
+// cycle and `hang` would go red -- but stuck low is invisible to everything
+// else in the tree until a program does a text-region load, and none does yet.
+module accessor_tb;
+  logic clk = 0;
+  always #5 clk = ~clk;
+
+  logic reset;
+  executor_output in;
+  logic [31:0] mem_addr, mem_wdata;
+  logic [3:0]  mem_wstrb;
+  logic [31:0] mem_rdata = 32'hcafef00d;
+  logic        mem_ren, stalled, pending_valid;
+  logic [4:0]  pending_rd;
+  accessor_output out;
+
+  accessor dut (
+    .clk(clk),
+    .reset(reset),
+    .in(in),
+    .mem_addr(mem_addr),
+    .mem_wstrb(mem_wstrb),
+    .mem_wdata(mem_wdata),
+    .mem_ren(mem_ren),
+    .mem_rdata(mem_rdata),
+    .stalled(stalled),
+    .pending_valid(pending_valid),
+    .pending_rd(pending_rd),
+    .out(out)
+  );
+
+  int errors = 0;
+
+  task automatic check_bit(input string what, input logic got, input logic expected);
+    begin
+      if (got !== expected) begin
+        $display("MISMATCH %s: got=%b expected=%b", what, got, expected);
+        errors++;
+      end
+    end
+  endtask
+
+  task automatic check_hex(input string what, input logic [31:0] got, input logic [31:0] expected);
+    begin
+      if (got !== expected) begin
+        $display("MISMATCH %s: got=%08x expected=%08x", what, got, expected);
+        errors++;
+      end
+    end
+  endtask
+
+  // A payload with no execution flag set. Everything else is zeroed, so a
+  // vector cannot inherit a flag from the one before it.
+  task automatic present(input logic valid, input logic [31:0] addr);
+    begin
+      in = '0;
+      in.valid = valid;
+      in.rd = 5'd7;
+      in.mem_addr = addr;
+      in.mem_data = 32'h1234_5678;
+    end
+  endtask
+
+  // One load of the given width, presented and then drained through its
+  // response cycle. The enable is one predicate over five flags, so each width
+  // gets its own vector rather than `lw` standing in for all of them.
+  task automatic load_raises(input string what, input logic [4:0] widths);
+    begin
+      present(1'b1, 32'h0000_0500);
+      {in.is_lw, in.is_lhu, in.is_lh, in.is_lbu, in.is_lb} = widths;
+      #1;
+      check_bit(what, mem_ren, 1'b1);
+      @(posedge clk);
+      #1;
+      present(1'b0, 32'b0);
+      @(posedge clk);
+      #1;
+    end
+  endtask
+
+  initial begin
+    reset = 1;
+    present(1'b1, 32'h0000_0100);
+    in.is_lw = 1'b1;
+    repeat (2) @(posedge clk);
+    #1;
+    // Reset outranks the payload: the request block drives no address, and a
+    // read enable that ignored reset would steal a fetch out of the reset
+    // pulse itself.
+    check_bit("no read enable while reset is high", mem_ren, 1'b0);
+    check_hex("...and no address either", mem_addr, 32'b0);
+    reset = 0;
+    #1;
+
+    check_bit("a load's request cycle raises the read enable", mem_ren, 1'b1);
+    check_hex("...at the word-aligned load address", mem_addr, 32'h0000_0100);
+    check_bit("...which is also the load-response stall", stalled, 1'b1);
+    check_bit("...and is not a write", |mem_wstrb, 1'b0);
+
+    // The response cycle. rtl/decoder.v froze upstream and rtl/executor.v
+    // bubbled, so `in` is a bubble here -- and the enable must fall, or the
+    // idle turnaround would take a fetch window of its own.
+    @(posedge clk);
+    #1;
+    present(1'b0, 32'b0);
+    #1;
+    check_bit("the load's own response cycle drops it", mem_ren, 1'b0);
+    check_bit("...with the response really in flight", pending_valid, 1'b1);
+    @(posedge clk);
+    #1;
+    check_bit("the load completed", out.valid, 1'b1);
+
+    // Every other bus cycle. A store holds the write port instead, and
+    // rtl/imemory.v steals on the strobe for that -- not on this.
+    present(1'b1, 32'h0000_0200);
+    in.is_sw = 1'b1;
+    #1;
+    check_bit("a store does not raise the read enable", mem_ren, 1'b0);
+    check_hex("...but it does drive the bus", {28'b0, mem_wstrb}, 32'hf);
+    @(posedge clk);
+    #1;
+
+    present(1'b1, 32'h0000_0300);
+    #1;
+    check_bit("an instruction that touches no memory does not raise it", mem_ren, 1'b0);
+    @(posedge clk);
+    #1;
+
+    present(1'b0, 32'h0000_0400);
+    in.is_lb = 1'b1;
+    #1;
+    check_bit("a bubble carrying a load flag does not raise it", mem_ren, 1'b0);
+
+    load_raises("lb raises it",  5'b00001);
+    load_raises("lbu raises it", 5'b00010);
+    load_raises("lh raises it",  5'b00100);
+    load_raises("lhu raises it", 5'b01000);
+    load_raises("lw raises it",  5'b10000);
+
+    if (errors != 0) begin
+      $display("FAILED: %0d mismatches", errors);
+      $fatal(1);
+    end else begin
+      $display("PASSED: accessor read enable");
+      $finish;
+    end
+  end
+endmodule

--- a/test/decoder_tb.v
+++ b/test/decoder_tb.v
@@ -54,6 +54,10 @@ module decoder_tb;
   executor_output executor_out = '0;
   logic divider_stall = 1'b0;
   logic accessor_stall = 1'b0;
+  // ADR-0059's steal, driven per vector below: it is the sixth stall reason,
+  // and the only one whose interaction with the other five is a ruling rather
+  // than a consequence.
+  logic fetch_stall = 1'b0;
   logic accessor_pending_valid = 1'b0;
   logic [4:0] accessor_pending_rd = 5'b0;
   // ADR-0026's drain slot: nothing is in flight in this bench, so the pipe
@@ -86,6 +90,7 @@ module decoder_tb;
     .executor_out(executor_out),
     .divider_stall(divider_stall),
     .accessor_stall(accessor_stall),
+    .fetch_stall(fetch_stall),
     .accessor_pending_valid(accessor_pending_valid),
     .accessor_pending_rd(accessor_pending_rd),
     .accessor_out_valid(accessor_out_valid),
@@ -275,7 +280,7 @@ module decoder_tb;
     executor_out.rd = 5'd0;
     present_and_fetch(32'h340515f3);
     check_bit("a CSR instruction serializes while the pipe is busy",
-              dut.csr_serialize, 1'b1);
+              dut.serialize, 1'b1);
     check_bit("...and that is a stall", dut.stall, 1'b1);
     check_bit("...so nothing issues", dut.issuing, 1'b0);
     check_bit("...and no CSR write commits", dut.csr_wen, 1'b0);
@@ -476,7 +481,7 @@ module decoder_tb;
     executor_out.valid = 1'b1;
     executor_out.rd = 5'd0;
     present_and_fetch(32'h30200073);
-    check_bit("mret serializes while the pipe is busy", dut.csr_serialize, 1'b1);
+    check_bit("mret serializes while the pipe is busy", dut.serialize, 1'b1);
     check_bit("...so it does not commit yet", mret_entry, 1'b0);
     check_bit("...and it bubbles decoder_out rather than holding it",
               out.valid, 1'b0);
@@ -488,6 +493,80 @@ module decoder_tb;
     @(posedge clk);
     #1;
     check_hex("mret redirects pc to mepc", pc, 32'h0000_0244);
+
+    // ---- the steal, the sixth stall reason (ADR-0059 / ADR-0060) ----------
+    // `addi x1, x0, 1`, issued once so decoder_out holds something a bubble
+    // would visibly destroy.
+    present_and_fetch(32'h00100093);
+    @(posedge clk);
+    #1;
+    check_bit("the instruction issued", out.valid, 1'b1);
+    check_hex("...into decoder_out", {27'b0, out.rd}, 32'd1);
+
+    fetch_stall = 1'b1;
+    #1;
+    check_bit("a stolen fetch window is a stall", dut.stall, 1'b1);
+    check_bit("...so nothing issues", dut.issuing, 1'b0);
+    check_hex("...and the pc holds, so the instruction is presented again",
+              next_pc, pc);
+    check_bit("...and no trap is committed out of the stolen window", trap_entry, 1'b0);
+
+    // The coincidence, both ways round. A freeze holds decoder_out because the
+    // instruction in it has not been consumed; a steal bubbles because there is
+    // nothing to publish. On a cycle with both, holding wins -- bubbling would
+    // drop the held instruction. Nothing but the publish block's arm order
+    // decides this, which is why it is a vector rather than an argument.
+    accessor_stall = 1'b1;
+    #1;
+    @(posedge clk);
+    #1;
+    check_bit("a steal coinciding with an accessor freeze holds decoder_out",
+              out.valid, 1'b1);
+    check_hex("...unchanged", {27'b0, out.rd}, 32'd1);
+    accessor_stall = 1'b0;
+    divider_stall = 1'b1;
+    #1;
+    @(posedge clk);
+    #1;
+    check_bit("...and so does one coinciding with a divide", out.valid, 1'b1);
+    divider_stall = 1'b0;
+    #1;
+    @(posedge clk);
+    #1;
+    check_bit("a steal on its own bubbles decoder_out instead", out.valid, 1'b0);
+    fetch_stall = 1'b0;
+    #1;
+    @(posedge clk);
+    #1;
+    check_bit("...and the same instruction issues once the window is back",
+              out.valid, 1'b1);
+    check_hex("...as itself", {27'b0, out.rd}, 32'd1);
+
+    // ---- fence.i serializes (ADR-0061) -----------------------------------
+    // Text is writable, so a store ahead of a `fence.i` can change the very
+    // words being fetched behind it. Draining the pipe is what puts the older
+    // store's write edge before the fetch address published on `fence.i`'s own
+    // issue edge. `executor_out.valid` stands for that in-flight store, exactly
+    // as it does for the Zicsr vectors above.
+    executor_out.valid = 1'b1;
+    executor_out.rd = 5'd0;
+    present_and_fetch(32'h0000100f);
+    check_bit("fence.i serializes while the pipe is busy", dut.serialize, 1'b1);
+    check_bit("...and that is a stall", dut.stall, 1'b1);
+    check_bit("...so nothing issues", dut.issuing, 1'b0);
+    check_bit("...and it bubbles decoder_out rather than holding it",
+              out.valid, 1'b0);
+    executor_out.valid = 1'b0;
+    #1;
+    check_bit("the drained pipe releases it", dut.pipe_drained, 1'b1);
+    check_bit("...so it issues now", dut.issuing, 1'b1);
+
+    // A plain `fence` has nothing to wait for: one bus, one access in flight.
+    executor_out.valid = 1'b1;
+    in.instr = 32'h0ff0000f;
+    #1;
+    check_bit("a plain fence does not serialize", dut.serialize, 1'b0);
+    executor_out.valid = 1'b0;
 
     if (errors != 0) begin
       $display("FAILED: %0d mismatches", errors);

--- a/test/probe_gates.sh
+++ b/test/probe_gates.sh
@@ -1098,11 +1098,11 @@ probe "control: the declared list matches the tree exactly" 0 \
 
 probe "a bench in test/ that make does not run is named" 2 \
   "in test/ but not in UNIT_BENCHES: monitor_tb" \
-  "$MB UNIT_BENCHES='exec_tb mem_tb imem_tb decoder_tb regfile_tb csr_tb'"
+  "$MB UNIT_BENCHES='exec_tb mem_tb imem_tb decoder_tb regfile_tb csr_tb accessor_tb'"
 
 probe "a declared bench with no file is named the other way" 2 \
   "in UNIT_BENCHES but not in test/: nope_tb" \
-  "$MB UNIT_BENCHES='exec_tb mem_tb imem_tb decoder_tb regfile_tb csr_tb monitor_tb nope_tb'"
+  "$MB UNIT_BENCHES='exec_tb mem_tb imem_tb decoder_tb regfile_tb csr_tb accessor_tb monitor_tb nope_tb'"
 
 probe "a declared bench with no UNIT_BENCH_SRC_* would build with no design under test" 2 \
   "monitor_tb is in UNIT_BENCHES with no UNIT_BENCH_SRC_monitor_tb" \

--- a/test/testbench.v
+++ b/test/testbench.v
@@ -50,7 +50,10 @@ module testbench(
   logic [31:0] mem_addr;
   logic [31:0] mem_wdata;
   logic [3:0]  mem_wstrb;
+  logic        mem_ren;
   logic [31:0] mem_rdata;
+  // ADR-0059/ADR-0060: the steal, and the sixth stall reason it drives.
+  logic        fetch_stall;
   // Both memories answer zero outside their own range, so the two buses join
   // with an OR. Same wiring as rtl/littlesoc.v, which is the point: the range
   // decode and the steal live in rtl/imemory.v, so the two legs cannot end up
@@ -109,11 +112,9 @@ module testbench(
     .mem_addr(mem_addr),
     .mem_wdata(mem_wdata),
     .mem_wstrb(mem_wstrb),
-    // Tied off and unconnected exactly as rtl/littlesoc.v ties them: the core
-    // has no read enable to drive and no stall input to take the steal.
-    .mem_ren(1'b0),
+    .mem_ren(mem_ren),
     .mem_rdata(imem_mem_rdata),
-    .fetch_stall()
+    .fetch_stall(fetch_stall)
   );
 
   littlecpu uut (
@@ -127,7 +128,9 @@ module testbench(
     .mem_addr(mem_addr),
     .mem_wdata(mem_wdata),
     .mem_wstrb(mem_wstrb),
+    .mem_ren(mem_ren),
     .mem_rdata(mem_rdata),
+    .fetch_stall(fetch_stall),
     .trap(trap)
    `ifdef RISCV_FORMAL
     , .rvfi_valid(rvfi_valid),


### PR DESCRIPTION
Closes JEF-723.

Step 3 of `docs/ideas/one-address-space-over-two-memories.md`. #100 gave `rtl/imemory.v` the write
port, the data read and the steal, with both ends dark. This turns them on: `mem_ren` out of the
accessor, `fetch_stall` into decode as the sixth stall reason, and `fence.i` onto the serialization
drain. Two ADRs — **ADR-0060** (the stall reason, the coincidence ruling, the depth moves) and
**ADR-0061** (`fence.i`, amending ADR-0002).

## What changed

- **`rtl/accessor.v`** exports `mem_ren` = `!reset && in_valid && is_load`. Not cosmetic: the idle
  bus presents address 0, which is inside the text range, so without it every idle cycle steals a
  fetch and the core never runs.
- **`rtl/decoder.v`** takes `fetch_stall` — sixth stall reason, existing bubble mechanism, `pc`
  holds and `out <= '0`. No flush and nothing to flush: `issuing = !reset && !stall` gates trap
  commit, the CSR write and `minstret`, and `stall` sits above every redirect in `next_pc`.
- **The coincidence is a ruling, not statement order.** A steal bubbles; a divider/accessor freeze
  holds; on a cycle with both, **holding wins** — bubbling would drop an instruction nothing
  downstream has consumed. Asserted in both directions in the decoder's `FORMAL` block and driven as
  vectors in `test/decoder_tb.v`, because reordering two `else if` arms is otherwise silent. This
  extends invariant 8 rule (a).
- **`fence.i` serializes.** `pipe_drained` needs all four in-flight slots empty, and
  `accessor_out.valid` is the one that carries a store — so a drained pipe means the older store's
  write edge has passed, and the fetch address published on `fence.i`'s own issue edge is latched
  against the written array.
- **Ports wired at every site**: `formal/{wrapper.v,imemcheck.sv,dmemcheck.sv,cover.sv,complete.sv,
  pcloop.sv}`, `test/testbench.v`, `rtl/littlesoc.v`.
- **`formal/pcloop.sv`** gains `fetch_stall` in `f_may_stall` plus an assertion that the steal holds
  the pc. That is the ADR-0046 trap; a stale `f_may_stall` is what left `components_pcloop` red on
  main for eight commits.

## The depths moved, and F and G were re-measured here

ADR-0057 predicted `insn 15 → 19`, `ill 15 → 19`, `reg 15 20 → 15 22` from scratch RTL. Re-run
against this implementation by `formal/checks.cfg`'s own recipe:

| sweep | verdict |
|---|---|
| `hang` check cycle 6 | `bad state property 0 reachable at bound k = 6` |
| `hang` check cycle 7 | PASS |
| `liveness` trig 10, gap 4 | red at k = 14 |
| `liveness` trig 10, gap 5 | red at k = 15 |
| `liveness` trig 10, gap 6 | **PASS** |
| `liveness` trig 15, gap 5 | red at k = 20 |
| `liveness` trig 15, gap 6 | **PASS** |

**F = 6 (unchanged), G = 4 → 6**, at two triggers rather than one. F + 2G = 18, so `insn`/`ill` go to
19 and `reg`'s window to 7. The three lines land in this commit, not after it: ADR-0057 ran the whole
ladder at `insn 15` under this environment and got 85/85 with three checks green having stopped
asking.

`formal/wrapper.v` drives `fetch_stall` from a transcription of the memory's equation — never free,
because a free stall input starves `hang`/`liveness` (ADR-0042) — and weakens the same-address
stability assumption on the cycle after any text access and, for a store, the cycle after that.
`imemcheck`/`dmemcheck`/`cover`/`complete` tie it low; each says why at the site, in ADR-0049's
FACT/DISCHARGED/SCOPE form.

## Gates

Local box, Homebrew Yosys 0.67+post (`b8e7da6f`), **machine load 9-40 throughout** — a sibling agent
was running synthesis spikes, so the wall times below are not comparable to CI's.

| gate | result |
|---|---|
| `make test` | **56/56**, `EXPECTED_FAIL` empty, 125 probes green |
| `make test-units` | **8/8** (`accessor_tb` is new) |
| `make -C formal check JOBS=4` | **85 checks, 85 pass**, both set equalities exact, at the new depths (~24 min under load) |
| `components_decoder` / `_executor` / `_pcloop` | PASS, PASS, PASS (k-induction) |
| `nonperturbation` | PASS |
| `imemcheck` / `dmemcheck` / `cover` | PASS / PASS / PASS |
| `complete` / `complete_cover` / exclusions | PASS / PASS / PASS |
| `make lint` | clean in both passes |
| `make elaborate-strict` + `vvp testbench.vvp` | zero promoted warnings; 79 retires / 20 writes, unchanged |
| `make fit` | **3899** of 4100 (was 3875; +24 is inside the ±50 churn floor) |
| `make soc-timing` | **95.74 / 96.67 / 98.06 ns across three placements = 10.20-10.44 MHz**, 35.9% logic / 64.1% routing, 34 levels (28 LUT + 7 carry), `imem.in_range → imem.rom_even.0.0_RDATA[1]` |

The timing distribution overlaps the **10.18-10.32 MHz** ADR-0059 measured for the memory half
alone, so turning the ports on sits inside the placement band and costs nothing measurable. The
ratchet holds with the same thin margin ADR-0059 flagged.

`make cosim-suite` was **not** run: `tools/sail` is not installed on this box.

## `test/OBSERVED_FLOOR` — diffed deliberately, and it does not move

The ticket expected retire counts to move. They do not, and the file is unchanged: **every count is
identical program by program**, not merely above the floor. No program in `test/asm` does a
text-region data access — `.data` is based at `0x10000` and the bench's text ends at `0x4000` — so
the steal never fires in the suite. That matches the brief's "zero on the current suite", and it
also means **the suite does not exercise this change end to end**. `selfmod.S` / `textload.S` /
a contention test are the brief's step 5 and are not here.

## Mutations, each red for its own reason

| mutation | caught by |
|---|---|
| `fetch_stall` dropped from `stall` | `components_pcloop` (`pcloop.sv:379`) and `decoder_tb` |
| bubble arm wins the coincidence | `components_decoder` (`decoder.v:1199`) and `decoder_tb` |
| `instr_fencei` dropped from the serialization term | `decoder_tb`, 5 mismatches |
| `mem_ren` tied low | `accessor_tb`, every load width |
| `mem_ren` from word/half flags only | `accessor_tb` (`lbu`), after the bench's per-width vectors were collapsed into a task |

## Decisions made without asking

1. **`imemcheck`/`dmemcheck`/`cover`/`complete` tie `fetch_stall` low** rather than modelling the
   arbiter. They model no memory — `imem_data` is free or `rand_const`, answered in the same cycle —
   so a steal there adds stall cycles and no coverage, and would push `cover`'s goals and
   `complete`'s depth-50 walk out for nothing. Recorded as an assumption at each site; the ladder is
   where a stealing memory is modelled. `imemcheck` is where this has to be paid off, with the write
   path the brief's step 4 gives it.
2. **The wrapper's stability assumption is weakened in this change**, not deferred to the formal
   ticket. G = 6 is only reachable under the weakened form; shipping the depths derived from it while
   leaving the assumption at full strength would be quoting a floor measured in a different
   environment.
3. **`csr_serialize` renamed `serialize`** — it covers three instruction kinds now.
4. **A new `accessor_tb`** (`UNIT_BENCHES` 7 → 8). `mem_ren` stuck *high* is caught by the ladder
   (`hang` would go red); stuck *low* is invisible everywhere until a program does a text load, and
   none does yet.

## Reviewer notes / risks

- **`insn` and `reg` still clear their floors by exactly one cycle.** A seventh stall reason reopens
  all of this.
- **The ladder's wall time roughly doubled.** ADR-0057 measured 7m14s → 13m42s at `JOBS=4` on an
  unloaded box; CI's `formal` job was 4m22s against `timeout-minutes: 20`, so the margin goes from
  about 5× to about 2×. Left alone here — worth watching on the first CI run.
- **DECISION NEEDED (small):** `formal/wrapper.v`'s `TEXT_BYTES` is `0x2000`, the SoC's `ROM_WORDS`.
  The bench runs 4096 words. Nothing in the ladder depends on the size — it decides how often a steal
  is reachable, not whether — but it is a third place the map is written down, and the architect may
  prefer it derived. I took the constant with the reasoning at the site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJ77ZZJ6pDiL3vj3Qw9hKs
