### PR TITLE
Delete the comments in the build and grading scripts (JEF-719)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,31 +1,17 @@
 include formal/pin.mk
 
-# A recipe that dies partway through must not leave a truncated target behind
-# looking newer than its prerequisites — several targets here are shell
-# redirections, which create the output file before the generator has written
-# a byte of it.
 .DELETE_ON_ERROR:
 
-# Macro names that turn RVFI on (ADR-0006), shared by both sim legs below so
-# they can't drift apart on which -D flags mean "RVFI is live" -- the whole
-# point is that both legs check the same thing. One list of names;
-# each consumer applies its own flag syntax (iverilog: -DNAME, yosys
-# `read_verilog`: -D NAME) via $(addprefix ...) since no single literal string
-# satisfies both.
 RISCV_FORMAL_MACROS := RISCV_FORMAL RISCV_FORMAL_COMPRESSED RISCV_FORMAL_ALIGNED_MEM RISCV_FORMAL_NRET=1 RISCV_FORMAL_XLEN=32 RISCV_FORMAL_ILEN=32
 
 rvfi_macros.vh: $(RISCV_FORMAL_DIR)/checks/rvfi_macros.py
 	python3 $^ > $@
 
-# The RTL both sim legs elaborate, named ONCE. This list used to be written out
-# per recipe, and .github/workflows/ci.yml's `elaborate` job carried a fourth
-# hand-maintained copy under a comment asserting that it "reads the same
-# sources, so the two cannot diverge on what they elaborate". They diverged the
-# moment ADR-0054 put rtl/imemory.v and rtl/memory.v on the graph: the gate went
-# on elaborating a testbench whose memory instances resolved to nothing, and
-# reported every bit of `imem_data2` as undriven. The gate was right and its
-# file list was stale. Nothing may spell this list out again -- the `elaborate`
-# job calls `make elaborate-strict` (below) so there is one copy to update.
+# The RTL both sim legs elaborate, named once. Do not spell this list out
+# anywhere else: ci.yml's `elaborate` job carried a fourth copy, it went stale
+# the moment rtl/imemory.v and rtl/memory.v landed, and the gate spent a run
+# elaborating a testbench whose memory instances resolved to nothing. That job
+# calls `make elaborate-strict` below, so there is one copy to update.
 SIM_RTL_SRCS := rtl/structs.v rtl/accessor.v rtl/csrs.v rtl/decoder.v rtl/executor.v \
                 rtl/fetcher.v rtl/imemory.v rtl/memory.v rtl/regfile.v rtl/writeback.v \
                 rtl/littlecpu.v
@@ -33,66 +19,19 @@ SIM_RTL_SRCS := rtl/structs.v rtl/accessor.v rtl/csrs.v rtl/decoder.v rtl/execut
 testbench.vvp: $(SIM_RTL_SRCS) rvfi_macros.vh test/testbench.v test/monitor.sim.v
 	iverilog -I./rtl/ -DICARUS $(addprefix -D,$(RISCV_FORMAL_MACROS)) -g2012 -o $@ $^
 
-# ADR-0007: iverilog is the waveform leg, not cxxrtl (`./sim` now requires
-# --rom/--ram/--cycles and was never a VCD demo — see the `sim:` rule
-# above). testbench.vvp already `$dumpfile`s/`$dumpvars`s under `ifdef
-# ICARUS` (test/testbench.v) and already carries test/monitor.sim.v, so this
-# waveform is also a self-checking per-retire run, not just a raw trace. It
-# runs the fixed increment-loop program test/testbench.v writes into the ROM's
-# two banks from an `ifdef ICARUS` block (ADR-0054) for 200 cycles -- there's no
-# --rom flag on this leg, unlike ./sim's.
 .PHONY: waves
 waves: waves.vcd
 waves.vcd: testbench.vvp
 	vvp $<
 	mv testbench.vcd $@
 
-# -O2 -DNDEBUG: the sim binary is the primary runner (ADR-0007) and needs to
-# run 46 tests well under a minute; -g -O0 (the old flags) is 5-10x slower
-# for no benefit here. -isystem (not -I) for the vendored cxxrtl runtime
-# headers so -Wall -Wextra -Werror only fails on warnings in code this repo
-# owns, not on the third-party runtime's.
 sim: test/cxxrtl.cc test/rtl.cc
 	clang++ -O2 -DNDEBUG -std=c++17 -Wall -Wextra -Werror \
 	  -isystem $$(yosys-config --datdir)/include/backends/cxxrtl/runtime $< -o $@
 
-# ---------------------------------------------------------------------------
-# Sail co-simulation (docs/adr/0032, docs/adr/0039) -- deliberately opt-in.
-#
-# Nothing below is reachable from `make test`, `make test-units` or CI's
-# required set. The whole point of keeping it off the default path is that
-# `make test` must still work on a machine with no Sail installed, and an
-# experiment must not quietly become a merge gate. Run it by hand:
-#
-#     make sail-setup     # once: fetch, verify and unpack the pinned release
-#     make cosim          # build the architectural-state tracer
-#     make cosim-run      # run it on one program (PROG=add.S by default)
-#     make cosim-suite    # run the whole suite, graded against the baseline
-# ---------------------------------------------------------------------------
-
-# The sail-riscv release this spike was run against, pinned the way
-# formal/pin.mk pins riscv-formal and for the same reason (ADR-0013): an oracle
-# that moves under you is not an oracle -- and this one is EXECUTED, by the
-# `--version` probe at the end of the fetch below and by every `make cosim-run`
-# after it, via test/cosim.py.
-#
-# A GitHub release asset is MUTABLE, so a version on its own pins a FILENAME,
-# not BYTES. The SHA-256 beside each asset name below is what pins the bytes,
-# and it is checked before anything is extracted, let alone run. Bumping the
-# version therefore means re-pinning all three digests; that friction is the
-# point, exactly as it is for RISCV_FORMAL_SHA.
-#
-# An attempt to set the version from outside is REJECTED rather than ignored:
-# `override` alone would make `make SAIL_RISCV_VERSION=...` silently do
-# nothing, which reads as a working knob. This is a supply-chain control, not
-# a knob.
-#
-# ADR-0033 gap 4 recorded the unverified fetch as accepted-because-opt-in, with
-# "give it pin.mk's treatment" as the precondition for ever putting co-sim on
-# `make test` or CI. That precondition is met here. ADR-0039 then landed the
-# `tohost` doubleword and the `test/COSIM_EXPECTED_FAIL` baseline behind
-# `make cosim-suite`, and co-simulation still stays off every default path:
-# `make test`, `make test-units` and CI's required set do not reach any of it.
+# Sail co-simulation is deliberately opt-in: nothing from here to `cosim-suite`
+# is reachable from `make test`, `make test-units` or CI's required set, so that
+# `make test` keeps working on a machine with no Sail installed (ADR-0032).
 ifneq ($(filter command line environment,$(origin SAIL_RISCV_VERSION)),)
 $(error SAIL_RISCV_VERSION cannot be set from the command line or the \
   environment: it pins bytes this repo executes. Change it in the Makefile, \
@@ -100,29 +39,14 @@ $(error SAIL_RISCV_VERSION cannot be set from the command line or the \
 endif
 override SAIL_RISCV_VERSION := 0.13.1
 
-# Three-part, so a branch name, `latest`, or one of upstream's rolling
-# date-and-SHA tags (`2026-07-27-9901550`) cannot be written here by accident.
-# Upstream also ships two-part tags (`0.13`, `0.12`): bumping to one means
-# widening this regex deliberately, in the same commit as the new digests,
-# rather than discovering at fetch time that the guard was never the control.
-# The digests are.
 ifeq ($(shell printf '%s' '$(SAIL_RISCV_VERSION)' | grep -cE '^[0-9]+\.[0-9]+\.[0-9]+$$'),0)
 $(error SAIL_RISCV_VERSION must be a three-part release version like 0.13.1, \
   not a branch, a moving tag or a range: '$(SAIL_RISCV_VERSION)')
 endif
 
-# Prebuilt, first-party release binaries from github.com/riscv/sail-riscv.
-# Building the model from source needs opam + OCaml + the Sail compiler
-# (there is no `brew install sail-riscv`; homebrew's `sail` formula is an
-# unrelated WordPress deploy tool). The upstream release ships a macOS arm64
-# and two Linux tarballs, which covers every machine this repo is developed
-# and CI'd on, so the source build is not worth its cost here.
-#
-# Digests are `shasum -a 256` over all three 0.13.1 assets, downloaded fresh
-# and cross-checked against the per-asset digest the GitHub releases API
-# reports. All three are pinned deliberately: a host whose asset has no digest
-# here must fail closed rather than fetch something unverifiable, so the
-# recipe below refuses to run rather than skipping the check for one platform.
+# Prebuilt binaries because building from source needs opam, OCaml and the Sail
+# compiler: there is no `brew install sail-riscv`, and homebrew's `sail` formula
+# is an unrelated WordPress deploy tool.
 SAIL_SHA256_sail-riscv-Mac-arm64     := 53d0c6fd84edd898728e7ba01c1575e66e5f17efd098847c5273690abbbd0737
 SAIL_SHA256_sail-riscv-Linux-x86_64  := ee052f64494a2f5f071afd9c2cb4aa5eaae4ba84753e4f77e442b4f83f2e9469
 SAIL_SHA256_sail-riscv-Linux-aarch64 := 3cd33a323d6749aec4667e54f71d2bf8e8e6e220a4e4bafd9083440f9a7e55f0
@@ -136,24 +60,11 @@ SAIL_SIM_BIN   := $(SAIL_RISCV_DIR)/bin/sail_riscv_sim
 SAIL_ASSET     := $(SAIL_ASSET_$(shell uname -s)_$(shell uname -m))
 SAIL_SHA256    := $(SAIL_SHA256_$(SAIL_ASSET))
 
-# tools/sail/.sail-pin, written only after the digest check passes. Line 1 is
-# the pin the tree was fetched under; line 2 is the SHA-256 of the unpacked
-# sail_riscv_sim, which is what test/cosim.py checks the binary against before
-# executing it. Line 1 is what makes a version bump re-fetch instead of
-# silently reusing whatever landed first -- the old rule keyed on the binary
-# merely existing, so the first binary to arrive was executed forever.
 SAIL_STAMP := $(SAIL_RISCV_DIR)/.sail-pin
 SAIL_PIN   := $(SAIL_RISCV_VERSION) $(SAIL_ASSET) $(SAIL_SHA256)
 
-# Fail closed, the way formal/pin.mk's HEAD check does: a tree on disk at
-# anything other than the pin stops the target that would execute it, rather
-# than being silently reused. `sail-setup` is exempt because it is the way out
-# of this state (pin.mk exempts `clean` for the same reason) -- it re-fetches
-# on a pin mismatch.
-#
-# Scoped to the goals that actually run the binary. A stale tools/sail must not
-# break `make test`: co-simulation is opt-in (ADR-0032) and a guard on it that
-# could fail the suite would have made it a gate by the back door.
+# Scoped to the goals that actually run the binary: a stale tools/sail that
+# could fail `make test` would make co-simulation a gate by the back door.
 ifneq ($(filter cosim-run cosim-suite,$(MAKECMDGOALS)),)
 ifneq ($(wildcard $(SAIL_SIM_BIN)),)
 SAIL_PIN_ON_DISK := $(shell sed -n 1p $(SAIL_STAMP) 2>/dev/null)
@@ -164,10 +75,6 @@ endif
 endif
 endif
 
-# Download to a file, verify the digest, audit the member paths, and only then
-# extract -- the previous recipe piped curl straight into tar, so bytes from
-# the network were unpacked before anything could reject them. `--version` runs
-# last, after verification, which is the order the comment above claims.
 .PHONY: sail-setup
 sail-setup:
 	@set -e; \
@@ -239,11 +146,6 @@ sail-setup:
 	mv $$tmp $(SAIL_RISCV_DIR)
 	@$(SAIL_SIM_BIN) --version
 
-# The co-simulation runner: a SECOND cxxrtl binary, not a change to `sim`.
-# It reads the real `uut regfile regs` array through debug_items and reads no
-# rvfi_* signal at all; see the header comment in test/cosim.cc for why that
-# distinction is the entire value of this leg. Shares test/rtl.cc with `sim`,
-# so it costs one extra compile and no extra elaboration.
 cosim: test/cosim.cc test/rtl.cc
 	clang++ -O2 -DNDEBUG -std=c++17 -Wall -Wextra -Werror \
 	  -isystem $$(yosys-config --datdir)/include/backends/cxxrtl/runtime $< -o $@
@@ -253,91 +155,36 @@ PROG ?= add.S
 cosim-run: cosim
 	./test/cosim.py $(PROG)
 
-# The whole suite under co-simulation, graded by set equality in BOTH
-# directions against test/COSIM_EXPECTED_FAIL -- the same contract `make test`
-# applies to test/EXPECTED_FAIL (ADR-0014, ADR-0035). See docs/adr/0039.
-#
-# Deliberately NOT a prerequisite of `test`, `test-units` or anything CI
-# requires (ADR-0032). It needs a Sail install that `make test` must keep
-# working without, and the moment it became required it would stop being the
-# opt-in experiment it was accepted as. The regfile-to-block-RAM change gates
-# on it by pasting its output into the PR, not by branch protection.
-#
-# The fourth argument is the suite manifest -- test/OBSERVED_FLOOR, the same
-# file `make test` grades retire counts against. Both legs read the same one on
-# purpose: two lists of what the suite is could come to disagree, and then the
-# interesting failure would be about the lists rather than about the core.
 .PHONY: cosim-suite
 cosim-suite: cosim
 	./test/run_cosim.sh ./cosim test/asm test/COSIM_EXPECTED_FAIL test/OBSERVED_FLOOR
 
-# test/monitor.sim.v is a build-time-only, gitignored derivative of the
-# tracked test/monitor.v (ADR-0019). test/monitor.v itself stays
-# pristine and tracked (CLAUDE.md invariant 7); regenerate this file, never
-# hand-edit it, and never commit it. BOTH sim legs read this file, so they
-# cannot drift into checking different specs -- and it is therefore
-# load-bearing for correctness, not just elaboration: changing a rule in the
-# sanitizer changes the oracle.
-#
-# The three rules, and why each exists, live in test/sanitize_monitor.py.
-# They were an inline `sed` chain here until the third one (the !spec_trap
-# gate) arrived: that rule is a structural insert across a 45-line span, not
-# a line substitution, and the script additionally asserts a site count per
-# rule so a pin bump that changes the generator's output fails loudly instead
-# of silently shipping an unapplied sanitizer. `diff test/monitor.v
-# test/monitor.sim.v` is eight lines; if it stops being readable at a glance,
-# fix the generator upstream instead.
+# Both sim legs read this derived file, so changing a sanitizer rule changes the
+# oracle rather than fixing an elaboration problem (ADR-0019).
 test/monitor.sim.v: test/monitor.v test/sanitize_monitor.py
 	python3 test/sanitize_monitor.py $< > $@
 
-# $(RISCV_FORMAL_MACROS) turns on the rvfi_* ports and their driving logic
-# throughout rtl/ and test/testbench.v's `monitor` instance (ADR-0006);
-# only RISCV_FORMAL itself is actually read by rtl/ or test/testbench.v
-# today, the rest ride along for consistency with testbench.vvp above.
-# test/monitor.sim.v (not test/monitor.v) supplies the `monitor` module
-# here; see its rule above for why.
 test/rtl.cc: $(SIM_RTL_SRCS) rvfi_macros.vh test/testbench.v test/monitor.sim.v
 	yosys -p 'read_verilog -sv $(addprefix -D ,$(RISCV_FORMAL_MACROS)) $^; hierarchy -top testbench; write_cxxrtl $@'
 
-# The `elaborate` gate (.github/workflows/ci.yml). The SAME SOURCES as
-# test/rtl.cc above -- guaranteed by the variable rather than asserted by a
-# comment -- with `proc; opt_clean; check` ahead of write_cxxrtl. `check` is
-# what actually reports an undriven wire; the bare recipe above elaborates one
-# with zero diagnostic output and exit 0, which is the whole reason a strict
-# pipeline exists.
-#
-# DELIBERATELY UNLIKE test/rtl.cc, this reads no `-D RISCV_FORMAL*` and no
-# test/monitor.sim.v: the gate elaborates the plain functional configuration,
-# so `ifdef RISCV_FORMAL` shadow logic and the generated monitor are out of
-# frame. That predates this target and is preserved, not inherited by accident.
-# It is also why the gate needs no riscv-formal clone to run.
-#
-# It lives here rather than in the workflow so the file list cannot drift from
-# the build it claims to mirror. The promotion-to-error POLICY stays in the
-# workflow, where it belongs: this target elaborates and reports; the gate
-# decides which warnings are fatal.
+# `check` is what reports an undriven wire; the test/rtl.cc recipe above
+# elaborates one with no diagnostic and exit 0.
 ELABORATE_STRICT_OUT ?= /tmp/elaborate-strict.cc
 
-# One line on purpose. A backslash-continuation inside the single-quoted script
-# is NOT removed by the shell -- single quotes make it literal -- so yosys reads
-# the backslash as a command and dies with "No such command: \". It survived a
-# local run and failed on the gate, which is the wrong way round to find out.
+# Keep the yosys script on one physical line. A backslash-continuation inside
+# the single quotes is not removed by the shell, so yosys reads the backslash
+# as a command and dies with "No such command: \".
 .PHONY: elaborate-strict
 elaborate-strict: $(SIM_RTL_SRCS) test/testbench.v
 	yosys -p 'read_verilog -sv $(SIM_RTL_SRCS) test/testbench.v; hierarchy -top testbench; proc; opt_clean; check; write_cxxrtl $(ELABORATE_STRICT_OUT)'
 
-# test/monitor.v is generated by riscv-formal's monitor/generate.py at
-# RISCV_FORMAL_SHA (formal/pin.mk — bump the pin there, not here). generate.py
-# opens ../insns/isa_<isa>.txt relative to its own CWD, so it must be run from
-# riscv-formal/monitor/, not the repo root (see ADR-0007). The tracked file is
-# regenerated in place; use `make monitor-check` to check freshness without
-# touching it.
+# The `cd` is required: generate.py opens ../insns/isa_<isa>.txt relative to its
+# own CWD.
 MONITOR_GEN = cd $(RISCV_FORMAL_DIR)/monitor && python3 generate.py -i rv32imc -c 1 -a -p monitor
 
-# Depends on the generator and the pin, NOT on the clone directory: a directory's
-# mtime bumps on any write anywhere inside it, which would make routine builds
-# overwrite this tracked file (CLAUDE.md invariant 7) at unpredictable moments and
-# defeat the point of monitor-check. The clone is order-only.
+# The clone is order-only on purpose. A directory's mtime bumps on any write
+# inside it, so a normal prerequisite would have routine builds overwriting this
+# tracked file (invariant 7) at unpredictable moments.
 test/monitor.v: $(RISCV_FORMAL_DIR)/monitor/generate.py formal/pin.mk | $(RISCV_FORMAL_DIR)
 	$(MONITOR_GEN) > $(CURDIR)/$@
 
@@ -348,10 +195,6 @@ monitor-check: $(RISCV_FORMAL_DIR)/monitor/generate.py | $(RISCV_FORMAL_DIR)
 	($(MONITOR_GEN)) > "$$tmp" && \
 	diff -u test/monitor.v "$$tmp"
 
-# Installs the RISC-V cross compiler the test suite is assembled with
-# (ADR-0007/ADR-0008). Both packages are freestanding-only (no multilib/
-# newlib needed, since the tests are `-nostdlib`), and both are verified
-# real, bottled/packaged builds — not a hallucinated package name.
 .PHONY: setup
 setup:
 ifeq ($(shell uname -s),Darwin)
@@ -368,28 +211,6 @@ else
 	@echo "builds from an unpinned crates.io tarball -- prefer lint-setup."
 endif
 
-# ---------------------------------------------------------------------------
-# Structural lint (.svlint.toml) -- the THIRD SystemVerilog frontend.
-#
-# svlint parses with sv-parser, which is neither yosys's nor iverilog's
-# frontend. Read .svlint.toml's header for why this gate exists and why nearly
-# every rule it enables reports zero findings today; read the rule comments
-# there before changing any of them.
-#
-# rtl/ only. test/ benches use delays, `$display` and `initial` blocks these
-# rules were never meant for.
-# ---------------------------------------------------------------------------
-
-# Pinned the way formal/pin.mk pins riscv-formal and the sail spike above pins
-# sail-riscv, and for the same reason (ADR-0013): this fetches a 45 MB
-# EXECUTABLE off the network. A GitHub release asset is MUTABLE, so a version
-# on its own pins a FILENAME, not BYTES -- the SHA-256 beside each asset name
-# is what pins the bytes, and it is checked before anything is extracted, let
-# alone run. Bumping the version means re-pinning every digest; that friction
-# is the point.
-#
-# `override` + an origin check so this cannot be redirected from a script or a
-# CI job. A supply-chain control, not a knob.
 ifneq ($(filter command line environment,$(origin SVLINT_VERSION)),)
 $(error SVLINT_VERSION cannot be set from the command line or the environment: \
   it pins bytes this repo executes. Change it in the Makefile, together with \
@@ -397,24 +218,14 @@ $(error SVLINT_VERSION cannot be set from the command line or the environment: \
 endif
 override SVLINT_VERSION := 0.9.5
 
-# Three-part, so a branch name or a moving tag cannot be written here by
-# accident.
 ifeq ($(shell printf '%s' '$(SVLINT_VERSION)' | grep -cE '^[0-9]+\.[0-9]+\.[0-9]+$$'),0)
 $(error SVLINT_VERSION must be a three-part release version like 0.9.5, not a \
   branch, a moving tag or a range: '$(SVLINT_VERSION)')
 endif
 
-# `shasum -a 256` over each 0.9.5 asset, downloaded fresh and cross-checked
-# against the per-asset digest the GitHub releases API reports. Upstream ships
-# no Linux aarch64 build, so that host has no line here and `lint-setup` fails
-# closed on it rather than fetching something it cannot verify (use `brew` or
-# `cargo install` there).
-#
-# The version is spelled out in each variable NAME, not interpolated. That is
-# deliberate: bumping SVLINT_VERSION without re-pinning makes the lookup below
-# resolve to empty, and `lint-setup` refuses to fetch. A digest that silently
-# carried over to a new version would be a control that reads as protection
-# while providing none (ADR-0013).
+# Do not interpolate $(SVLINT_VERSION) into these names. Spelling it out is what
+# makes bumping the version without re-pinning resolve the lookup to empty, so
+# `lint-setup` refuses to fetch instead of carrying a stale digest forward.
 SVLINT_SHA256_svlint-v0.9.5-x86_64-lnx  := 0bbb3850b8ef604d7ccf25c2b0d2a751154ac2e18b2a12753ae1648f237a8ceb
 SVLINT_SHA256_svlint-v0.9.5-x86_64-mac  := 53838f356862b6492777347999ccf44c1b44bc78f51cb032759b9e17bd213519
 SVLINT_SHA256_svlint-v0.9.5-aarch64-mac := d032be600f0ee04130e0663daa05da3cc562d3d34bbc4305d6b70cb99310c6df
@@ -427,27 +238,12 @@ SVLINT_DIR   := tools/svlint
 SVLINT_ASSET := $(SVLINT_ASSET_$(shell uname -s)_$(shell uname -m))
 SVLINT_SHA256 := $(SVLINT_SHA256_$(SVLINT_ASSET))
 
-# Prefer whatever is on PATH (brew, cargo, the distro) and fall back to the
-# tree `lint-setup` unpacks, so a developer who already has svlint installed
-# never pays for the download and CI needs no extra PATH plumbing.
 SVLINT ?= $(shell command -v svlint 2>/dev/null || echo ./$(SVLINT_DIR)/bin/svlint)
 
-# TWO passes, and both are load-bearing. Roughly a fifth of rtl/ sits behind
-# `ifdef RISCV_FORMAL` (rvfi_* capture in structs/decoder/accessor/writeback);
-# svlint's preprocessor drops those blocks unless the macros are defined, so a
-# single undefined pass would leave the RVFI instrumentation unlinted --
-# exactly the code ADR-0020 says must stay write-only with respect to the core
-# and that nothing else structurally checks. Same macro list as both sim legs
-# ($(RISCV_FORMAL_MACROS), defined at the top of this file) so the three
-# cannot drift on what "RVFI is live" means.
-#
 # `-i rtl` is required, not decorative: svlint resolves `include "structs.v"`
-# relative to the include path only, and without it every module that includes
-# it fails to parse. Neither yosys nor iverilog surfaces that.
-#
-# `--github-actions` when GITHUB_ACTIONS is set turns findings into
-# ::error file=...,line=... annotations on the PR diff; plain `-1`
-# (one finding per line) otherwise.
+# through the include path only. Both passes below are load-bearing too — a
+# fifth of rtl/ sits behind `ifdef RISCV_FORMAL`, and svlint's preprocessor
+# drops those blocks unless the macros are defined.
 SVLINT_FLAGS := -c .svlint.toml -i rtl $(if $(GITHUB_ACTIONS),--github-actions,-1)
 
 .PHONY: lint
@@ -461,10 +257,6 @@ lint:
 	$(SVLINT) $(SVLINT_FLAGS) $(addprefix -D ,$(RISCV_FORMAL_MACROS)) rtl/*.v
 	@echo "svlint: clean in both passes"
 
-# Download to a file, verify the digest, audit the member paths, and only then
-# extract -- the same order `sail-setup` above uses, and for the same reason:
-# bytes from the network must not be unpacked before anything can reject them.
-# tools/svlint is gitignored; never commit the binary.
 .PHONY: lint-setup
 lint-setup:
 	@set -e; \
@@ -510,51 +302,8 @@ lint-setup:
 	mv $$tmp $(SVLINT_DIR)
 	@./$(SVLINT_DIR)/bin/svlint --version
 
-# Seven small benches. Four landed in `eb18320` and `a4662a2` with no runner
-# (rtl/executor.v, rtl/memory.v, rtl/decoder.v, rtl/regfile.v respectively —
-# regfile_tb.v covers the write-through bypass and x0 semantics, the single
-# most load-bearing change in the project, and was verified by hand via
-# iverilog+vvp before this rule existed to run it in CI). csr_tb is the fifth,
-# covering rtl/csrs.v's read mux, the address set its `implemented` output
-# accepts (that output decides whether a Zicsr encoding is a recognised
-# instruction at all), and its WARL masks — which the riscv-formal ladder
-# structurally cannot check, since rvfi_csrw_check.sv has no WARL model; see
-# formal/checks.cfg's [csrs] note. imem_tb is the sixth (ADR-0054): it walks
-# rtl/imemory.v's bank select at every word index and both parities against a
-# FLAT reference array, plus the range decode at the last word and past it --
-# corners the .S suite cannot reach, since real programs only produce the
-# alignments they happen to produce. The seventh,
-# monitor_tb, is not an RTL bench at all: it drives the sanitized monitor
-# (test/monitor.sim.v) directly with hand-built RVFI retires, because that
-# file is the oracle both sim legs check against and nothing else exercises
-# it on inputs whose correct verdict is known independently of the core
-# (ADR-0019). Compiled and run straight through iverilog/vvp; each bench
-# $fatal(1)s on a mismatch and $finish (exit 0) on success, so vvp's own exit
-# code is the pass/fail signal — no output-parsing needed. A separate target
-# from `test` (that one is the ADR-0007 cxxrtl regression gate over
-# test/asm/*.S; these are unit benches with their own, unrelated pass/fail
-# mechanism) but `test` depends on it so one `make test` still catches
-# everything.
-#
-# `set -e` comes FIRST, before mktemp and before the trap (ADR-0035). The
-# other order installed the cleanup trap on an unchecked $$tmp: a failed
-# mktemp left it empty, every -o path collapsed to the filesystem root, and
-# the trap then removed nothing.
-#
-# THE BENCH LIST IS ASSERTED AGAINST THE TREE, not merely written out. Six
-# iverilog+vvp invocations used to be spelled out in the recipe with nothing
-# tying that list to test/*_tb.v, so a seventh bench could land, be committed,
-# pass review and never run — and the gate would report six benches green
-# exactly as before. That is the same hole test/OBSERVED_FLOOR closes for the
-# .S suite and formal/EXPECTED_CHECKS closes for the ladder: a verdict cannot
-# report on something that never ran. UNIT_BENCHES is the declaration,
-# `check-unit-benches` compares it against `ls test/*_tb.v` in BOTH directions,
-# and the recipe below is DRIVEN by it — so the list cannot be satisfied by
-# adding a name without also giving the bench its sources.
 UNIT_BENCHES := exec_tb mem_tb imem_tb decoder_tb regfile_tb csr_tb accessor_tb monitor_tb
 
-# Per-bench RTL. monitor_tb is not an RTL bench at all: its source is the
-# sanitized monitor, which is why it names a file under test/ rather than rtl/.
 UNIT_BENCH_SRC_exec_tb     := rtl/structs.v rtl/executor.v
 UNIT_BENCH_SRC_mem_tb      := rtl/memory.v
 UNIT_BENCH_SRC_imem_tb     := rtl/imemory.v
@@ -564,10 +313,13 @@ UNIT_BENCH_SRC_csr_tb      := rtl/structs.v rtl/csrs.v
 UNIT_BENCH_SRC_accessor_tb := rtl/structs.v rtl/accessor.v
 UNIT_BENCH_SRC_monitor_tb  := test/monitor.sim.v
 
-# `present` is derived from the tree inside the recipe rather than from a
-# $(wildcard) at parse time: make caches directory contents, and a check whose
-# idea of what is on disk can be stale is a check that can be wrong in the one
-# direction that matters.
+# `present` is derived inside the recipe, not from a $(wildcard) at parse time:
+# make caches directory contents, and a check whose idea of what is on disk can
+# be stale is a check that can be wrong in the direction that matters.
+#
+# `set -e` comes first here and in `test-units`, before mktemp and before the
+# trap. The other order installed the trap on an unchecked $$tmp: a failed
+# mktemp left it empty and every path collapsed to the filesystem root.
 .PHONY: check-unit-benches
 check-unit-benches:
 	@set -e; \
@@ -611,83 +363,26 @@ test-units: check-unit-benches test/monitor.sim.v
 	  vvp $$tmp/$(b).vvp; ) \
 	true
 
-# THE GRADING LAYER'S OWN RED DIRECTION. Every graded comparison in the two
-# suite runners, the manifest check, the co-simulation comparison, the monitor
-# sanitizer and the two formal gates is forced to FAIL here, and required to
-# fail for the reason it was written for. Five of this repo's recorded defects
-# lived in that layer and every one was in a script (ADR-0037 §4, ADR-0040,
-# ADR-0033 gap 1, and the sanitizer's rule 3); the class is the comparison
-# whose failure path was never executed.
-#
-# It is a prerequisite of `test` rather than a target of its own on purpose.
-# A gate reached by no automation reads like coverage and is not — CLAUDE.md
-# records `make waves` and `make -C formal all` as exactly that — and hanging
-# it off `test` puts it in CI's required job with no workflow change and no
-# branch-protection change (ADR-0036 makes the latter a human action anyway).
-# It needs no RISC-V toolchain, no Sail, no yosys and no sby, so it cannot
-# narrow where `make test` runs.
+# A prerequisite of `test` rather than a target of its own, so it runs inside
+# CI's required job with no workflow change. It needs no toolchain, no Sail, no
+# yosys and no sby, so it cannot narrow where `make test` runs (ADR-0053).
 .PHONY: probe-gates
 probe-gates:
 	@./test/probe_gates.sh
 
-# Assembles every test/asm/*.S (rv32im_zicsr, -nostdlib, ADR-0008's memory
-# map), runs each under `sim`, and checks the pass/fail table against
-# test/EXPECTED_FAIL — the sprint-1 baseline. Exits 0 only when the actual
-# failure list matches that file exactly, so this is a working regression
-# gate today, against the current (still-broken, see CLAUDE.md) core.
 .PHONY: test
 test: sim test-units probe-gates
 	@./test/run_tests.sh ./sim test/asm test/EXPECTED_FAIL test/OBSERVED_FLOOR
 
-# ---------------------------------------------------------------------------
-# `make fit` -- the repo's one and only area measurement (ADR-0038).
+# Area is counted in nextpnr logic cells, never yosys cell counts: a DFF whose D
+# input is not its co-located LUT's output takes a whole cell on its own, and
+# over a thousand of this design's cells are exactly that. Two planning
+# estimates were wrong in opposite directions from counting `SB_LUT4`.
 #
-# Area is measured in *nextpnr logic cells*, never in yosys cell counts, and
-# nothing on this path prints a yosys number. A logic cell holds one LUT4 AND
-# one flip-flop, but a DFF whose D input is not the output of its co-located
-# LUT consumes a whole cell on its own -- over a thousand of this design's
-# cells are exactly that, and an `SB_LUT4` count is structurally blind to it.
-# Two planning estimates were wrong in opposite directions because they counted
-# LUT4s: one said 102% where the truth was 126%, the other undercounted a
-# saving by more than half. Hence the synthesis log below goes to a file.
-#
-# The top is `littlecpu` with its memories external, not `littlesoc`: the SoC's
-# memories are placeholders whose real implementation will be SPRAM and will
-# not consume logic cells. This replaces the `riscv.json`/`riscv.asc`/`timing`
-# targets that stood here, which synthesised `littlesoc` -- whose only outputs
-# are the flash pins, so yosys deleted the entire core and place-and-route
-# reported *4 LCs, 0%*. They measured an empty design and looked like a metric.
-#
-# WHY THIS TARGET TOLERATES A FAILED PLACEMENT, ON PURPOSE:
-# `littlecpu` with memories external presents 231 `SB_IO` against sg48's 39,
-# so nextpnr ALWAYS errors out -- after printing the utilisation table. Even a
-# configuration using 76% of the part fails, and it fails on an `imem_data2`
-# pad, not on logic cells. A top with realistic IO means a real pinout, which
-# means the SoC memory system, which is out of scope here. So a `make fit` that
-# required successful placement would never run at all, which is worse than
-# having no metric because it would look like one (ADR-0038 decision 1a). The
-# measurement is the utilisation nextpnr prints *before* it attempts placement.
-#
-# `icetime` IS DELIBERATELY OUT OF SCOPE, for the same reason: it needs an
-# `.asc`, which needs a completed placement, which needs that real pinout. Fmax
-# stays *declared* at 12 MHz and unmeasured (ADR-0038 decision 2); raising it
-# means breaking invariant 1 or invariant 6 and needs its own ADR. That is also
-# why the `pll.v`/`icepll` rule that fed off `timing` is gone.
-#
-# The contract is therefore inverted from a normal build, and the check below
-# is the whole point of the target:
-#
-#   nextpnr ran, printed a table, then failed to place -> EXPECTED, exit 0
-#   nextpnr absent, crashed, or printed no table       -> exit NONZERO
-#
-# A missing binary or a truncated JSON must not yield a green run with no
-# number in it. nextpnr's exit status cannot tell those apart -- it is nonzero
-# either way -- so the presence of the utilisation table is what decides.
-#
-# The whole table is printed, not just the logic-cell line: `SB_GB` is already
-# at 8/8, so a global-buffer overflow is a placement failure that no logic-cell
-# ratchet would ever predict.
-# ---------------------------------------------------------------------------
+# Do not try to make the placement succeed. This top presents 231 `SB_IO`
+# against sg48's 39, so nextpnr always errors on a pad — after printing the
+# utilisation table, which is the measurement. Placing it needs a real pinout,
+# which means the SoC memory system (ADR-0038).
 FIT_SRCS := rtl/structs.v rtl/accessor.v rtl/csrs.v rtl/decoder.v rtl/executor.v \
             rtl/fetcher.v rtl/regfile.v rtl/writeback.v rtl/littlecpu.v
 
@@ -696,95 +391,28 @@ fit.json: $(FIT_SRCS)
 	@yosys -p 'read_verilog -sv $^; synth_ice40 -dsp -top littlecpu -json $@' \
 	  > fit.synth.log 2>&1 || { tail -40 fit.synth.log; exit 1; }
 
-# THE RATCHET (ADR-0042). `make fit` was report-only while the core did not
-# fit at all; it does now, and a number nothing defends drifts back.
-#
-# WHY THE BUDGET IS NOT THE MEASUREMENT. `littlecpu` measures 4208 logic cells
-# at ADR-0052, under CI's pinned OSS CAD Suite -- which is the number to quote,
-# and the reason to say which toolchain took it: the same commit measures 4187
-# under a local Homebrew yosys, 21 cells apart on the synthesiser build alone.
-# (ADR-0042's 4236 was likewise a local number.) The budget is looser than that,
-# because the measurement is not stable to the cell: edits that synthesise to
-# identical hardware -- renaming a wire, reordering two independent
-# assignments, hoisting a struct field into a named signal -- move it by tens
-# of cells, since ABC's result depends on the order it sees the netlist in. A
-# ratchet pinned to the measurement of the day would go red on changes that
-# alter nothing, and the only way to clear it would be to raise the number,
-# which is how a ratchet becomes a rubber stamp. The 4236 -> 4208 drift is
-# itself an instance, and 4208 vs 4187 is a second axis of the same problem:
-# nobody set out to move either number.
-#
-# 4400 is 192 cells of headroom, about 4.6% of the measurement and more than
-# three times the observed noise band. A change that trips it has grown the
-# core by more than any resynthesis artifact can account for, and the right
-# response is to find out why -- not to edit this line. Lowering it after a
-# real reduction is always welcome; raising it needs a reason in the commit
-# message.
-#
-# It is NOT set at the part's 5280. Fitting is the floor, not the goal: 80%
-# with the SoC memory system still to come is the number worth defending.
-#
-# LOWERED FROM 4400 AT ADR-0054, after a reduction that is real rather than
-# resynthesis drift. Lifting the PC redirects out of rtl/decoder.v's publish
-# block replaced six independent `cond ? pc+imm : pc+inc` writes to `pc` with
-# one `branch_taken` and one priority mux, and it measures **4187 -> 3875 logic
-# cells on this branch, both under the SAME local Homebrew yosys**: 312 cells,
-# six times the +/-50 churn floor, and measured as a delta rather than quoted
-# across toolchains (which is the trap ADR-0052 records). Expect roughly 3896
-# under CI's pinned OSS CAD Suite, on that +21-cell axis; the `fit` job is where
-# the number that counts is taken.
-#
-# 4100 keeps ~204 cells of headroom over the local measurement, the same
-# proportion 4400 kept over 4208 and still well clear of both noise axes.
+# Deliberately not the measurement (3899 cells locally): edits that synthesise
+# to identical hardware move it by tens of cells, and the pinned CI toolchain
+# reads ~21 higher than a local one, so 4100 keeps headroom over both. Raising
+# this to clear a red is how a ratchet becomes a rubber stamp.
 FIT_MAX_LC := 4100
 
-# The table-presence check and the ratchet both live in soc/fit_report.py, not
-# here, so test/probe_gates.sh can drive them against a fixture log instead of
-# a second copy of this parsing (ADR-0053; the pattern soc/timing_split.py
-# already uses for `make soc-timing`'s ratchet).
 .PHONY: fit
 fit: fit.json
 	@nextpnr-ice40 --up5k --package sg48 --json $< --pcf-allow-unconstrained \
 	  > fit.log 2>&1 || true
 	@python3 soc/fit_report.py fit.log --max-lc $(FIT_MAX_LC)
 
-# ---------------------------------------------------------------------------
-# `make soc-timing` -- the SoC place-and-route and the FIRST REAL TIMING NUMBER
-# this project has ever had (ADR-0054).
-#
-# DELIBERATELY NOT `make fit`, AND IT MEASURES A DIFFERENT THING. `fit` is the
-# core's area ratchet: `littlecpu` with its memories external, tolerating a
-# failed placement because 231 `SB_IO` against sg48's 39 can never place
-# (ADR-0038 decision 1a). This target is the whole SoC -- core plus a block-RAM
-# ROM plus an SPRAM data RAM plus four pins -- and it MUST place, because
-# `icetime` reads an `.asc` and there is no `.asc` without a completed
-# placement. The two numbers are separate on purpose and must not be merged: the
-# SoC's logic-cell count includes the ROM's depth mux, the RAM's range decode
-# and the LED taps, none of which are the core.
-#
-# The contract is therefore the ordinary one, inverted back from `fit`'s:
-#
-#   nextpnr places, icetime reports a path   -> exit 0, the numbers are printed
-#   anything fails                           -> exit NONZERO
-#
-# WHAT THE NUMBER DOES NOT DESCRIBE, since a timing figure travels further than
-# its caveats: it is `icetime`'s static estimate for one placement of one build
-# of one program's ROM contents, at the default (worst-case) corner, on a part
-# whose routing dominates. ADR-0038 declares Fmax at 12 MHz as an INTENT and
-# ADR-0054 does not move it in either direction -- reconciling a measurement
-# with an intent is a decision, not a consequence.
-#
-# The ROM image is a real program, assembled with the same toolchain and the
-# same link script `make test` uses, so this needs the RISC-V cross compiler.
-# That is why it is a hand-run target and not a CI job. Override the program
-# with `make soc-timing SOC_PROG=lw.S`.
-# ---------------------------------------------------------------------------
+# A different design from `make fit`'s, whose numbers must not be merged with
+# these: this is the core plus a block-RAM ROM, an SPRAM data RAM and four pins,
+# so its logic-cell count includes the ROM's depth mux, the RAM's range decode
+# and the LED taps. Unlike `fit` it must place, because `icetime` reads an
+# `.asc` (ADR-0054).
 SOC_PROG      ?= add.S
 SOC_ROM_WORDS := 2048
-# The hard-block census the design is DECLARED to produce. Both are properties
-# of the RTL, not of placement, so they are exact rather than budgeted the way
-# FIT_MAX_LC is: 2 SPRAM for the 64 KB data RAM, and 16 EBR for the 8 KB banked
-# ROM plus 4 for rtl/regfile.v.
+# Exact rather than budgeted the way FIT_MAX_LC is, because both are properties
+# of the RTL rather than of placement: 2 SPRAM for the 64 KB data RAM, and 16
+# EBR for the 8 KB banked ROM plus 4 for rtl/regfile.v.
 SOC_EXPECT_SPRAM := 2
 SOC_EXPECT_EBR   := 20
 
@@ -792,14 +420,9 @@ SOC_SRCS      := rtl/structs.v rtl/accessor.v rtl/csrs.v rtl/decoder.v \
                  rtl/executor.v rtl/fetcher.v rtl/imemory.v rtl/memory.v \
                  rtl/regfile.v rtl/writeback.v rtl/littlecpu.v rtl/littlesoc.v
 
-# The ROM image, de-interleaved into rtl/imemory.v's two banks. soc/rom_banks.py
-# refuses to truncate a program that does not fit -- a ROM ceiling breached is a
-# finding about the part, not something to silently cut in half.
-#
-# PHONY on purpose, so `soc.json` resynthesises every run. The image depends on
-# SOC_PROG, which make cannot see a change to, and a stale ROM would make the
-# measurement describe a program nobody asked for. This target is hand-run and
-# the whole flow is ~33 s; correctness is worth more than incrementality here.
+# PHONY so `soc.json` resynthesises every run: the image depends on SOC_PROG,
+# which make cannot see a change to, and a stale ROM would make the measurement
+# describe a program nobody asked for.
 .PHONY: soc-rom
 soc-rom:
 	@set -e; \
@@ -837,23 +460,14 @@ soc.json: $(SOC_SRCS) soc-rom
 	@python3 soc/cell_census.py soc.synth.log SB_RAM40_4K $(SOC_EXPECT_EBR) \
 	  "rtl/imemory.v or rtl/regfile.v has stopped inferring block RAM, or the ROM size changed"
 
-# nextpnr's exit status is NOT the signal here, and tolerating it is a decision
-# rather than a convenience. It defaults to a 12 MHz target on ice40 and EXITS
-# NONZERO when the design misses it -- which this one does (ADR-0054: 11.70 MHz
-# by nextpnr's own analysis, 11.30 MHz by icetime). The placement itself
-# succeeded and the `.asc` is written before that check runs, so throwing it away
-# would mean no `icetime` report at all, i.e. no measurement, because the design
-# is 6% slow. The graded conditions are below: the `.asc` exists, nextpnr printed
-# a utilisation table, and the frequency clears SOC_MIN_MHZ.
+# nextpnr's exit status is deliberately not the signal: it defaults to a 12 MHz
+# target and exits nonzero when the design misses it, which this one does, having
+# already written the `.asc`. Honouring the status would mean no icetime report
+# at all because the design is 6% slow. `.DELETE_ON_ERROR` is why the `||` is
+# needed rather than merely tidy — without it make deletes that `.asc`.
 #
-# `.DELETE_ON_ERROR` at the top of this file is why the `||` matters: without
-# tolerating the status, make deletes the `.asc` nextpnr just wrote.
-#
-# `SOC_SEED=<n>` places the same netlist differently. One placement of one build
-# is a sample, not a measurement: ADR-0057 measured the spread across four
-# placements at 1-2% for this design and ADR-0058 saw 87.43 to 88.51 ns on
-# unmodified `main`, which is wider than several changes worth arguing about.
-# Compare distributions, not single runs.
+# `SOC_SEED=<n>` places the same netlist differently. One placement is a sample:
+# unmodified `main` spans 87.43-88.51 ns over four of them (ADR-0058).
 SOC_SEED ?=
 
 soc.asc: soc.json soc/littlesoc.pcf
@@ -874,29 +488,11 @@ soc.asc: soc.json soc/littlesoc.pcf
 	  exit 1; \
 	}
 
-# A REGRESSION RATCHET, SET BELOW THE MEASUREMENT -- NOT ADR-0038's 12 MHz.
-# The design measures 11.30 MHz by icetime and does not close 12 (ADR-0054).
-# Pinning this at 12 would be a gate that is red on arrival, which is a gate
-# nobody keeps; pinning it at 11.30 would be red on the next edit, and that is
-# not a guess.
-#
-# THE CHURN AXIS IS MEASURED, AND IT IS BIGGER THAN `make fit`'s. Two logically
-# identical spellings of rtl/memory.v's write/read arms -- a module that is not
-# on the critical path at all -- give 88.51 ns and 91.67 ns, 41 and 53 logic
-# levels, on 11 logic cells' difference in the netlist. **3.6%**, from an edit
-# that changes no hardware, because placement redistributes. Each figure is
-# reproducible run to run (nextpnr is seeded); it is the EDIT the number is
-# unstable under, exactly as ADR-0038 found for logic cells at ~1.2%.
-#
-# So the headroom is set at roughly four times that band, the same ratio
-# FIT_MAX_LC keeps: 10.0 MHz is 11.5% under the measurement. A change that trips
-# it has slowed the fetch->decode->next-PC loop by more than placement churn can
-# account for.
-#
-# RAISING THIS AFTER A REAL IMPROVEMENT IS ALWAYS WELCOME. Lowering it needs a
-# reason in the commit message, and closing the gap to 12 MHz is a DESIGN
-# decision (it means shortening the loop invariant 1 puts in one cycle), not
-# something to buy by editing this line.
+# A regression floor below the measurement, not ADR-0038's declared 12 MHz: the
+# design measures 11.30 MHz, and the churn axis here is ~3.6% — two logically
+# identical spellings of a module NOT on the critical path give 88.51 ns and
+# 91.67 ns, because placement redistributes. Closing the gap to 12 MHz is a
+# design decision, not something to buy by editing this line.
 SOC_MIN_MHZ := 10.0
 
 .PHONY: soc-timing
@@ -946,5 +542,4 @@ clean:
 	@# `clean` was never asked to rebuild. `make lint-setup` re-fetches
 	@# unconditionally, so `rm -rf tools/svlint` is the blunt instrument there.
 
-# The riscv-formal clone rule and its pin guard live in formal/pin.mk, included
-# above, so the root and formal/ Makefiles cannot drift apart on it.
+# The riscv-formal clone rule and its pin guard live in formal/pin.mk.

--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,11 @@ RISCV_FORMAL_MACROS := RISCV_FORMAL RISCV_FORMAL_COMPRESSED RISCV_FORMAL_ALIGNED
 rvfi_macros.vh: $(RISCV_FORMAL_DIR)/checks/rvfi_macros.py
 	python3 $^ > $@
 
-# The RTL both sim legs elaborate, named once. Do not spell this list out
-# anywhere else: ci.yml's `elaborate` job carried a fourth copy, it went stale
-# the moment rtl/imemory.v and rtl/memory.v landed, and the gate spent a run
-# elaborating a testbench whose memory instances resolved to nothing. That job
-# calls `make elaborate-strict` below, so there is one copy to update.
+# Both sim legs build from this list. Do not copy it anywhere else — a second
+# copy goes stale and the gate then checks a different design than it says it
+# does. The CI job had one; it missed rtl/imemory.v and rtl/memory.v when they
+# landed, and spent a run elaborating a testbench whose memories were not there.
+# That job calls `make elaborate-strict` now, so there is one list to update.
 SIM_RTL_SRCS := rtl/structs.v rtl/accessor.v rtl/csrs.v rtl/decoder.v rtl/executor.v \
                 rtl/fetcher.v rtl/imemory.v rtl/memory.v rtl/regfile.v rtl/writeback.v \
                 rtl/littlecpu.v
@@ -29,9 +29,10 @@ sim: test/cxxrtl.cc test/rtl.cc
 	clang++ -O2 -DNDEBUG -std=c++17 -Wall -Wextra -Werror \
 	  -isystem $$(yosys-config --datdir)/include/backends/cxxrtl/runtime $< -o $@
 
-# Sail co-simulation is deliberately opt-in: nothing from here to `cosim-suite`
-# is reachable from `make test`, `make test-units` or CI's required set, so that
-# `make test` keeps working on a machine with no Sail installed (ADR-0032).
+# Sail co-simulation is opt-in. Nothing from here down to `cosim-suite` is
+# reachable from `make test` or `make test-units`. Keep it that way: the runner
+# stops with an error when Sail is not installed, so making any of this a
+# prerequisite would break the merge gate on every machine without it.
 ifneq ($(filter command line environment,$(origin SAIL_RISCV_VERSION)),)
 $(error SAIL_RISCV_VERSION cannot be set from the command line or the \
   environment: it pins bytes this repo executes. Change it in the Makefile, \
@@ -44,9 +45,9 @@ $(error SAIL_RISCV_VERSION must be a three-part release version like 0.13.1, \
   not a branch, a moving tag or a range: '$(SAIL_RISCV_VERSION)')
 endif
 
-# Prebuilt binaries because building from source needs opam, OCaml and the Sail
-# compiler: there is no `brew install sail-riscv`, and homebrew's `sail` formula
-# is an unrelated WordPress deploy tool.
+# Prebuilt binaries. Building from source needs opam, OCaml and the Sail
+# compiler. There is no `brew install sail-riscv`; homebrew's `sail` is an
+# unrelated WordPress tool.
 SAIL_SHA256_sail-riscv-Mac-arm64     := 53d0c6fd84edd898728e7ba01c1575e66e5f17efd098847c5273690abbbd0737
 SAIL_SHA256_sail-riscv-Linux-x86_64  := ee052f64494a2f5f071afd9c2cb4aa5eaae4ba84753e4f77e442b4f83f2e9469
 SAIL_SHA256_sail-riscv-Linux-aarch64 := 3cd33a323d6749aec4667e54f71d2bf8e8e6e220a4e4bafd9083440f9a7e55f0
@@ -63,8 +64,8 @@ SAIL_SHA256    := $(SAIL_SHA256_$(SAIL_ASSET))
 SAIL_STAMP := $(SAIL_RISCV_DIR)/.sail-pin
 SAIL_PIN   := $(SAIL_RISCV_VERSION) $(SAIL_ASSET) $(SAIL_SHA256)
 
-# Scoped to the goals that actually run the binary: a stale tools/sail that
-# could fail `make test` would make co-simulation a gate by the back door.
+# Only for the goals that run the binary. If this check could stop `make test`,
+# an out-of-date tools/sail would break the merge gate for everyone.
 ifneq ($(filter cosim-run cosim-suite,$(MAKECMDGOALS)),)
 ifneq ($(wildcard $(SAIL_SIM_BIN)),)
 SAIL_PIN_ON_DISK := $(shell sed -n 1p $(SAIL_STAMP) 2>/dev/null)
@@ -159,21 +160,22 @@ cosim-run: cosim
 cosim-suite: cosim
 	./test/run_cosim.sh ./cosim test/asm test/COSIM_EXPECTED_FAIL test/OBSERVED_FLOOR
 
-# Both sim legs read this derived file, so changing a sanitizer rule changes the
-# oracle rather than fixing an elaboration problem (ADR-0019).
+# Both sim legs check every retired instruction against this file. A rule in
+# test/sanitize_monitor.py therefore decides what counts as a correct result.
+# Changing one changes what the tests mean. It is not an elaboration fix.
 test/monitor.sim.v: test/monitor.v test/sanitize_monitor.py
 	python3 test/sanitize_monitor.py $< > $@
 
 test/rtl.cc: $(SIM_RTL_SRCS) rvfi_macros.vh test/testbench.v test/monitor.sim.v
 	yosys -p 'read_verilog -sv $(addprefix -D ,$(RISCV_FORMAL_MACROS)) $^; hierarchy -top testbench; write_cxxrtl $@'
 
-# `check` is what reports an undriven wire; the test/rtl.cc recipe above
-# elaborates one with no diagnostic and exit 0.
+# `check` is what reports a wire nothing drives. The test/rtl.cc recipe above
+# builds one of those quietly and exits 0.
 ELABORATE_STRICT_OUT ?= /tmp/elaborate-strict.cc
 
-# Keep the yosys script on one physical line. A backslash-continuation inside
-# the single quotes is not removed by the shell, so yosys reads the backslash
-# as a command and dies with "No such command: \".
+# Keep the yosys script on one line. A line split with a backslash inside single
+# quotes stays literal, so yosys reads the backslash as a command and dies with
+# "No such command: \". It works with the make on macOS and fails on the runner.
 .PHONY: elaborate-strict
 elaborate-strict: $(SIM_RTL_SRCS) test/testbench.v
 	yosys -p 'read_verilog -sv $(SIM_RTL_SRCS) test/testbench.v; hierarchy -top testbench; proc; opt_clean; check; write_cxxrtl $(ELABORATE_STRICT_OUT)'
@@ -182,9 +184,11 @@ elaborate-strict: $(SIM_RTL_SRCS) test/testbench.v
 # own CWD.
 MONITOR_GEN = cd $(RISCV_FORMAL_DIR)/monitor && python3 generate.py -i rv32imc -c 1 -a -p monitor
 
-# The clone is order-only on purpose. A directory's mtime bumps on any write
-# inside it, so a normal prerequisite would have routine builds overwriting this
-# tracked file (invariant 7) at unpredictable moments.
+# The clone is an order-only prerequisite, after the `|`. A directory's
+# timestamp changes whenever anything is written inside it, so as a normal
+# prerequisite it would go out of date on unrelated work. This file is checked
+# in, so that means builds rewriting it and the diff showing up in someone
+# else's commit.
 test/monitor.v: $(RISCV_FORMAL_DIR)/monitor/generate.py formal/pin.mk | $(RISCV_FORMAL_DIR)
 	$(MONITOR_GEN) > $(CURDIR)/$@
 
@@ -223,9 +227,9 @@ $(error SVLINT_VERSION must be a three-part release version like 0.9.5, not a \
   branch, a moving tag or a range: '$(SVLINT_VERSION)')
 endif
 
-# Do not interpolate $(SVLINT_VERSION) into these names. Spelling it out is what
-# makes bumping the version without re-pinning resolve the lookup to empty, so
-# `lint-setup` refuses to fetch instead of carrying a stale digest forward.
+# Do not put $(SVLINT_VERSION) in these names. Spelling the version out is what
+# makes the lookup below come back empty when someone bumps the version and
+# forgets the digests, so `lint-setup` refuses to download anything.
 SVLINT_SHA256_svlint-v0.9.5-x86_64-lnx  := 0bbb3850b8ef604d7ccf25c2b0d2a751154ac2e18b2a12753ae1648f237a8ceb
 SVLINT_SHA256_svlint-v0.9.5-x86_64-mac  := 53838f356862b6492777347999ccf44c1b44bc78f51cb032759b9e17bd213519
 SVLINT_SHA256_svlint-v0.9.5-aarch64-mac := d032be600f0ee04130e0663daa05da3cc562d3d34bbc4305d6b70cb99310c6df
@@ -240,10 +244,10 @@ SVLINT_SHA256 := $(SVLINT_SHA256_$(SVLINT_ASSET))
 
 SVLINT ?= $(shell command -v svlint 2>/dev/null || echo ./$(SVLINT_DIR)/bin/svlint)
 
-# `-i rtl` is required, not decorative: svlint resolves `include "structs.v"`
-# through the include path only. Both passes below are load-bearing too — a
-# fifth of rtl/ sits behind `ifdef RISCV_FORMAL`, and svlint's preprocessor
-# drops those blocks unless the macros are defined.
+# `-i rtl` is required. svlint looks up `include "structs.v"` on the include path
+# and nowhere else, so without it nothing parses. The two passes below both
+# matter as well: about a fifth of rtl/ is inside `ifdef RISCV_FORMAL`, and
+# svlint skips those lines unless the macros are defined.
 SVLINT_FLAGS := -c .svlint.toml -i rtl $(if $(GITHUB_ACTIONS),--github-actions,-1)
 
 .PHONY: lint
@@ -313,13 +317,13 @@ UNIT_BENCH_SRC_csr_tb      := rtl/structs.v rtl/csrs.v
 UNIT_BENCH_SRC_accessor_tb := rtl/structs.v rtl/accessor.v
 UNIT_BENCH_SRC_monitor_tb  := test/monitor.sim.v
 
-# `present` is derived inside the recipe, not from a $(wildcard) at parse time:
-# make caches directory contents, and a check whose idea of what is on disk can
-# be stale is a check that can be wrong in the direction that matters.
+# `present` is read from disk inside the recipe, not with $(wildcard). Make reads
+# a directory once and remembers it, and a check working from a stale listing can
+# miss a bench that is really there.
 #
 # `set -e` comes first here and in `test-units`, before mktemp and before the
-# trap. The other order installed the trap on an unchecked $$tmp: a failed
-# mktemp left it empty and every path collapsed to the filesystem root.
+# trap. The other way round, a failed mktemp left $$tmp empty, the trap was set
+# on nothing, and every path below turned into a path at the root of the disk.
 .PHONY: check-unit-benches
 check-unit-benches:
 	@set -e; \
@@ -363,9 +367,10 @@ test-units: check-unit-benches test/monitor.sim.v
 	  vvp $$tmp/$(b).vvp; ) \
 	true
 
-# A prerequisite of `test` rather than a target of its own, so it runs inside
-# CI's required job with no workflow change. It needs no toolchain, no Sail, no
-# yosys and no sby, so it cannot narrow where `make test` runs (ADR-0053).
+# Hangs off `test` rather than standing alone, so it runs in the job CI already
+# requires and nobody has to add a step for it. It needs no cross compiler, no
+# Sail, no yosys and no sby, so it does not stop `make test` running anywhere it
+# ran before.
 .PHONY: probe-gates
 probe-gates:
 	@./test/probe_gates.sh
@@ -374,15 +379,16 @@ probe-gates:
 test: sim test-units probe-gates
 	@./test/run_tests.sh ./sim test/asm test/EXPECTED_FAIL test/OBSERVED_FLOOR
 
-# Area is counted in nextpnr logic cells, never yosys cell counts: a DFF whose D
-# input is not its co-located LUT's output takes a whole cell on its own, and
-# over a thousand of this design's cells are exactly that. Two planning
-# estimates were wrong in opposite directions from counting `SB_LUT4`.
+# Count logic cells from nextpnr, never cell counts from yosys. A flip-flop that
+# cannot share a cell with the LUT feeding it takes a whole cell by itself, and
+# over a thousand of this design's cells are like that. Counting `SB_LUT4`
+# instead gave two planning estimates that were wrong in opposite directions.
 #
-# Do not try to make the placement succeed. This top presents 231 `SB_IO`
-# against sg48's 39, so nextpnr always errors on a pad — after printing the
-# utilisation table, which is the measurement. Placing it needs a real pinout,
-# which means the SoC memory system (ADR-0038).
+# Placement always fails here, and that is fine. This top has its memories
+# outside the chip, so it needs far more pins than the sg48 package has and
+# nextpnr gives up on one. It prints the utilisation table before it gets that
+# far, and that table is the number we want. Making it place would mean picking
+# real pins, which means building the SoC memory first.
 FIT_SRCS := rtl/structs.v rtl/accessor.v rtl/csrs.v rtl/decoder.v rtl/executor.v \
             rtl/fetcher.v rtl/regfile.v rtl/writeback.v rtl/littlecpu.v
 
@@ -391,10 +397,10 @@ fit.json: $(FIT_SRCS)
 	@yosys -p 'read_verilog -sv $^; synth_ice40 -dsp -top littlecpu -json $@' \
 	  > fit.synth.log 2>&1 || { tail -40 fit.synth.log; exit 1; }
 
-# Deliberately not the measurement (3899 cells locally): edits that synthesise
-# to identical hardware move it by tens of cells, and the pinned CI toolchain
-# reads ~21 higher than a local one, so 4100 keeps headroom over both. Raising
-# this to clear a red is how a ratchet becomes a rubber stamp.
+# Set above the measurement, which is 3899 cells here. The number moves by tens
+# of cells on edits that build the same hardware, and CI's yosys reads about 21
+# higher than a local one, so the budget has to leave room for both. If this goes
+# red, find out what grew. Raising it to make it pass defeats the point.
 FIT_MAX_LC := 4100
 
 .PHONY: fit
@@ -403,11 +409,10 @@ fit: fit.json
 	  > fit.log 2>&1 || true
 	@python3 soc/fit_report.py fit.log --max-lc $(FIT_MAX_LC)
 
-# A different design from `make fit`'s, whose numbers must not be merged with
-# these: this is the core plus a block-RAM ROM, an SPRAM data RAM and four pins,
-# so its logic-cell count includes the ROM's depth mux, the RAM's range decode
-# and the LED taps. Unlike `fit` it must place, because `icetime` reads an
-# `.asc` (ADR-0054).
+# This builds `littlesoc`, not the `littlecpu` that `make fit` measures. It
+# includes the ROM and the data RAM, so its cell count is bigger and the two
+# numbers are not comparable. This one also has to place, because icetime reads
+# the `.asc` file that only a finished placement writes.
 SOC_PROG      ?= add.S
 SOC_ROM_WORDS := 2048
 # Exact rather than budgeted the way FIT_MAX_LC is, because both are properties
@@ -466,8 +471,8 @@ soc.json: $(SOC_SRCS) soc-rom
 # at all because the design is 6% slow. `.DELETE_ON_ERROR` is why the `||` is
 # needed rather than merely tidy — without it make deletes that `.asc`.
 #
-# `SOC_SEED=<n>` places the same netlist differently. One placement is a sample:
-# unmodified `main` spans 87.43-88.51 ns over four of them (ADR-0058).
+# `SOC_SEED=<n>` places the same design differently. One placement is a sample,
+# not a measurement — compare a few seeds before believing a change helped.
 SOC_SEED ?=
 
 soc.asc: soc.json soc/littlesoc.pcf
@@ -488,11 +493,11 @@ soc.asc: soc.json soc/littlesoc.pcf
 	  exit 1; \
 	}
 
-# A regression floor below the measurement, not ADR-0038's declared 12 MHz: the
-# design measures 11.30 MHz, and the churn axis here is ~3.6% — two logically
-# identical spellings of a module NOT on the critical path give 88.51 ns and
-# 91.67 ns, because placement redistributes. Closing the gap to 12 MHz is a
-# design decision, not something to buy by editing this line.
+# A floor to catch regressions, deliberately set below what the design measures.
+# It is not the 12 MHz target. The measured number moves by a few percent on
+# edits that change no hardware, because the placer lays everything out again,
+# so a floor at the current measurement would go red for no reason. Getting to
+# 12 MHz means shortening the fetch-to-next-PC path. Do not buy it here.
 SOC_MIN_MHZ := 10.0
 
 .PHONY: soc-timing

--- a/formal/check-baseline.sh
+++ b/formal/check-baseline.sh
@@ -1,20 +1,22 @@
 #!/bin/bash
-# The riscv-formal ladder's gate: the generated check set must equal
-# formal/EXPECTED_CHECKS, and the not-PASS set must equal formal/EXPECTED_FAIL,
-# both by set equality in both directions.
+# Checks the ladder two ways: the checks that were generated must match
+# formal/EXPECTED_CHECKS, and the ones that did not pass must match
+# formal/EXPECTED_FAIL. Both comparisons run in both directions, so a check that
+# starts passing fails this too, until someone moves its line.
 #
-# The check set is asserted because checks.cfg's [depth] table is the list of
-# checks that EXIST — genchecks silently skips a check with no depth line — so
-# a lost line drops a check from the results and from EXPECTED_FAIL at once, and
-# the verdict comparison alone calls that a clean match.
+# The first comparison is there because the [depth] table in checks.cfg is what
+# decides which checks exist. Delete a line and that check is never generated, so
+# it vanishes from the results and from EXPECTED_FAIL at the same time, and
+# comparing failures alone sees nothing wrong.
 #
-# The status is compared, not just the name, because ERROR is a broken harness
-# where FAIL is a failed property. On a machine without `btorsim` every red
-# check flips FAIL -> ERROR and a name-only equality still matches (ADR-0036).
+# The status is compared as well as the name. FAIL means the check ran and the
+# property did not hold. ERROR means sby did not get that far. Those need
+# different fixes, so the gate should not treat them as the same red.
 #
-# Nothing here is a verdict about the core: every check is `mode bmc` under
-# RISCV_FORMAL_ALTOPS, so a passing insn_mul says nothing about the real
-# multiplier (ADR-0010).
+# None of this says the core is correct. Every check searches to a fixed depth,
+# so passing means no counterexample was found that shallow. The ladder also
+# defines RISCV_FORMAL_ALTOPS, which replaces multiply and divide with simpler
+# stand-ins, so insn_mul passing says nothing about the real multiplier.
 #
 # Usage: check-baseline.sh <checks-dir> <expected-fail-file> [expected-checks-file]
 set -u
@@ -44,9 +46,8 @@ for f in "$EXPECTED_FAIL" "$EXPECTED_CHECKS"; do
   fi
 done
 
-# `NF` must gate the rebuild rather than follow it: awk forces NF to 1 when $1
-# is assigned, so `{$1=$1} NF` would resurrect every blank and comment-only line
-# as an entry. Same idiom, same reason, as test/run_tests.sh.
+# `NF` has to come before the rebuild, not after. Assigning to $1 sets NF to 1,
+# so `{$1=$1} NF` would bring every blank and comment line back as an entry.
 strip() {
   sed -e 's/#.*//' "$1" | awk 'NF { $1 = $1; print }' | sort
 }
@@ -65,9 +66,10 @@ known_status() {
 }
 
 # The strictly smaller set EXPECTED_FAIL may carry. ERROR and NO-STATUS mean the
-# harness broke rather than the property failing, so baselining one would
-# re-create the btorsim hole with this gate's blessing on it. TIMEOUT and
-# UNKNOWN are budget exhaustion, which is a real verdict, so they are accepted.
+# harness broke rather than a property failing, and a baseline line saying "this
+# check is expected to not run" would make a missing solver look like a known
+# result forever. TIMEOUT and UNKNOWN are a real verdict about a check that did
+# not converge in its budget, so those are accepted.
 baselineable_status() {
   case $1 in
     FAIL | TIMEOUT | UNKNOWN) return 0 ;;

--- a/formal/check-baseline.sh
+++ b/formal/check-baseline.sh
@@ -1,58 +1,20 @@
 #!/bin/bash
-# The riscv-formal ladder's gate. Asserts TWO things, and both are set
-# equalities in both directions (ADR-0014's contract, applied to the formal
-# ladder per ADR-0022 -- an unexpected *pass*, or an unexpected *check*,
-# fails this as loudly as a regression):
+# The riscv-formal ladder's gate: the generated check set must equal
+# formal/EXPECTED_CHECKS, and the not-PASS set must equal formal/EXPECTED_FAIL,
+# both by set equality in both directions.
 #
-#   1. SHAPE.  The checks genchecks generated (formal/checks/*.sby) are
-#      exactly the ones formal/EXPECTED_CHECKS names.
-#   2. VERDICT. The checks whose status is not PASS are exactly the ones
-#      formal/EXPECTED_FAIL names, WITH THE STATUS EACH ONE CARRIES.
+# The check set is asserted because checks.cfg's [depth] table is the list of
+# checks that EXIST — genchecks silently skips a check with no depth line — so
+# a lost line drops a check from the results and from EXPECTED_FAIL at once, and
+# the verdict comparison alone calls that a clean match.
 #
-# (2) matched on the name alone until ADR-0036 was executed, and that made
-# ERROR, TIMEOUT, UNKNOWN and NO-STATUS indistinguishable from FAIL to this
-# gate. ADR-0036 measured the consequence rather than argued it: a ladder run
-# on a machine WITHOUT `btorsim` reported "82 checks: 72 pass, 10 fail /
-# Failure list matches EXPECTED_FAIL exactly" and exited 0, while all ten of
-# those checks had status `ERROR 16 2`. `btormc` had found the
-# counterexamples; `sby` then failed to render the traces, because the step
-# that does so shells out to `btorsim`. "A real counterexample at the
-# configured depth" and "the trace renderer is missing" were the same result.
-# The failure mode that matters is the inverse: if `btorsim` vanished from CI's
-# pinned OSS CAD Suite, every red check would flip FAIL -> ERROR,
-# the set equality would still match, and the ladder would stay green having
-# stopped distinguishing a proof failure from a tooling failure. Same shape as
-# ADR-0033's gaps -- a check that can stop checking without anything going red
-# -- one level down, in the status field rather than the check list. This is
-# the identical amendment ADR-0035 made to test/EXPECTED_FAIL, applied to the
-# formal side, and the reasoning is written out in formal/EXPECTED_FAIL's own
-# header.
+# The status is compared, not just the name, because ERROR is a broken harness
+# where FAIL is a failed property. On a machine without `btorsim` every red
+# check flips FAIL -> ERROR and a name-only equality still matches (ADR-0036).
 #
-# (1) is not decoration. Without it this script could not tell a ladder that
-# shrank from one that passed. formal/checks.cfg's [depth] table is the list
-# of checks that EXIST -- genchecks skips any check with no depth line,
-# silently -- so deleting one line removes a check from the results AND from
-# EXPECTED_FAIL at the same time, and (2) alone reports a clean match on
-# less coverage than it claims. That is ADR-0033's gap 1, and (1) closes it.
-#
-# This script deliberately enumerates the generated `*.sby` FILES, not the
-# run directories. `sby` creates a directory only for a check it actually
-# STARTS, so globbing directories made a generated-but-never-scheduled check
-# invisible: it fell out of the actual set, it was never in the baseline,
-# and set equality called that a match. Reading the .sby files instead means
-# such a check resolves to NO-STATUS and counts as non-PASS, which is what
-# this script's header has promised since it was written -- "make stopped
-# scheduling it, or it's still running" is a failure, not a quiet pass.
-#
-# A check named in EXPECTED_CHECKS with no .sby on disk is likewise
-# NO-STATUS, so a lost [depth] line trips BOTH assertions rather than
-# neither.
-#
-# Nothing here is a verdict about the core. Every check on this ladder is
-# `mode bmc`: PASS means no counterexample was found within that check's
-# configured depth, not that the property holds. And the whole ladder runs
-# under RISCV_FORMAL_ALTOPS, so a passing insn_mul/insn_div says nothing
-# whatever about the real multiplier or divider (ADR-0010).
+# Nothing here is a verdict about the core: every check is `mode bmc` under
+# RISCV_FORMAL_ALTOPS, so a passing insn_mul says nothing about the real
+# multiplier (ADR-0010).
 #
 # Usage: check-baseline.sh <checks-dir> <expected-fail-file> [expected-checks-file]
 set -u
@@ -67,13 +29,8 @@ EXPECTED_FAIL=$2
 EXPECTED_CHECKS=${3:-$(dirname "$0")/EXPECTED_CHECKS}
 
 # READABLE, not merely present. This script sets `set -u` and neither `-e` nor
-# `pipefail`, so a `sed` that cannot open its input writes to stderr and yields
-# an EMPTY string, and an empty expected set against an all-passing ladder
-# prints "Failure list matches ... exactly" and exits 0 -- having compared
-# nothing, and having silently dropped whatever the baseline named. Measured
-# with `chmod 000 formal/EXPECTED_FAIL`; see the probe in test/probe_gates.sh.
-# ADR-0035 item 4 made exactly this fix on test/run_tests.sh's baseline and it
-# was never carried across to the formal side.
+# `pipefail`, so a `sed` that cannot open its input yields an EMPTY string — and
+# an empty expected set matches an all-passing ladder exactly.
 for f in "$EXPECTED_FAIL" "$EXPECTED_CHECKS"; do
   if [ ! -f "$f" ]; then
     echo "error: no such file: $f" >&2
@@ -87,12 +44,9 @@ for f in "$EXPECTED_FAIL" "$EXPECTED_CHECKS"; do
   fi
 done
 
-# `#` comments and blank lines out, as both baseline files already allow.
-# Interior whitespace is squeezed too, so EXPECTED_FAIL's two fields can be
-# column-aligned for a human without changing what is compared. `NF` must gate
-# the rebuild rather than follow it: awk forces NF to 1 when $1 is assigned, so
-# `{$1=$1} NF` would resurrect every blank and comment-only line as an empty
-# entry. (Same idiom, same reason, as test/run_tests.sh.)
+# `NF` must gate the rebuild rather than follow it: awk forces NF to 1 when $1
+# is assigned, so `{$1=$1} NF` would resurrect every blank and comment-only line
+# as an entry. Same idiom, same reason, as test/run_tests.sh.
 strip() {
   sed -e 's/#.*//' "$1" | awk 'NF { $1 = $1; print }' | sort
 }
@@ -100,17 +54,9 @@ strip() {
 expected_checks=$(strip "$EXPECTED_CHECKS")
 expected_fail=$(strip "$EXPECTED_FAIL")
 
-# THE STATUS VOCABULARY, ENUMERATED IN BOTH DIRECTIONS.
-#
-# `sby` writes its verdict as the first word of <workdir>/status, and the rest
-# of that line is engine bookkeeping (`PASS 0 31`, `ERROR 16 2`) that no
-# baseline should ever pin. Only the first word is compared.
-#
-# known_status: everything sby can write, plus this script's own NO-STATUS for
-# "there is no status file". A status outside this set means sby's output
-# changed under us -- a pin bump, a different engine -- and is reported rather
-# than bucketed into "not PASS", because bucketing is the whole defect this
-# gate just stopped having.
+# Everything sby can write, plus this script's own NO-STATUS. A status outside
+# the set means sby's output changed under us, and is reported rather than
+# bucketed into "not PASS".
 known_status() {
   case $1 in
     PASS | FAIL | ERROR | UNKNOWN | TIMEOUT | NO-STATUS) return 0 ;;
@@ -118,26 +64,10 @@ known_status() {
   esac
 }
 
-# baselineable_status: the strictly smaller set a line in EXPECTED_FAIL may
-# carry. Three are rejected, each for its own reason:
-#
-#   PASS       is unreachable here by construction -- a PASS check never
-#              enters the failure set -- so a line carrying it could never
-#              match anything, which is a comparison whose failure branch is
-#              the only branch.
-#   ERROR      is sby failing to run or to render, not the core failing a
-#              property. ADR-0036: "with ERROR never a legitimate baselined
-#              value". Baselining one would re-create the btorsim hole with
-#              this gate's blessing on it.
-#   NO-STATUS  is "the check was generated and never scheduled, or is still
-#              running". Same argument: a broken harness, not a known-red
-#              property.
-#
-# TIMEOUT and UNKNOWN ARE accepted. They are budget exhaustion rather than
-# tooling breakage -- a real, recorded verdict about a check that did not
-# converge (ADR-0023's `reg` was exactly this before ADR-0024 changed the
-# engine) -- and a change that turned one into the other is a change this gate
-# should report, which is only possible if both are spellable.
+# The strictly smaller set EXPECTED_FAIL may carry. ERROR and NO-STATUS mean the
+# harness broke rather than the property failing, so baselining one would
+# re-create the btorsim hole with this gate's blessing on it. TIMEOUT and
+# UNKNOWN are budget exhaustion, which is a real verdict, so they are accepted.
 baselineable_status() {
   case $1 in
     FAIL | TIMEOUT | UNKNOWN) return 0 ;;
@@ -145,16 +75,8 @@ baselineable_status() {
   esac
 }
 
-# Validate the baseline's FORMAT before anything expensive, and before any
-# comparison -- a rejected line must read as "this file is wrong", never as a
-# regression in the ladder. Exit 2 is this script's existing code for "the
-# inputs are broken", as distinct from exit 1, "the ladder disagrees with
-# them".
-#
-# A one-field line is the pre-ADR-0036 format. Accepting it silently would
-# make every legacy entry unmatchable in a way that reads exactly like a
-# regression, so it is named instead. An empty file has no lines and is
-# therefore fine -- which is the state the ladder is in today.
+# Exit 2 is "the inputs are broken" against exit 1's "the ladder disagrees with
+# them", so a rejected line cannot read as a regression in the ladder.
 baseline_errors=""
 while IFS= read -r line; do
   [ -n "$line" ] || continue
@@ -197,11 +119,10 @@ if [ -n "$baseline_errors" ]; then
   exit 2
 fi
 
-# The generated set: one line per checks/<name>.sby. `find` rather than a
-# glob, so a missing or empty directory yields nothing instead of the
-# literal unexpanded pattern -- which would otherwise become a one-element
-# set named `*.sby` and produce a confusing diff instead of the explicit
-# error below.
+# The `.sby` FILES, not the run directories: sby creates a directory only for a
+# check it actually starts, so globbing directories made a generated-but-never-
+# scheduled check fall out of the results and out of the baseline at once. `find`
+# rather than a glob so an empty directory yields nothing, not `*.sby`.
 generated=$(find "$CHECKS_DIR" -maxdepth 1 -name '*.sby' \
   -exec basename {} .sby \; 2>/dev/null | sort)
 
@@ -225,9 +146,8 @@ if [ "$generated" != "$expected_checks" ]; then
   failed=1
 fi
 
-# Status is read over the UNION of what was generated and what was expected,
-# so a name missing from either side still gets a verdict rather than
-# dropping out of the tally entirely.
+# The UNION, so a name missing from either side still gets a verdict rather than
+# dropping out of the tally.
 all_checks=$(printf '%s\n%s\n' "$generated" "$expected_checks" | sort -u)
 
 total=0
@@ -235,10 +155,8 @@ declare -a actual_fail=()
 declare -a unknown_statuses=()
 for name in $all_checks; do
   total=$((total + 1))
-  # First word of the first NON-BLANK line. sby's status line is
-  # `<VERDICT> <engine> <depth>`; only the verdict is compared, because the
-  # numbers after it are bookkeeping that moves with the engine and would
-  # make the baseline pin something it is not asserting.
+  # First word only: sby writes `<VERDICT> <engine> <depth>`, and the numbers
+  # move with the engine.
   status=$(awk 'NF { print $1; exit }' "$CHECKS_DIR/$name/status" 2>/dev/null)
   if [ -z "$status" ]; then
     status="NO-STATUS"
@@ -254,11 +172,6 @@ done
 passed=$((total - ${#actual_fail[@]}))
 echo "$total checks: $passed pass, ${#actual_fail[@]} fail"
 
-# A status sby has never written here before is reported on its own, not left
-# to be read out of a diff. It means the tool's output changed, which is a
-# different problem from the ladder disagreeing with its baseline, and the two
-# want different fixes. It still counts as non-PASS above, so it cannot pass
-# quietly either way.
 if [ ${#unknown_statuses[@]} -gt 0 ]; then
   echo
   echo "Unrecognised status(es) on disk -- not one of PASS FAIL ERROR UNKNOWN"

--- a/formal/genchecks-audit.py
+++ b/formal/genchecks-audit.py
@@ -1,25 +1,25 @@
 #!/usr/bin/env python3
 #
-# Generates the riscv-formal ladder and asserts its shape. Run from formal/,
-# exactly like `python3 genchecks-local.py`, which it replaces.
+# Generates the riscv-formal ladder and checks which checks came out of it. Run
+# from formal/, the same way `python3 genchecks-local.py` was.
 #
-# `checks.cfg`'s `[depth]` section reads as a tuning table but is the list of
-# checks that EXIST: both of genchecks' call sites end with
+# The `[depth]` section of checks.cfg looks like a tuning table. It is really the
+# list of checks that exist. Both call sites in genchecks end with
 #
 #     if depth_cfg is None: return
 #
-# so a check with no `[depth]` line is not generated at all -- no `.sby`, no
-# warning, exit 0 -- and is then absent from the results and from EXPECTED_FAIL
-# at once, which that file's set equality calls a clean match (ADR-0033).
+# so a check with no depth line is never generated: no `.sby`, no warning, exit
+# 0. It then disappears from the results and from EXPECTED_FAIL together, and
+# comparing failures alone sees nothing wrong.
 #
-# The trace is not a second copy of genchecks' naming logic: `genchecks-local.py`
-# must stay byte-comparable with the pin (ADR-0031), so it cannot be
-# instrumented. `sys.settrace` records each `get_depth_cfg` call's `patterns`
-# and whether it returned None, and the last pattern is the check name.
+# The trace below is not a second copy of the naming logic. genchecks-local.py
+# has to stay a byte-for-byte copy of the upstream file except for two lines, so
+# it cannot be edited to report anything. Instead `sys.settrace` watches each
+# `get_depth_cfg` call and records its `patterns` argument and whether it
+# returned None. The last pattern is the check name.
 #
-# That assumption is checked, not trusted: the traced names must equal genchecks'
-# own bookkeeping AND the .sby files on disk, so a pin that changes how a name is
-# built fails here instead of reporting a wrong inventory.
+# main() then checks that guess rather than trusting it, against genchecks' own
+# lists and against the `.sby` files on disk.
 
 import os
 import re
@@ -38,8 +38,8 @@ OMIT_RE = re.compile(r"^#omit\s+(\S+)\s+(\S.*)$")
 
 
 def read_name_list(path):
-    """One name per line; `#` comments and blank lines ignored, as
-    formal/EXPECTED_FAIL and test/EXPECTED_FAIL already do."""
+    """One name per line. `#` comments and blank lines are ignored, the same way
+    formal/EXPECTED_FAIL and test/EXPECTED_FAIL allow them."""
     names = []
     with open(path) as f:
         for line in f:
@@ -60,7 +60,7 @@ def read_omit_decls(path):
 
 
 def report_set_diff(label, expected, actual, expected_label, actual_label):
-    """Both directions, ADR-0014's contract. Returns True on mismatch."""
+    """Compare both ways round. Returns True on mismatch."""
     missing = sorted(expected - actual)
     extra = sorted(actual - expected)
     if not missing and not extra:

--- a/formal/genchecks-audit.py
+++ b/formal/genchecks-audit.py
@@ -1,52 +1,25 @@
 #!/usr/bin/env python3
 #
-# Generates the riscv-formal ladder and asserts its SHAPE -- which checks
-# exist -- before anything runs them.
+# Generates the riscv-formal ladder and asserts its shape. Run from formal/,
+# exactly like `python3 genchecks-local.py`, which it replaces.
 #
-# Why this exists (ADR-0033, gap 1). `formal/checks.cfg`'s `[depth]` section
-# reads as a tuning table. It is not: it is the list of checks that exist.
-# Both of genchecks' call sites end with
+# `checks.cfg`'s `[depth]` section reads as a tuning table but is the list of
+# checks that EXIST: both of genchecks' call sites end with
 #
 #     if depth_cfg is None: return
 #
-# so a check with no matching `[depth]` line is not generated at all -- no
-# `.sby`, no directory, no status file, no warning, exit 0. Deleting or
-# mistyping one line therefore removes a check from the ladder silently, and
-# nothing downstream notices: a never-generated check is absent from the
-# results AND absent from `formal/EXPECTED_FAIL` at once, so that file's
-# set-equality reports a clean match with less coverage than it claims.
+# so a check with no `[depth]` line is not generated at all -- no `.sby`, no
+# warning, exit 0 -- and is then absent from the results and from EXPECTED_FAIL
+# at once, which that file's set equality calls a clean match (ADR-0033).
 #
-# This script closes that by deriving, from the generator's own behaviour,
-# the two sets a reader cares about:
+# The trace is not a second copy of genchecks' naming logic: `genchecks-local.py`
+# must stay byte-comparable with the pin (ADR-0031), so it cannot be
+# instrumented. `sys.settrace` records each `get_depth_cfg` call's `patterns`
+# and whether it returned None, and the last pattern is the check name.
 #
-#   generated  every check genchecks emitted a .sby for
-#   dropped    every check genchecks CONSIDERED and skipped for want of a
-#              [depth] line
-#
-# and asserting both against files the repo commits to -- `EXPECTED_CHECKS`
-# and `checks.cfg`'s `#omit` declarations -- with set equality in BOTH
-# directions, per ADR-0014's contract: an unexpected *addition* trips this as
-# loudly as a disappearance. That matters after a pin bump (ADR-0013), which
-# is exactly when upstream may grow a check nobody here has ruled on.
-#
-# HOW the derivation works, and why it is not a second copy of genchecks'
-# logic. `genchecks-local.py` must stay byte-comparable with the pin except
-# for `basedir` (ADR-0031), so it cannot be instrumented. Instead this script
-# runs it under `sys.settrace` and records every `get_depth_cfg` call: its
-# `patterns` argument and whether it returned None. The LAST pattern in that
-# argument is, at every call site, the fully-qualified check name --
-# `insn_add_ch0`, `csrw_mcycle_ch0`, `causal_ch0`, `hang` -- which is what
-# makes a name recoverable without re-deriving it here.
-#
-# That assumption is not trusted, it is CHECKED: the names this script
-# recovers as generated must equal genchecks' own `consistency_checks |
-# instruction_checks` sets, and those must equal the `.sby` files actually on
-# disk. If a future pin changes how a check name is built, or adds a
-# `filter-checks` drop this script cannot see, the three disagree and this
-# fails rather than quietly reporting a wrong inventory.
-#
-# Run from formal/, exactly like `python3 genchecks-local.py`, which it
-# replaces as the `checks` target's recipe.
+# That assumption is checked, not trusted: the traced names must equal genchecks'
+# own bookkeeping AND the .sby files on disk, so a pin that changes how a name is
+# built fails here instead of reporting a wrong inventory.
 
 import os
 import re
@@ -59,9 +32,8 @@ CFG = os.path.join(HERE, "checks.cfg")
 EXPECTED_CHECKS = os.path.join(HERE, "EXPECTED_CHECKS")
 CHECKS_DIR = os.path.join(HERE, "checks")
 
-# `#omit <check-name> <one-line reason>` in checks.cfg. genchecks' own cfg
-# parser drops every line starting with `#` before it sees a section, so
-# these are invisible to it and cannot perturb generation.
+# genchecks' own parser drops every `#` line before it sees a section, so these
+# cannot perturb generation.
 OMIT_RE = re.compile(r"^#omit\s+(\S+)\s+(\S.*)$")
 
 
@@ -101,8 +73,6 @@ def report_set_diff(label, expected, actual, expected_label, actual_label):
     return True
 
 
-# ---------------------------------------------------------------- the trace
-
 records = []
 
 
@@ -119,10 +89,9 @@ def call_tracer(frame, event, arg):
 
 
 def main():
-    # genchecks reads `checks.cfg` and writes `checks/` relative to the
-    # working directory, and takes `corename` from its last path component.
-    # Running it from anywhere else silently produces a ladder somewhere
-    # else, so refuse rather than do that.
+    # genchecks reads `checks.cfg` and writes `checks/` relative to the cwd and
+    # takes `corename` from its last component, so running it elsewhere silently
+    # produces a ladder elsewhere.
     if os.path.realpath(os.getcwd()) != os.path.realpath(HERE):
         print(f"error: run from {HERE}, not {os.getcwd()}", file=sys.stderr)
         return 1
@@ -161,9 +130,8 @@ def main():
 
     failed = False
 
-    # 1. The derivation validates itself against genchecks' own bookkeeping.
-    #    If these disagree, every count below is wrong and none of the
-    #    set-equalities beneath mean anything.
+    # If the trace disagrees with genchecks' own bookkeeping, none of the set
+    # equalities below mean anything.
     genchecks_own = set(genchecks["consistency_checks"]) | set(
         genchecks["instruction_checks"]
     )
@@ -175,7 +143,6 @@ def main():
         "trace",
     )
 
-    # 2. ...and against what is actually on disk, which is what sby runs.
     on_disk = {
         e[: -len(".sby")] for e in os.listdir(CHECKS_DIR) if e.endswith(".sby")
     }
@@ -187,7 +154,6 @@ def main():
         "disk",
     )
 
-    # 3. The ladder is the size the repo says it is (ADR-0033's assertion).
     expected = set(read_name_list(EXPECTED_CHECKS))
     failed |= report_set_diff(
         "generated ladder vs formal/EXPECTED_CHECKS",
@@ -197,9 +163,8 @@ def main():
         "generated",
     )
 
-    # 4. Every check upstream offered and this ladder declined is declined on
-    #    purpose, in writing, next to [depth]. This is what makes the
-    #    omission count derived rather than prose.
+    # Every check upstream offered and this ladder declined is declined in
+    # writing, next to [depth].
     omitted = read_omit_decls(CFG)
     failed |= report_set_diff(
         "dropped checks vs checks.cfg #omit declarations",

--- a/test/probe_gates.sh
+++ b/test/probe_gates.sh
@@ -1,78 +1,32 @@
 #!/bin/bash
 # Forces every graded comparison in this repo's grading scripts to FAIL, and
-# asserts that each one goes red for the reason it was written for.
+# asserts that each one goes red for the reason it was written for. The defect
+# class is the comparison whose failure path was never executed, and this repo
+# has shipped five of them.
 #
 # Usage: probe_gates.sh          # run every probe; exit 0 only if all pass
 #
-# WHY THIS EXISTS. Five of this repo's recorded defects live in the layer that
-# decides what "green" means, and every one of them was in a script:
+# A probe pins the exit STATUS and a fragment of the DIAGNOSTIC. Status alone is
+# nearly worthless: a script that exited 1 on a mistyped fixture path would
+# satisfy every exit-status probe here while demonstrating nothing. Every group
+# also carries a control, because a grader degenerated into `exit 1` would
+# otherwise pass the lot.
 #
-#   * the graded comparison piped into `tee`, so a `run:` block's errexit
-#     (which is not pipefail) took `tee`'s status and the gate could not go red
-#     -- ADR-0022's central guarantee had never held (ADR-0037 §4);
-#   * `make -C formal check` re-grading the PREVIOUS run, because its `checks`
-#     target named a directory whose mtime sby bumps (ADR-0040);
-#   * `formal/check-baseline.sh` globbing run directories, so a check that was
-#     never scheduled fell out of the results and out of the baseline at once
-#     and set equality called that a match (ADR-0033 gap 1);
-#   * `test/sanitize_monitor.py`'s rule 3, whose site count proved a rule fired
-#     but not what it swallowed -- mutation showed the pre-change script
-#     accepting every attack at exit 0;
-#   * `check-baseline.sh` computing a verdict and discarding it.
+# Hermetic: no RISC-V toolchain, no `sim`, no Sail, no yosys, no sby, so this can
+# run inside `make test` on any machine. It is all fork and no work, so the wall
+# time is the host's property rather than this file's.
 #
-# The class is THE COMPARISON WHOSE FAILURE PATH WAS NEVER EXECUTED. Each of
-# those five was green, in CI, for months, while checking less than it claimed
-# -- and in every case the reasoning at the site was sound. Reading the script
-# is what missed them. So this file does not read: it breaks the thing each
-# comparison guards and requires the red.
-#
-# WHAT A PROBE ASSERTS, and why the second half is not optional. A probe pins
-# the exit STATUS and a distinguishing fragment of the DIAGNOSTIC. Status alone
-# is nearly worthless here: a script that exited 1 because a fixture path was
-# mistyped would satisfy every exit-status probe in this file while
-# demonstrating nothing. The text is what ties the red to the comparison it is
-# supposed to be about.
-#
-# EVERY GROUP CARRIES A CONTROL -- the same fixtures, unmutated, required to
-# exit 0. Without one, a grader that had degenerated into `exit 1` would pass
-# every probe here. That is this file's own anti-vacuity check and it is the
-# same argument formal/complete_cover.sby makes for `complete`.
-#
-# HERMETIC ON PURPOSE. No RISC-V toolchain, no `sim`, no Sail, no yosys, no
-# sby: the failing objcopy, the crashing runner, the diverging reference model
-# and the compiler that is not installed are all stubs on a scratch PATH. That
-# is what lets this run inside `make test` on any machine, rather than being a
-# document nobody executes -- which is the failure mode CLAUDE.md records for
-# `make waves` and `make -C formal all`.
-#
-# IT IS ALL FORK, NO WORK, so its wall time is a property of the host and not
-# of this file. Measured on the machine it was written on: ~1500 exec()s for
-# about 4s of user time and 68-90s of wall, because that laptop takes ~27ms to
-# exec /bin/echo and ~62ms to exec a freshly written script. Do not "optimise"
-# it by deleting probes -- measure `time (for i in $(seq 1 100); do /bin/echo x
-# >/dev/null; done)` first and see whether the host is the reason. The
-# per-group seconds printed below are there so that stays visible.
-#
-# WHAT IS NOT HERE, and it is a short list. Four failure paths need something
-# this file deliberately does not have, and each was demonstrated by hand
-# instead, with the command recorded at its own site:
-#
-#   * test/cxxrtl.cc's exit 4 (a live RVFI monitor mismatch) and exit 5
-#     (trap-to-zero), which need the elaborated design;
-#   * formal/genchecks-audit.py's three set equalities, which need the pinned
-#     riscv-formal clone and a real generation run (only its working-directory
-#     guard is probed below);
-#   * test/cosim.cc's regs_a/regs_b divergence check, which needs the design.
-#
+# Four failure paths need the elaborated design or the pinned clone and are
+# demonstrated by hand instead: test/cxxrtl.cc's exits 4 and 5, test/cosim.cc's
+# divergence check, and genchecks-audit.py's three set equalities.
 set -euo pipefail
 
 HERE=$(cd "$(dirname "$0")" && pwd)
 REPO=$(cd "$HERE/.." && pwd)
 
-# The number of probes this file must run. Pinned as a literal for the same
-# reason test/exec_tb.v pins its vector count: a probe that is deleted, or that
-# stops being reached by an early `return`, would otherwise reduce the coverage
-# of this file while it kept printing a green summary.
+# Pinned as a literal: a probe that is deleted, or that stops being reached by
+# an early `return`, would otherwise cut this file's coverage while it kept
+# printing a green summary.
 PROBES_EXPECTED=125
 
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/littlecpu-probe.XXXXXX") || {
@@ -89,10 +43,9 @@ probes=0
 failed=0
 group=""
 
-# Every fixture gets its own directory. `mktemp -d` rather than a counter
-# because these are built inside `$(...)`, which is a subshell: a counter would
-# never advance in the parent and every fixture would land on top of the last
-# one -- silently, and with the probes still reporting on something.
+# `mktemp -d` rather than a counter because fixtures are built inside `$(...)`,
+# a subshell: a counter would never advance in the parent, so every fixture
+# would land on top of the last one and the probes would still report something.
 new_case() {
   mktemp -d "$tmp/case.XXXXXX"
 }
@@ -119,11 +72,10 @@ probe() {
   rc=$?
   set -e
   local why=""
-  # A here-string, not a pipe. `grep -q` exits at the first match and closes
-  # the pipe, and against a large output (the sanitized monitor is 11k lines)
-  # the writer then dies of SIGPIPE -- which under `set -o pipefail` becomes
-  # the pipeline's status, so a MATCHING probe reported no match. Found by
-  # this file failing its own control.
+  # A here-string, not a pipe. `grep -q` exits at the first match and closes the
+  # pipe, so against a large output the writer dies of SIGPIPE -- which under
+  # pipefail becomes the pipeline's status, making a MATCHING probe report no
+  # match.
   if [ "$rc" -ne "$want_exit" ]; then
     why="exited $rc, expected $want_exit"
   elif ! grep -qF -- "$want_text" <<< "$out"; then
@@ -138,17 +90,10 @@ probe() {
   fi
 }
 
-# ---------------------------------------------------------------------------
-# Stubs. Each stands in for one thing this file refuses to depend on, and each
-# is steered by environment variables so a probe reads as one line.
-#
-# They are written ONCE, up front, and shared by every fixture below -- as are
-# the scratch copies of the scripts under test. Per-fixture copies cost seconds:
-# macOS re-scans an executable the first time it is exec'd after being written,
-# so a probe that created its own stub tree measured 1.5-3.3s of wall against
-# 0.06s of user time. Fixtures create data files only; nothing a fixture writes
-# is ever executed.
-# ---------------------------------------------------------------------------
+# Written once and shared by every fixture, as are the scratch copies of the
+# scripts under test: macOS re-scans an executable the first time it is exec'd
+# after being written, so a probe that created its own stub tree measured
+# 1.5-3.3s of wall against 0.06s of user time.
 
 make_toolchain_stubs() {  # $1 = bin dir
   local bin=$1
@@ -252,25 +197,18 @@ STUB
   chmod +x "$1"
 }
 
-# The shared tree. `bin` is a complete stub toolchain; `bin-noobjcopy` is the
-# half-installed one; `bin-none` is a machine with no cross compiler at all.
 # `leg-rt` / `leg-rc` are scratch copies of the two suite runners, because each
 # resolves its helper scripts relative to its own path.
 mkdir -p "$tmp/bin-none" "$tmp/leg-rt" "$tmp/leg-rc" "$tmp/leg-rc-nopy"
 
-# `bin-none` is "this machine has no cross compiler", and for the one probe that
-# claims that it has to be the WHOLE path: with /usr/bin behind it, run_tests.sh
-# finds a real riscv64-unknown-elf-gcc on any host that has one installed there,
-# which is every CI runner -- and that is exactly how that probe went green here
-# and red on CI. So it carries symlinks to the utilities the scripts need before
-# their compiler probe, resolved from this shell's own PATH rather than assumed
-# to live in /usr/bin. Every OTHER probe keeps /usr/bin on the end (the stub
-# directory is in front, so the stubs still win) because test/cosim.py runs
-# under `#!/usr/bin/env python3` and a python3 that is a version-manager shim
-# needs an interpreter of its own.
-# No python3 and no env here on purpose: nothing runs before a compiler probe
-# needs them, and a python3 that is a version-manager shim would shadow the real
-# interpreter for every OTHER probe's PATH, which has this directory on it too.
+# For the one probe that claims "no cross compiler", `bin-none` has to be the
+# WHOLE path: with /usr/bin behind it, run_tests.sh finds a real
+# riscv64-unknown-elf-gcc on any host that has one there, which is every CI
+# runner -- that is how that probe went green here and red on CI.
+#
+# No python3 and no env here on purpose: a python3 that is a version-manager shim
+# would shadow the real interpreter for every OTHER probe, whose PATH has this
+# directory on it too.
 for util in sed awk sort uniq comm basename dirname wc tr cat rm mktemp diff \
              grep find head; do
   path=$(command -v "$util") || {
@@ -292,9 +230,6 @@ cp "$HERE/run_cosim.sh" "$HERE/check_suite_shape.sh" "$tmp/leg-rc-nopy/"
 make_cosim_py_stub "$tmp/leg-rc-nopy/cosim.py"
 chmod -x "$tmp/leg-rc-nopy/cosim.py"
 
-# ===========================================================================
-# 1. test/check_suite_shape.sh -- the manifest check both sim legs run first.
-# ===========================================================================
 begin_group "test/check_suite_shape.sh"
 
 SHAPE="$HERE/check_suite_shape.sh"
@@ -344,9 +279,6 @@ d=$(shape_fixture); : > "$d/asm/unlisted.S"
 probe "the other direction: a .S that landed without a manifest line" 1 \
   "runs unmeasured" "$SHAPE '$d/asm' '$d/MANIFEST'"
 
-# ===========================================================================
-# 2. test/run_tests.sh -- the merge gate.
-# ===========================================================================
 begin_group "test/run_tests.sh"
 
 rt_fixture() {
@@ -359,8 +291,6 @@ rt_fixture() {
   printf '%s' "$d"
 }
 
-# `sections.lds` is not a program and must not be counted as one; the manifest
-# check and this loop both key on `*.S`, which is why the fixture can carry it.
 RT="$tmp/leg-rt/run_tests.sh"
 rt() { printf "PATH='%s/bin:%s/bin-none:/usr/bin:/bin' %s %s/sim %s/asm %s/BASELINE %s/FLOOR" \
   "$tmp" "$tmp" "$RT" "$tmp" "$1" "$1" "$1"; }
@@ -436,9 +366,6 @@ probe "runner exit 6 is MONITOR-SILENT: the oracle never looked" 1 \
 probe "an unexpected runner status is RUNNER-ERROR, carrying it" 1 \
   "RUNNER-ERROR 3" "STUB_SIM_EXIT=3 $(rt "$d")"
 
-# ADR-0035's measured reason for `set +e` around the runner: bash 3.2 rewrites
-# a 127 to 1 under errexit, which would report an unstartable runner as a
-# verdict about the CPU.
 probe "an unstartable runner is RUNNER-ERROR 127, never FAIL" 1 \
   "RUNNER-ERROR 127" \
   "PATH='$tmp/bin:$tmp/bin-none:/usr/bin:/bin' $RT $tmp/no-such-sim $d/asm $d/BASELINE $d/FLOOR"
@@ -452,8 +379,6 @@ probe "a program that went quiet is BELOW-FLOOR on retires" 1 \
 probe "retires that stopped being spec-checked is its own status" 1 \
   "BELOW-FLOOR spec-checked" "STUB_SIM_SPEC=1 $(rt "$d")"
 
-# ADR-0014's contract runs in BOTH directions, and ADR-0035 made the element a
-# name-and-status pair. Three probes, because the three are different claims.
 d=$(rt_fixture); printf 'add.S FAIL 7\n' > "$d/BASELINE"
 probe "control: a baselined failure that fails exactly that way is green" 0 \
   "Failure list matches" "STUB_SIM_EXIT=1 $(rt "$d")"
@@ -464,9 +389,6 @@ probe "a baselined test that starts failing a DIFFERENT way is red" 1 \
 probe "an unexpected PASS is red too -- the baseline is not a ceiling" 1 \
   "does NOT match" "$(rt "$d")"
 
-# ===========================================================================
-# 3. test/run_cosim.sh -- the co-simulation suite runner.
-# ===========================================================================
 begin_group "test/run_cosim.sh"
 
 rc_fixture() {
@@ -533,15 +455,11 @@ probe "a baselined program that diverges SOMEWHERE ELSE is red" 1 \
 probe "an unexpected agreement is red -- both directions, as everywhere" 1 \
   "does NOT match" "$(rcs "$d")"
 
-# ===========================================================================
-# 4. test/cosim.py -- the comparison itself, driven end to end through stubs.
-# ===========================================================================
 begin_group "test/cosim.py"
 
-# Sail's trace format (test/cosim.py's INSN_RE / GPR_RE) and test/cosim.cc's
-# CS record stream, both replayed from fixtures. Everything between them --
-# the distinct-state reduction, the two cursors, the divergence labels, the
-# HTIF verdict cross-check -- is the real script.
+# Only the two ends are fixtures; everything between them -- the distinct-state
+# reduction, the two cursors, the divergence labels, the HTIF verdict
+# cross-check -- is the real cosim.py.
 cp_fixture() {
   local d; d=$(new_case)
   cat > "$d/sail.trace" <<'TRACE'
@@ -622,9 +540,8 @@ d=$(cp_fixture)
 probe "a failing assembler is fatal, not a divergence" 3 "failed" \
   "STUB_CC_EXIT=1 $(cps "$d")"
 
-# The NONCOMPARABLE_CSRS relaxation. It is the one thing in this script that
-# makes the comparison weaker, so both halves are probed: that it is taken and
-# printed, and that it still requires a change to EXACTLY that register.
+# NONCOMPARABLE_CSRS is the one thing in cosim.py that makes the comparison
+# weaker, so both halves are probed.
 d=$(cp_fixture)
 cat > "$d/sail.trace" <<'TRACE'
 [1] [M]: 0x00000000 (0xb00025f3) csrr x11, mcycle
@@ -643,9 +560,6 @@ printf 'CS 0 10 x12=00000099 @pc=00000004\nCS END PASS 10\n' > "$d/dut.out"
 probe "the exemption does not extend to a write of the WRONG register" 1 \
   "COSIM-STATUS DISAGREE" "$(cps "$d")"
 
-# ===========================================================================
-# 5. formal/check-baseline.sh -- the ladder's gate.
-# ===========================================================================
 begin_group "formal/check-baseline.sh"
 
 CB="$REPO/formal/check-baseline.sh"
@@ -673,11 +587,6 @@ probe "wrong argument count is exit 2 -- the inputs are broken, not the ladder" 
 probe "a missing baseline file is exit 2, not an empty expected set" 2 \
   "no such file" "$CB $d/checks $d/NOPE $d/EXPECTED_CHECKS"
 
-# The false green this ticket found. `set -u` with no `-e` and no `pipefail`
-# means an unreadable baseline yields an EMPTY expected set, and an empty
-# expected set matches an all-passing ladder exactly. Before the `-r` check
-# this printed "Failure list matches ... exactly" and exited 0, having also
-# silently dropped the entry the baseline named.
 d=$(cb_fixture); printf 'beta FAIL\n' > "$d/EXPECTED_FAIL"; chmod 000 "$d/EXPECTED_FAIL"
 probe "an UNREADABLE baseline is refused, not read as an empty one" 2 \
   "exists but is not readable" "$(cbs "$d")"
@@ -724,9 +633,6 @@ printf 'beta FAIL\n' > "$d/EXPECTED_FAIL"
 probe "control: a baselined red check at the baselined status is green" 0 \
   "Failure list matches" "$(cbs "$d")"
 
-# ADR-0036's measured hole, and the newest comparison in this script: on a
-# machine without btorsim every red check flipped FAIL -> ERROR and the
-# name-only set equality still matched.
 printf 'ERROR 16 2\n' > "$d/checks/beta/status"
 probe "still red, but for a DIFFERENT reason: FAIL baselined, ERROR on disk" 1 \
   "beta ERROR" "$(cbs "$d")"
@@ -753,17 +659,13 @@ d=$(cb_fixture); printf 'WOBBLE 1 2\n' > "$d/checks/beta/status"
 probe "a status sby has never written here is reported on its own" 1 \
   "Unrecognised status" "$(cbs "$d")"
 
-# ===========================================================================
-# 6. formal/check-complete-exclusions.py -- the exclusion set's gate.
-# ===========================================================================
 begin_group "formal/check-complete-exclusions.py"
 
 CE="$REPO/formal/check-complete-exclusions.py"
 
-# The riscv-formal stand-in carries only what clause 5 reads: an insns/
-# directory and its isa list. Naming `add` and `lw` there is what makes the
-# control probe meaningful -- the file is non-empty and simply does not name
-# any excluded mnemonic.
+# The riscv-formal stand-in carries only what clause 5 reads. Naming `add` and
+# `lw` is what makes the control meaningful: the file is non-empty and names no
+# excluded mnemonic.
 ce_fixture() {
   local d; d=$(new_case)
   mkdir -p "$d/rf/insns"
@@ -829,8 +731,6 @@ sed -i.bak 's|^MISC-MEM  0001111  fence fence.i$|MISC-MEM  00011 fence fence.i|'
 probe "a baseline opcode that is not seven binary digits is named" 1 \
   "seven binary digits" "$(ces "$d")"
 
-# Clause 5, the one a baseline alone cannot give you: a stale exclusion covers
-# less and less of the ISA while staying green.
 d=$(ce_fixture); : > "$d/rf/insns/insn_fence.v"
 probe "a pin that ADDS a spec model makes the exclusion stale, and red" 1 \
   "EXISTS at the pin" "$(ces "$d")"
@@ -843,8 +743,8 @@ d=$(ce_fixture); rm "$d/rf/insns/isa_rv32imc.txt"
 probe "an unreadable clone makes 'no spec model' unmeasurable, and fatal" 1 \
   "cannot read" "$(ces "$d")"
 
-# Clause 2 -- a recorded restriction with nothing recorded. The reason lives on
-# the comment lines under the header, so deleting them is the mutation.
+# The reason lives on the comment lines under the header, so deleting them is
+# the mutation.
 d=$(ce_fixture)
 python3 - "$d/complete.sv" <<'PY'
 import sys
@@ -866,21 +766,12 @@ PY
 probe "an exclusion with no reason written under it is rejected" 1 \
   "has no reason written under it" "$(ces "$d")"
 
-# ===========================================================================
-# 7. test/sanitize_monitor.py -- the oracle both sim legs read.
-#
-# These assertions were mutation-confirmed once, when rule 3's three content
-# layers landed. They are RE-RUN here, not re-derived: re-deriving
-# TRAP_GATE_ENCLOSED_CODES from whatever the generator currently emits is
-# exactly how a change gets laundered into the expectation, which that list's
-# own comment forbids. Nothing below edits the script's constants; each probe
-# mutates a COPY of the tracked test/monitor.v and requires the sanitizer to
-# refuse it.
-# ===========================================================================
+# Nothing below edits the sanitizer's constants: each probe mutates a COPY of
+# the tracked test/monitor.v and requires the sanitizer to refuse it. Re-deriving
+# TRAP_GATE_ENCLOSED_CODES from whatever the generator currently emits is how a
+# change gets laundered into the expectation, which that list's comment forbids.
 begin_group "test/sanitize_monitor.py"
 
-# Not executable in the tree (the Makefile invokes it through python3), so this
-# does too -- a probe that failed on the mode bit would look like a rule fault.
 SM="python3 $REPO/test/sanitize_monitor.py"
 
 sm_fixture() {
@@ -921,7 +812,6 @@ PY
 probe "rule 2 likewise -- ADR-0019's DIV/REM repair cannot silently stop applying" 1 \
   "matched 1 site(s), expected 2" "$SM $d/monitor.v"
 
-# Layer 1: the generator relocates the trap comparison between the anchors.
 d=$(sm_fixture)
 sm_mutate "$d/monitor.v" <<'PY'
 import sys
@@ -936,7 +826,6 @@ PY
 probe "layer 1: the trap comparison moved INTO the span is refused, not gated" 1 \
   "the generator now emits the" "$SM $d/monitor.v"
 
-# Layer 2: any other check moving into or out of the span.
 d=$(sm_fixture)
 sm_mutate "$d/monitor.v" <<'PY'
 import sys
@@ -948,8 +837,7 @@ PY
 probe "layer 2: the enclosed handle_error multiset is pinned, not merely counted" 1 \
   "the span encloses" "$SM $d/monitor.v"
 
-# Layer 3: the generator dropping the trap comparison altogether -- which
-# layers 1 and 2 both accept, because neither looks outside the span.
+# Layers 1 and 2 both accept this one, because neither looks outside the span.
 d=$(sm_fixture)
 sm_mutate "$d/monitor.v" <<'PY'
 import sys
@@ -960,31 +848,16 @@ PY
 probe "layer 3: error 101 vanishing from the OUTPUT is caught after every rule" 1 \
   "the trap comparison survives" "$SM $d/monitor.v"
 
-# ===========================================================================
-# 8. formal/genchecks-audit.py -- only the guard that needs no clone.
-# ===========================================================================
 begin_group "formal/genchecks-audit.py"
 
-# The three set equalities this script makes need the pinned riscv-formal clone
-# and a real generation run, so they are demonstrated by hand rather than here;
-# the commands and their output are recorded in the pull request that added this
-# file. What IS hermetic is the working-directory guard, and it is not
-# decoration: genchecks takes `corename` from the last path component and writes
-# `checks/` relative to the cwd, so running it from anywhere else silently
-# produces a ladder somewhere else.
 probe "running the generator from the wrong directory is refused, not done" 1 \
   "error: run from" "cd '$tmp' && python3 '$REPO/formal/genchecks-audit.py'"
 
-# ===========================================================================
-# 9. soc/timing_split.py -- make soc-timing's SOC_MIN_MHZ ratchet.
-# ===========================================================================
 begin_group "soc/timing_split.py"
 
 TS="python3 $REPO/soc/timing_split.py"
 
-# One LogicCell40 hop, one routing hop, and the two summary lines the script
-# derives everything else from. 1.50 ns total is 666.67 MHz, clear of every
-# floor these probes use.
+# 1.50 ns is 666.67 MHz, clear of every floor these probes use.
 ts_fixture() {
   local d; d=$(new_case)
   cat > "$d/report.rpt" <<'RPT'
@@ -1016,8 +889,6 @@ sed -i.bak 's/^Total path delay: 1.50 ns/Total path delay: 5.00 ns/' "$d/report.
 probe "a hop sum that does not reconcile blames the script, not the design" 1 \
   "summed hops come to" "$TS $d/report.rpt --min-mhz 10.0"
 
-# A carry hop needs no interconnect and a LUT level does, so one costs about a
-# tenth of the other and the two must not be added up (ADR-0058).
 ts_carry_fixture() {
   local d; d=$(new_case)
   cat > "$d/report.rpt" <<'RPT'
@@ -1053,9 +924,6 @@ RPT
 probe "a path with no LUT level at all reports zero rather than dividing by it" 0 \
   "0.00 ns per LUT level" "$TS $d/report.rpt"
 
-# ===========================================================================
-# 10. soc/cell_census.py -- make soc-timing's SPRAM/EBR census.
-# ===========================================================================
 begin_group "soc/cell_census.py"
 
 CC="python3 $REPO/soc/cell_census.py"
@@ -1082,15 +950,11 @@ d=$(cc_fixture)
 probe "a cell type the log never mentions reads as zero, not a crash" 1 \
   "0 SB_RGBA_DRV cells, expected 1" "$CC $d/soc.synth.log SB_RGBA_DRV 1 reason"
 
-# ===========================================================================
-# 11. check-unit-benches -- the UNIT_BENCHES / test/*_tb.v list equality.
-# ===========================================================================
 begin_group "check-unit-benches"
 
-# Driven against the REAL Makefile and the REAL test/*_tb.v tree, with the
-# declaration overridden on the command line: UNIT_BENCHES lives in the
-# tracked Makefile, and duplicating its comparison here would be the
-# second-parser risk this file exists to avoid elsewhere.
+# Driven against the real Makefile and the real test/*_tb.v tree with the
+# declaration overridden on the command line: duplicating the comparison here
+# would be the second-parser risk this file exists to avoid elsewhere.
 MB="make -C $REPO check-unit-benches"
 
 probe "control: the declared list matches the tree exactly" 0 \
@@ -1108,9 +972,6 @@ probe "a declared bench with no UNIT_BENCH_SRC_* would build with no design unde
   "monitor_tb is in UNIT_BENCHES with no UNIT_BENCH_SRC_monitor_tb" \
   "$MB UNIT_BENCH_SRC_monitor_tb="
 
-# ===========================================================================
-# 12. soc/fit_report.py -- make fit's FIT_MAX_LC ratchet.
-# ===========================================================================
 begin_group "soc/fit_report.py"
 
 FR="python3 $REPO/soc/fit_report.py"
@@ -1146,7 +1007,6 @@ d=$(fr_fixture); sed -i.bak '/ICESTORM_LC:/d' "$d/fit.log"
 probe "no utilisation table is a failure, not a 0% fit" 1 \
   "printed no utilisation table" "$FR $d/fit.log --max-lc 4100"
 
-# ===========================================================================
 echo
 if [ "$probes" -ne "$PROBES_EXPECTED" ]; then
   echo "error: ran $probes probes, expected $PROBES_EXPECTED." >&2

--- a/test/probe_gates.sh
+++ b/test/probe_gates.sh
@@ -113,10 +113,10 @@ exit ${STUB_CC_EXIT:-0}
 STUB
   cat > "$bin/riscv64-elf-objcopy" <<'STUB'
 #!/bin/sh
-# The last argument is the output image (run_tests.sh and cosim.py both call it
-# that way). STUB_OBJCOPY_FAIL is a full disk or a binutils without
-# --verilog-data-width; STUB_OBJCOPY_EMPTY is the quiet one ADR-0035 names --
-# exit 0 with no bytes, which parses fine and makes `tohost` read zero.
+# The last argument is the output image; run_tests.sh and cosim.py both call it
+# that way. STUB_OBJCOPY_FAIL stands in for a full disk or a binutils too old for
+# --verilog-data-width. STUB_OBJCOPY_EMPTY is the quiet one: exit 0 having
+# written nothing, which still parses and makes `tohost` read zero.
 for out; do :; done
 if [ -n "${STUB_OBJCOPY_FAIL:-}" ]; then
   echo "stub objcopy: refusing" >&2

--- a/test/run_cosim.sh
+++ b/test/run_cosim.sh
@@ -5,14 +5,15 @@
 #
 # Usage: run_cosim.sh <cosim-binary> <asm-dir> <expected-fail-file> <manifest>
 #
-# Deliberately NOT on `make test`'s path and not in CI's required set: it needs
-# a Sail install that `make test` must keep working without (ADR-0032). It is
-# the only oracle here that reads the real register array rather than the core's
-# RVFI self-report, so a change to rtl/regfile.v gates on it by carrying its
-# output in the pull request.
+# Deliberately NOT on `make test`'s path and not in the set CI requires: it needs
+# a Sail install, and the merge gate has to keep working on machines without one.
+# It is also the only oracle here that reads the core's real register array
+# instead of the core's own report of what it retired, so a change to
+# rtl/regfile.v is checked against it by carrying this output in the pull
+# request rather than by a gate.
 #
-# The guards below are run_tests.sh's, against the same false green, and are
-# probed from test/probe_gates.sh.
+# The guards below are run_tests.sh's, against the same false green: a run that
+# reports success having compared nothing.
 set -euo pipefail
 
 if [ "$#" -ne 4 ]; then
@@ -38,9 +39,8 @@ if [ ! -x "$COSIM_PY" ]; then
   exit 1
 fi
 
-# `NF` must gate the rebuild rather than follow it: awk forces NF to 1 when $1
-# is assigned, so `{$1=$1} NF` would resurrect blank and comment-only lines as
-# empty entries. Same idiom, same reason, as test/run_tests.sh.
+# `NF` has to come before the rebuild, not after. Assigning to $1 sets NF to 1,
+# so `{$1=$1} NF` would bring every blank and comment line back as an entry.
 expected_sorted=$(sed -e 's/#.*//' "$EXPECTED_FAIL" | awk 'NF { $1=$1; print }' | sort)
 
 malformed=$(printf '%s\n' "$expected_sorted" | awk 'NF == 1 {print}')

--- a/test/run_cosim.sh
+++ b/test/run_cosim.sh
@@ -1,43 +1,18 @@
 #!/bin/bash
-# Runs every test/asm/*.S under Sail co-simulation (test/cosim.py, ADR-0032)
-# and checks the resulting table against test/COSIM_EXPECTED_FAIL — the same
-# set-equality contract, in both directions, on name-and-status pairs, that
-# test/run_tests.sh applies to test/EXPECTED_FAIL (ADR-0014, ADR-0035).
-# Invoked by `make cosim-suite`. See docs/adr/0039.
+# Runs every test/asm/*.S under Sail co-simulation (test/cosim.py) and grades
+# the table against test/COSIM_EXPECTED_FAIL, under the same contract
+# test/run_tests.sh applies to test/EXPECTED_FAIL. Invoked by `make cosim-suite`.
 #
 # Usage: run_cosim.sh <cosim-binary> <asm-dir> <expected-fail-file> <manifest>
 #
-# This is NOT on `make test`'s path and NOT in CI's required set, deliberately
-# (ADR-0032): it needs a Sail install that `make test` must keep working
-# without. What it is instead is the gate the block-RAM regfile change has to
-# pass, because it is the only oracle in this repo that reads the real
-# register array rather than the core's RVFI self-report.
+# Deliberately NOT on `make test`'s path and not in CI's required set: it needs
+# a Sail install that `make test` must keep working without (ADR-0032). It is
+# the only oracle here that reads the real register array rather than the core's
+# RVFI self-report, so a change to rtl/regfile.v gates on it by carrying its
+# output in the pull request.
 #
-# That makes a FALSE GREEN the failure mode that matters, exactly as in
-# run_tests.sh, and the properties below exist only for it:
-#
-#   * the baseline is read and format-checked BEFORE the suite runs, so a
-#     mistyped path fails in a second rather than after a full run having
-#     compared nothing;
-#   * the program list is checked against a MANIFEST, not merely for emptiness.
-#     The emptiness guard caught a suite of size zero; it did nothing about a
-#     suite that shrank from 52 programs to 12, which prints "12/12 agreed",
-#     matches an empty baseline exactly and exits 0. The manifest is
-#     test/OBSERVED_FLOOR — the same file test/run_tests.sh grades against, read
-#     by the same test/check_suite_shape.sh, in both directions, before the
-#     setup probe. Two legs that disagreed about what the suite is would be
-#     worse than neither of them checking;
-#   * the per-program status comes from cosim.py's own COSIM-STATUS line, not
-#     from its exit code alone, and a run that produced no such line is
-#     labelled COSIM-ERROR rather than being scored as a verdict about the
-#     core. "The harness broke" and "the core diverged" must not be the same
-#     table entry;
-#   * the failure set records NAME AND STATUS. A baselined program that
-#     starts diverging at a different point, in a different way, or that stops
-#     running at all, is a red gate rather than a match.
-#
-# `set -e` is on; every place a nonzero status is expected handles it at its
-# own call site.
+# The guards below are run_tests.sh's, against the same false green, and are
+# probed from test/probe_gates.sh.
 set -euo pipefail
 
 if [ "$#" -ne 4 ]; then
@@ -63,15 +38,11 @@ if [ ! -x "$COSIM_PY" ]; then
   exit 1
 fi
 
-# Whitespace-normalised name-and-status pairs. `NF` gates the rebuild rather
-# than following it: awk forces NF to 1 when $1 is assigned, so `{$1=$1} NF`
-# would resurrect blank and comment-only lines as empty entries.
+# `NF` must gate the rebuild rather than follow it: awk forces NF to 1 when $1
+# is assigned, so `{$1=$1} NF` would resurrect blank and comment-only lines as
+# empty entries. Same idiom, same reason, as test/run_tests.sh.
 expected_sorted=$(sed -e 's/#.*//' "$EXPECTED_FAIL" | awk 'NF { $1=$1; print }' | sort)
 
-# A one-field line is a name with no status. Accepting it would make the entry
-# unmatchable in a way that reads like a regression, so name the format — and
-# do it HERE, before the suite runs, rather than after ten seconds of work that
-# was never going to be gradeable.
 malformed=$(printf '%s\n' "$expected_sorted" | awk 'NF == 1 {print}')
 if [ -n "$malformed" ]; then
   echo "error: $EXPECTED_FAIL has entries with no status (the format is" >&2
@@ -80,29 +51,21 @@ if [ -n "$malformed" ]; then
   exit 1
 fi
 
-# THE SUITE'S SHAPE, and deliberately BEFORE the setup probe below. It costs
-# milliseconds, needs no Sail, and a suite that does not match its manifest was
-# never going to produce a gradeable run — so there is no reason to make it wait
-# behind a toolchain check. Both directions; see check_suite_shape.sh.
+# Against a manifest, not merely for emptiness: an emptiness guard catches a
+# suite of size zero and does nothing about one that shrank to a dozen programs,
+# which prints "12/12 agreed", matches an empty baseline exactly and exits 0.
 if ! "$HERE/check_suite_shape.sh" "$ASM_DIR" "$MANIFEST"; then
   echo "error: the .S suite does not match its manifest; nothing was run." >&2
   exit 1
 fi
 echo
 
-# One setup probe for the whole suite: the cross compiler, the pinned and
-# digest-checked sail binary, and the cxxrtl co-sim runner. Without Sail this
-# is where the run stops, with the message naming `make sail-setup` — which is
-# the whole point of the leg being opt-in.
 if ! "$COSIM_PY" --check-setup --cosim-binary "$COSIM_BIN"; then
   echo "error: co-simulation setup is incomplete; nothing was run." >&2
   exit 1
 fi
 echo
 
-# The emptiness guard that used to be here is subsumed by the manifest check
-# above, which rejects an empty glob against a non-empty manifest and names
-# every program that went missing rather than only reporting that they all did.
 shopt -s nullglob
 programs=("$ASM_DIR"/*.S)
 shopt -u nullglob
@@ -126,16 +89,15 @@ for src in "${programs[@]}"; do
   base=${name%.S}
   log="$tmp/$base.log"
 
-  # Error-exit is lifted for exactly this call — cosim.py's nonzero exits are
-  # verdicts, not accidents — and restored immediately.
+  # Lifted for exactly this call: cosim.py's nonzero exits are verdicts.
   set +e
   "$COSIM_PY" --quiet --cosim-binary "$COSIM_BIN" "$name" > "$log" 2>&1
   rc=$?
   set -e
 
-  # The status line is the contract; the exit code is the cross-check. They
-  # disagreeing means cosim.py changed under this script, which is a broken
-  # harness and must not read as a verdict about the core.
+  # The status line is the contract and the exit code is the cross-check. Them
+  # disagreeing is a broken harness, and must not read as a verdict about the
+  # core.
   status=$(awk '/^COSIM-STATUS /{ $1=""; sub(/^ /,""); print; exit }' "$log")
   if [ -z "$status" ]; then
     status="COSIM-ERROR $rc"
@@ -158,7 +120,6 @@ printf '%s\n' "${table[@]}"
 echo
 echo "$agreed/${#table[@]} agreed"
 
-# Normalised the same way $expected_sorted was, up at the top of the script.
 actual_sorted=$(printf '%s\n' "${failures[@]:-}" | awk 'NF { $1=$1; print }' | sort)
 
 if [ "$actual_sorted" = "$expected_sorted" ]; then

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -4,12 +4,13 @@
 #
 # Usage: run_tests.sh <sim-binary> <asm-dir> <expected-fail-file> <floor-file>
 #
-# This is the merge gate, so the failure mode that matters is a FALSE GREEN —
-# reporting success without having tested anything. That is what every guard
-# below is for, and each one is probed from test/probe_gates.sh.
+# This is the merge gate. The failure that matters is passing without having
+# tested anything, and that is what every check below is for. test/probe_gates.sh
+# breaks each one and makes sure it fails, because a check whose failing branch
+# has never run may not work at all.
 #
-# `set -e` is on; a nonzero exit that is expected is handled at its own call
-# site so error-exit stays on everywhere else.
+# `set -e` is on. Where a command is expected to exit nonzero it is handled right
+# there, so error-exit stays on everywhere else.
 set -euo pipefail
 
 if [ "$#" -ne 4 ]; then
@@ -24,9 +25,9 @@ OBSERVED_FLOOR=$4
 CYCLES=5000
 HERE=$(cd "$(dirname "$0")" && pwd)
 
-# A missing or unreadable baseline yields an EMPTY expected set, which against
-# an all-passing suite prints "Failure list matches ... exactly" having compared
-# nothing.
+# A baseline that is missing or cannot be read gives an empty expected set. If
+# every test passes, that matches, and the run prints "Failure list matches"
+# having compared nothing.
 if [ ! -f "$EXPECTED_FAIL" ] || [ ! -r "$EXPECTED_FAIL" ]; then
   echo "error: baseline '$EXPECTED_FAIL' does not exist or is not readable." >&2
   echo "The gate compares the failure set against it; without it there is no gate." >&2
@@ -40,17 +41,17 @@ if [ ! -f "$OBSERVED_FLOOR" ] || [ ! -r "$OBSERVED_FLOOR" ]; then
   exit 1
 fi
 
-# Before anything is assembled, because a suite that shrank otherwise matches an
-# empty baseline exactly. A separate script because test/run_cosim.sh runs the
-# identical check against the identical file, and two legs that disagreed about
-# what the suite is would be worse than neither of them checking.
+# Runs before anything is assembled. Without it, a suite that lost half its
+# programs still passes every program it found and matches an empty baseline.
+# It is a separate script so test/run_cosim.sh can run the same check on the
+# same file, rather than the two legs each deciding what the suite is.
 if ! "$HERE/check_suite_shape.sh" "$ASM_DIR" "$OBSERVED_FLOOR"; then
   echo "error: the .S suite does not match its manifest; nothing was run." >&2
   exit 1
 fi
 
-# A malformed line is named rather than skipped: a line this cannot parse is a
-# floor that is not enforced.
+# A line this cannot parse is a floor nothing enforces, so say so rather than
+# skipping it.
 floors=$(sed -e 's/#.*//' "$OBSERVED_FLOOR" | awk 'NF { $1=$1; print }')
 malformed_floor=$(printf '%s\n' "$floors" | awk 'NF && (NF != 3 || $2 !~ /^[0-9]+$/ || $3 !~ /^[0-9]+$/) { print }')
 if [ -n "$malformed_floor" ]; then
@@ -83,8 +84,9 @@ tmp=$(mktemp -d "${TMPDIR:-/tmp}/littlecpu-test.XXXXXX") || {
   echo "error: could not create a temporary directory under ${TMPDIR:-/tmp}." >&2
   exit 1
 }
-# mktemp is fatal here: an mktemp that exits 0 with empty output would collapse
-# every artifact path to /<base>.hex and defeat the trap below.
+# Stop if mktemp gave us nothing. An empty $tmp turns every path below into
+# /<name>.hex, at the root of the disk, and leaves the trap with nothing to
+# clean up.
 if [ -z "$tmp" ] || [ ! -d "$tmp" ]; then
   echo "error: mktemp -d produced no usable directory under ${TMPDIR:-/tmp}." >&2
   exit 1
@@ -104,8 +106,8 @@ for src in "$ASM_DIR"/*.S; do
   ram_hex="$tmp/$base.ram.hex"
 
   status="PASS"
-  # Cleared per iteration: a carried-over value would let a run that printed no
-  # counts be graded against its predecessor's.
+  # Cleared every time round. Left over from the previous program, these would
+  # be checked against this program's floor.
   retires=""
   spec_retires=""
   if ! "$CC" -march=rv32imc_zicsr_zifencei -mabi=ilp32 -nostdlib -I "$ASM_DIR" \
@@ -115,9 +117,9 @@ for src in "$ASM_DIR"/*.S; do
     status="ASSEMBLE-WARNING"
   fi
 
-  # The empty case is the dangerous one and gets its own label: an empty RAM
-  # image parses fine, `tohost` reads zero, and every test with no data
-  # dependency still reaches RVTEST_PASS (ADR-0035).
+  # The empty case gets its own label because it is the quiet one. An empty RAM
+  # image still parses, so the simulator starts, `tohost` reads zero, and every
+  # test that does not depend on data in RAM says PASS.
   if [ "$status" = "PASS" ]; then
     for region in rom ram; do
       if [ "$region" = rom ]; then
@@ -141,18 +143,18 @@ for src in "$ASM_DIR"/*.S; do
   fi
 
   if [ "$status" = "PASS" ]; then
-    # Lifted rather than guarded with `|| sim_status=$?` because bash 3.2
-    # (macOS /bin/bash) rewrites a 127 to 1 under errexit, which would report an
-    # unstartable runner as a FAIL — a verdict about the CPU.
+    # Turned off rather than using `|| sim_status=$?`. With errexit on, bash 3.2
+    # (macOS /bin/bash) turns a 127 from a missing binary into a 1, and a 1 here
+    # means the test failed. A runner that will not start would look like a bug
+    # in the CPU.
     set +e
     "$SIM" --rom "$rom_hex" --ram "$ram_hex" --cycles "$CYCLES" \
       > "$tmp/$base.run.log" 2>&1
     sim_status=$?
     set -e
-    # The exit ladder is test/cxxrtl.cc's. 4, 5 and 6 each get their own label
-    # because lumping any into RUNNER-ERROR reads as "the sim would not start"
-    # when it means the oracle disagreed, a trap preceded its handler, or the
-    # oracle never looked.
+    # These exit codes come from test/cxxrtl.cc. 4, 5 and 6 get their own labels
+    # because RUNNER-ERROR reads as "the simulator would not start", and none of
+    # them mean that.
     case $sim_status in
       0) status="PASS" ;;
       1) num=$(awk '/^FAIL/{print $2; exit}' "$tmp/$base.run.log")
@@ -170,21 +172,21 @@ for src in "$ASM_DIR"/*.S; do
     spec_retires=${2:-}
   fi
 
-  # A PASS with no counts line means the binary this gate ran is not the runner
-  # it grades, and every observation check below would then silently not run.
+  # A PASS with no counts means the binary that ran is not the runner this
+  # script expects, and the two checks below would quietly do nothing.
   if [ "$status" = "PASS" ] && { [ -z "$retires" ] || [ -z "$spec_retires" ]; }; then
     status="NO-COUNTS"
   fi
 
-  # `>=` and not set equality: the counts move for legitimate reasons, and the
-  # thing that must not happen is a program going quiet. Only PASS programs are
-  # graded — anything already failing has a more specific status.
+  # `>=`, not an exact match. The counts move for ordinary reasons; what we are
+  # looking for is a program that stopped reporting anything. Only PASS programs
+  # are checked, since a failing one already has a more useful status.
   if [ "$status" = "PASS" ]; then
     floor=$(printf '%s\n' "$floors" | awk -v n="$name" '$1 == n { print $2, $3; found = 1 } END { exit !found }') || floor=""
     if [ -z "$floor" ]; then
-      # Unreachable while check_suite_shape.sh runs above, and kept anyway: a
-      # silent empty `$floor` would make the comparisons below compare against
-      # nothing. If it fires, the two checks have gone out of step.
+      # check_suite_shape.sh above already requires every program to have a
+      # line, so this should never happen. It is here because an empty $floor
+      # would make the two comparisons below compare against nothing.
       status="NO-FLOOR"
     else
       set -- $floor
@@ -209,9 +211,9 @@ for src in "$ASM_DIR"/*.S; do
       cat "$build_log" >&2
     fi
   fi
-  # The counts stay outside the name-and-status pair the baseline matches on:
-  # putting a quantity that legitimately moves into the failure set would make
-  # every baseline entry unmatchable the first time it moved.
+  # The counts stay out of the name and status the baseline matches on. They
+  # move for ordinary reasons, and putting them in would break every baseline
+  # entry the first time one did.
   table+=("$(printf '%-16s %-22s %s' "$name" "$status" \
     "retires=${retires:--} spec-checked=${spec_retires:--}")")
 done
@@ -220,9 +222,8 @@ printf '%s\n' "${table[@]}"
 echo
 echo "$passed/${#table[@]} passed"
 
-# `NF` must gate the rebuild rather than follow it: awk forces NF to 1 when $1
-# is assigned, so `{$1=$1} NF` would resurrect every blank and comment-only line
-# as an empty entry.
+# `NF` has to come before the rebuild, not after. Assigning to $1 sets NF to 1,
+# so `{$1=$1} NF` would bring every blank and comment line back as an entry.
 actual_sorted=$(printf '%s\n' "${failures[@]:-}" | awk 'NF { $1=$1; print }' | sort)
 expected_sorted=$(sed -e 's/#.*//' "$EXPECTED_FAIL" | awk 'NF { $1=$1; print }' | sort)
 

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -1,49 +1,15 @@
 #!/bin/bash
-# Assembles every test/asm/*.S file, runs it under the cxxrtl runner (`sim`),
-# and checks the resulting pass/fail table against test/EXPECTED_FAIL — the
-# sprint-1 baseline (ADR-0007, ADR-0008, ADR-0014). Invoked by `make test`.
+# Assembles every test/asm/*.S, runs it under the cxxrtl runner (`sim`), and
+# grades the pass/fail table against test/EXPECTED_FAIL. Invoked by `make test`.
 #
 # Usage: run_tests.sh <sim-binary> <asm-dir> <expected-fail-file> <floor-file>
 #
-# This script is the merge gate, so the failure mode that matters is a FALSE
-# GREEN — reporting success without having tested anything. Four properties
-# below exist only for that (ADR-0035):
+# This is the merge gate, so the failure mode that matters is a FALSE GREEN —
+# reporting success without having tested anything. That is what every guard
+# below is for, and each one is probed from test/probe_gates.sh.
 #
-#   * every build step's exit status is checked, and the simulator runs only
-#     when the image it would read was actually produced. An unchecked objcopy
-#     that emits an empty RAM image makes `tohost` read zero, which every test
-#     with no data dependency still turns into a PASS;
-#   * the failure set records NAME AND STATUS, not just the name, so the
-#     set-equality check against test/EXPECTED_FAIL pins the failure *mode*.
-#     A baselined test that starts failing for a new reason — a broken
-#     assembly, a crashing runner, a timeout — is a red gate, not a match;
-#   * `set -e` is on and mktemp is fatal. Without it a failed mktemp leaves
-#     $tmp empty, every artifact path collapses to the filesystem root, and a
-#     later run can pick up the previous run's stale image;
-#   * THE SUITE'S SHAPE IS ASSERTED BEFORE ANYTHING RUNS. This gate verified
-#     that every program it FOUND passed; it had no idea how many it should
-#     find, and with both baselines empty there was no red entry whose
-#     disappearance would say the suite had shrunk. test/OBSERVED_FLOOR is the
-#     manifest — it already names every program — and test/check_suite_shape.sh
-#     compares its name set against test/asm in BOTH directions up front. The
-#     orphan check that used to do half of that at the END of the run is gone;
-#     doing it after 52 assemblies and 52 simulations was strictly worse;
-#   * OBSERVATION IS COUNTED, NOT INFERRED. The RVFI monitor is this gate's
-#     per-retire oracle and nothing measured whether it ever fired. A monitor
-#     that never saw a retire — an under-sensitivity defect of the ADR-0037
-#     kind, an `ifdef` that dropped the shadow payload, a `write_cxxrtl` that
-#     optimised the instance away — left every program reporting PASS off
-#     `tohost` alone, and with test/EXPECTED_FAIL empty there was no red entry
-#     whose disappearance would say so. ADR-0032 measured that end-state
-#     checking on its own is blind to real architectural corruption. So the
-#     runner now prints how many retires the monitor examined and how many of
-#     those its spec model checked, and this script grades both: zero of either
-#     is MONITOR-SILENT (the runner's own exit 6), and a drop below
-#     test/OBSERVED_FLOOR is BELOW-FLOOR. Both are failing statuses in the same
-#     name-and-status set as everything else.
-#
-# Any nonzero exit that is *expected* is handled at its own call site (`if !`,
-# `|| status=$?`) so that error-exit stays on everywhere else.
+# `set -e` is on; a nonzero exit that is expected is handled at its own call
+# site so error-exit stays on everywhere else.
 set -euo pipefail
 
 if [ "$#" -ne 4 ]; then
@@ -58,19 +24,15 @@ OBSERVED_FLOOR=$4
 CYCLES=5000
 HERE=$(cd "$(dirname "$0")" && pwd)
 
-# Read before running anything: a mistyped or missing baseline path used to
-# yield an empty expected set, and with an all-passing suite the gate then
-# printed "Failure list matches ... exactly" having compared nothing. Fail
-# here, in a second, rather than after the whole suite has run.
+# A missing or unreadable baseline yields an EMPTY expected set, which against
+# an all-passing suite prints "Failure list matches ... exactly" having compared
+# nothing.
 if [ ! -f "$EXPECTED_FAIL" ] || [ ! -r "$EXPECTED_FAIL" ]; then
   echo "error: baseline '$EXPECTED_FAIL' does not exist or is not readable." >&2
   echo "The gate compares the failure set against it; without it there is no gate." >&2
   exit 1
 fi
 
-# Same treatment, and for the same reason: a missing floor file would make
-# every per-program floor lookup miss, and a lookup that always misses is a
-# check that never runs.
 if [ ! -f "$OBSERVED_FLOOR" ] || [ ! -r "$OBSERVED_FLOOR" ]; then
   echo "error: floor file '$OBSERVED_FLOOR' does not exist or is not readable." >&2
   echo "It records how much each program was observed to retire; without it" >&2
@@ -78,20 +40,17 @@ if [ ! -f "$OBSERVED_FLOOR" ] || [ ! -r "$OBSERVED_FLOOR" ]; then
   exit 1
 fi
 
-# THE SUITE'S SHAPE, before a single program is assembled. OBSERVED_FLOOR names
-# every program the suite must contain, and this compares that name set against
-# $ASM_DIR in both directions. It is a separate script because test/run_cosim.sh
-# runs the identical check against the identical file: two legs that disagreed
-# about what the suite is would be worse than neither checking.
+# Before anything is assembled, because a suite that shrank otherwise matches an
+# empty baseline exactly. A separate script because test/run_cosim.sh runs the
+# identical check against the identical file, and two legs that disagreed about
+# what the suite is would be worse than neither of them checking.
 if ! "$HERE/check_suite_shape.sh" "$ASM_DIR" "$OBSERVED_FLOOR"; then
   echo "error: the .S suite does not match its manifest; nothing was run." >&2
   exit 1
 fi
 
-# Read once, comments stripped, whitespace normalised — the same treatment the
-# baseline gets below. Three fields, not two: name, retire floor, spec-checked
-# floor. A malformed line is named rather than silently skipped, because a line
-# this loop cannot parse is a floor that is not enforced.
+# A malformed line is named rather than skipped: a line this cannot parse is a
+# floor that is not enforced.
 floors=$(sed -e 's/#.*//' "$OBSERVED_FLOOR" | awk 'NF { $1=$1; print }')
 malformed_floor=$(printf '%s\n' "$floors" | awk 'NF && (NF != 3 || $2 !~ /^[0-9]+$/ || $3 !~ /^[0-9]+$/) { print }')
 if [ -n "$malformed_floor" ]; then
@@ -100,8 +59,6 @@ if [ -n "$malformed_floor" ]; then
   exit 1
 fi
 
-# Toolchain: brew's riscv64-elf-gcc on macOS, apt's gcc-riscv64-unknown-elf
-# (binary name riscv64-unknown-elf-gcc) on Linux. See `make setup`.
 CC=""
 for candidate in riscv64-elf-gcc riscv64-unknown-elf-gcc; do
   if command -v "$candidate" >/dev/null 2>&1; then
@@ -115,10 +72,6 @@ if [ -z "$CC" ]; then
   exit 1
 fi
 
-# objcopy is derived from the compiler's name but probed like the compiler,
-# rather than assumed to exist because gcc did. A half-installed toolchain is
-# a setup problem and should say so once, up front, instead of surfacing as 52
-# identical per-test build failures.
 OBJCOPY=${CC%gcc}objcopy
 if ! command -v "$OBJCOPY" >/dev/null 2>&1; then
   echo "error: found $CC but not its matching $OBJCOPY." >&2
@@ -130,8 +83,8 @@ tmp=$(mktemp -d "${TMPDIR:-/tmp}/littlecpu-test.XXXXXX") || {
   echo "error: could not create a temporary directory under ${TMPDIR:-/tmp}." >&2
   exit 1
 }
-# Belt and braces: an mktemp that exits 0 with empty output would otherwise
-# collapse every artifact path to /<base>.hex and defeat the trap below.
+# mktemp is fatal here: an mktemp that exits 0 with empty output would collapse
+# every artifact path to /<base>.hex and defeat the trap below.
 if [ -z "$tmp" ] || [ ! -d "$tmp" ]; then
   echo "error: mktemp -d produced no usable directory under ${TMPDIR:-/tmp}." >&2
   exit 1
@@ -151,8 +104,7 @@ for src in "$ASM_DIR"/*.S; do
   ram_hex="$tmp/$base.ram.hex"
 
   status="PASS"
-  # Cleared per iteration, not merely assigned when the runner produces them: a
-  # carried-over value from the previous program would let a run that printed no
+  # Cleared per iteration: a carried-over value would let a run that printed no
   # counts be graded against its predecessor's.
   retires=""
   spec_retires=""
@@ -160,18 +112,12 @@ for src in "$ASM_DIR"/*.S; do
        -T "$ASM_DIR/sections.lds" "$src" -o "$elf" > "$build_log" 2>&1; then
     status="ASSEMBLE-ERROR"
   elif [ -s "$build_log" ]; then
-    # Any assembler output (warnings included) on an otherwise-successful
-    # build is still a defect per criterion 7 — zero assembler warnings.
     status="ASSEMBLE-WARNING"
   fi
 
-  # ADR-0008's two images. Both statuses are checked: a failing objcopy
-  # (a binutils without --verilog-data-width, a full disk) used to leave the
-  # previous file — or no file — in place and let the simulator run against
-  # it, reporting its verdict as if it were about the CPU. The empty case is
-  # the dangerous one and gets its own label: an empty RAM image parses fine,
-  # `tohost` reads zero, and every test with no data dependency still reaches
-  # RVTEST_PASS.
+  # The empty case is the dangerous one and gets its own label: an empty RAM
+  # image parses fine, `tohost` reads zero, and every test with no data
+  # dependency still reaches RVTEST_PASS (ADR-0035).
   if [ "$status" = "PASS" ]; then
     for region in rom ram; do
       if [ "$region" = rom ]; then
@@ -195,25 +141,18 @@ for src in "$ASM_DIR"/*.S; do
   fi
 
   if [ "$status" = "PASS" ]; then
-    # The one place error-exit is lifted, and it is lifted rather than guarded
-    # with `|| sim_status=$?` because bash 3.2 (macOS /bin/bash) rewrites a
-    # 127 "command not found" to 1 while `set -e` is in force — which would
-    # report an unstartable runner as a `FAIL`, i.e. as a verdict about the
-    # CPU. Measured, not assumed. Restored immediately after.
+    # Lifted rather than guarded with `|| sim_status=$?` because bash 3.2
+    # (macOS /bin/bash) rewrites a 127 to 1 under errexit, which would report an
+    # unstartable runner as a FAIL — a verdict about the CPU.
     set +e
     "$SIM" --rom "$rom_hex" --ram "$ram_hex" --cycles "$CYCLES" \
       > "$tmp/$base.run.log" 2>&1
     sim_status=$?
     set -e
-    # The runner's exit ladder (test/cxxrtl.cc): 0 pass, 1 tohost fail, 2 cycle
-    # limit, 3 usage/setup, 4 RVFI monitor error, 5 trap-to-zero. 4 and 5 get
-    # their own labels because each means something entirely different from
-    # "the test failed": 4 is the per-retire oracle disagreeing with the core
-    # mid-run (ADR-0019), a wrong-result report rather than a broken harness,
-    # and 5 is a trap taken before a handler was installed (ADR-0029), which
-    # would otherwise surface as a TIMEOUT naming neither the fault nor its
-    # cause. Lumping either into RUNNER-ERROR made it indistinguishable from
-    # "the sim could not be started at all".
+    # The exit ladder is test/cxxrtl.cc's. 4, 5 and 6 each get their own label
+    # because lumping any into RUNNER-ERROR reads as "the sim would not start"
+    # when it means the oracle disagreed, a trap preceded its handler, or the
+    # oracle never looked.
     case $sim_status in
       0) status="PASS" ;;
       1) num=$(awk '/^FAIL/{print $2; exit}' "$tmp/$base.run.log")
@@ -226,40 +165,26 @@ for src in "$ASM_DIR"/*.S; do
       *) status="RUNNER-ERROR $sim_status" ;;
     esac
 
-    # The runner prints exactly one `RETIRES <n> SPEC-CHECKED <m>` line on every
-    # path that reached the simulation loop, whatever its verdict, so these are
-    # available for the table even when the program failed.
     set -- $(awk '/^RETIRES /{print $2, $4; exit}' "$tmp/$base.run.log")
     retires=${1:-}
     spec_retires=${2:-}
   fi
 
-  # A PASS with no counts line is not a pass. It means the binary this gate ran
-  # is not the runner this script grades — a stale `sim` from before the
-  # counters existed, or one whose output was truncated — and every one of the
-  # observation checks below would then silently not run. Naming it is the
-  # difference between a gate and a formality.
+  # A PASS with no counts line means the binary this gate ran is not the runner
+  # it grades, and every observation check below would then silently not run.
   if [ "$status" = "PASS" ] && { [ -z "$retires" ] || [ -z "$spec_retires" ]; }; then
     status="NO-COUNTS"
   fi
 
-  # THE FLOOR, graded with `>=` and not set equality. The counts move for
-  # legitimate reasons — the assembler is free to compress differently, a test
-  # gains an instruction — and an exact ratchet on 52 numbers is one nobody
-  # would keep. What must not happen is a program going quiet: retiring nothing,
-  # or having its retires stop being spec-checked. `>=` catches that and
-  # tolerates the rest. Only PASS programs are graded; anything already failing
-  # has a more specific status, and overwriting it would lose the real reason.
+  # `>=` and not set equality: the counts move for legitimate reasons, and the
+  # thing that must not happen is a program going quiet. Only PASS programs are
+  # graded — anything already failing has a more specific status.
   if [ "$status" = "PASS" ]; then
     floor=$(printf '%s\n' "$floors" | awk -v n="$name" '$1 == n { print $2, $3; found = 1 } END { exit !found }') || floor=""
     if [ -z "$floor" ]; then
-      # UNREACHABLE as long as check_suite_shape.sh runs above: it has already
-      # required every program in $ASM_DIR to have a manifest line, and failed
-      # the whole run naming this one if it did not. Kept because the lookup has
-      # to handle the not-found case regardless, and a silent empty `$floor`
-      # would make the two comparisons below compare against nothing. If this
-      # ever fires, the two checks have gone out of step with each other, which
-      # is worth a named status rather than an arithmetic error.
+      # Unreachable while check_suite_shape.sh runs above, and kept anyway: a
+      # silent empty `$floor` would make the comparisons below compare against
+      # nothing. If it fires, the two checks have gone out of step.
       status="NO-FLOOR"
     else
       set -- $floor
@@ -284,12 +209,9 @@ for src in "$ASM_DIR"/*.S; do
       cat "$build_log" >&2
     fi
   fi
-  # The observation counts are a THIRD column, deliberately outside the
-  # name-and-status pair the baseline matches on (ADR-0035): they are a measured
-  # quantity that moves, not a verdict, and putting them in the failure set
-  # would make every baseline entry unmatchable the first time an instruction
-  # count changed. The verdict they imply — MONITOR-SILENT, BELOW-FLOOR,
-  # NO-COUNTS, NO-FLOOR — is in the status, where the gate can pin it.
+  # The counts stay outside the name-and-status pair the baseline matches on:
+  # putting a quantity that legitimately moves into the failure set would make
+  # every baseline entry unmatchable the first time it moved.
   table+=("$(printf '%-16s %-22s %s' "$name" "$status" \
     "retires=${retires:--} spec-checked=${spec_retires:--}")")
 done
@@ -298,26 +220,12 @@ printf '%s\n' "${table[@]}"
 echo
 echo "$passed/${#table[@]} passed"
 
-# Both directions of the floor file's name set (ADR-0014's contract, the same
-# one EXPECTED_FAIL and formal/EXPECTED_CHECKS are under) were checked HERE,
-# after the whole suite had run. They now run before it, in
-# check_suite_shape.sh, called at the top of this script — a manifest mismatch
-# means the run was never going to be gradeable, so spending 52 assemblies and
-# 52 simulations to discover it was the wrong order. Nothing is checked twice.
-
-# Both sides are name-and-status pairs, whitespace-normalised so the baseline
-# can stay readable. `NF` must gate the rebuild rather than follow it: awk
-# forces NF to 1 when $1 is assigned, so `{$1=$1} NF` would resurrect every
-# blank and comment-only line as an empty entry.
-# ADR-0035 amends ADR-0014: matching on the name alone let a baselined test
-# change failure mode — ASSEMBLE-ERROR, TIMEOUT, RUNNER-ERROR instead of the
-# baselined MONITOR-ERROR — and still satisfy set equality.
+# `NF` must gate the rebuild rather than follow it: awk forces NF to 1 when $1
+# is assigned, so `{$1=$1} NF` would resurrect every blank and comment-only line
+# as an empty entry.
 actual_sorted=$(printf '%s\n' "${failures[@]:-}" | awk 'NF { $1=$1; print }' | sort)
 expected_sorted=$(sed -e 's/#.*//' "$EXPECTED_FAIL" | awk 'NF { $1=$1; print }' | sort)
 
-# A one-field line is the pre-ADR-0035 format. Silently accepting it would
-# make every baselined entry unmatchable for a reason that reads like a
-# regression, so name it instead.
 malformed=$(printf '%s\n' "$expected_sorted" | awk 'NF == 1 {print}')
 if [ -n "$malformed" ]; then
   echo "error: $EXPECTED_FAIL has entries with no status (ADR-0035 format is" >&2

--- a/test/sanitize_monitor.py
+++ b/test/sanitize_monitor.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
 """Derive test/monitor.sim.v from the tracked, generated test/monitor.v.
 
-test/monitor.v is riscv-formal's `monitor/generate.py` output at the pinned SHA
-(formal/pin.mk). It is tracked but never hand-edited (CLAUDE.md invariant 7);
-defects in it are repaired here, at build time, in a gitignored derivative that
-BOTH sim legs read -- so the two legs cannot drift into checking different specs
-(ADR-0019).
+test/monitor.v is riscv-formal's `monitor/generate.py` output at the SHA pinned
+in formal/pin.mk. Do not edit it by hand. `make monitor-check` regenerates it
+into a temp file and diffs, so a hand edit shows up there as a failure, and the
+`test/monitor.v` rule overwrites it. Fix it here instead: this script rewrites it
+at build time into a gitignored copy that both sim legs read, so the two legs
+cannot end up checking different rules.
 
 This used to be a two-rule `sed` chain in the root Makefile. It moved into a
 script when the third rule arrived, because that one is a structural insert
@@ -45,49 +46,52 @@ TIME_IN_DISPLAY = (
 # branch of a conditional whose other branches are unsigned, and per IEEE 1800
 # sign-context rules that makes the division evaluate UNSIGNED -- silently, and
 # for negative operands only. `$signed()` makes it self-determined so the
-# enclosing conditional cannot downgrade it (ADR-0019).
+# enclosing conditional cannot downgrade it.
 UNSIGNED_SIGNED_DIVREM = (
     re.compile(r'\$signed\((rvfi_rs1_rdata)\) ([/%]) \$signed\((rvfi_rs2_rdata)\);'),
     r'$signed($signed(\1) \2 $signed(\3));',
     2,
 )
 
-# Rule 3. On a trapping instruction the spec model still reports what the
-# instruction WOULD have done, while a correct core writes no register, strobes
-# no memory and redirects to `mtvec`. riscv-formal's own checker gates those
-# comparisons on `!spec_trap`; the monitor generator never emits that gate, so
-# the ungated monitor reports errors 104/105/106 and 110-113 on correct hardware
-# in both sim legs (ADR-0019).
+# Rule 3. When an instruction traps, the spec model still reports what it would
+# have done had it not. A correct core writes no register, touches no memory and
+# jumps to `mtvec`, so those comparisons all disagree. riscv-formal's own checker
+# skips them when the spec model says trap; the monitor generator does not, so
+# without this it reports errors 104, 105, 106 and 110-113 on hardware that is
+# working.
 #
-# The span is selected by POSITION, first anchor to last, so the site count
-# proves the rule fired and not what it swallowed. Error 101 is the one
-# comparison upstream deliberately keeps live under `spec_trap`; a pin bump
-# emitting it between the anchors would keep the count at 1 and make "did the
-# core trap when the spec says it must" vacuous in both legs. Hence three
-# content layers: forbidden literals in the span, the exact multiset of enclosed
-# handle_error codes, and a post-check that 101 survives into the output.
+# The span below is found by position, from the first anchor to the last. That
+# means counting the matches tells us the rule fired but not what it wrapped.
+# Error 101 is the one comparison that must keep running when an instruction
+# traps -- it is the check that the core trapped at all. If a new version of the
+# generator moved it between the two anchors, the count would still be 1 and that
+# check would quietly stop working in both sim legs. So there are three more
+# checks below: literals that must not appear inside the span, the exact list of
+# error codes it is allowed to contain, and one afterwards that 101 is still in
+# the output.
 TRAP_GATE_SPAN = re.compile(
     r'(?P<indent>[ ]*)if \((?P<ch>ch\d+)_rvfi_rs1_addr != (?P=ch)_spec_rs1_addr\b.*?'
     r'(?P=ch)_handle_error\(\d+, "mismatch in mem_addr"\);\n[ ]*end\n',
     re.DOTALL,
 )
 
-# Layer 1. Both spellings of the trap comparison the generator emits today.
+# Both ways the generator currently writes the trap comparison. Either one
+# inside the span means it has moved and must not be wrapped.
 TRAP_GATE_FORBIDDEN = (
     '"mismatch in trap"',
     '_rvfi_trap != ',
 )
 
-# Layer 2. DERIVED from test/monitor.v at the pin, not chosen. After a pin bump,
-# re-derive it and confirm each code belongs under `!spec_trap` per
-# checks/rvfi_insn_check.sv. Do not edit it to make a failure go away: a code
-# appearing here that upstream keeps outside the gate is the silent-oracle
-# failure this list exists to catch.
+# Read off test/monitor.v at the current pin, not chosen. After a pin bump, read
+# it off again and check each code against riscv-formal's own checker to see that
+# it really does belong inside the gate. Do not edit this list to make a failure
+# go away — a code turning up here that upstream keeps outside the gate is
+# exactly what this list is here to catch.
 TRAP_GATE_ENCLOSED_CODES = sorted(
     [102, 103, 104, 105, 106, 108, 110, 120, 111, 121, 112, 122, 113, 123, 107]
 )
 
-# Layer 3. The monitor is generated `-c 1`, so exactly one channel emits it.
+# The monitor is generated with one retire channel, so there is exactly one.
 TRAP_COMPARISON = re.compile(r'ch\d+_handle_error\(101, "mismatch in trap"\)')
 TRAP_COMPARISON_SITES = 1
 
@@ -144,12 +148,11 @@ RULES = [
 
 
 def _check_trap_comparison_survives(text):
-    """Layer 3: the trap comparison must still be in the sanitized output.
+    """Error 101 must still be in the output.
 
-    Layers 1 and 2 catch the generator MOVING error 101 inside the gate. Neither
-    notices it disappearing altogether -- the enclosed-code list would still
-    match and the site count would still be 1, while the sanitized oracle no
-    longer checks whether the core traps at all.
+    The other two checks catch the generator moving it inside the gate. Neither
+    notices it going away entirely: the code list would still match and the count
+    would still be 1, while nothing checked whether the core trapped at all.
     """
     found = len(TRAP_COMPARISON.findall(text))
     if found != TRAP_COMPARISON_SITES:

--- a/test/sanitize_monitor.py
+++ b/test/sanitize_monitor.py
@@ -32,109 +32,62 @@ Usage: sanitize_monitor.py <monitor.v>   # sanitized source on stdout
 import re
 import sys
 
-# ---------------------------------------------------------------------------
-# Rule 1 -- strip `$time` from the `$display` error banners.
-#
-# yosys's AST_AUTOWIRE elaboration trips on `$time` used as a bare `$display`
-# argument (iverilog handles it fine, yosys does not), so the cxxrtl leg cannot
-# read the file as generated. The iverilog leg loses a timestamp in its error
-# banner; that is a diagnostic nicety, not a check.
-# ---------------------------------------------------------------------------
+# Rule 1. yosys's AST_AUTOWIRE elaboration trips on `$time` as a bare `$display`
+# argument, so the cxxrtl leg cannot read the file as generated. The iverilog leg
+# loses a timestamp from an error banner, which is not a check.
 TIME_IN_DISPLAY = (
     re.compile(r' at time %0t --------", ([A-Za-z0-9_]+), \$time\)'),
     r' --------", \1)',
     4,
 )
 
-# ---------------------------------------------------------------------------
-# Rule 2 -- make signed DIV/REM self-determined (ADR-0019).
-#
-# monitor_insn_div / monitor_insn_rem compute the signed result as one branch of
-# a conditional whose other branches are unsigned. Per IEEE 1800 sign-context
-# rules the conditional's type is unsigned and that propagates down into the
-# division, which is then evaluated UNSIGNED -- silently, and wrongly, for
-# negative operands only. Wrapping the arithmetic in `$signed()` makes it
-# self-determined, so the enclosing conditional can no longer downgrade it.
-# Anchored on the exact operand names and the trailing semicolon so it cannot
-# match anywhere it was not meant to. Two sites: DIV's `/` and REM's `%`.
-# ---------------------------------------------------------------------------
+# Rule 2. monitor_insn_div / monitor_insn_rem compute the signed result as one
+# branch of a conditional whose other branches are unsigned, and per IEEE 1800
+# sign-context rules that makes the division evaluate UNSIGNED -- silently, and
+# for negative operands only. `$signed()` makes it self-determined so the
+# enclosing conditional cannot downgrade it (ADR-0019).
 UNSIGNED_SIGNED_DIVREM = (
     re.compile(r'\$signed\((rvfi_rs1_rdata)\) ([/%]) \$signed\((rvfi_rs2_rdata)\);'),
     r'$signed($signed(\1) \2 $signed(\3));',
     2,
 )
 
-# ---------------------------------------------------------------------------
-# Rule 3 -- gate the spec-value checks on `!spec_trap`.
+# Rule 3. On a trapping instruction the spec model still reports what the
+# instruction WOULD have done, while a correct core writes no register, strobes
+# no memory and redirects to `mtvec`. riscv-formal's own checker gates those
+# comparisons on `!spec_trap`; the monitor generator never emits that gate, so
+# the ungated monitor reports errors 104/105/106 and 110-113 on correct hardware
+# in both sim legs (ADR-0019).
 #
-# riscv-formal's own checker (checks/rvfi_insn_check.sv) puts rs1_addr,
-# rs2_addr, rd_addr, rd_wdata, pc_wdata and every mem_* assertion inside
-# `if (!spec_trap)`, leaving only `assert(spec_trap == trap)` outside. The
-# monitor generator never emits that gate: it runs all of those comparisons
-# unconditionally once spec_valid holds.
-#
-# On a trapping instruction the spec model still reports what the instruction
-# WOULD have done -- for a misaligned `lw`, spec_rd_addr is the destination
-# register, spec_rd_wdata is the loaded value, spec_pc_wdata is pc+4 and
-# spec_mem_rmask is the byte mask. A correct core writes no register, strobes no
-# memory and redirects to `mtvec` (ADR-0028). So the ungated monitor reports
-# errors 104/105/106 and 110-113 on correct hardware, in both sim legs, for
-# every trapping retire. That is a defect in the generated oracle, and per
-# ADR-0019 it is repaired here rather than parked in test/EXPECTED_FAIL.
-#
-# The span wrapped runs from the rs1_addr comparison (error 102) through the
-# mem_addr comparison (error 107) -- i.e. everything the generator emits inside
-# `if (chN_spec_valid)` except the trap-flag comparison (error 101), which is
-# exactly the partition upstream's checker uses. Two lines are inserted and
-# nothing is reindented, so the diff stays readable.
-#
-# The span is selected by POSITION -- first anchor to last anchor -- so the site
-# count alone only proves the rule fired, not what it swallowed. That is not
-# enough. `assert(spec_trap == trap)` (error 101) is the one comparison
-# upstream's checker deliberately keeps live under `spec_trap`; if a pin bump
-# emitted it anywhere between the two anchors, the count would still read 1, the
-# diff would still be eight lines, and "did the core trap when the spec says it
-# should" would become vacuous on every trapping retire -- in BOTH sim legs,
-# silently, exactly as M3 starts producing trapping retires. So the rule also
-# asserts on the CONTENTS of what it is about to wrap, in three layers:
-#
-#   1. two literal markers that must not appear inside the span;
-#   2. the exact list of handle_error codes enclosed, which catches a relocated
-#      check however its comparison is spelled -- 101 is not on the list;
-#   3. after all rules run, that the trap comparison still exists in the output
-#      (see _check_trap_comparison_survives), which catches the generator
-#      dropping it rather than moving it.
-# ---------------------------------------------------------------------------
+# The span is selected by POSITION, first anchor to last, so the site count
+# proves the rule fired and not what it swallowed. Error 101 is the one
+# comparison upstream deliberately keeps live under `spec_trap`; a pin bump
+# emitting it between the anchors would keep the count at 1 and make "did the
+# core trap when the spec says it must" vacuous in both legs. Hence three
+# content layers: forbidden literals in the span, the exact multiset of enclosed
+# handle_error codes, and a post-check that 101 survives into the output.
 TRAP_GATE_SPAN = re.compile(
     r'(?P<indent>[ ]*)if \((?P<ch>ch\d+)_rvfi_rs1_addr != (?P=ch)_spec_rs1_addr\b.*?'
     r'(?P=ch)_handle_error\(\d+, "mismatch in mem_addr"\);\n[ ]*end\n',
     re.DOTALL,
 )
 
-# Layer 1. Both spellings of the trap comparison the generator emits today. A
-# match means the generator relocated it inside the span and gating it would
-# disable it.
+# Layer 1. Both spellings of the trap comparison the generator emits today.
 TRAP_GATE_FORBIDDEN = (
     '"mismatch in trap"',
     '_rvfi_trap != ',
 )
 
-# Layer 2. DERIVED, not chosen: this is the exact multiset of handle_error codes
-# the generator emits between the two anchors, read off test/monitor.v at the
-# SHA in formal/pin.mk. Compared sorted, so a harmless reordering inside the
-# span does not trip it but an added, removed or duplicated check does.
-#
-# After a pin bump, RE-DERIVE this from the new test/monitor.v -- read what the
-# generator now emits inside `if (chN_spec_valid)` and confirm each code belongs
-# under `!spec_trap` per riscv-formal's checks/rvfi_insn_check.sv. Do NOT edit it
-# to make a failure go away: a code appearing here that upstream keeps outside
-# the gate is precisely the silent-oracle failure this list exists to catch.
+# Layer 2. DERIVED from test/monitor.v at the pin, not chosen. After a pin bump,
+# re-derive it and confirm each code belongs under `!spec_trap` per
+# checks/rvfi_insn_check.sv. Do not edit it to make a failure go away: a code
+# appearing here that upstream keeps outside the gate is the silent-oracle
+# failure this list exists to catch.
 TRAP_GATE_ENCLOSED_CODES = sorted(
     [102, 103, 104, 105, 106, 108, 110, 120, 111, 121, 112, 122, 113, 123, 107]
 )
 
-# Layer 3. The generated monitor is `generate.py -c 1` (one retire channel, see
-# the root Makefile's MONITOR_GEN), so exactly one channel emits the check.
+# Layer 3. The monitor is generated `-c 1`, so exactly one channel emits it.
 TRAP_COMPARISON = re.compile(r'ch\d+_handle_error\(101, "mismatch in trap"\)')
 TRAP_COMPARISON_SITES = 1
 


### PR DESCRIPTION
Comments only, in the build and the grading layer. Closes JEF-719.

Two passes: delete first, then replace every document reference with the thing it
was standing in for.

## References to ADRs and invariants: zero

```
$ grep -rnE 'ADR-[0-9]+|invariant [0-9]' <the seven files> | grep -cE ':[0-9]+:\s*#'
0
```

Twelve remain in `@echo` strings, `probe` labels and error messages. Those are
code — they are what the tools print at runtime — so changing them is not a
comment change. They are listed at the bottom.

## Comments-only proof

```
$ git diff -U0 origin/main | grep '^[+-]' | grep -v '^[+-][+-]' | grep -vE '^[+-]\s*(#|$)'
```

Prints only Python docstring lines, which are prose. Behaviour is unchanged,
checked three ways:

- **`make -n` compared old against new across 26 targets** — all byte-identical.
  The `@#` lines inside the `clean`, `soc.json` and `soc-timing` recipes are shell
  commands, not make comments, and are untouched.
- **`sanitize_monitor.py`'s output on `test/monitor.v` is byte-identical.**
- `bash -n` and `py_compile` on all seven.

## Two claims were wrong, and checking is what found them

**`sanitize_monitor.py` said a hand edit to `test/monitor.v` "would be silently
reverted by the next `make monitor-check`".** It would not. The recipe is
`($(MONITOR_GEN)) > "$$tmp" && diff -u test/monitor.v "$$tmp"` — it regenerates
into a temp file and diffs. It reverts nothing; it fails. The comment now says
that, and names the `test/monitor.v` rule as the thing that does overwrite.

**The `make fit` comment said the design presents 231 `SB_IO`.** The current
`fit.log` says **265**. That is the same class as the nine stale numbers from the
first pass, so the count is dropped rather than re-pinned.

## Three figures I could not verify, deleted rather than repeated

- `soc-timing`'s **11.30 MHz** and its **87.43–88.51 ns** seed spread. This
  machine measures 10.44 MHz. The point they supported — one placement is a
  sample, the number moves on edits that change no hardware — is stated without
  them.
- **"A missing `btorsim` turns every FAIL into ERROR."** Plausible, not checkable
  from the code, and not what the reader needs. What the gate needs them to know
  is that FAIL and ERROR want different fixes.

## Before/after

**A tripwire that named a defect, now naming the mechanism**

```diff
-# The RTL both sim legs elaborate, named ONCE. This list used to be written out
-# per recipe, and .github/workflows/ci.yml's `elaborate` job carried a fourth
-# hand-maintained copy under a comment asserting that it "reads the same
-# sources, so the two cannot diverge on what they elaborate". They diverged the
-# moment ADR-0054 put rtl/imemory.v and rtl/memory.v on the graph: [...]
+# Both sim legs build from this list. Do not copy it anywhere else — a second
+# copy goes stale and the gate then checks a different design than it says it
+# does. The CI job had one; it missed rtl/imemory.v and rtl/memory.v when they
+# landed, and spent a run elaborating a testbench whose memories were not there.
+# That job calls `make elaborate-strict` now, so there is one list to update.
```

**The wrong one**

```diff
-(formal/pin.mk). It is tracked but never hand-edited (CLAUDE.md invariant 7);
+in formal/pin.mk. Do not edit it by hand. `make monitor-check` regenerates it
+into a temp file and diffs, so a hand edit shows up there as a failure, and the
+`test/monitor.v` rule overwrites it.
```

**A number that had drifted**

```diff
-# Do not try to make the placement succeed. This top presents 231 `SB_IO`
-# against sg48's 39, so nextpnr always errors on a pad [...] (ADR-0038).
+# Placement always fails here, and that is fine. This top has its memories
+# outside the chip, so it needs far more pins than the sg48 package has and
+# nextpnr gives up on one. It prints the utilisation table before it gets that
+# far, and that table is the number we want.
```

## Per-file deltas (comment lines)

| File | before | after | delta | deleted |
|---|---|---|---|---|
| `Makefile` | 483 | 85 | **-398** | 82% |
| `test/probe_gates.sh` | 231 | 91 | -140 | 61% |
| `test/run_tests.sh` | 140 | 50 | -90 | 64% |
| `formal/check-baseline.sh` | 130 | 45 | -85 | 65% |
| `test/sanitize_monitor.py` | 77 | 33 | -44 | 57% |
| `test/run_cosim.sh` | 64 | 25 | -39 | 61% |
| `formal/genchecks-audit.py` | 65 | 31 | -34 | 52% |
| **total** | **1190** | **360** | **-830** | **70%** |

## Stale numbers corrected (first pass, still corrected)

`test-units` "seven benches" → **eight**. `sim` "46 tests" and `run_tests.sh`'s
three "52" counts → **56**. `make test` `-march=rv32im_zicsr` → the script
assembles `rv32imc_zicsr_zifencei`. `EXPECTED_FAIL` "the sprint-1 baseline" of a
"still-broken" core → it is empty. `FIT_MAX_LC`'s 4400/4208/4236/4187/3875 and
"roughly 3896" → **3899 of 4100**. `check-baseline.sh`'s 82-check ladder → **85**.
`run_cosim.sh` "52 programs to 12" → count-free. `probe_gates.sh`'s host timings →
deleted. Plus the two above, found this pass.

## Tripwires

None dropped. Each is now a mechanism rather than a pointer: `SIM_RTL_SRCS` in one
place, the yosys script on one physical line, the clone as an order-only
prerequisite, `set -e` before `mktemp`, objcopy's empty image, the sanitizer's
site counts and content checks, and `check-baseline.sh` on an unreadable baseline.

## References left in code (not comments)

`Makefile` 516, 518 (`@echo`) · `run_tests.sh` 232 (`echo`) · `probe_gates.sh`
326, 605, 812 (`probe` labels) · `sanitize_monitor.py` 192 (error f-string) ·
`genchecks-audit.py` 186 (error string) · `check-baseline.sh` 103, 118, 145, 197
(`echo` / error text).

## Gates

| Gate | Result |
|---|---|
| `make -C formal check JOBS=4` | **85 checks: 85 pass, 0 fail**, both set equalities matching. 21m34s at host load 7-11 of 10 cores |
| `make test` | **56/56 passed** |
| `make test-units` | **8 benches** |
| `make probe-gates` | **125 graded comparisons** |
| `make lint` | clean in both passes |
| `make fit` | **3899 of 4100 — OK** |
| `make soc-timing` | **10.44 MHz against a 10.00 floor — OK** |

`/soundcheck:pr-review`: no Critical or High findings. Pins, guards, extract
ordering and traversal audits are byte-identical to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
