### PR TITLE
Delete the comments in the formal harness and the benches (JEF-719)

### DIFF
--- a/formal/dmemcheck.sv
+++ b/formal/dmemcheck.sv
@@ -30,15 +30,8 @@ module testbench (
 
   logic [31:0] imem_addr;
   logic [31:0] imem_data;
-  // ADR-0003: dmemcheck only cares about the data bus, so the dual-word
-  // fetch window's second port is left free just like imem_addr/imem_data
-  // above -- unconstrained, no assumes.
   logic [31:0] imem_addr2;
   logic [31:0] imem_data2;
-  // ADR-0054: the fetch address one cycle early, for a synchronous memory.
-  // Unread here for the same reason as the pair above: this task is about the
-  // data bus. Connected rather than left dangling so every instantiation of the
-  // core names every port.
   logic [31:0] imem_addr_next;
   logic [31:0] mem_addr;
   logic [31:0] mem_wdata;
@@ -46,29 +39,16 @@ module testbench (
   logic        mem_ren;
   logic [31:0] mem_rdata;
 
-  // ADR-0059's steal, tied low: this task is about the data bus, and its fetch
-  // side is free every cycle from a memory it does not model, so a steal would
-  // add stall cycles and no coverage. formal/wrapper.v is where the arbiter is
-  // transcribed and driven.
+  // Tied low rather than left free: this task is about the data bus, so a steal
+  // would add stall cycles and no coverage. formal/wrapper.v models the arbiter.
   logic        fetch_stall = 1'b0;
 
-  // rvfi_dmem_check (riscv-formal, unmodified) already builds its own
-  // load-after-store shadow purely from rvfi_mem_*, so it needs no
-  // connection to the raw bus at all -- the block below exists only to
-  // constrain the *environment*: without it mem_rdata is a free signal
-  // every cycle (see wrapper.v), and no design, buggy or not, could ever
-  // satisfy that RVFI-level shadow's assertion. It has to be built from
-  // the raw bus because rvfi_dmem_check has no visibility into cycles that
-  // don't retire a memory op.
-  //
-  // Write side: rtl/accessor.v (ADR-0015) drives a store's address, data,
-  // and strobe together, combinationally, in the one cycle the request
-  // fires ("mem_wdata must be combinational, in lockstep with
-  // mem_addr/mem_wstrb" -- accessor.v's own comment on the bug this fixed).
-  // Gating on `mem_wstrb` alone is exact: rtl/accessor.v's always_comb
-  // defaults `mem_wstrb = 0` every cycle that isn't a real store, so no
-  // separate valid signal is needed here the way the wave-0
-  // mem_valid/mem_ready handshake needed one.
+  // Constrains the environment rather than duplicating the checker, which
+  // builds its own load-after-store shadow from rvfi_mem_* alone: mem_rdata is
+  // otherwise free every cycle and no design could satisfy that assertion. It
+  // reads the raw bus because rvfi_dmem_check cannot see cycles that retire no
+  // memory op. Gating on `mem_wstrb` alone is exact, since rtl/accessor.v
+  // defaults the strobe to 0 on every cycle that is not a real store.
   logic [31:0] dmem_data;
   always_ff @(posedge clk) begin
     if (!reset && mem_addr == dmem_addr) begin
@@ -79,44 +59,17 @@ module testbench (
     end
   end
 
-  // FACT       the data bus returns, one cycle after the request, whatever was
-  //            last written to that address -- an ordinary memory, modelled at
-  //            one address because that is all rvfi_dmem_check pins.
-  // DISCHARGED PARTIALLY, and only for part of the address space, which is
-  //            what separates it from the imem assumes in wrapper.v and
-  //            imemcheck.sv (those model rtl/imemory.v, a ROM that really does
-  //            behave this way at every address). test/mem_tb.v checks
-  //            rtl/memory.v's read-after-write behaviour directly and is on
-  //            `make test-units` -- ADR-0010's "in no current test path" is
-  //            stale, and mem_tb.v's own header repeats it. But rtl/memory.v
-  //            answers an address at or past 4*RAM with `mem_rdata <=
-  //            mem_wdata`, not with stored data, and mem_tb.v only asserts
-  //            that such a read does not ALIAS ram[0] -- it never says what it
-  //            returns. `dmem_addr` here is a free 32-bit value, so the model
-  //            this proof assumes and the only writable memory this repo has
-  //            disagree over most of the address space. ADR-0044 rules the
-  //            placeholder out as a starting point and does not replace it, so
-  //            when the real memory system is built there is no check anywhere
-  //            that will hold it to what this proof assumed (ADR-0049 F4).
-  // SCOPE      the one rvfi_dmem_check assertion this task contains -- what it
-  //            was written for, and nothing more. Like imemcheck.sv's four,
-  //            this constrains a DUT INPUT (mem_rdata), so it narrows the
-  //            environment and can never excuse the core.
+  // Assumed: the bus returns, one cycle after the request, whatever was last
+  // written to that address. Discharged only inside the mapped region, by
+  // test/mem_tb.v -- outside it the real memory drops the write and reads zero
+  // while this model retains, and `dmem_addr` is free, so the assume is
+  // stronger than rtl/memory.v over most of the address space (ADR-0049 F4).
+  // Its scope is the one rvfi_dmem_check assertion here, and it constrains a
+  // DUT input, so it narrows the environment and can never excuse the core.
   //
-  // Read side is genuinely one cycle behind the request, unlike the
-  // wave-0 handshake harness this replaces: ADR-0015's load turnaround
-  // registers mem_rdata the cycle *after* the address is presented, and
-  // rtl/accessor.v's always_comb reverts mem_addr to its 0 default on that
-  // response cycle (no new request is in flight), so this cycle's
-  // mem_rdata must be checked against *last* cycle's mem_addr, not this
-  // cycle's. $past(mem_addr) == dmem_addr can also fire for an ordinary
-  // idle cycle when the solver happens to pick dmem_addr == 0 (RAM base
-  // per ADR-0008, so 0 is a legal address and, absent a valid signal,
-  // genuinely indistinguishable from idle by address alone) -- that
-  // coincidence is harmless: rtl/accessor.v only ever reads mem_rdata on
-  // the cycle following a *real* load request (its internal
-  // `pending_valid`, invisible from here), so constraining mem_rdata on a
-  // cycle the core doesn't consume it changes nothing observable.
+  // Against LAST cycle's mem_addr because ADR-0015's load turnaround registers
+  // mem_rdata the cycle after the address is presented, and rtl/accessor.v
+  // reverts mem_addr to 0 on that response cycle.
   always_ff @(posedge clk) begin
     if (!reset && $past(mem_addr) == dmem_addr && !$past(mem_wstrb))
       assume(dmem_data == mem_rdata);

--- a/formal/dmemcheck.sv
+++ b/formal/dmemcheck.sv
@@ -43,12 +43,12 @@ module testbench (
   // would add stall cycles and no coverage. formal/wrapper.v models the arbiter.
   logic        fetch_stall = 1'b0;
 
-  // Constrains the environment rather than duplicating the checker, which
-  // builds its own load-after-store shadow from rvfi_mem_* alone: mem_rdata is
-  // otherwise free every cycle and no design could satisfy that assertion. It
-  // reads the raw bus because rvfi_dmem_check cannot see cycles that retire no
-  // memory op. Gating on `mem_wstrb` alone is exact, since rtl/accessor.v
-  // defaults the strobe to 0 on every cycle that is not a real store.
+  // rvfi_dmem_check does its own tracking and does not need this. What this is
+  // for: mem_rdata is otherwise a free input every cycle, and no design could
+  // satisfy the check against a memory that answers anything it likes. It reads
+  // the bus directly because rvfi_dmem_check only sees cycles that retire a
+  // load or a store. Watching mem_wstrb alone is enough, because rtl/accessor.v
+  // sets it to 0 on every cycle that is not a store.
   logic [31:0] dmem_data;
   always_ff @(posedge clk) begin
     if (!reset && mem_addr == dmem_addr) begin
@@ -59,17 +59,21 @@ module testbench (
     end
   end
 
-  // Assumed: the bus returns, one cycle after the request, whatever was last
-  // written to that address. Discharged only inside the mapped region, by
-  // test/mem_tb.v -- outside it the real memory drops the write and reads zero
-  // while this model retains, and `dmem_addr` is free, so the assume is
-  // stronger than rtl/memory.v over most of the address space (ADR-0049 F4).
-  // Its scope is the one rvfi_dmem_check assertion here, and it constrains a
-  // DUT input, so it narrows the environment and can never excuse the core.
+  // Assumed: the bus returns whatever was last written to that address, one
+  // cycle after the request.
   //
-  // Against LAST cycle's mem_addr because ADR-0015's load turnaround registers
-  // mem_rdata the cycle after the address is presented, and rtl/accessor.v
-  // reverts mem_addr to 0 on that response cycle.
+  // test/mem_tb.v checks that rtl/memory.v really does this, but only inside
+  // the mapped region. Outside it the real memory drops the write and reads
+  // zero, where this keeps the value. dmem_addr is a free 32-bit input, so over
+  // most of the address space this assumes a memory the core does not have.
+  //
+  // It reaches only the one rvfi_dmem_check assertion below. It constrains an
+  // input to the core rather than an output, so it can narrow what the solver
+  // may try but it cannot excuse a bug.
+  //
+  // Compared against last cycle's mem_addr. A load's data arrives the cycle
+  // after its address, and rtl/accessor.v has already put mem_addr back to 0 by
+  // then.
   always_ff @(posedge clk) begin
     if (!reset && $past(mem_addr) == dmem_addr && !$past(mem_wstrb))
       assume(dmem_data == mem_rdata);

--- a/formal/pcloop.sv
+++ b/formal/pcloop.sv
@@ -1,16 +1,16 @@
-// The fetcher and the decoder wired together as rtl/littlecpu.v wires them, so
-// that the pc echo rtl/decoder.v's standalone task has to assume becomes an
-// assertion here. Under that assumption its pc-increment assertions read
-// `pc <= pc + pc_inc`, which is what they are trying to prove (ADR-0017).
+// The fetcher and the decoder, wired together the way rtl/littlecpu.v wires
+// them. On its own the decoder cannot prove its pc arithmetic. It has to assume
+// the fetcher hands back the pc it was given, and under that assumption its own
+// assertions say pc == pc + pc_inc. Here that echo is asserted instead.
 //
-// formal/components.sby must keep reading the RTL WITHOUT -formal for this
-// task. Compiled with it the decoder brings its own `assume(in.pc == pc)`
-// along, assumes the echo asserted here, and turns a broken fetcher into an
+// Keep reading the RTL without -formal for this task; formal/components.sby
+// does. With -formal the decoder brings its own assume along, and it assumes
+// the very thing this task asserts. A broken fetcher would come out as an
 // unreachable state instead of a counterexample.
 //
-// Everything this task does not instantiate stays a free input, which is the
-// stronger environment and costs nothing: reg_rs1, mtvec and mepc reach pc
-// arithmetic only on cycles the increment assertion already excludes.
+// Everything not instantiated here is a free input. That is safe. reg_rs1,
+// mtvec and mepc only reach the pc on jump, branch, trap and mret cycles, and
+// the increment assertion skips all of those.
 `default_nettype none
 
 module pcloop (
@@ -38,7 +38,6 @@ module pcloop (
   fetcher_output fetcher_out;
   decoder_output decoder_out;
   logic [4:0] rs1, rs2;
-  // rtl/csrs.v's half of the decoder's output, unread here but for f_redirect.
   logic [11:0] csr_addr;
   logic        csr_ren, csr_wen, instret;
   logic [31:0] csr_wdata;
@@ -96,31 +95,34 @@ module pcloop (
   initial clocked = 0;
   always_ff @(posedge clk) clocked <= 1;
 
-  // Assumed: reset is asserted before the first edge and never returns -- true
-  // of every harness in the tree, asserted by none of them, and unguarded, so
-  // it is in force over every assertion here rather than only the pc-history
-  // pair it was written for (ADR-0049).
+  // Assumed: reset is high before the first clock edge and low forever after.
+  // Every harness in this tree drives it that way. Nothing proves it, so this
+  // is a convention, not a fact.
+  //
+  // It is unguarded, so it holds over every assertion below, not just the two
+  // that compare pc across a cycle. Those two are why it is here. Reset sets
+  // next_pc to 0, so a solver free to raise reset again could zero pc between
+  // the two cycles and satisfy them for the wrong reason.
   initial assume(reset);
   always_comb if (!clocked) assume(reset);
   always_comb if (clocked) assume(!reset);
 
-  // Never reach into the decoder instance for a guard signal: yosys does not
-  // resolve `decoder.uncompressed`, it implicitly declares an undriven wire of
-  // that name and lets the solver drive it freely. An earlier revision of this
-  // file got a "counterexample" that way, in which pc stepped 0 -> 4 correctly
-  // while the sampled history claimed the instruction was compressed.
+  // Build the guard signals below from this module's own ports. Do not write
+  // `decoder.uncompressed` or anything like it. yosys does not reach into the
+  // instance: it makes a new wire with that name, nothing drives it, and the
+  // solver picks the value. An earlier version of this file did that and got a
+  // counterexample where pc stepped 0 -> 4 correctly while the recorded history
+  // said the instruction was compressed.
   //
-  // Re-deriving is also stronger, and decoder.v's upper-half masking cannot
-  // make it disagree: every uncompressed match below requires quadrant ==
-  // 2'b11, where the mask is the identity, and every compressed match reads
-  // only instr[15:0].
+  // The decoder zeroes instr[31:16] when the low two bits are not 2'b11. That
+  // cannot put these terms out of step with it. Every 32-bit match below needs
+  // those bits to be 2'b11, and every compressed match reads only instr[15:0].
   logic [31:0] f_instr;
   assign f_instr = fetcher_out.instr;
   logic f_uncompressed;
   assign f_uncompressed = f_instr[1:0] == 2'b11;
-  // A branch opcode with funct3 2'b01x matches none of the six instr_b* flags,
-  // takes no arm in the publish block and falls through to the sequential pc,
-  // so it is deliberately not excluded here.
+  // A branch opcode with funct3 010 or 011 is none of the six branches. The
+  // decoder gives it no arm and the pc advances normally, so do not exclude it.
   logic f_jump_branch;
   assign f_jump_branch =
       // jal / jalr (rtl/decoder.v instr_jal_op / instr_jalr_op)
@@ -137,11 +139,10 @@ module pcloop (
       (f_instr[1:0] == 2'b10 && f_instr[15:13] == 3'b100 && f_instr[6:2] == 5'b0 &&
          f_instr[11:7] != 5'b0);
 
-  // Every term here over-approximates rtl/decoder.v's `stall`, which also
-  // requires the instruction to consume the operand; restating that would
-  // duplicate most of decode. Excusing a superset of the stall cycles is sound
-  // for the increment assertion, and the RAW-hazard hold it gives up is
-  // asserted in rtl/decoder.v's own FORMAL block.
+  // These terms are wider than the decoder's real stall conditions. The decoder
+  // also checks that the instruction uses the register, and copying that would
+  // mean copying most of decode. Wider is safe: it only skips more cycles. The
+  // cycles it skips are covered by rtl/decoder.v's own proof.
   logic f_live_rs1, f_live_rs2, f_may_stall;
   assign f_live_rs1 = rs1 != 0 &&
       ((decoder_out.valid && decoder_out.rd == rs1) ||
@@ -151,15 +152,14 @@ module pcloop (
       ((decoder_out.valid && decoder_out.rd == rs2) ||
        (executor_out.valid && executor_out.rd == rs2) ||
        (accessor_pending_valid && accessor_pending_rd == rs2));
-  // The whole SYSTEM opcode rather than the six csrr* funct3s, because `mret`
-  // serializes too and has funct3 == 0.
+  // The whole SYSTEM opcode, not just the six csrr* funct3 values. mret waits
+  // for the pipeline too, and its funct3 is 0.
   logic f_system;
   assign f_system = f_uncompressed && f_instr[6:2] == 5'b11100;
 
-  // This term does not hollow out the increment assertion, for a structural
-  // reason: `operand_stall` holds the pc, so the same word is re-presented and
-  // rs1/rs2 are unchanged on the cycle the instruction actually issues. Every
-  // cycle the pc really advances on is therefore a cycle it calls quiet.
+  // Widening this one does not make the increment assertion useless. A stalled
+  // decoder holds the pc, so the same instruction word comes back next cycle
+  // and rs1/rs2 do not change. On the cycle the pc really moves, this is low.
   logic [4:0] f_prev_rs1, f_prev_rs2;
   logic       f_read_taken, f_operand_fetch;
   always_ff @(posedge clk) begin
@@ -175,28 +175,31 @@ module pcloop (
   end
   assign f_operand_fetch = !f_read_taken || f_prev_rs1 != rs1 || f_prev_rs2 != rs2;
 
-  // `f_may_stall` must name every stall reason the decoder has -- six now. A
-  // missing one makes the sequential-advance assertion cover a cycle the
-  // decoder legitimately holds the pc on and the task goes red on correct RTL,
-  // which is how ADR-0042's operand-fetch cycle left it failing. `f_system`
-  // cannot cover `fence.i`: that is the SYSTEM opcode and this is MISC-MEM.
+  // List every reason decode can stall. Miss one and the assertion below covers
+  // a cycle where the pc is allowed to hold, then fails there instead of
+  // finding a real bug. This has happened before: the register file read became
+  // synchronous, that added a stall, and this list did not know about it.
+  //
+  // f_system does not cover fence.i. That term matches SYSTEM; fence.i is
+  // MISC-MEM.
   logic f_fencei;
   assign f_fencei = f_uncompressed && f_instr[6:2] == 5'b00011;
 
   assign f_may_stall = divider_stall || accessor_stall || fetch_stall ||
       f_live_rs1 || f_live_rs2 || f_system || f_fencei || f_operand_fetch;
 
-  // The one guard not re-derived from `f_instr`, because "would the decoder
-  // consider this word illegal" is decode. Taking it off the DUT's own output
-  // ports excuses cycles on the DUT's say-so, which is why the two assertions
-  // at the bottom pin where the pc went on exactly those cycles: a decoder
-  // claiming a spurious trap would then have to land on mtvec.
+  // Read off the decoder's outputs rather than decoded here. Working out
+  // whether a word is illegal is most of decode, and copying it would defeat
+  // the point of this file.
+  //
+  // That lets the decoder excuse its own cycles, so the last two assertions
+  // below check where the pc actually went on them. Claim a trap you did not
+  // take and you still have to land on mtvec.
   logic f_redirect;
   assign f_redirect = trap_entry || mret_entry;
 
-  // Sampled at the same posedge that updates pc, which is the right phase
-  // because `pc <= fetcher_pc + pc_inc` computes both addends combinationally
-  // from the pre-edge state.
+  // Sampled on the same edge that updates pc. That is the right edge: pc is
+  // computed from values that had settled before it.
   logic [31:0] past_pc, prev_mtvec, prev_mepc;
   logic prev_reset, prev_may_stall, prev_hard_stall, prev_jump_branch, prev_uncompressed;
   logic prev_trap_entry, prev_mret_entry, prev_fetch_stall;
@@ -216,33 +219,32 @@ module pcloop (
 
   always_comb if (clocked && !reset) assert(fetcher_out.pc == pc);
 
-  // The fetch lockstep (ADR-0054). Nothing else holds the core to it: breaking
-  // it has one symptom, the SoC fetching the wrong instruction, with no
-  // elaboration error, no lint finding, and no ladder check in contact with the
-  // port -- formal/wrapper.v answers imem_data combinationally and never reads
-  // it.
+  // The memory latches its address a cycle early, so imem_addr_next this cycle
+  // must be imem_addr next cycle. rtl/decoder.v checks the same thing one level
+  // up, on pc and next_pc. This one is on the fetcher's output ports, so it
+  // also covers the two word-alignment masks: change one and forget the other
+  // and only this fails. Nothing on the riscv-formal ladder reads either port.
   logic [31:0] past_imem_addr_next;
   always_ff @(posedge clk) past_imem_addr_next <= imem_addr_next;
   always_comb if (clocked) assert(imem_addr == past_imem_addr_next);
 
-  // The advance provably routed through the real fetcher: rtl/decoder.v adds
-  // `fetcher_pc`, not its own pc, and only the echo assertion above ties that
-  // back to past_pc.
+  // The increment goes through the real fetcher. rtl/decoder.v adds fetcher_pc,
+  // not its own pc, and only the echo assertion above ties fetcher_pc back to
+  // past_pc.
   always_ff @(posedge clk)
     if (clocked && !prev_reset && !prev_may_stall && !prev_jump_branch)
       assert(pc == past_pc + (prev_uncompressed ? 32'd4 : 32'd2));
 
-  // `pc_inc == (uncompressed ? 4 : 2)` is deliberately NOT asserted here: it
-  // restates rtl/decoder.v, and the standalone decoder task already pins both
-  // constants.
+  // pc_inc == (uncompressed ? 4 : 2) is not asserted here. It would just
+  // restate rtl/decoder.v, whose own proof already pins both constants.
 
   always_ff @(posedge clk)
     if (clocked && prev_hard_stall && !prev_reset) assert(pc == past_pc);
 
-  // Holding the pc is what makes the steal a bubble rather than something
-  // needing a kill signal (CLAUDE.md invariant 1): the same instruction is
-  // presented again, so there is nothing to undo. Separate from the freeze
-  // above because the two reach the pc through different publish arms.
+  // Holding the pc is what makes a stolen fetch cycle harmless. The same
+  // instruction comes back next cycle, so nothing issued and nothing needs
+  // undoing. Separate from the freeze above: the two take different arms of the
+  // publish block.
   always_ff @(posedge clk)
     if (clocked && prev_fetch_stall && !prev_reset) assert(pc == past_pc);
 

--- a/formal/pcloop.sv
+++ b/formal/pcloop.sv
@@ -1,32 +1,16 @@
-// Composed fetcher + decoder proof: the PC loop, with nothing assumed about it.
+// The fetcher and the decoder wired together as rtl/littlecpu.v wires them, so
+// that the pc echo rtl/decoder.v's standalone task has to assume becomes an
+// assertion here. Under that assumption its pc-increment assertions read
+// `pc <= pc + pc_inc`, which is what they are trying to prove (ADR-0017).
 //
-// rtl/decoder.v's own component task has to `assume(in.pc == pc)` -- it stands
-// alone, so `in` is a free input and the solver would otherwise hand it a
-// fetcher_pc unrelated to what the decoder itself last drove. That assumption
-// is sound (it models rtl/fetcher.v's `out.pc = pc` plus littlecpu.v's pc->pc
-// wiring, and ADR-0017 requires it to say so) but it makes the pc-increment
-// assertions near-tautological: substitute it into `pc <= fetcher_pc + pc_inc`
-// and you get `pc <= pc + pc_inc`, which is what is being asserted.
+// formal/components.sby must keep reading the RTL WITHOUT -formal for this
+// task. Compiled with it the decoder brings its own `assume(in.pc == pc)`
+// along, assumes the echo asserted here, and turns a broken fetcher into an
+// unreachable state instead of a counterexample.
 //
-// So this task wires the two modules together for real, the way littlecpu.v
-// does: decoder.pc drives fetcher.pc, and fetcher.out feeds decoder.in. The
-// pc-increment assertions are restated against that closed loop, and the echo
-// itself becomes an assertion rather than an assumption. Break rtl/fetcher.v's
-// `out.pc = pc` and this task fails -- which the standalone decoder task
-// cannot do, because it assumes exactly that away.
-//
-// One build-level rule makes this non-circular: components.sby reads the RTL
-// WITHOUT -formal for this task (see the note there). Compiled with it, the
-// decoder instance would carry its own standalone-task `assume(in.pc == pc)`
-// into this proof -- assuming the very echo this task asserts, and reducing a
-// broken fetcher to an unreachable state instead of a counterexample.
-//
-// Everything the decoder needs from stages this task does not instantiate
-// (reg_rs1/rs2, executor_out, the accessor's stall and pending-load slots)
-// stays a free input. reg_rs1 does reach pc arithmetic -- it is the jalr base
-// and a branch comparand -- but only on cycles the increment assertion
-// already excludes as jump/branch cycles, so leaving all of them
-// unconstrained makes the proof stronger, not weaker.
+// Everything this task does not instantiate stays a free input, which is the
+// stronger environment and costs nothing: reg_rs1, mtvec and mepc reach pc
+// arithmetic only on cycles the increment assertion already excludes.
 `default_nettype none
 
 module pcloop (
@@ -39,45 +23,25 @@ module pcloop (
     input executor_output executor_out,
     input logic divider_stall,
     input logic accessor_stall,
-    // ADR-0059's steal. Free here, like the other two stall inputs: this task
-    // instantiates no memory, so the solver may assert it on any cycle, which
-    // is the stronger environment for the assertions below.
     input logic fetch_stall,
     input logic accessor_pending_valid,
     input logic [4:0] accessor_pending_rd,
-    // ADR-0026's drain slot and the CSR file's read side. rtl/csrs.v is not
-    // instantiated here -- this task is about the PC loop -- so both stay
-    // free inputs, which is the stronger environment: the solver may claim
-    // any CSR address is implemented and hand back any read value.
     input logic accessor_out_valid,
     input logic [31:0] csr_rdata,
     input logic csr_implemented,
-    // ADR-0028's trap-entry pair, free for the same reason: rtl/csrs.v is not
-    // instantiated here, so the solver may present any mtvec and any mepc.
-    // That is the stronger environment for this task -- the PC-increment
-    // assertions below exclude trap and mret cycles as jumps (see
-    // f_jump_branch), so an arbitrary redirect target cannot make them pass;
-    // it can only make them harder to satisfy on the cycles they do cover.
     input logic [31:0] mtvec,
     input logic [31:0] mepc
 );
   logic [31:0] pc;
   logic [31:0] imem_addr, imem_addr2;
-  // ADR-0054: decode publishes the next PC combinationally and fetch turns it
-  // into the address a synchronous instruction memory must latch. Both halves
-  // of that are in this task's scope, so the relationship between them is
-  // asserted below rather than assumed anywhere.
   logic [31:0] next_pc, imem_addr_next;
   fetcher_output fetcher_out;
   decoder_output decoder_out;
   logic [4:0] rs1, rs2;
-  // Driven by the decoder, read by nothing here: rtl/csrs.v is the consumer
-  // in the real pipeline (rtl/littlecpu.v).
+  // rtl/csrs.v's half of the decoder's output, unread here but for f_redirect.
   logic [11:0] csr_addr;
   logic        csr_ren, csr_wen, instret;
   logic [31:0] csr_wdata;
-  // Likewise driven by the decoder and read by nothing here: rtl/csrs.v is the
-  // consumer in the real pipeline, and this task is about the PC loop.
   logic        trap_entry, mret_entry;
   logic [31:0] trap_cause, trap_epc;
 
@@ -132,48 +96,31 @@ module pcloop (
   initial clocked = 0;
   always_ff @(posedge clk) clocked <= 1;
 
-  // Reset is a once-at-the-start pulse everywhere in this design -- the same
-  // assumption rtl/decoder.v and rtl/executor.v make in their own tasks, for
-  // the same reason: without it the solver can reassert reset between the two
-  // cycles these assertions compare and force pc back to 0 in between.
+  // Assumed: reset is asserted before the first edge and never returns -- true
+  // of every harness in the tree, asserted by none of them, and unguarded, so
+  // it is in force over every assertion here rather than only the pc-history
+  // pair it was written for (ADR-0049).
   initial assume(reset);
   always_comb if (!clocked) assume(reset);
   always_comb if (clocked) assume(!reset);
 
-  // Every guard signal below is re-derived HERE, from pcloop's own ports and
-  // wires -- never by hierarchical reference into the decoder instance.
-  // yosys's Verilog frontend does not resolve `decoder.uncompressed`-style
-  // references: it implicitly declares a fresh, undriven wire of that dotted
-  // name in this module (the build log warned twice -- "Identifier
-  // `\decoder.uncompressed' is implicitly declared", then "Wire
-  // pcloop.\decoder.uncompressed is used but has no driver") and the solver
-  // then drives the phantom wire freely. An earlier revision of this file
-  // sampled those phantoms and got a "counterexample" in which pc correctly
-  // stepped 0 -> 4 for an uncompressed word while its sampled history
-  // claimed the instruction was compressed.
+  // Never reach into the decoder instance for a guard signal: yosys does not
+  // resolve `decoder.uncompressed`, it implicitly declares an undriven wire of
+  // that name and lets the solver drive it freely. An earlier revision of this
+  // file got a "counterexample" that way, in which pc stepped 0 -> 4 correctly
+  // while the sampled history claimed the instruction was compressed.
   //
-  // Re-deriving is also the honest formulation: the width and jump guards
-  // become an independent restatement of the fetched word's decode, so the
-  // assertion compares the DUT against the instruction stream itself rather
-  // than against the decoder's own opinion of it.
-
-  // Width and control-flow facts of the word the fetcher presents this
-  // cycle. Field positions mirror rtl/decoder.v (quadrant = instr[1:0],
-  // opcode = instr[6:2], funct3 = instr[14:12], cfunct3 = instr[15:13]).
-  // decoder.v's upper-half masking cannot make these disagree with the
-  // decoder's view: every uncompressed match below requires quadrant ==
+  // Re-deriving is also stronger, and decoder.v's upper-half masking cannot
+  // make it disagree: every uncompressed match below requires quadrant ==
   // 2'b11, where the mask is the identity, and every compressed match reads
-  // only instr[15:0], which the mask preserves.
+  // only instr[15:0].
   logic [31:0] f_instr;
   assign f_instr = fetcher_out.instr;
   logic f_uncompressed;
   assign f_uncompressed = f_instr[1:0] == 2'b11;
-  // Exactly the instructions whose case arm in rtl/decoder.v's publish block
-  // may write a non-sequential pc: jal/jalr, the six branches, and their
-  // compressed forms (c.j, c.jal, c.jr, c.jalr, c.beqz, c.bnez). A branch
-  // opcode with funct3 2'b01x matches none of the six instr_b* flags, takes
-  // no case arm, and falls through to the sequential pc -- so it is
-  // deliberately NOT excluded here.
+  // A branch opcode with funct3 2'b01x matches none of the six instr_b* flags,
+  // takes no arm in the publish block and falls through to the sequential pc,
+  // so it is deliberately not excluded here.
   logic f_jump_branch;
   assign f_jump_branch =
       // jal / jalr (rtl/decoder.v instr_jal_op / instr_jalr_op)
@@ -190,17 +137,11 @@ module pcloop (
       (f_instr[1:0] == 2'b10 && f_instr[15:13] == 3'b100 && f_instr[6:2] == 5'b0 &&
          f_instr[11:7] != 5'b0);
 
-  // A cycle on which the decoder may legitimately hold pc. Deliberately an
-  // OVER-approximation of rtl/decoder.v's `stall`: the real hazard also
-  // requires that the instruction consumes rs1/rs2 as register operands
-  // (uses_rs1/uses_rs2), and restating that here would mean duplicating most
-  // of decode. Skipping a superset of the stall cycles is sound for the
-  // increment assertion (it only ever *excuses* cycles, and hazard implies
-  // this signal); what it forgoes -- proving pc holds on a RAW-hazard cycle
-  // -- is asserted where `stall` is visible, in rtl/decoder.v's own FORMAL
-  // block. Built entirely from pcloop-scope nets: rs1/rs2 and decoder_out
-  // are decoder output ports, the rest are this module's free inputs, and
-  // the producer test transcribes rtl/decoder.v's live_producer().
+  // Every term here over-approximates rtl/decoder.v's `stall`, which also
+  // requires the instruction to consume the operand; restating that would
+  // duplicate most of decode. Excusing a superset of the stall cycles is sound
+  // for the increment assertion, and the RAW-hazard hold it gives up is
+  // asserted in rtl/decoder.v's own FORMAL block.
   logic f_live_rs1, f_live_rs2, f_may_stall;
   assign f_live_rs1 = rs1 != 0 &&
       ((decoder_out.valid && decoder_out.rd == rs1) ||
@@ -210,41 +151,15 @@ module pcloop (
       ((decoder_out.valid && decoder_out.rd == rs2) ||
        (executor_out.valid && executor_out.rd == rs2) ||
        (accessor_pending_valid && accessor_pending_rd == rs2));
-  // ADR-0026's fourth stall reason, transcribed the same way: a Zicsr access
-  // is held in decode until the pipe drains, and `mret` joins it there
-  // (CLAUDE.md invariant 5). Over-approximated like the rest -- the real term
-  // also requires the pipe to be busy, and this deliberately does not look at
-  // that -- so it only ever excuses more cycles, never fewer.
-  //
-  // Widened to the WHOLE SYSTEM opcode rather than the six csrr* funct3s,
-  // because `mret` has funct3 == 0 and the narrower test missed it: a
-  // serializing `mret` held the pc on a cycle this signal called quiet and the
-  // increment assertion below failed. `ecall`/`ebreak` come along for the ride
-  // and are covered by f_redirect anyway, since they now trap.
+  // The whole SYSTEM opcode rather than the six csrr* funct3s, because `mret`
+  // serializes too and has funct3 == 0.
   logic f_system;
   assign f_system = f_uncompressed && f_instr[6:2] == 5'b11100;
 
-  // ADR-0042's FIFTH stall reason, the operand-fetch cycle: the regfile read
-  // is synchronous, so decode presents the rs1/rs2 address pair for one cycle,
-  // holds the pc, bubbles, and issues on the next (CLAUDE.md invariant 9).
-  // Without this term the sequential-advance assertion below covers a cycle on
-  // which the decoder legitimately held the pc, and it FAILS at basecase step
-  // 3 -- which is exactly what it did from `e4f5250` until this file caught up,
-  // uncaught because nothing ran this task.
-  //
-  // A verbatim transcription of rtl/decoder.v's prev_rs1/prev_rs2/read_taken
-  // register, then over-approximated at the comparison the same way every other
-  // term here is: the real `operand_stall` also requires that the instruction
-  // consumes the port (uses_rs1/uses_rs2), and restating that would mean
-  // duplicating most of decode. Dropping the gate only ever excuses more
-  // cycles, never fewer.
-  //
-  // It does NOT hollow out the assertion, and the reason is structural rather
-  // than lucky: `operand_stall` holds the pc, so the same word is re-presented
-  // and rs1/rs2 are unchanged on the cycle the instruction actually issues.
-  // Every cycle on which the pc really advances is therefore a cycle this term
-  // calls quiet. The mutation ADR-0017 requires still fires -- break
-  // rtl/fetcher.v's `out.pc = pc` and this task fails.
+  // This term does not hollow out the increment assertion, for a structural
+  // reason: `operand_stall` holds the pc, so the same word is re-presented and
+  // rs1/rs2 are unchanged on the cycle the instruction actually issues. Every
+  // cycle the pc really advances on is therefore a cycle it calls quiet.
   logic [4:0] f_prev_rs1, f_prev_rs2;
   logic       f_read_taken, f_operand_fetch;
   always_ff @(posedge clk) begin
@@ -260,50 +175,28 @@ module pcloop (
   end
   assign f_operand_fetch = !f_read_taken || f_prev_rs1 != rs1 || f_prev_rs2 != rs2;
 
-  // ADR-0059's steal is the sixth stall reason, and it is a direct input here,
-  // so it needs no transcription -- only inclusion. Leaving it out is the trap
-  // ADR-0046 walked into: a new stall reason plus a stale `f_may_stall` makes
-  // the sequential-advance assertion cover a cycle on which the decoder
-  // legitimately holds the pc, and the task goes red on correct RTL.
-  //
-  // `fence.i` joins the serialization drain too (ADR-0061), and `f_system`
-  // does not reach it -- that term is the SYSTEM opcode and this is MISC-MEM.
-  // Widened to the whole opcode for the same reason `f_system` is: `fence`
-  // comes along, is never held, and being excused costs nothing.
+  // `f_may_stall` must name every stall reason the decoder has -- six now. A
+  // missing one makes the sequential-advance assertion cover a cycle the
+  // decoder legitimately holds the pc on and the task goes red on correct RTL,
+  // which is how ADR-0042's operand-fetch cycle left it failing. `f_system`
+  // cannot cover `fence.i`: that is the SYSTEM opcode and this is MISC-MEM.
   logic f_fencei;
   assign f_fencei = f_uncompressed && f_instr[6:2] == 5'b00011;
 
   assign f_may_stall = divider_stall || accessor_stall || fetch_stall ||
       f_live_rs1 || f_live_rs2 || f_system || f_fencei || f_operand_fetch;
 
-  // Trap entry and `mret` also write a non-sequential pc (ADR-0028: a trap is
-  // a branch), so the sequential-advance assertion must not cover those
-  // cycles either. Unlike everything above, these are NOT re-derived from
-  // `f_instr`: "would the decoder consider this word illegal" is decode, and
-  // restating it here would be the duplication this file refuses. They are
-  // read off the decoder's own OUTPUT PORTS instead -- pcloop-scope nets, not
-  // the phantom hierarchical references the note above warns about.
-  //
-  // Excusing a cycle on the DUT's own say-so would be a hole if nothing else
-  // covered it, so nothing else is left uncovered: the two assertions at the
-  // bottom of this block pin where the pc actually went on exactly these
-  // cycles. A decoder that claimed a spurious trap to escape the increment
-  // assertion would then have to land on mtvec to satisfy those.
+  // The one guard not re-derived from `f_instr`, because "would the decoder
+  // consider this word illegal" is decode. Taking it off the DUT's own output
+  // ports excuses cycles on the DUT's say-so, which is why the two assertions
+  // at the bottom pin where the pc went on exactly those cycles: a decoder
+  // claiming a spurious trap would then have to land on mtvec.
   logic f_redirect;
   assign f_redirect = trap_entry || mret_entry;
 
-  // Registered history, sampled at the same posedge that updates pc. That
-  // same-edge sample is the phase relationship rtl/decoder.v:442 dictates:
-  // `pc <= fetcher_pc + pc_inc` computes both addends combinationally from
-  // the PRE-edge state (fetcher_pc = pc through the fetcher's echo, pc_inc
-  // from the word the fetch window presents at that same pre-edge pc), so
-  // the width that produced the post-edge pc is `uncompressed` as it stood
-  // just before the edge -- exactly what a plain registered copy holds one
-  // cycle later. Every history bit here copies a signal that is real and
-  // driven on every non-reset cycle (fetcher_out is reset-muxed to zero, the
-  // ports are always driven), and the one garbage sample possible -- the
-  // pre-reset initial state at cycle 0 -- lands under prev_reset = 1, which
-  // every assertion below excludes.
+  // Sampled at the same posedge that updates pc, which is the right phase
+  // because `pc <= fetcher_pc + pc_inc` computes both addends combinationally
+  // from the pre-edge state.
   logic [31:0] past_pc, prev_mtvec, prev_mepc;
   logic prev_reset, prev_may_stall, prev_hard_stall, prev_jump_branch, prev_uncompressed;
   logic prev_trap_entry, prev_mret_entry, prev_fetch_stall;
@@ -321,68 +214,38 @@ module pcloop (
     prev_mepc         <= mepc;
   end
 
-  // The echo, asserted rather than assumed. This one line is what turns the
-  // standalone task's `assume(in.pc == pc)` into a proof obligation.
   always_comb if (clocked && !reset) assert(fetcher_out.pc == pc);
 
-  // ---- ADR-0054: the instruction memory's whole contract -------------------
-  // `imem_addr_next` is published combinationally in cycle N; `imem_addr` holds
-  // that same value in cycle N+1. A synchronous ROM that latches the former on
-  // the edge between them therefore answers the latter for the whole of the
-  // cycle that reads it, which is what keeps fetch combinational from decode's
-  // point of view (CLAUDE.md invariant 1) on a part with no combinational-read
-  // memory (ADR-0044).
-  //
-  // It is asserted HERE, on the composed fetcher+decoder loop, because that is
-  // where both halves are real: the decoder's own task would be asserting its
-  // own next_pc against its own pc with the fetcher's word-alignment mask
-  // absent. And it is asserted rather than reasoned about because breaking it
-  // has exactly one symptom -- the SoC fetches the wrong instruction -- with no
-  // elaboration error, no lint finding, and nothing on the riscv-formal ladder
-  // in contact with it (formal/wrapper.v answers imem_data combinationally and
-  // never reads this port).
+  // The fetch lockstep (ADR-0054). Nothing else holds the core to it: breaking
+  // it has one symptom, the SoC fetching the wrong instruction, with no
+  // elaboration error, no lint finding, and no ladder check in contact with the
+  // port -- formal/wrapper.v answers imem_data combinationally and never reads
+  // it.
   logic [31:0] past_imem_addr_next;
   always_ff @(posedge clk) past_imem_addr_next <= imem_addr_next;
   always_comb if (clocked) assert(imem_addr == past_imem_addr_next);
 
-  // Sequential advance: on a cycle whose predecessor was quiet -- not reset,
-  // no possible stall, not a jump or branch -- pc moved by exactly the width
-  // of the word the fetcher presented, with the width judged independently
-  // from that word itself. The advance provably routed through the real
-  // fetcher: rtl/decoder.v:442 adds fetcher_pc, not its own pc, and only the
-  // echo assertion above ties fetcher_pc back to past_pc.
+  // The advance provably routed through the real fetcher: rtl/decoder.v adds
+  // `fetcher_pc`, not its own pc, and only the echo assertion above ties that
+  // back to past_pc.
   always_ff @(posedge clk)
     if (clocked && !prev_reset && !prev_may_stall && !prev_jump_branch)
       assert(pc == past_pc + (prev_uncompressed ? 32'd4 : 32'd2));
 
-  // Deliberately NOT asserted here: `pc_inc == (uncompressed ? 4 : 2)` is a
-  // verbatim restatement of rtl/decoder.v:343, so it would prove nothing
-  // about the loop -- and the standalone decoder task already pins pc_inc's
-  // two constants (mutating it to `uncompressed ? 4 : 4` fails there). What
-  // this task adds is that the increment reaches pc *through a real fetcher*.
+  // `pc_inc == (uncompressed ? 4 : 2)` is deliberately NOT asserted here: it
+  // restates rtl/decoder.v, and the standalone decoder task already pins both
+  // constants.
 
-  // A divider/accessor freeze holds the PC (ADR-0009 / ADR-0015: upstream of
-  // a stalling stage freezes). Under-approximated to the two unconditional
-  // stall sources on purpose -- both are direct inputs here, and
-  // rtl/decoder.v's first publish arm holds pc whenever either is up,
-  // hazard or no hazard. The RAW-hazard hold is the standalone decoder
-  // task's assertion, as above.
   always_ff @(posedge clk)
     if (clocked && prev_hard_stall && !prev_reset) assert(pc == past_pc);
 
-  // The steal holds the pc too, which is what makes it a bubble rather than
-  // something needing a kill signal (ADR-0059, CLAUDE.md invariant 1): the same
-  // instruction is presented again next cycle, so nothing was issued and there
-  // is nothing to undo. Stated separately from the freeze above because the two
-  // reach the pc through different arms of the publish block.
+  // Holding the pc is what makes the steal a bubble rather than something
+  // needing a kill signal (CLAUDE.md invariant 1): the same instruction is
+  // presented again, so there is nothing to undo. Separate from the freeze
+  // above because the two reach the pc through different publish arms.
   always_ff @(posedge clk)
     if (clocked && prev_fetch_stall && !prev_reset) assert(pc == past_pc);
 
-  // The redirect cycles the increment assertion above steps around, covered
-  // here instead of merely excused. A trap goes to mtvec and an mret goes to
-  // mepc -- through the real closed loop, so the decoder's `pc` output and the
-  // address the fetcher will present next cycle are the same thing (the echo
-  // assertion above is what ties them together).
   always_ff @(posedge clk)
     if (clocked && !prev_reset && prev_trap_entry) assert(pc == prev_mtvec);
   always_ff @(posedge clk)

--- a/test/asm/riscv_test.h
+++ b/test/asm/riscv_test.h
@@ -1,4 +1,4 @@
-// Local, minimal riscv_test.h (ADR-0008). Every consumer -- both cxxrtl
+// Local, minimal riscv_test.h. Every consumer -- both cxxrtl
 // runners, the iverilog bench and the Sail model -- terminates on the `tohost`
 // write below, so nothing here depends on ecall or mtvec.
 //
@@ -12,7 +12,7 @@
 //      assembler compresses freely at -march=rv32imc_zicsr. Tests that
 //      terminate from inside the handler are unconstrained.
 //   2. Install the handler before faulting. `mtvec` resets to 0, which is
-//      `_start`, so a trap before installation restarts the program (ADR-0029).
+//      `_start`, so a trap before installation restarts the program.
 //   3. Assert in band. riscv-formal has no spec model for csrr*/ecall/ebreak/
 //      mret at the pin, so the per-retire monitor says nothing about the
 //      instructions these tests exist to exercise.
@@ -41,7 +41,7 @@ _start:                                                                      \
 // The upper word first and the verdict last, because there is no 64-bit store
 // and Sail's HTIF fires on whichever half-write completes the pair: this way
 // the verdict store is what stops the reference model, on the same instruction
-// the cxxrtl runners stop on (ADR-0039).
+// the cxxrtl runners stop on.
 #define RVTEST_PASS                                                          \
         li      TESTNUM, 1;                                                 \
         la      t0, tohost;                                                 \

--- a/test/asm/riscv_test.h
+++ b/test/asm/riscv_test.h
@@ -1,36 +1,23 @@
-// Local, minimal riscv_test.h (ADR-0008). This core has no privilege modes and
-// no PMP, so none of upstream riscv-tests' env/p setup belongs here.
-// RVTEST_PASS/RVTEST_FAIL write the riscv-tests `tohost` encoding to a fixed
-// doubleword at the base of RAM and spin; both cxxrtl runners, the iverilog
-// bench and the Sail model watch that address and terminate on it, so nothing
-// depends on ecall or mtvec. See RVTEST_DATA_BEGIN for why the width matters.
+// Local, minimal riscv_test.h (ADR-0008). Every consumer -- both cxxrtl
+// runners, the iverilog bench and the Sail model -- terminates on the `tohost`
+// write below, so nothing here depends on ecall or mtvec.
 //
 // The trap macros at the bottom are opt-in, and RVTEST_CODE_BEGIN must stay
-// untouched by them so the other tests keep assembling to the same bytes. A
-// test opts in with RVTEST_TRAP_DATA (in .data), RVTEST_TRAP_HANDLER (in .text)
-// and RVTEST_INSTALL_TRAP_HANDLER.
+// untouched by them so the other tests keep assembling to the same bytes.
+// Three constraints on a test that uses them:
 //
-// Three constraints on trap tests:
-//
-//   1. The handler cannot read the faulting instruction -- this core is Harvard
-//      with disjoint buses (ADR-0008), so no load reaches ROM and nothing can
-//      inspect insn[1:0] to choose between mepc+2 and mepc+4. The resume path
-//      adds 4 unconditionally, so every trapping instruction in a resuming test
-//      must be wrapped in `.option norvc` / `.option pop`: the assembler
-//      compresses freely at -march=rv32imc_zicsr, and a `lw` that became a
-//      `c.lw` would make the resume skip a whole instruction. Tests that
+//   1. Wrap every trapping instruction in `.option norvc` / `.option pop`. The
+//      handler resumes at mepc+4 unconditionally, because Harvard buses mean it
+//      cannot read the faulting instruction to tell 2 bytes from 4, and the
+//      assembler compresses freely at -march=rv32imc_zicsr. Tests that
 //      terminate from inside the handler are unconstrained.
 //   2. Install the handler before faulting. `mtvec` resets to 0, which is
-//      `_start` (ADR-0029), so a trap taken before installation restarts the
-//      program.
-//   3. Trap tests must self-check in band. riscv-formal ships no spec model for
-//      csrr*/ecall/ebreak/mret at the pinned SHA, so `spec_valid` is 0 for all
-//      of them and the per-retire monitor has nothing to say about the very
-//      instructions these tests exercise. A passing trap test was checked
-//      against its own assertions, not against an oracle.
+//      `_start`, so a trap before installation restarts the program (ADR-0029).
+//   3. Assert in band. riscv-formal has no spec model for csrr*/ecall/ebreak/
+//      mret at the pin, so the per-retire monitor says nothing about the
+//      instructions these tests exist to exercise.
 //
-// The handler clobbers t0 and t1, so a test body must not hold live values
-// there across an instruction that may trap.
+// The handler clobbers t0 and t1.
 
 #ifndef __RISCV_TEST_H
 #define __RISCV_TEST_H
@@ -38,9 +25,7 @@
 // riscv-tests' test_macros.h expects TESTNUM to already be defined.
 #define TESTNUM gp
 
-// A leftover of upstream's env selection that the `.S` files still invoke, not
-// an XLEN claim. It expands to nothing: this core is RV32 only (ADR-0002) and
-// has no privilege setup to do.
+// A leftover of upstream's env selection, not an XLEN claim.
 #define RVTEST_RV64U
 
 #define RVTEST_CODE_BEGIN                                                    \
@@ -50,18 +35,13 @@
 _start:                                                                      \
         li      TESTNUM, 0;
 
-// Unreachable in a well-formed test, since RVTEST_PASS/RVTEST_FAIL each end in
-// an infinite loop -- but spin rather than run off the end of ROM.
 #define RVTEST_CODE_END                                                      \
 1:      j       1b
 
-// The upper word is written first and the verdict last, and the order matters:
-// this core has no 64-bit store, so the doubleword goes out as two `sw`s, and
-// Sail's HTIF fires on whichever half-write completes the pair. Writing the
-// always-zero upper word first makes the verdict store the single event that
-// stops the reference model -- the same store the cxxrtl runners stop on when
-// RAM_BASE's low word goes non-zero -- so both sides end on the same
-// instruction (ADR-0039).
+// The upper word first and the verdict last, because there is no 64-bit store
+// and Sail's HTIF fires on whichever half-write completes the pair: this way
+// the verdict store is what stops the reference model, on the same instruction
+// the cxxrtl runners stop on (ADR-0039).
 #define RVTEST_PASS                                                          \
         li      TESTNUM, 1;                                                 \
         la      t0, tohost;                                                 \
@@ -77,12 +57,10 @@ _start:                                                                      \
         sw      TESTNUM, 0(t0);                                             \
 1:      j       1b
 
-// `tohost` must stay a full doubleword, 8-byte aligned. HTIF defines it as a
-// 64-bit location, and every consumer that speaks the protocol -- Sail among
-// them -- claims the whole doubleword at the symbol as an IO window as soon as
-// it sees the symbol in the ELF. As a 32-bit `.word` it put the start of `.data`
-// four bytes inside that window, and Sail answered every load from there with
-// zero (ADR-0039, amending ADR-0008).
+// `tohost` must stay a full doubleword, 8-byte aligned: HTIF defines it as a
+// 64-bit location and every consumer claims the whole doubleword at the symbol
+// as an IO window. As a 32-bit `.word` it put the start of `.data` four bytes
+// inside that window, and Sail answered every load from there with zero.
 #define RVTEST_DATA_BEGIN                                                    \
         .pushsection .tohost,"aw",@progbits;                                \
         .align  3;                                                          \
@@ -95,8 +73,8 @@ tohost:                                                                      \
 
 #define RVTEST_DATA_END
 
-// Where the handler records what it saw. Invoke it after RVTEST_DATA_BEGIN so
-// it lands in RAM, the only memory a load can reach on this Harvard core.
+// Invoke after RVTEST_DATA_BEGIN so it lands in RAM, the only memory a load can
+// reach on this Harvard core.
 #define RVTEST_TRAP_DATA                                                     \
         .align  2;                                                          \
         .global trap_count;                                                 \
@@ -109,19 +87,14 @@ trap_cause:                                                                  \
 trap_epc:                                                                    \
         .word   0;
 
-// The recording handler: bump `trap_count`, store `mcause` and `mepc`, resume
-// at mepc+4. The +4 is unconditional (constraint 1 at the top of this file), so
-// the trapping instruction must be uncompressed. Clobbers t0 and t1.
+// Invoke in .text somewhere control cannot fall into -- after TEST_PASSFAIL by
+// convention, since both of those paths end in an infinite loop. The `.align 2`
+// satisfies mtvec's 4-byte-aligned WARL base.
 //
-// Invoke it in .text somewhere control cannot fall into -- after TEST_PASSFAIL
-// by convention, since both of those paths end in an infinite loop. The
-// `.align 2` satisfies mtvec's 4-byte-aligned WARL base (ADR-0005).
-//
-// The body is `.option norvc` and straight-line, so every instruction is 4
-// bytes and `(trap_handler_end - trap_handler) / 4` is how many instructions
-// one trap entry retires. A test reasoning about `minstret` across a trap
-// should compute that rather than hardcode a count, so editing this macro
-// cannot silently invalidate it.
+// The body is straight-line and uncompressed, so
+// `(trap_handler_end - trap_handler) / 4` is how many instructions one trap
+// entry retires. A test reasoning about `minstret` across a trap should compute
+// that rather than hardcode a count.
 #define RVTEST_TRAP_HANDLER                                                  \
         .align  2;                                                          \
 trap_handler:                                                                \
@@ -143,17 +116,13 @@ trap_handler:                                                                \
 trap_handler_end:                                                            \
         .option pop;
 
-// Any trap is a test failure, reported against whatever test number was live.
-// It terminates from inside the handler, so the uncompressed-instruction
-// constraint does not apply. Use at most one of the two handlers per test --
-// they share the `trap_handler` symbol.
+// Terminates from inside the handler, so constraint 1 does not apply.
 #define RVTEST_TRAP_HANDLER_FATAL                                            \
         .align  2;                                                          \
 trap_handler:                                                                \
         RVTEST_FAIL
 
-// Point mtvec at the handler, direct mode -- mtvec[1:0] = 0, which the
-// handler's `.align 2` guarantees. Clobbers t0.
+// Direct mode: mtvec[1:0] = 0, which the handler's `.align 2` guarantees.
 #define RVTEST_INSTALL_TRAP_HANDLER                                          \
         la      t0, trap_handler;                                           \
         csrw    mtvec, t0;

--- a/test/asm/test_macros.h
+++ b/test/asm/test_macros.h
@@ -2,7 +2,7 @@
 //
 // Vendored from riscv-tests, including its RV64 and floating-point macros,
 // which no program in test/asm invokes. MASK_XLEN keys off __riscv_xlen, so it
-// narrows to 32 bits here on its own (ADR-0008).
+// narrows to 32 bits here on its own.
 
 #ifndef __TEST_MACROS_SCALAR_H
 #define __TEST_MACROS_SCALAR_H

--- a/test/asm/test_macros.h
+++ b/test/asm/test_macros.h
@@ -1,12 +1,12 @@
 // See LICENSE for license details.
+//
+// Vendored from riscv-tests, including its RV64 and floating-point macros,
+// which no program in test/asm invokes. MASK_XLEN keys off __riscv_xlen, so it
+// narrows to 32 bits here on its own (ADR-0008).
 
 #ifndef __TEST_MACROS_SCALAR_H
 #define __TEST_MACROS_SCALAR_H
 
-
-#-----------------------------------------------------------------------
-# Helper macros
-#-----------------------------------------------------------------------
 
 #define MASK_XLEN(x) ((x) & ((1 << (__riscv_xlen - 1) << 1) - 1))
 
@@ -16,9 +16,6 @@ test_ ## testnum: \
     li  x29, MASK_XLEN(correctval); \
     li  TESTNUM, testnum; \
     bne testreg, x29, fail;
-
-# We use a macro hack to simpify code generation for various numbers
-# of bubble cycles.
 
 #define TEST_INSERT_NOPS_0
 #define TEST_INSERT_NOPS_1  nop; TEST_INSERT_NOPS_0
@@ -32,14 +29,6 @@ test_ ## testnum: \
 #define TEST_INSERT_NOPS_9  nop; TEST_INSERT_NOPS_8
 #define TEST_INSERT_NOPS_10 nop; TEST_INSERT_NOPS_9
 
-
-#-----------------------------------------------------------------------
-# RV64UI MACROS
-#-----------------------------------------------------------------------
-
-#-----------------------------------------------------------------------
-# Tests for instructions with immediate operand
-#-----------------------------------------------------------------------
 
 #define SEXT_IMM(x) ((x) | (-(((x) >> 11) & 1) << 11))
 
@@ -89,10 +78,6 @@ test_ ## testnum: \
       inst x0, x1, SEXT_IMM(imm); \
     )
 
-#-----------------------------------------------------------------------
-# Tests for an instruction with register operands
-#-----------------------------------------------------------------------
-
 #define TEST_R_OP( testnum, inst, result, val1 ) \
     TEST_CASE( testnum, x14, result, \
       li  x1, val1; \
@@ -116,10 +101,6 @@ test_ ## testnum: \
       li  x5, 2; \
       bne x4, x5, 1b \
     )
-
-#-----------------------------------------------------------------------
-# Tests for an instruction with register-register operands
-#-----------------------------------------------------------------------
 
 #define TEST_RR_OP( testnum, inst, result, val1, val2 ) \
     TEST_CASE( testnum, x14, result, \
@@ -210,10 +191,6 @@ test_ ## testnum: \
       li x2, MASK_XLEN(val2); \
       inst x0, x1, x2; \
     )
-
-#-----------------------------------------------------------------------
-# Test memory instructions
-#-----------------------------------------------------------------------
 
 #define TEST_LD_OP( testnum, inst, result, offset, base ) \
     TEST_CASE( testnum, x14, result, \
@@ -337,10 +314,6 @@ test_ ## testnum: \
     li  x5, 2; \
     bne x4, x5, 1b \
 
-#-----------------------------------------------------------------------
-# Test jump instructions
-#-----------------------------------------------------------------------
-
 #define TEST_JR_SRC1_BYPASS( testnum, nop_cycles, inst ) \
 test_ ## testnum: \
     li  TESTNUM, testnum; \
@@ -365,14 +338,6 @@ test_ ## testnum: \
     li  x5, 2; \
     bne x4, x5, 1b \
 
-
-#-----------------------------------------------------------------------
-# RV64UF MACROS
-#-----------------------------------------------------------------------
-
-#-----------------------------------------------------------------------
-# Tests floating-point instructions
-#-----------------------------------------------------------------------
 
 #define qNaNf 0f:7fc00000
 #define sNaNf 0f:7f800001
@@ -423,7 +388,6 @@ test_ ## testnum: \
   .result; \
   .popsection
 
-// TODO: assign a separate mem location for the comparison address?
 #define TEST_FP_OP_D32_INTERNAL( testnum, flags, result, val1, val2, val3, code... ) \
 test_ ## testnum: \
   li  TESTNUM, testnum; \
@@ -467,7 +431,6 @@ test_ ## testnum: \
 #define TEST_FP_OP1_D32( testnum, inst, flags, result, val1 ) \
   TEST_FP_OP_D32_INTERNAL( testnum, flags, double result, val1, 0.0, 0.0, \
                     inst f3, f0; fsd f3, 0(a0); lw t2, 4(a0); lw a0, 0(a0))
-// ^: store computation result in address from a0, load high-word into t2
 
 #define TEST_FP_OP1_D( testnum, inst, flags, result, val1 ) \
   TEST_FP_OP_D_INTERNAL( testnum, flags, double result, val1, 0.0, 0.0, \
@@ -480,7 +443,6 @@ test_ ## testnum: \
 #define TEST_FP_OP1_D32_DWORD_RESULT( testnum, inst, flags, result, val1 ) \
   TEST_FP_OP_D32_INTERNAL( testnum, flags, dword result, val1, 0.0, 0.0, \
                     inst f3, f0; fsd f3, 0(a0); lw t2, 4(a0); lw a0, 0(a0))
-// ^: store computation result in address from a0, load high-word into t2
 
 #define TEST_FP_OP1_D_DWORD_RESULT( testnum, inst, flags, result, val1 ) \
   TEST_FP_OP_D_INTERNAL( testnum, flags, dword result, val1, 0.0, 0.0, \
@@ -493,7 +455,6 @@ test_ ## testnum: \
 #define TEST_FP_OP2_D32( testnum, inst, flags, result, val1, val2 ) \
   TEST_FP_OP_D32_INTERNAL( testnum, flags, double result, val1, val2, 0.0, \
                     inst f3, f0, f1; fsd f3, 0(a0); lw t2, 4(a0); lw a0, 0(a0))
-// ^: store computation result in address from a0, load high-word into t2
 
 #define TEST_FP_OP2_D( testnum, inst, flags, result, val1, val2 ) \
   TEST_FP_OP_D_INTERNAL( testnum, flags, double result, val1, val2, 0.0, \
@@ -506,7 +467,6 @@ test_ ## testnum: \
 #define TEST_FP_OP3_D32( testnum, inst, flags, result, val1, val2, val3 ) \
   TEST_FP_OP_D32_INTERNAL( testnum, flags, double result, val1, val2, val3, \
                     inst f3, f0, f1, f2; fsd f3, 0(a0); lw t2, 4(a0); lw a0, 0(a0))
-// ^: store computation result in address from a0, load high-word into t2
 
 #define TEST_FP_OP3_D( testnum, inst, flags, result, val1, val2, val3 ) \
   TEST_FP_OP_D_INTERNAL( testnum, flags, double result, val1, val2, val3, \
@@ -609,8 +569,7 @@ test_ ## testnum: \
   .double result; \
   .popsection
 
-// We need some special handling here to allow 64-bit comparison in 32-bit arch
-// TODO: find a better name and clean up when intended for general usage?
+// A 64-bit comparison on a 32-bit arch, done as two 32-bit halves.
 #define TEST_CASE_D32( testnum, testreg1, testreg2, correctval, code... ) \
 test_ ## testnum: \
     code; \
@@ -626,12 +585,9 @@ test_ ## testnum: \
     .dword correctval; \
     .popsection
 
-// ^ x14 is used in some other macros, to avoid issues we use x15 for upper word
+// x15 rather than x14 for the upper word, because other macros use x14.
 
-#-----------------------------------------------------------------------
-# Pass and fail code (assumes test num is in TESTNUM)
-#-----------------------------------------------------------------------
-
+// Assumes the test number is in TESTNUM.
 #define TEST_PASSFAIL \
         bne x0, TESTNUM, pass; \
 fail: \
@@ -639,10 +595,6 @@ fail: \
 pass: \
         RVTEST_PASS \
 
-
-#-----------------------------------------------------------------------
-# Test data section
-#-----------------------------------------------------------------------
 
 #define TEST_DATA
 

--- a/test/csr_tb.v
+++ b/test/csr_tb.v
@@ -2,12 +2,17 @@
 `default_nettype none
 `include "structs.v"
 
-// rtl/csrs.v's access port, driven directly. `implemented` feeds
-// rtl/decoder.v's `instr_valid`, so an address wrongly accepted or rejected
-// reads as an execution bug rather than a CSR one in a `.S` test; and the WARL
-// masks are unreachable from the ladder, because rvfi_csrw_check.sv has no WARL
-// model and mtvec/mepc/mstatus are off formal/checks.cfg's [csrs] list for that
-// reason.
+// rtl/csrs.v's access port, driven directly.
+//
+// Two things here are checked nowhere else. `implemented` feeds
+// rtl/decoder.v's `instr_valid`, so an address wrongly accepted becomes an
+// instruction the core executes and one wrongly rejected becomes an illegal
+// instruction -- in a `.S` test either reads as an execution bug rather than a
+// CSR one. And the WARL masks cannot be checked on the riscv-formal ladder at
+// all: rvfi_csrw_check.sv compares the write against the value the core says it
+// wrote, with no model of a register that legally keeps only some bits, so a
+// correctly masked CSR fails it. That is why mtvec, mepc and mstatus are kept
+// off the `[csrs]` list in formal/checks.cfg.
 module csr_tb;
   logic clk = 0;
   always #5 clk = ~clk;
@@ -73,7 +78,6 @@ module csr_tb;
     end
   endtask
 
-  // Read `a` combinationally, without issuing anything.
   task automatic peek(input logic [11:0] a);
     begin
       addr = a;
@@ -83,7 +87,6 @@ module csr_tb;
     end
   endtask
 
-  // Commit one write on the next edge, the way rtl/decoder.v does.
   task automatic poke(input logic [11:0] a, input logic [31:0] d);
     begin
       addr = a;
@@ -105,7 +108,6 @@ module csr_tb;
     end
   endtask
 
-  // Commit one trap entry on the next edge, the way rtl/decoder.v does.
   task automatic take_trap(input logic [31:0] cause, input logic [31:0] epc);
     begin
       trap_cause = cause;
@@ -181,7 +183,7 @@ module csr_tb;
     check_hex("...and reads 0", rdata, 32'h0);
     peek(12'h306); // mcounteren: a real CSR name this core does not have
     check_bit("mcounteren is not implemented", implemented, 1'b0);
-    peek(12'hC00); // the unprivileged cycle alias: M-mode only (ADR-0005)
+    peek(12'hC00); // the unprivileged cycle alias; this core has no user mode
     check_bit("the unprivileged cycle alias is not implemented", implemented, 1'b0);
     peek(12'h000);
     check_bit("address 0 is not implemented", implemented, 1'b0);
@@ -264,13 +266,14 @@ module csr_tb;
     check_read("an explicit mcycle write beats the increment", 12'hB00, 32'h0000_0000);
     check_read("...and does not disturb mcycleh", 12'hB80, before_hi);
 
-    // Do not drop these as duplicates of the two vectors above. "Any CSR write
-    // takes precedence over the automatic increment" (priv spec 20211203
-    // §3.1.11) is about the 64-bit counter rather than the half the address
-    // names, so the carry boundary is the only place it can be false -- and
-    // nothing else in the tree reaches that cycle, since rvfi_csrw_check.sv
-    // never observes the register and every ladder check is `mode bmc` from
-    // reset.
+    // Do not drop these as duplicates of the two vectors above. A CSR write
+    // takes precedence over that cycle's automatic increment for the whole
+    // 64-bit counter, not just for the half the address names, so the carry
+    // boundary is the one place the rule can be broken: with the low half at
+    // 0xffff_ffff a write to it must also suppress the carry into the high
+    // half. Nothing else reaches that cycle -- the ladder's CSR checks read
+    // only what the core reports writing and never look at the register, and a
+    // `.S` program lands a write there only by calibrating instruction spacing.
     poke(12'hB80, 32'h0000_0000);
     poke(12'hB00, 32'hffff_fffe);
     @(posedge clk);
@@ -280,7 +283,6 @@ module csr_tb;
     check_read("a write at the boundary still beats the increment", 12'hB00, 32'h0000_0000);
     check_read("...and its discarded carry does not reach mcycleh", 12'hB80, 32'h0000_0000);
 
-    // The same for minstret, driven into the boundary by `instret`.
     poke(12'hB82, 32'h0000_0000);
     poke(12'hB02, 32'hffff_fffe);
     instret = 1'b1;
@@ -292,9 +294,10 @@ module csr_tb;
     check_read("a write at the boundary still beats the increment", 12'hB02, 32'h0000_0000);
     check_read("...and its discarded carry does not reach minstreth", 12'hB82, 32'h0000_0000);
 
-    // Nothing on the ladder sees any of this: rvfi_insn_check drops every value
-    // assertion under `spec_trap`, and these CSRs are off the [csrs] list per
-    // the header. This bench and test/asm/trap.S are all there is.
+    // Nothing on the riscv-formal ladder sees any of this. Its per-instruction
+    // checks drop every value assertion for a retire that traps, and the CSRs a
+    // trap writes are the WARL ones the header explains cannot go on the
+    // `[csrs]` list, so this bench and test/asm/trap.S are all there is.
     poke(12'h305, 32'h0000_0100);   // mtvec = 0x100
     poke(12'h300, 32'h0000_0008);   // mstatus.MIE = 1, MPIE = 0
     check_hex("mtvec_value echoes mtvec for the decoder", mtvec_value, 32'h0000_0100);
@@ -311,7 +314,6 @@ module csr_tb;
     check_read("...and leaves mepc alone", 12'h341, 32'h0000_0080);
     check_read("...and leaves mcause alone", 12'h342, 32'd4);
 
-    // The value pushed is MIE, not a constant.
     poke(12'h300, 32'h0000_0000);
     take_trap(32'd2, 32'h0000_0200);
     check_read("a trap with MIE clear pushes a clear MPIE", 12'h300, 32'h0000_1800);

--- a/test/csr_tb.v
+++ b/test/csr_tb.v
@@ -2,21 +2,12 @@
 `default_nettype none
 `include "structs.v"
 
-// rtl/csrs.v's own bench: drive the access port directly rather than infer the
-// CSR file's behaviour from a whole-pipeline run. Three things it covers that
-// nothing else can.
-//
-//  1. The read mux, including which addresses `implemented` accepts. That
-//     output feeds rtl/decoder.v's `instr_valid`, so an address wrongly
-//     accepted becomes an instruction the core executes and one wrongly
-//     rejected becomes an illegal instruction -- neither reads as a CSR bug in
-//     a `.S` test.
-//  2. WARL masking, per field, which the riscv-formal ladder structurally
-//     cannot check: rvfi_csrw_check.sv has no WARL model, so mtvec/mepc/mstatus
-//     are off formal/checks.cfg's [csrs] list on purpose.
-//  3. Write suppression as seen from this side -- wen low means nothing
-//     changes. Which instructions drive wen low is the decoder's business and
-//     is checked in test/decoder_tb.v.
+// rtl/csrs.v's access port, driven directly. `implemented` feeds
+// rtl/decoder.v's `instr_valid`, so an address wrongly accepted or rejected
+// reads as an execution bug rather than a CSR one in a `.S` test; and the WARL
+// masks are unreachable from the ladder, because rvfi_csrw_check.sv has no WARL
+// model and mtvec/mepc/mstatus are off formal/checks.cfg's [csrs] list for that
+// reason.
 module csr_tb;
   logic clk = 0;
   always #5 clk = ~clk;
@@ -28,8 +19,8 @@ module csr_tb;
   logic [31:0] rdata;
   logic        implemented;
   logic        instret;
-  // The second write port. rtl/decoder.v drives these for exactly the cycle it
-  // commits a trap (or an mret); this bench drives them directly (ADR-0028).
+  // The second write port, driven for exactly the cycle rtl/decoder.v commits
+  // a trap or an mret.
   logic        trap_entry, mret_entry;
   logic [31:0] trap_cause, trap_epc;
   logic [31:0] mtvec_value, mepc_value;
@@ -153,12 +144,9 @@ module csr_tb;
     reset = 1'b0;
 
     check_read("mscratch resets to 0", 12'h340, 32'h0);
-    // 0 rather than an unmapped address: the harness, not the RTL, is what makes
-    // a trap taken before a handler is installed loud (ADR-0029).
     check_read("mtvec resets to 0", 12'h305, 32'h0);
     check_read("mepc resets to 0", 12'h341, 32'h0);
     check_read("mcause resets to 0", 12'h342, 32'h0);
-    // MPP is hardwired to M-mode out of reset, MIE/MPIE clear.
     check_read("mstatus resets to MPP=M", 12'h300, 32'h0000_1800);
 
     check_read("misa", 12'h301, 32'h4000_1104);
@@ -174,24 +162,20 @@ module csr_tb;
     check_read("mcycleh", 12'hB80, 32'h0);
 
     // The privileged spec lists both unconditionally for RV32 machine mode, so
-    // `implemented` low on either is a conformance failure rather than a scope
-    // choice -- ADR-0005's set is a floor, not a closed list.
+    // `implemented` low on either is a conformance failure, not a scope choice.
     check_read("mstatush reads 0", 12'h310, 32'h0);
     check_read("mconfigptr reads 0", 12'hF15, 32'h0);
 
-    // mstatush is writable by encoding (addr[11:10] == 2'b00) and has no
-    // implemented fields, so a write is a legal WARL no-op: it must neither trap
-    // nor retain, which are conformance bugs in opposite directions.
+    // Writable by encoding with no implemented fields, so a write is a legal
+    // WARL no-op: neither trapping nor retaining, which are conformance bugs in
+    // opposite directions.
     poke(12'h310, 32'hFFFF_FFFF);
     check_read("mstatush still reads 0 after a write", 12'h310, 32'h0);
 
-    // mconfigptr is read-only by encoding (addr[11:10] == 2'b11), so the
-    // decoder rejects a write before rtl/csrs.v is asked. Only the read side is
-    // this module's half.
+    // Read-only by encoding, so the decoder rejects a write before rtl/csrs.v
+    // is asked; only the read side is this module's half.
     check_read("mconfigptr reads 0 after an attempted write", 12'hF15, 32'h0);
 
-    // Addresses this core does not have. `implemented` low is what makes
-    // rtl/decoder.v call the instruction unrecognised.
     peek(12'h7C0); // a custom/unimplemented machine CSR
     check_bit("0x7c0 is not implemented", implemented, 1'b0);
     check_hex("...and reads 0", rdata, 32'h0);
@@ -207,7 +191,6 @@ module csr_tb;
     poke(12'h342, 32'h0000_000b);
     check_read("mcause round-trips", 12'h342, 32'h0000_000b);
 
-    // wen low changes nothing, even with a live address and data.
     addr = 12'h340;
     wdata = 32'h0;
     ren = 1'b1;
@@ -217,11 +200,10 @@ module csr_tb;
     ren = 1'b0;
     check_read("wen low leaves mscratch alone", 12'h340, 32'hdead_beef);
 
-    // mtvec: direct mode, 4-byte aligned base. The two low bits never stick.
     poke(12'h305, 32'h0000_0103);
     check_read("mtvec masks bits [1:0]", 12'h305, 32'h0000_0100);
-    // mepc masks bit 0 only. Bit 1 is a legal value -- C makes 2-byte targets
-    // legal -- so masking it too would be a bug rather than extra safety.
+    // Bit 1 of mepc is a legal value, because C makes 2-byte targets legal, so
+    // masking it too would be a bug rather than extra safety.
     poke(12'h341, 32'h0000_0103);
     check_read("mepc masks bit 0 only", 12'h341, 32'h0000_0102);
     poke(12'h300, 32'h0000_0000);
@@ -231,11 +213,10 @@ module csr_tb;
     poke(12'h300, 32'h0000_0008);
     check_read("mstatus MIE alone", 12'h300, 32'h0000_1808);
 
-    // Read-only CSRs ignore writes rather than trapping here: rtl/csrs.v never
-    // decides an access is illegal, and the read-only test on the address lives
-    // in rtl/decoder.v with every other trap cause. The real core therefore no
-    // longer produces these writes, but the WARL fallback that swallows them is
-    // what makes the RVFI report tell the truth about what landed.
+    // rtl/csrs.v never decides an access is illegal -- the read-only test on
+    // the address is in rtl/decoder.v with every other trap cause -- so the
+    // WARL fallback that swallows these is what makes the RVFI report tell the
+    // truth about what landed.
     poke(12'h301, 32'hffff_ffff);
     check_read("misa ignores a write", 12'h301, 32'h4000_1104);
     poke(12'h304, 32'hffff_ffff);
@@ -247,15 +228,12 @@ module csr_tb;
     poke(12'hF14, 32'hffff_ffff);
     check_read("mhartid ignores a write", 12'hF14, 32'h0);
 
-    // mcycle counts cycles on its own; nothing has to ask it to.
     peek(12'hB00);
     before_lo = rdata;
     @(posedge clk);
     peek(12'hB00);
     check_hex("mcycle advances every cycle", rdata, before_lo + 32'd1);
 
-    // minstret counts only the cycles decode says an instruction issued
-    // (ADR-0027).
     peek(12'hB02);
     before_lo = rdata;
     instret = 1'b0;
@@ -269,15 +247,12 @@ module csr_tb;
     peek(12'hB02);
     check_hex("minstret counts an issue", rdata, before_lo + 32'd1);
 
-    // An explicit write beats that cycle's increment. Driven with instret high,
-    // which is the case that would otherwise land value+1.
+    // Driven with instret high, the case that would otherwise land value+1.
     instret = 1'b1;
     poke(12'hB02, 32'h0000_0100);
     instret = 1'b0;
     check_read("an explicit minstret write beats the increment", 12'hB02, 32'h0000_0100);
 
-    // The halves are separate addresses of one 64-bit counter: writing the
-    // low one leaves the high one alone.
     poke(12'hB82, 32'h0000_0007);
     check_read("minstreth round-trips", 12'hB82, 32'h0000_0007);
     poke(12'hB02, 32'h0000_0000);
@@ -289,17 +264,13 @@ module csr_tb;
     check_read("an explicit mcycle write beats the increment", 12'hB00, 32'h0000_0000);
     check_read("...and does not disturb mcycleh", 12'hB80, before_hi);
 
-    // The same at the carry boundary, which is the only place that last claim
-    // can be false. "Any CSR write takes precedence over the automatic
-    // increment" (priv spec 20211203 §3.1.11) is about the 64-bit counter, not
-    // the half the address names, so with mcycle == 32'hffff_ffff a write to the
-    // low half must suppress a carry that would otherwise land in mcycleh.
-    //
-    // Nothing else in the tree can reach it: rvfi_csrw_check.sv reads only the
-    // self-reported masks and never observes the register, every ladder check is
-    // `mode bmc` from reset, and a `.S` program lands a write on that one cycle
-    // only by calibrating instruction spacing. Do not drop these vectors as
-    // duplicates of the two above (ADR-0048).
+    // Do not drop these as duplicates of the two vectors above. "Any CSR write
+    // takes precedence over the automatic increment" (priv spec 20211203
+    // §3.1.11) is about the 64-bit counter rather than the half the address
+    // names, so the carry boundary is the only place it can be false -- and
+    // nothing else in the tree reaches that cycle, since rvfi_csrw_check.sv
+    // never observes the register and every ladder check is `mode bmc` from
+    // reset.
     poke(12'hB80, 32'h0000_0000);
     poke(12'hB00, 32'hffff_fffe);
     @(posedge clk);
@@ -309,8 +280,7 @@ module csr_tb;
     check_read("a write at the boundary still beats the increment", 12'hB00, 32'h0000_0000);
     check_read("...and its discarded carry does not reach mcycleh", 12'hB80, 32'h0000_0000);
 
-    // The same rule for minstret, where `instret` rather than the clock is
-    // what drives the counter into the boundary.
+    // The same for minstret, driven into the boundary by `instret`.
     poke(12'hB82, 32'h0000_0000);
     poke(12'hB02, 32'hffff_fffe);
     instret = 1'b1;
@@ -322,11 +292,9 @@ module csr_tb;
     check_read("a write at the boundary still beats the increment", 12'hB02, 32'h0000_0000);
     check_read("...and its discarded carry does not reach minstreth", 12'hB82, 32'h0000_0000);
 
-    // Trap entry and mret: the privileged-spec sequence, driven directly.
-    // Nothing on the riscv-formal ladder can see any of it -- rvfi_insn_check
-    // drops every value assertion under `spec_trap`, and mtvec/mepc/mcause/
-    // mstatus are off the [csrs] list because rvfi_csrw_check.sv has no WARL
-    // model. This bench and test/asm/trap.S are the whole coverage.
+    // Nothing on the ladder sees any of this: rvfi_insn_check drops every value
+    // assertion under `spec_trap`, and these CSRs are off the [csrs] list per
+    // the header. This bench and test/asm/trap.S are all there is.
     poke(12'h305, 32'h0000_0100);   // mtvec = 0x100
     poke(12'h300, 32'h0000_0008);   // mstatus.MIE = 1, MPIE = 0
     check_hex("mtvec_value echoes mtvec for the decoder", mtvec_value, 32'h0000_0100);
@@ -337,22 +305,19 @@ module csr_tb;
     check_read("...pushes MIE into MPIE and clears MIE", 12'h300, 32'h0000_1880);
     check_hex("mepc_value echoes mepc for the decoder", mepc_value, 32'h0000_0080);
 
-    // mret pops it back: MIE <- MPIE, MPIE <- 1. mepc is NOT touched by mret;
-    // the handler's own `csrw mepc` is what moves it (test/asm/riscv_test.h).
+    // mepc is not touched by mret; the handler's own `csrw mepc` moves it.
     take_mret();
     check_read("mret restores MIE from MPIE and sets MPIE", 12'h300, 32'h0000_1888);
     check_read("...and leaves mepc alone", 12'h341, 32'h0000_0080);
     check_read("...and leaves mcause alone", 12'h342, 32'd4);
 
-    // A trap taken with MIE already clear leaves MPIE clear too -- the value
-    // pushed is MIE, not a constant.
+    // The value pushed is MIE, not a constant.
     poke(12'h300, 32'h0000_0000);
     take_trap(32'd2, 32'h0000_0200);
     check_read("a trap with MIE clear pushes a clear MPIE", 12'h300, 32'h0000_1800);
     check_read("...and records the new cause", 12'h342, 32'd2);
 
-    // mepc's WARL mask applies to trap entry too, and masks bit 0 only: a
-    // compressed instruction faulting at pc % 4 == 2 must record an mepc with
+    // A compressed instruction faulting at pc % 4 == 2 must record an mepc with
     // bit 1 set, or the handler resumes two bytes early. test/asm/trap.S faults
     // a real `c.lw` at that alignment for the same reason.
     take_trap(32'd4, 32'h0000_0146);

--- a/test/decoder_tb.v
+++ b/test/decoder_tb.v
@@ -91,11 +91,14 @@ module decoder_tb;
     end
   endtask
 
-  // `pc` must have exactly one driver and it must be `next_pc` (CLAUDE.md
-  // invariant 1): the memory latches its address off `next_pc` a cycle early,
-  // so a second driver puts fetch out of step with decode, and no ladder check
-  // is in contact with that port. Every edge, not one directed vector, because
-  // such an edit shows up on some instructions and not others.
+  // pc must have exactly one driver, and it must be next_pc. The memory latches
+  // its address off next_pc one cycle before the fetch that reads it. Give pc a
+  // second driver and the memory runs a cycle out of step with decode, so the
+  // core executes whatever is at the wrong addresses. Nothing on the
+  // riscv-formal ladder reads that port.
+  //
+  // Checked on every edge rather than in one vector, because a change like that
+  // shows up on some instructions and not on others.
   logic [31:0] prev_next_pc;
   logic        prev_next_pc_valid = 1'b0;
   always @(posedge clk) begin
@@ -114,11 +117,11 @@ module decoder_tb;
     end
   endtask
 
-  // The `addi x0, x0, 0` is load-bearing: `operand_stall` compares the address
-  // pair against the pair captured at the last clock edge, and most vectors
-  // here take no edge at all, so without parking on x0 first the pair left by
-  // an earlier vector can coincide with this instruction's, no fetch cycle
-  // happens, and every issue-time check below lands a cycle early.
+  // The addi x0, x0, 0 matters. operand_stall compares rs1 and rs2 against
+  // whatever they were at the last clock edge, and most vectors here take no
+  // edge at all. Without parking on x0 first, an earlier vector can leave the
+  // same pair behind, no fetch cycle happens, and every check below lands a
+  // cycle early.
   task automatic present_and_fetch(input logic [31:0] instr);
     begin
       in.instr = 32'h00000013;
@@ -133,8 +136,8 @@ module decoder_tb;
   initial begin
     reset = 1;
     in = '0;
-    // rtl/fetcher.v drives this to exactly !reset (CLAUDE.md invariant 1),
-    // so the real decoder never sees a non-reset cycle with it low.
+    // rtl/fetcher.v drives this to exactly !reset, so the real decoder never
+    // sees a non-reset cycle with it low.
     in.valid = 1'b1;
     reg_rs1 = 0;
     reg_rs2 = 0;
@@ -150,11 +153,10 @@ module decoder_tb;
     check_hex("xori math_arg", dut.math_arg, 32'hffffffff);
     check_bit("a newly presented instruction stalls for its operands",
               dut.operand_stall, 1'b1);
-    // The two halves of the operand stall, checked separately because dropping
-    // either is silent: without the `stall` term the instruction issues with an
-    // operand the regfile has not fetched, and without the bubble arm it
-    // publishes into decoder_out during its own fetch cycle. Both mutations
-    // leave every other vector here passing.
+    // Two separate things to get wrong, both silent. Drop the stall and the
+    // instruction issues with a register the file has not read yet. Drop the
+    // bubble and it publishes during its own fetch cycle. Either way every
+    // other vector here still passes.
     check_bit("...so it does not issue in that cycle", dut.issuing, 1'b0);
     operand_fetch_cycle();
     check_bit("...and the fetch cycle bubbled decoder_out", out.valid, 1'b0);
@@ -253,8 +255,8 @@ module decoder_tb;
     check_hex("...with cause 2", trap_cause, 32'd2);
     csr_implemented = 1'b1;
 
-    // Unrecognised means illegal instruction now, so a legal encoding dropped
-    // from `instr_valid` faults.
+    // Anything the decoder does not recognise traps, so a legal encoding left
+    // out of instr_valid faults.
     in.instr = 32'h0ff0000f;   // fence iorw, iorw
     #1;
     check_bit("fence is a valid instruction", dut.instr_valid, 1'b1);
@@ -328,9 +330,9 @@ module decoder_tb;
     check_bit("reading a read-only CSR is not a write", dut.csr_readonly_write, 1'b0);
     check_bit("...and does not trap", dut.trap_pending, 1'b0);
 
-    // Re-run on a drained pipe, because a CSR instruction serializes whether or
-    // not it is legal and the checks below would otherwise be satisfied by the
-    // stall rather than by the trap.
+    // Run again with nothing in the pipeline. A CSR instruction waits either
+    // way, legal or not, so otherwise the checks below pass because it stalled
+    // rather than because it trapped.
     present_and_fetch(32'hf1151073);
     check_bit("...it issues once the pipe drains", dut.issuing, 1'b1);
     check_bit("a trapping issue does not count in minstret", instret, 1'b0);
@@ -381,10 +383,9 @@ module decoder_tb;
               next_pc, pc);
     check_bit("...and no trap is committed out of the stolen window", trap_entry, 1'b0);
 
-    // A freeze holds decoder_out and a steal bubbles it, so on a cycle with
-    // both, holding has to win or the held instruction is dropped. Nothing but
-    // the publish block's arm order decides that, and reordering two `else if`
-    // arms is otherwise silent.
+    // A freeze holds decoder_out; a steal clears it. On a cycle with both,
+    // holding has to win or the held instruction is lost. Only the order of the
+    // arms in the publish block decides that, and swapping them is silent.
     accessor_stall = 1'b1;
     #1;
     @(posedge clk);
@@ -411,9 +412,9 @@ module decoder_tb;
               out.valid, 1'b1);
     check_hex("...as itself", {27'b0, out.rd}, 32'd1);
 
-    // Text is writable, so a store ahead of a `fence.i` can change the words
-    // being fetched behind it. Draining is what puts the older store's write
-    // edge before the fetch address published on `fence.i`'s issue edge.
+    // Text is writable, so a store just before a fence.i can change the words
+    // being fetched right behind it. Waiting is what puts that store's write
+    // ahead of the next fetch address.
     executor_out.valid = 1'b1;
     executor_out.rd = 5'd0;
     present_and_fetch(32'h0000100f);

--- a/test/decoder_tb.v
+++ b/test/decoder_tb.v
@@ -2,37 +2,11 @@
 `default_nettype none
 `include "structs.v"
 
-// Decode-vector bench (see `eb18320`): confirms the SLTI/SLTIU/XORI
-// immediate-source fix (decoder.v's `instr_shift`) and the funct12-exact EBREAK
-// fix, directly against the decoder — no full pipeline needed for either check.
+// Decode vectors, driven straight at rtl/decoder.v with no pipeline around it.
 //
-// TIMING DISCIPLINE, REWRITTEN FOR ADR-0042. rtl/regfile.v's read is
-// registered, so decode presents rs1/rs2 for one cycle and issues on the next:
-// `operand_stall` is high for exactly the cycles in which the address pair
-// differs from the pair presented last cycle, and decode bubbles then. This
-// bench drives `in.instr` directly rather than through rtl/fetcher.v, so that
-// fetch cycle has to be spent explicitly — `operand_fetch_cycle()` below is it.
-//
-// Two rules follow, and both are why this bench was re-timed rather than
-// extended:
-//
-//   * A COMBINATIONAL decode flag (instr_*, trap_cause, csr_arg, uses_rs1,
-//     math_arg...) is readable the instant `in.instr` settles, exactly as
-//     before. Those vectors are untouched.
-//   * Anything about ISSUING, PUBLISHING or COMMITTING (dut.issuing, out.*,
-//     csr_wen, instret, trap_entry, pc) must be checked after the fetch cycle.
-//     Five checks here failed on that alone when the registered read landed,
-//     with nothing wrong in the RTL.
-//
-// The serialization vectors changed shape for a second, subtler reason. They
-// used to rely on the PREVIOUS decode vector still sitting in `decoder_out` to
-// make `pipe_drained` false. The operand-fetch bubble now clears that slot one
-// cycle ahead of every instruction, so `decoder_out` is always empty by the
-// time a CSR instruction is eligible to issue. Serialization is still real --
-// `pipe_drained` also reads the executor, accessor and pending-load slots,
-// which a decode bubble does not clear -- so these vectors now drive
-// `executor_out.valid` to stand for the in-flight instruction, which is what
-// they were always trying to say.
+// The one timing rule: a combinational decode flag is readable the instant
+// `in.instr` settles, but anything about issuing, publishing or committing has
+// to be checked after the operand-fetch cycle is spent.
 module decoder_tb;
   logic clk = 0;
   always #5 clk = ~clk;
@@ -41,41 +15,24 @@ module decoder_tb;
   fetcher_output in;
   logic [31:0] reg_rs1, reg_rs2;
   logic [31:0] pc;
-  // ADR-0054: the combinational next PC, which the instruction memory latches
-  // a cycle early. Checked directly below -- the registered `pc` this bench
-  // already reads is the same value one edge later, so a bench that only
-  // watched `pc` would pass on a `next_pc` that had stopped matching it.
   logic [31:0] next_pc;
   logic [4:0] rs1, rs2;
   decoder_output out;
-  // No in-flight producer at the executor stage and no divide in progress:
-  // this bench exercises decode vectors in isolation, not the hazard
-  // scoreboard (see test/regfile_tb.v and test/asm/hazard.S for that).
+  // Driven high by the vectors that need something in flight to serialize
+  // against; the hazard scoreboard is test/regfile_tb.v's and hazard.S's.
   executor_output executor_out = '0;
   logic divider_stall = 1'b0;
   logic accessor_stall = 1'b0;
-  // ADR-0059's steal, driven per vector below: it is the sixth stall reason,
-  // and the only one whose interaction with the other five is a ruling rather
-  // than a consequence.
   logic fetch_stall = 1'b0;
   logic accessor_pending_valid = 1'b0;
   logic [4:0] accessor_pending_rd = 5'b0;
-  // ADR-0026's drain slot: nothing is in flight in this bench, so the pipe
-  // always reads as drained and a CSR instruction never serializes here.
   logic accessor_out_valid = 1'b0;
-  // The CSR file (rtl/csrs.v) is a sibling of the decoder, not part of it,
-  // so this bench stubs its read port. `csr_implemented` is driven per
-  // vector below, because it is what decides whether a Zicsr encoding is a
-  // recognised instruction at all (ADR-0005).
+  // rtl/csrs.v is a sibling of the decoder, not part of it, so it is stubbed.
   logic [31:0] csr_rdata = 32'b0;
   logic csr_implemented = 1'b0;
   logic [11:0] csr_addr;
   logic csr_ren, csr_wen, instret;
   logic [31:0] csr_wdata;
-  // ADR-0028's trap-entry pair. rtl/csrs.v is a sibling of the decoder, not
-  // part of it, so these are stubbed the same way the read port above is:
-  // mtvec/mepc are driven to recognisable constants and the trap-commit
-  // outputs are observed.
   logic [31:0] mtvec = 32'h0000_0100;
   logic [31:0] mepc  = 32'h0000_0244;
   logic trap_entry, mret_entry;
@@ -134,18 +91,11 @@ module decoder_tb;
     end
   endtask
 
-  // ADR-0054: `next_pc` is the value `pc` takes on the next edge, and the
-  // instruction memory latches its address off it a cycle early
-  // (rtl/littlesoc.v). This runs on EVERY edge this bench takes rather than in
-  // one directed vector, because the thing it guards against -- a later edit
-  // that gives `pc` a driver `next_pc` does not account for -- would show up on
-  // some instructions and not others. Every redirect the vectors below exercise
-  // (branches, jal/jalr, mret, trap entry) is therefore covered by it.
-  //
-  // Both signals are read in the active region at the edge, so `pc` is still
-  // its pre-edge value and `next_pc` is the combinational value that produced
-  // it -- which is exactly the pair this compares one cycle apart. The bench
-  // moves stimulus at `#1` after each edge, so nothing is racing here.
+  // `pc` must have exactly one driver and it must be `next_pc` (CLAUDE.md
+  // invariant 1): the memory latches its address off `next_pc` a cycle early,
+  // so a second driver puts fetch out of step with decode, and no ladder check
+  // is in contact with that port. Every edge, not one directed vector, because
+  // such an edit shows up on some instructions and not others.
   logic [31:0] prev_next_pc;
   logic        prev_next_pc_valid = 1'b0;
   always @(posedge clk) begin
@@ -157,10 +107,6 @@ module decoder_tb;
     prev_next_pc_valid <= 1'b1;
   end
 
-  // ADR-0042: spend the operand-fetch cycle. On entry `in.instr` has just
-  // changed, so rtl/decoder.v's `operand_stall` is high and this edge bubbles
-  // decoder_out while rtl/regfile.v captures the read. On exit the instruction
-  // is eligible to issue and issue-time state is meaningful.
   task automatic operand_fetch_cycle();
     begin
       @(posedge clk);
@@ -168,17 +114,11 @@ module decoder_tb;
     end
   endtask
 
-  // Present an instruction and spend its operand-fetch cycle, deterministically.
-  //
-  // The nop first is load-bearing, not decoration. `operand_stall` compares the
-  // address pair against the pair captured at the LAST CLOCK EDGE, and most
-  // vectors in this bench are combinational-only -- they change `in.instr` and
-  // check a decode flag without taking an edge at all. So the pair captured at
-  // the previous edge is whatever some earlier vector happened to leave, and if
-  // it coincides with this instruction's, the fetch cycle correctly does not
-  // happen and an issue-time check lands a cycle early. Parking on x0 first
-  // makes the fetch cycle unconditional. `addi x0, x0, 0` reads rs1 = rs2 = x0
-  // and writes nothing.
+  // The `addi x0, x0, 0` is load-bearing: `operand_stall` compares the address
+  // pair against the pair captured at the last clock edge, and most vectors
+  // here take no edge at all, so without parking on x0 first the pair left by
+  // an earlier vector can coincide with this instruction's, no fetch cycle
+  // happens, and every issue-time check below lands a cycle early.
   task automatic present_and_fetch(input logic [31:0] instr);
     begin
       in.instr = 32'h00000013;
@@ -206,17 +146,15 @@ module decoder_tb;
     // opcode=0010011 (I-type math-immediate).
     in.instr = 32'hfff14093;
     in.pc = 32'h0;
-    #1; // math_arg is purely combinational off `in.instr`; no clock edge needed
+    #1;
     check_hex("xori math_arg", dut.math_arg, 32'hffffffff);
-    // ADR-0042, asserted directly rather than assumed: a newly presented
-    // instruction spends one cycle fetching its operands, and exactly one.
     check_bit("a newly presented instruction stalls for its operands",
               dut.operand_stall, 1'b1);
-    // The two halves of ADR-0042's stall, checked separately, because dropping
-    // either one is silent: without the `stall` term the instruction issues
-    // with an operand the regfile has not fetched yet, and without the bubble
-    // arm it publishes into decoder_out during its own fetch cycle. Both
-    // mutations leave every other vector in this bench passing.
+    // The two halves of the operand stall, checked separately because dropping
+    // either is silent: without the `stall` term the instruction issues with an
+    // operand the regfile has not fetched, and without the bubble arm it
+    // publishes into decoder_out during its own fetch cycle. Both mutations
+    // leave every other vector here passing.
     check_bit("...so it does not issue in that cycle", dut.issuing, 1'b0);
     operand_fetch_cycle();
     check_bit("...and the fetch cycle bubbled decoder_out", out.valid, 1'b0);
@@ -227,32 +165,23 @@ module decoder_tb;
     #1;
     check_hex("xori out.rs2 (registered math_arg)", out.rs2, 32'hffffffff);
 
-    // ebreak is funct12 == 1 EXACTLY; mret (0x302) and wfi (0x105) are
-    // different SYSTEM instructions sharing funct3 == 0 with it, and folding
-    // them into ebreak was the original defect here.
-    //
-    // Read off the decode flag rather than off `out.is_ebreak`, because since
-    // trap entry landed `ebreak` traps (cause 3) and ADR-0028 suppresses every
-    // execution flag on a trapping issue -- so the registered flag is now 0
-    // for all three and the vector would pass vacuously.
-    in.instr = 32'h00100073;
+    // Read off the decode flag, not `out.is_ebreak`: a trapping issue
+    // suppresses every execution flag, so the registered flag is 0 for all
+    // three of these and the vector would pass vacuously.
+    in.instr = 32'h00100073;   // ebreak
     #1;
     check_bit("ebreak sets instr_ebreak", dut.instr_ebreak, 1'b1);
-    in.instr = 32'h30200073;
+    in.instr = 32'h30200073;   // mret
     #1;
     check_bit("mret does not set instr_ebreak", dut.instr_ebreak, 1'b0);
     check_bit("...it sets instr_mret", dut.instr_mret, 1'b1);
-    in.instr = 32'h10500073;
+    in.instr = 32'h10500073;   // wfi
     #1;
     check_bit("wfi does not set instr_ebreak", dut.instr_ebreak, 1'b0);
     check_bit("...it sets instr_wfi", dut.instr_wfi, 1'b1);
     @(posedge clk);
     #1;
 
-    // ---- Zicsr (ADR-0005) ------------------------------------------------
-    // The three immediate forms used to be folded straight into the register
-    // forms, which lost the zimm-vs-rs1 distinction. These vectors are the
-    // regression for that split; test/csr_tb.v covers the CSR file itself.
     csr_implemented = 1'b1;
 
     // csrrw a1, mscratch, a0  ->  0x340515f3
@@ -269,15 +198,8 @@ module decoder_tb;
     check_bit("csrrw uses rs1", dut.uses_rs1, 1'b1);
     check_bit("an implemented CSR is a valid instruction", dut.instr_valid, 1'b1);
 
-    // CLAUDE.md invariant 5 / ADR-0026: it does NOT issue while anything is in
-    // flight. `executor_out.valid` stands for that in-flight instruction --
-    // rd == x0 so it raises no RAW hazard of its own and serialization is the
-    // only thing being tested. (Before ADR-0042 this vector leaned on the
-    // previous decode vector still sitting in decoder_out; the operand-fetch
-    // bubble now clears that slot a cycle early, so it had to say what it
-    // meant.)
     executor_out.valid = 1'b1;
-    executor_out.rd = 5'd0;
+    executor_out.rd = 5'd0;   // x0 raises no RAW hazard of its own
     present_and_fetch(32'h340515f3);
     check_bit("a CSR instruction serializes while the pipe is busy",
               dut.serialize, 1'b1);
@@ -298,9 +220,7 @@ module decoder_tb;
     check_bit("...as an add", out.is_add, 1'b1);
     check_hex("...to the encoded rd", {27'b0, out.rd}, 32'd11);
 
-    // csrrsi a0, mscratch, 0x1f  ->  0x340fe573. The zimm is not a register
-    // index: no rs1 interlock, and the operand comes out of the encoding.
-    in.instr = 32'h340fe573;
+    in.instr = 32'h340fe573;   // csrrsi a0, mscratch, 0x1f
     executor_out.valid = 1'b1;
     executor_out.rd = 5'd31; // == the zimm bits, if they were read as rs1
     #1;
@@ -310,31 +230,22 @@ module decoder_tb;
     check_bit("csrrsi does not use rs1", dut.uses_rs1, 1'b0);
     check_bit("...so the zimm raises no interlock", dut.hazard_rs1, 1'b0);
 
-    // csrrs a0, mscratch, x31 -- the register form of the same five bits
-    // DOES interlock (0x340fa573).
-    in.instr = 32'h340fa573;
+    in.instr = 32'h340fa573;   // csrrs a0, mscratch, x31: the same five bits
     #1;
     check_bit("csrrs x31 uses rs1", dut.uses_rs1, 1'b1);
     check_bit("...and interlocks on it", dut.hazard_rs1, 1'b1);
     executor_out.valid = 1'b0;
 
-    // csrr a0, misa  ==  csrrs a0, misa, x0 (0x30102573): rs1 == x0
-    // suppresses the write, which is what makes it legal on a read-only CSR.
-    in.instr = 32'h30102573;
+    in.instr = 32'h30102573;   // csrr a0, misa == csrrs a0, misa, x0
     #1;
     check_bit("csrrs with rs1 == x0 suppresses the write", dut.csr_write_op, 1'b0);
     check_bit("...and still reads", dut.csr_read_op, 1'b1);
 
-    // csrw mscratch, a0  ==  csrrw x0, mscratch, a0 (0x34051073): rd == x0
-    // suppresses the read.
-    in.instr = 32'h34051073;
+    in.instr = 32'h34051073;   // csrw mscratch, a0 == csrrw x0, mscratch, a0
     #1;
     check_bit("csrrw with rd == x0 suppresses the read", dut.csr_read_op, 1'b0);
     check_bit("...and still writes", dut.csr_write_op, 1'b1);
 
-    // An unimplemented CSR is not a recognised instruction, and that is now
-    // how it becomes an illegal-instruction TRAP (ADR-0005) rather than a
-    // silently suppressed no-op.
     csr_implemented = 1'b0;
     #1;
     check_bit("an unimplemented CSR is not a valid instruction", dut.instr_valid, 1'b0);
@@ -342,16 +253,8 @@ module decoder_tb;
     check_hex("...with cause 2", trap_cause, 32'd2);
     csr_implemented = 1'b1;
 
-    // ---- M3 traps (CLAUDE.md invariant 2 / ADR-0005 / ADR-0030) ----------
-    // Every cause, taken directly against the decoder. The `.S` suite takes
-    // the same five through a real handler; this is where the CAUSE ENCODER
-    // itself is pinned, including the cases the suite cannot reach because
-    // they never co-occur with anything observable.
-
-    // The four M3 additions to instr_valid. Until trap entry landed these were
-    // merely unrecognised, which was harmless only while unrecognised meant
-    // "no trap" -- a legal `fence` would fault the moment that changed
-    // (ADR-0034 recorded this as the change that must fix it).
+    // Unrecognised means illegal instruction now, so a legal encoding dropped
+    // from `instr_valid` faults.
     in.instr = 32'h0ff0000f;   // fence iorw, iorw
     #1;
     check_bit("fence is a valid instruction", dut.instr_valid, 1'b1);
@@ -370,14 +273,12 @@ module decoder_tb;
     check_bit("...and does not trap", dut.trap_pending, 1'b0);
     check_bit("...and is not an ecall", dut.instr_ecall, 1'b0);
 
-    // Cause 2, the canonical illegal instruction: the all-zero word.
     in.instr = 32'h00000000;
     #1;
     check_bit("the all-zero word is illegal", dut.instr_illegal, 1'b1);
     check_hex("...cause 2", trap_cause, 32'd2);
     check_bit("...and traps", dut.trap_pending, 1'b1);
 
-    // Cause 3 and cause 11: ebreak and ecall.
     in.instr = 32'h00100073;
     #1;
     check_hex("ebreak is cause 3", trap_cause, 32'd3);
@@ -385,10 +286,8 @@ module decoder_tb;
     #1;
     check_hex("ecall is cause 11", trap_cause, 32'd11);
 
-    // Cause 4: a misaligned load. `lw a1, 4(a0)` (0x00452583) with a0 holding
-    // an odd address -- the effective address is what is tested, not the
-    // register and not the immediate.
-    in.instr = 32'h00452583;
+    // The EFFECTIVE address decides, not rs1 and not the immediate.
+    in.instr = 32'h00452583;   // lw a1, 4(a0)
     reg_rs1 = 32'h0001_0001;
     #1;
     check_hex("misaligned lw is cause 4", trap_cause, 32'd4);
@@ -396,14 +295,11 @@ module decoder_tb;
     reg_rs1 = 32'h0001_0000;
     #1;
     check_bit("an aligned lw does not trap", dut.trap_pending, 1'b0);
-    // 2-byte alignment is not enough for a word access.
     reg_rs1 = 32'h0001_0002;
     #1;
     check_bit("a 2-aligned lw still traps", dut.trap_pending, 1'b1);
 
-    // Cause 6: a misaligned store. `sh a1, 0(a0)` (0x00b51023) needs only
-    // 2-byte alignment, so an odd address traps and an even one does not.
-    in.instr = 32'h00b51023;
+    in.instr = 32'h00b51023;   // sh a1, 0(a0): only 2-byte alignment needed
     reg_rs1 = 32'h0001_0001;
     #1;
     check_hex("misaligned sh is cause 6", trap_cause, 32'd6);
@@ -411,46 +307,30 @@ module decoder_tb;
     #1;
     check_bit("a 2-aligned sh does not trap", dut.trap_pending, 1'b0);
 
-    // Byte accesses are aligned by construction and can never raise either
-    // cause -- which is what made the riscv-formal attribution checkable:
-    // insn_lb/insn_lbu/insn_sb passed while the nine word/halfword checks
-    // failed. `sb a1, 0(a0)` (0x00b50023) at the most awkward address there is.
-    in.instr = 32'h00b50023;
+    in.instr = 32'h00b50023;   // sb a1, 0(a0), at the most awkward address
     reg_rs1 = 32'h0001_0003;
     #1;
     check_bit("a byte store never traps", dut.trap_pending, 1'b0);
-    // `lb a1, 0(a0)` (0x00050583)
-    in.instr = 32'h00050583;
+    in.instr = 32'h00050583;   // lb a1, 0(a0)
     #1;
     check_bit("a byte load never traps", dut.trap_pending, 1'b0);
     reg_rs1 = 32'b0;
 
-    // Cause 2 again, the other illegal-CSR rule: a WRITE to a CSR that is
-    // read-only by address. mvendorid is 0xF11, so addr[11:10] == 2'b11.
-    // `csrw mvendorid, a0` == csrrw x0, mvendorid, a0 (0xf1151073).
-    in.instr = 32'hf1151073;
+    // The other illegal-CSR rule: read-only by address, addr[11:10] == 2'b11.
+    in.instr = 32'hf1151073;   // csrw mvendorid, a0
     #1;
     check_bit("an implemented read-only CSR is still a valid encoding",
               dut.instr_valid, 1'b1);
     check_bit("...but writing it is illegal", dut.csr_readonly_write, 1'b1);
     check_hex("...cause 2", trap_cause, 32'd2);
-    // ...while READING the same CSR is legal, because CSRRS with rs1 == x0
-    // suppresses the write. `csrr a0, mvendorid` (0xf1102573).
-    in.instr = 32'hf1102573;
+    in.instr = 32'hf1102573;   // csrr a0, mvendorid
     #1;
     check_bit("reading a read-only CSR is not a write", dut.csr_readonly_write, 1'b0);
     check_bit("...and does not trap", dut.trap_pending, 1'b0);
 
-    // ADR-0027: a trapping issue commits nothing outside the pipeline
-    // registers -- no minstret increment and no CSR access. Checked on the
-    // illegal CSR write above, which is both a trap AND a CSR instruction, so
-    // a gate that only looked at `instr_valid` (the pre-M3 spelling) would
-    // still let its write through.
-    //
-    // A CSR instruction serializes whether or not it is legal, so this needs a
-    // drained pipe to issue at all -- and the checks below would otherwise be
-    // satisfied by the stall rather than by the trap, which is exactly the
-    // vacuous pass worth avoiding here.
+    // Re-run on a drained pipe, because a CSR instruction serializes whether or
+    // not it is legal and the checks below would otherwise be satisfied by the
+    // stall rather than by the trap.
     present_and_fetch(32'hf1151073);
     check_bit("...it issues once the pipe drains", dut.issuing, 1'b1);
     check_bit("a trapping issue does not count in minstret", instret, 1'b0);
@@ -458,10 +338,6 @@ module decoder_tb;
     check_bit("...and no CSR read", csr_ren, 1'b0);
     check_bit("...but it does commit a trap", trap_entry, 1'b1);
 
-    // ADR-0028: the trapping instruction retires having architecturally done
-    // nothing -- pc goes to mtvec, rd is x0, and no memory flag survives, so
-    // rtl/accessor.v issues no bus request and rvfi_mem_* come out zero.
-    // Checked after the edge, on the published decoder_output.
     reg_rs1 = 32'h0001_0001;
     in.pc = 32'h0000_0080;
     present_and_fetch(32'h00452583);   // the misaligned lw again
@@ -474,10 +350,6 @@ module decoder_tb;
     check_bit("...and issuing no load", out.is_lw, 1'b0);
     reg_rs1 = 32'b0;
 
-    // mret is a branch to mepc, taken by the same mechanism. It serializes
-    // (CLAUDE.md invariant 5), so it needs a drained pipe to issue --
-    // `executor_out.valid` again standing for the in-flight instruction, for
-    // the same reason as the csrrw vector above.
     executor_out.valid = 1'b1;
     executor_out.rd = 5'd0;
     present_and_fetch(32'h30200073);
@@ -494,10 +366,8 @@ module decoder_tb;
     #1;
     check_hex("mret redirects pc to mepc", pc, 32'h0000_0244);
 
-    // ---- the steal, the sixth stall reason (ADR-0059 / ADR-0060) ----------
-    // `addi x1, x0, 1`, issued once so decoder_out holds something a bubble
-    // would visibly destroy.
-    present_and_fetch(32'h00100093);
+    // Issued once so decoder_out holds something a bubble would visibly destroy.
+    present_and_fetch(32'h00100093);   // addi x1, x0, 1
     @(posedge clk);
     #1;
     check_bit("the instruction issued", out.valid, 1'b1);
@@ -511,11 +381,10 @@ module decoder_tb;
               next_pc, pc);
     check_bit("...and no trap is committed out of the stolen window", trap_entry, 1'b0);
 
-    // The coincidence, both ways round. A freeze holds decoder_out because the
-    // instruction in it has not been consumed; a steal bubbles because there is
-    // nothing to publish. On a cycle with both, holding wins -- bubbling would
-    // drop the held instruction. Nothing but the publish block's arm order
-    // decides this, which is why it is a vector rather than an argument.
+    // A freeze holds decoder_out and a steal bubbles it, so on a cycle with
+    // both, holding has to win or the held instruction is dropped. Nothing but
+    // the publish block's arm order decides that, and reordering two `else if`
+    // arms is otherwise silent.
     accessor_stall = 1'b1;
     #1;
     @(posedge clk);
@@ -542,12 +411,9 @@ module decoder_tb;
               out.valid, 1'b1);
     check_hex("...as itself", {27'b0, out.rd}, 32'd1);
 
-    // ---- fence.i serializes (ADR-0061) -----------------------------------
-    // Text is writable, so a store ahead of a `fence.i` can change the very
-    // words being fetched behind it. Draining the pipe is what puts the older
-    // store's write edge before the fetch address published on `fence.i`'s own
-    // issue edge. `executor_out.valid` stands for that in-flight store, exactly
-    // as it does for the Zicsr vectors above.
+    // Text is writable, so a store ahead of a `fence.i` can change the words
+    // being fetched behind it. Draining is what puts the older store's write
+    // edge before the fetch address published on `fence.i`'s issue edge.
     executor_out.valid = 1'b1;
     executor_out.rd = 5'd0;
     present_and_fetch(32'h0000100f);

--- a/test/imem_tb.v
+++ b/test/imem_tb.v
@@ -1,33 +1,14 @@
 `timescale 1 ns / 1 ps
 `default_nettype none
 
-// Standalone bench for rtl/imemory.v -- the interleaved-bank instruction ROM
-// (ADR-0054).
+// rtl/imemory.v, the interleaved-bank instruction ROM (ADR-0054). The `.S`
+// suite exercises whatever alignments its programs happen to produce and cannot
+// reach the data port at all -- no program stores into the text region, and both
+// consumers tie `mem_ren` low -- so the bank select, the range decode, the write
+// port and the steal are checked here or nowhere.
 //
-// Two things here are not reachable from the `.S` suite, which is why this
-// bench exists rather than the suite being treated as coverage:
-//
-//   * THE BANK SELECT AT EVERY ALIGNMENT. The suite runs real programs, so it
-//     exercises whatever alignments those programs happen to produce. This
-//     walks every word index in a small ROM, both parities, and checks BOTH
-//     window words against a flat reference array -- so a bank swap, an
-//     off-by-one on the `+ W[0]` index bump, or a `imem_data`/`imem_data2`
-//     transposition is caught at the one address where it differs rather than
-//     wherever a program first noticed.
-//
-//   * THE RANGE DECODE. The last word of ROM is in range while the word after
-//     it is not, so a correct fetch there returns a real `imem_data` and a zero
-//     `imem_data2`. Getting that wrong aliases the top of ROM back to the
-//     bottom, which reads as a plausible instruction rather than as a fault.
-//
-//   * The data port. The `.S` suite cannot reach it at all: no program stores
-//     into the text region, and both consumers tie `mem_ren` low. So the write
-//     port, the borrowed read port and the steal are checked here or nowhere.
-//
-// The reference is a flat, independently-filled array indexed by word number,
-// and every write is applied to it byte by byte from the strobe. It is not
-// built from the bank images: the bank split is the thing under test, so a
-// reference derived from it would agree with any split at all.
+// The reference must stay a flat array filled independently of the bank images:
+// derived from them it would agree with any split, and the split is on test.
 module imem_tb;
   localparam int ROM_WORDS = 16;
 
@@ -53,8 +34,8 @@ module imem_tb;
     .fetch_stall(fetch_stall)
   );
 
-  // The flat reference. Word i holds a value that is unique in both halves, so
-  // a transposed window or a swapped bank cannot coincide with the right answer.
+  // Unique in both halves per word, so a transposed window or a swapped bank
+  // cannot coincide with the right answer.
   logic [31:0] ref_rom[0:ROM_WORDS-1];
 
   int errors = 0;
@@ -68,9 +49,8 @@ module imem_tb;
     end
   endtask
 
-  // One cycle, with every input named. Presenting an address and taking the
-  // edge that latches it IS the contract (ADR-0054): the outputs are valid for
-  // the whole of the cycle after, which is where they are read.
+  // Presenting an address and taking the edge that latches it is the contract
+  // (ADR-0054): the outputs are valid for the whole of the cycle after.
   task automatic step(input logic [31:0] fetch_addr,
                       input logic [31:0] data_addr,
                       input logic        ren,
@@ -87,15 +67,14 @@ module imem_tb;
     end
   endtask
 
-  // A fetch with the data bus idle. The idle bus presents address 0, which is
-  // inside the text range, so `mem_ren` low is the only thing keeping it from
-  // stealing every cycle.
+  // The idle bus presents address 0, which is inside the text range, so
+  // `mem_ren` low is the only thing keeping it from stealing every cycle.
   task automatic fetch(input logic [31:0] addr);
     step(addr, 32'b0, 1'b0, 4'b0000, 32'b0);
   endtask
 
-  // A data access. The fetch address is parked at word 0, so an answer that
-  // came off the fetch side rather than the data side reads as word 0.
+  // The fetch address parks at word 0, so an answer that came off the fetch
+  // side rather than the data side reads as word 0.
   task automatic dread(input logic [31:0] addr);
     step(32'b0, addr, 1'b1, 4'b0000, 32'b0);
   endtask
@@ -104,10 +83,9 @@ module imem_tb;
     check(what, {31'b0, fetch_stall}, {31'b0, expected});
   endtask
 
-  // A write, and the same write applied to the reference. One task so the two
-  // take the same arguments by construction. Out of range the reference does
-  // nothing, which is what makes the walk below a test that a dropped write
-  // really was dropped.
+  // One task, so the DUT and the reference take the same arguments by
+  // construction. Out of range the reference does nothing, which is what makes
+  // `check_all` a test that a dropped write really was dropped.
   task automatic write_word(input logic [31:0] addr, input logic [3:0] strb,
                             input logic [31:0] data);
     int word;
@@ -123,8 +101,7 @@ module imem_tb;
     end
   endtask
 
-  // Every word of the ROM, through the fetch path, against the reference. A
-  // write that landed in the wrong bank, at the wrong index, or on the wrong
+  // A write that landed in the wrong bank, at the wrong index or on the wrong
   // bytes shows up here even when the word it was aimed at reads correctly.
   task automatic check_all(input string what);
     int j;
@@ -138,29 +115,25 @@ module imem_tb;
   initial begin
     for (i = 0; i < ROM_WORDS; i++) begin
       ref_rom[i] = 32'hc0de_0000 + 32'(i) * 32'h0001_0101;
-      // The banks, filled from the reference by the same rule rtl/imemory.v's
-      // read side has to invert. soc/rom_banks.py writes the same split for
-      // the synthesis flow.
+      // The split soc/rom_banks.py writes for synthesis, which the read side
+      // has to invert.
       if (i % 2 == 0) dut.rom_even[i/2] = ref_rom[i];
       else            dut.rom_odd[i/2]  = ref_rom[i];
     end
 
     fetch(32'b0);
 
-    // Every word index, both parities, both window words.
     for (i = 0; i < ROM_WORDS - 1; i++) begin
       fetch(32'(i) * 4);
       check($sformatf("word %0d: imem_data", i), imem_data, ref_rom[i]);
       check($sformatf("word %0d: imem_data2", i), imem_data2, ref_rom[i+1]);
     end
 
-    // The last word: in range, and its successor is not.
     fetch(32'(ROM_WORDS - 1) * 4);
     check("last word: imem_data", imem_data, ref_rom[ROM_WORDS-1]);
     check("last word: imem_data2 is out of range", imem_data2, 32'b0);
 
-    // One past the end, and far past it. Both words zero; neither aliases
-    // ref_rom[0], which bit truncation alone would produce.
+    // Neither aliases ref_rom[0], which bit truncation alone would produce.
     fetch(32'(ROM_WORDS) * 4);
     check("one past the end: imem_data", imem_data, 32'b0);
     check("one past the end: imem_data2", imem_data2, 32'b0);
@@ -168,49 +141,37 @@ module imem_tb;
     check("far out of range: imem_data", imem_data, 32'b0);
     check("far out of range: imem_data2", imem_data2, 32'b0);
 
-    // The top of the address space, where a `word + 1` range test would wrap to
-    // 0 and answer the second word of the pair out of real ROM. rtl/imemory.v
-    // tests `word < ROM_WORDS - 1` instead -- an incrementer there would sit in
-    // series with the one that produced the address, which `make soc-timing`
-    // measured on the critical path -- so both words fault here.
+    // A `word + 1` range test would wrap to 0 here and answer the second word
+    // out of real ROM; rtl/imemory.v tests `word < ROM_WORDS - 1` instead.
     fetch(32'hffff_fffc);
     check("top of the address space: imem_data faults", imem_data, 32'b0);
     check("top of the address space: imem_data2 does not wrap to word 0",
           imem_data2, 32'b0);
 
-    // Back in range on the very next cycle, with no state carried over: the
-    // window is stateless (ADR-0003) and the range flags are per-cycle.
     fetch(32'h0000_0008);
     check("back in range after an out-of-range fetch", imem_data, ref_rom[2]);
     check("...and its second word", imem_data2, ref_rom[3]);
 
-    // The address is latched, so holding it re-presents the same words -- which
-    // is what makes a stalled cycle free (rtl/decoder.v holds `next_pc = pc`).
+    // Holding the address re-presents the same words, which is what makes a
+    // stalled cycle free (rtl/decoder.v holds `next_pc = pc`).
     fetch(32'h0000_0008);
     check("a held address re-presents the same word", imem_data, ref_rom[2]);
     check_stall("an idle data bus does not steal a fetch", 1'b0);
 
-    // ---- the data read path ------------------------------------------------
-    // Every word, both parities, out of the borrowed read port. The fetch
-    // address sits at word 0 throughout, so an answer that came from the fetch
-    // side instead of the data side would read as word 0's value.
     for (i = 0; i < ROM_WORDS; i++) begin
       dread(32'(i) * 4);
       check($sformatf("data read of word %0d", i), mem_rdata, ref_rom[i]);
       check_stall($sformatf("word %0d: a data read steals the fetch", i), 1'b1);
     end
 
-    // Out of range in both directions: zero, no alias, and no steal -- the
-    // fetch keeps the read port because the access was never ours.
+    // No steal out of range: the fetch keeps the port, the access was never ours.
     dread(32'(ROM_WORDS) * 4);
     check("data read one past the end", mem_rdata, 32'b0);
     check_stall("an out-of-range read steals nothing", 1'b0);
     dread(32'h0000_1004);
     check("far out-of-range data read does not alias", mem_rdata, 32'b0);
 
-    // A read and a fetch of the same word on adjacent cycles, at both
-    // parities. The read answers from the bank the word lives in and the fetch
-    // that follows is unaffected by having lost the port the cycle before.
+    // The fetch that follows a steal is unaffected by having lost the port.
     dread(32'h0000_0010);
     check("read word 4 (even bank)", mem_rdata, ref_rom[4]);
     fetch(32'h0000_0010);
@@ -224,14 +185,11 @@ module imem_tb;
     check("fetch word 5 the cycle after reading it", imem_data, ref_rom[5]);
     check("...and its second word", imem_data2, ref_rom[6]);
 
-    // The other order: a fetch, then a read of the word it just returned.
     fetch(32'h0000_0018);
     check("fetch word 6", imem_data, ref_rom[6]);
     dread(32'h0000_0018);
     check("read word 6 the cycle after fetching it", mem_rdata, ref_rom[6]);
 
-    // ---- the write port ----------------------------------------------------
-    // A whole word into each bank, then read back through both paths.
     write_word(32'h0000_0008, 4'b1111, 32'h1122_3344);
     check_stall("a write steals the fetch", 1'b1);
     fetch(32'h0000_0008);
@@ -244,10 +202,8 @@ module imem_tb;
     check("a written odd-bank word fetches back", imem_data, ref_rom[3]);
     check_all("after two word writes");
 
-    // Byte strobes, one lane at a time over a word that already holds data, at
-    // both parities. A strobe applied to the wrong lane, or a write that put
-    // the whole word down regardless of the strobe, changes bytes the
-    // reference keeps.
+    // A strobe applied to the wrong lane, or a write that put the whole word
+    // down regardless of it, changes bytes the reference keeps.
     for (i = 0; i < 4; i++) begin
       write_word(32'h0000_0010, 4'b0001 << i, 32'hdead_beef);
       check_all($sformatf("after sb into byte %0d of word 4", i));
@@ -255,21 +211,17 @@ module imem_tb;
       check_all($sformatf("after sb into byte %0d of word 5", i));
     end
 
-    // Halfword strobes, low and high, at both parities.
     write_word(32'h0000_0018, 4'b0011, 32'ha5a5_5a5a);
     write_word(32'h0000_0018, 4'b1100, 32'h1234_5678);
     write_word(32'h0000_001c, 4'b0011, 32'hbeef_cafe);
     write_word(32'h0000_001c, 4'b1100, 32'h9876_5432);
     check_all("after four sh writes");
 
-    // ---- the range boundary, on the write side -----------------------------
-    // The last word is in range and takes a write.
     write_word(32'(ROM_WORDS - 1) * 4, 4'b1111, 32'h0bad_f00d);
     check_all("after writing the last word");
 
-    // One past the end, and far past it at an address whose low bits index a
-    // real bank word. Both are dropped, and `check_all` is what says they did
-    // not land somewhere else instead.
+    // Addresses whose low bits index a real bank word. `check_all` is what says
+    // these were dropped rather than landing somewhere else.
     write_word(32'(ROM_WORDS) * 4, 4'b1111, 32'hffff_ffff);
     check_stall("a write past the end steals nothing", 1'b0);
     write_word(32'h0000_1004, 4'b1111, 32'hffff_ffff);

--- a/test/imem_tb.v
+++ b/test/imem_tb.v
@@ -1,14 +1,15 @@
 `timescale 1 ns / 1 ps
 `default_nettype none
 
-// rtl/imemory.v, the interleaved-bank instruction ROM (ADR-0054). The `.S`
-// suite exercises whatever alignments its programs happen to produce and cannot
-// reach the data port at all -- no program stores into the text region, and both
-// consumers tie `mem_ren` low -- so the bank select, the range decode, the write
-// port and the steal are checked here or nowhere.
+// rtl/imemory.v, the instruction ROM split across two banks.
 //
-// The reference must stay a flat array filled independently of the bank images:
-// derived from them it would agree with any split, and the split is on test.
+// The .S suite only hits whatever alignments its programs happen to produce,
+// and it never touches the data port: no program stores into the text region,
+// and both runners hold mem_ren low. So the bank select, the range decode, the
+// write port and the steal are checked here or nowhere.
+//
+// Keep the reference a flat array filled on its own. Build it from the bank
+// images and it will agree with any split, which is the thing being tested.
 module imem_tb;
   localparam int ROM_WORDS = 16;
 
@@ -49,8 +50,8 @@ module imem_tb;
     end
   endtask
 
-  // Presenting an address and taking the edge that latches it is the contract
-  // (ADR-0054): the outputs are valid for the whole of the cycle after.
+  // The memory latches the address on the edge. Its outputs are then valid for
+  // the whole of the next cycle, which is where they are read.
   task automatic step(input logic [31:0] fetch_addr,
                       input logic [31:0] data_addr,
                       input logic        ren,
@@ -83,9 +84,9 @@ module imem_tb;
     check(what, {31'b0, fetch_stall}, {31'b0, expected});
   endtask
 
-  // One task, so the DUT and the reference take the same arguments by
-  // construction. Out of range the reference does nothing, which is what makes
-  // `check_all` a test that a dropped write really was dropped.
+  // One task, so the memory and the reference always get the same arguments.
+  // Out of range the reference does nothing, which is how check_all tells that
+  // a dropped write really was dropped.
   task automatic write_word(input logic [31:0] addr, input logic [3:0] strb,
                             input logic [31:0] data);
     int word;

--- a/test/testbench.v
+++ b/test/testbench.v
@@ -1,5 +1,4 @@
 `timescale 1 ns / 1 ps
-//`define RISCV_FORMAL
 module testbench(
 `ifndef ICARUS
 	input clk,
@@ -118,14 +117,14 @@ module testbench(
    `endif
   );
  `ifdef RISCV_FORMAL
-  // The monitor, the spec probe and the retire counters all read `rvfi_valid`
-  // through this one wire. Keep it that way: a counter that could stay high
-  // while the monitor went blind would be telemetry about itself, and this
-  // makes the two go blind together by construction.
+  // The monitor, the spec probe and the counters all read rvfi_valid through
+  // this one wire. Keep it that way. A counter that could stay high while the
+  // monitor stopped looking would only be counting itself.
   //
-  // It is also the liveness probe. Replace the assign with `1'b0` and `make
-  // test` reports every program MONITOR-SILENT; before the counters existed the
-  // same edit passed the whole suite.
+  // It is also how to test the counters: set this to 1'b0 and every program
+  // should report MONITOR-SILENT. Do the same on a tree without the counters
+  // and the whole suite still passes, because each program reaches tohost on
+  // its own assertions with nothing checking a single instruction.
   logic rvfi_valid_observed;
   assign rvfi_valid_observed = rvfi_valid;
 
@@ -155,9 +154,9 @@ module testbench(
   );
 
  `ifdef ICARUS
-  // errcode is a one-cycle pulse (test/monitor.sim.v clears it every cycle), so
-  // it must be checked every cycle -- a read at the end of the run sees
-  // nothing. Matches test/cxxrtl.cc's exit 4.
+  // The error code is high for one cycle only; test/monitor.sim.v clears it
+  // every cycle. Check it every cycle -- reading it once at the end misses it.
+  // Same failure as test/cxxrtl.cc's exit 4.
   always @(posedge clk) begin
     if (rvfi_monitor_errcode != 16'b0) begin
       $display("RVFI MONITOR ERROR %0d -- see the diagnostic above", rvfi_monitor_errcode);
@@ -166,16 +165,17 @@ module testbench(
   end
  `endif
 
-  // A second `monitor_isa_spec` rather than a read of `ch0_spec_valid` inside
-  // the monitor, because test/monitor.v may not be hand-edited to export it
-  // (CLAUDE.md invariant 7) and yosys does not resolve a hierarchical
-  // reference -- it implicitly declares the name, so the counter would read a
-  // dangling constant while the build stayed clean. Keep these port
-  // connections identical to the monitor's above: rewiring one and not the
-  // other is what would make this count retires the monitor never checked.
+  // A second monitor_isa_spec, rather than reading ch0_spec_valid inside the
+  // monitor. Two reasons. test/monitor.v is generated and gets regenerated, so
+  // an edit exporting that signal would be lost. And yosys will not reach into
+  // the instance: it makes a new undriven wire with that name, so the counter
+  // would read a constant and the build would look fine.
   //
-  // A low spec-checked count is expected, since riscv-formal ships no spec
-  // model for `ecall`, `ebreak`, `mret` or `csrr*` at the pin. Only zero fails.
+  // Keep these connections the same as the monitor's above. Rewire one and not
+  // the other and this counts instructions the monitor never checked.
+  //
+  // A low spec-checked count is normal. riscv-formal has no model for ecall,
+  // ebreak, mret or csrr*, so those retire unchecked. Only zero is wrong.
   logic       probe_spec_valid;
   logic       probe_spec_trap;
   logic [4:0] probe_spec_rs1_addr;
@@ -208,9 +208,8 @@ module testbench(
     .spec_mem_wdata(probe_spec_mem_wdata)
   );
 
-  // `(* keep *)` because nothing in the design reads these and yosys would
-  // otherwise optimise them away. The gating mirrors the monitor's own outer
-  // condition, so they count what it looked at rather than an approximation.
+  // Nothing in the design reads these, so without (* keep *) yosys removes
+  // them. The gating matches the monitor's own, so they count what it looked at.
   (* keep *) logic [31:0] rvfi_retires;
   (* keep *) logic [31:0] rvfi_spec_retires;
   initial begin
@@ -237,15 +236,17 @@ module testbench(
     end
   end
 
-  // The baked-in program does 20 writes and 79 retires, so these sit a margin
-  // under both. They are what makes a deadlocked pipeline loud: reverting
-  // `live_rs1`/`live_rs2` to ADR-0037's `live_producer(r)` function form gives
-  // 0 writes and 1 retire.
+  // The program below does 20 writes and 79 retires. These sit under both, so a
+  // few extra stall cycles still pass but a pipeline that has stopped making
+  // progress fails. Write rtl/decoder.v's live_rs1 and live_rs2 as a function
+  // call instead of continuous assigns and this drops to 0 writes and 1 retire:
+  // iverilog builds the sensitivity list from the call arguments, so the assign
+  // never runs again when the signals inside the function change.
   localparam int unsigned WRITE_FLOOR  = 15;
   localparam int unsigned RETIRE_FLOOR = 60;
 
-  // Owns reset and the whole run, because the floor check needs the counters
-  // above and iverilog will not bind a forward reference.
+  // Drives reset and ends the run. It lives here because the check above needs
+  // the counters, and iverilog will not look forward for them.
   initial begin
     $dumpfile("testbench.vcd");
     $dumpvars(0, testbench);
@@ -300,11 +301,12 @@ module testbench(
     end
   end
 
-  // `mtvec` resets to 0 and sections.lds links `.text` there, so a trap taken
-  // before a test installs its handler restarts the program silently -- it
-  // looks like a livelock, with the real cause several instructions earlier
-  // (ADR-0029). A harness assertion, not an RTL one: a real program may
-  // legitimately put a handler at 0.
+  // mtvec resets to 0 and sections.lds puts .text there. So a trap before a
+  // test installs its handler jumps to _start and the program starts over. It
+  // looks like a hang, and the real fault was several instructions back.
+  //
+  // This belongs in the harness, not the RTL: a real program is allowed to put
+  // a handler at address 0.
   logic trap_taken_d;
   (* keep *) logic trap_to_zero;
   initial begin
@@ -323,10 +325,9 @@ module testbench(
     end
   end
 
-  // Two different consecutive stores legitimately produce two adjacent high
-  // cycles, so this looks for the same request repeating rather than for
-  // back-to-back nonzero ones. `$fatal` is Icarus-only because yosys's
-  // read_verilog does not implement it.
+  // Two different stores back to back are fine, so this looks for the same
+  // request repeating, not for two busy cycles in a row. $fatal is Icarus-only
+  // because yosys does not implement it.
   logic [31:0] prev_wstrb_mem_addr, prev_wstrb_mem_wdata;
   logic [3:0]  prev_mem_wstrb;
   initial prev_mem_wstrb = 4'b0000;

--- a/test/testbench.v
+++ b/test/testbench.v
@@ -6,58 +6,26 @@ module testbench(
 	input reset
 `endif
 );
-  // THE MEMORIES ARE THE REAL ONES (ADR-0054). This bench used to carry its
-  // own inline ROM and RAM -- a combinational `rom` array and an `always_ff`
-  // over `memory` -- and rtl/imemory.v / rtl/memory.v were reachable from no
-  // simulation at all. They are the modules instantiated below now, so the
-  // whole `.S` suite and the Sail co-simulation run against the memory system
-  // rtl/littlesoc.v synthesises, not against a second description of it.
-  //
-  // That is not bookkeeping: rtl/imemory.v is SYNCHRONOUS, addressed off the
-  // fetch address decode publishes one cycle early, and if that lockstep were
-  // wrong every program here would execute the wrong instructions. Before this
-  // change nothing in the tree would have noticed.
-  //
-  // Sized to test/asm/sections.lds (ADR-0008): rom holds >=16K of .text,
-  // ram holds >=4K of .data/.rodata/.bss based at RAM_BASE, which matches the
-  // ram region's ORIGIN there. RAM_BASE is non-zero so a wild store through an
-  // uninitialized/zero pointer lands outside the mapped region instead of
-  // silently aliasing real test data. The cxxrtl runner (test/cxxrtl.cc)
-  // subtracts RAM_BASE back out of the `--ram` image's word addresses before
-  // poking `dmem`'s array via debug_items, and de-interleaves the `--rom` image
-  // across `imem`'s two banks. rom grew from 8K/2048 words to 16K/4096 when
-  // test/asm/rvc.S landed (ADR-0003/ADR-0021) -- see sections.lds for why.
-  //
-  // ROM_WORDS HERE IS LARGER THAN THE SHIPPING SoC's, deliberately: simulation
-  // has no block RAM to run out of, and rtl/littlesoc.v's 2048 words are what
-  // the part's 30 EBRs allow (ADR-0054). rvc.S is the one program in the suite
-  // that needs more.
+  // Sized to test/asm/sections.lds. RAM_BASE is non-zero so a wild store
+  // through a zero pointer lands outside the mapped region rather than on real
+  // test data, and ROM_WORDS exceeds the shipping SoC's 2048 because simulation
+  // has no block RAM to run out of and rvc.S needs more than 30 EBRs allow.
   localparam logic [31:0] RAM_BASE  = 32'h0001_0000;
   localparam int          ROM_WORDS = 4096;
   localparam int          RAM_WORDS = 1024;
   logic [31:0] imem_addr;
   logic [31:0] imem_data;
-  // ADR-0003: the second word of the dual-word combinational fetch window
-  // (rtl/fetcher.v drives imem_addr2 = imem_addr + 4), read from the same
-  // `rom` array at a second, independent index.
   logic [31:0] imem_addr2;
   logic [31:0] imem_data2;
-  // ADR-0054: the word address the fetch window will read on the NEXT edge.
-  // rtl/imemory.v is synchronous (every memory primitive on the target part
-  // is, ADR-0044), so it latches this and answers `imem_addr` for the whole of
-  // the cycle that names it.
   logic [31:0] imem_addr_next;
   logic [31:0] mem_addr;
   logic [31:0] mem_wdata;
   logic [3:0]  mem_wstrb;
   logic        mem_ren;
   logic [31:0] mem_rdata;
-  // ADR-0059/ADR-0060: the steal, and the sixth stall reason it drives.
   logic        fetch_stall;
-  // Both memories answer zero outside their own range, so the two buses join
-  // with an OR. Same wiring as rtl/littlesoc.v, which is the point: the range
-  // decode and the steal live in rtl/imemory.v, so the two legs cannot end up
-  // on different maps.
+  // Both memories answer zero outside their own range, so the buses join with
+  // an OR. Same wiring as rtl/littlesoc.v, so the legs cannot drift apart.
   logic [31:0] imem_mem_rdata, dmem_mem_rdata;
   assign mem_rdata = imem_mem_rdata | dmem_mem_rdata;
   logic        trap;
@@ -81,11 +49,7 @@ module testbench(
   logic [3:0]  rvfi_mem_wmask;
   logic [31:0] rvfi_mem_rdata;
   logic [31:0] rvfi_mem_wdata;
-  // ADR-0006: the monitor's own per-retire error code (0 = no error this
-  // cycle). test/cxxrtl.cc reads this by hierarchical debug-item name
-  // ("monitor errcode") to turn a mismatch into a distinct process exit
-  // code; under iverilog the monitor's own $display diagnostics (which
-  // this triggers) are the loud failure.
+  // test/cxxrtl.cc reads this by debug-item name ("monitor errcode").
   logic [15:0] rvfi_monitor_errcode;
  `endif //  `ifdef RISCV_FORMAL
  `ifdef ICARUS
@@ -101,9 +65,8 @@ module testbench(
     .mem_rdata(dmem_mem_rdata)
   );
 
-  // No init files: every consumer of this bench fills the banks itself. The
-  // cxxrtl runners poke them through `debug_items` (test/cxxrtl.cc's
-  // `load_rom_banks`), and `make waves` writes the program in below.
+  // No init files: the cxxrtl runners fill the banks through `debug_items`
+  // (test/cxxrtl.cc's `load_rom_banks`); `make waves` writes its program below.
   imemory #(.ROM_WORDS(ROM_WORDS)) imem (
     .clk(clk),
     .imem_addr_next(imem_addr_next),
@@ -155,26 +118,14 @@ module testbench(
    `endif
   );
  `ifdef RISCV_FORMAL
-  // THE ONE WIRE EVERY RETIRE OBSERVER IN THIS BENCH READS. The monitor below,
-  // the spec probe that feeds the observation counters, and the counters
-  // themselves all take `rvfi_valid` through here rather than each reaching for
-  // the DUT's port separately. That is not decoration: a counter that could
-  // stay high while the monitor went blind would be telemetry about itself
-  // rather than about the oracle, and the whole point of the counters is that
-  // "the monitor observed nothing" cannot happen quietly. Wiring them together
-  // makes the two go blind together, structurally, instead of by promise.
+  // The monitor, the spec probe and the retire counters all read `rvfi_valid`
+  // through this one wire. Keep it that way: a counter that could stay high
+  // while the monitor went blind would be telemetry about itself, and this
+  // makes the two go blind together by construction.
   //
-  // It is also what makes this repo's liveness probe for the counters a single
-  // line. To watch the gate go red on a blind oracle:
-  //
-  //     assign rvfi_valid_observed = 1'b0;   // instead of = rvfi_valid
-  //
-  // then `make test`. Every program still reaches `tohost` and still PASSes on
-  // its own assertions; the gate reports 52 x MONITOR-SILENT and exits 1. The
-  // same edit on the tree before the counters existed reports 52/52 and exits
-  // 0, which is the defect this closes. Same idea as deleting the rs2
-  // write-through bypass to check that reg_ch0 can still fail: reach for it
-  // before believing a green `make test` means the oracle looked.
+  // It is also the liveness probe. Replace the assign with `1'b0` and `make
+  // test` reports every program MONITOR-SILENT; before the counters existed the
+  // same edit passed the whole suite.
   logic rvfi_valid_observed;
   assign rvfi_valid_observed = rvfi_valid;
 
@@ -204,9 +155,9 @@ module testbench(
   );
 
  `ifdef ICARUS
-  // Matches test/cxxrtl.cc's exit 4. errcode is a one-cycle pulse
-  // (test/monitor.sim.v resets it every cycle), so this checks every
-  // cycle rather than once at the end of the run.
+  // errcode is a one-cycle pulse (test/monitor.sim.v clears it every cycle), so
+  // it must be checked every cycle -- a read at the end of the run sees
+  // nothing. Matches test/cxxrtl.cc's exit 4.
   always @(posedge clk) begin
     if (rvfi_monitor_errcode != 16'b0) begin
       $display("RVFI MONITOR ERROR %0d -- see the diagnostic above", rvfi_monitor_errcode);
@@ -215,55 +166,16 @@ module testbench(
   end
  `endif
 
-  // ---------------------------------------------------------------------------
-  // DID THE ORACLE EVER LOOK?
+  // A second `monitor_isa_spec` rather than a read of `ch0_spec_valid` inside
+  // the monitor, because test/monitor.v may not be hand-edited to export it
+  // (CLAUDE.md invariant 7) and yosys does not resolve a hierarchical
+  // reference -- it implicitly declares the name, so the counter would read a
+  // dangling constant while the build stayed clean. Keep these port
+  // connections identical to the monitor's above: rewiring one and not the
+  // other is what would make this count retires the monitor never checked.
   //
-  // The monitor above is a per-retire oracle only on the cycles it actually
-  // examines. It examines a cycle when `rvfi_valid` is high, and it compares
-  // that retire's VALUES only when its spec model recognises the instruction
-  // (`ch0_spec_valid`). Neither was measured. `test/cxxrtl.cc` sampled the
-  // monitor's `errcode` and counted nothing, so a monitor that never saw a
-  // single retire — an under-sensitivity defect of exactly the kind ADR-0037
-  // found in the iverilog leg, an `ifdef` that dropped the shadow payload, a
-  // `write_cxxrtl` that optimised the instance away — left every program in
-  // test/asm reporting PASS off `tohost` alone. `test/EXPECTED_FAIL` is empty,
-  // so there was no red entry whose disappearance would have said otherwise
-  // either, and ADR-0032 already measured that end-state checking on its own
-  // misses real architectural corruption.
-  //
-  // So observation is a GRADED QUANTITY here, not an inference. These two
-  // counters are read by debug-item name in test/cxxrtl.cc, printed on every
-  // run, and graded by test/run_tests.sh: zero of either is MONITOR-SILENT, a
-  // failing status, and a count below test/OBSERVED_FLOOR is BELOW-FLOOR.
-  //
-  // WHY A SECOND `monitor_isa_spec` INSTEAD OF LOOKING INSIDE THE MONITOR.
-  // `ch0_spec_valid` is internal to the monitor, and test/monitor.v is
-  // generated-but-tracked (CLAUDE.md invariant 7) — it may not be hand-edited
-  // to export it, and giving test/sanitize_monitor.py a fourth rule for
-  // telemetry would perturb the most carefully built content assertions in the
-  // repo for no correctness gain. A hierarchical reference is not an option
-  // either, and fails in the worst possible way: yosys does not resolve one, it
-  // IMPLICITLY DECLARES the name and carries on ("Warning: Identifier
-  // `\monitor.ch0_spec_valid' is implicitly declared"), so the counter would
-  // read a dangling constant while the build stayed clean. This instead
-  // instantiates the same module the monitor instantiates, from the same wires
-  // its own instance is wired from, so `probe_spec_valid` is `ch0_spec_valid`
-  // by construction: one combinational function, one set of inputs. The one
-  // input that decides whether a retire is observed at all is shared through
-  // `rvfi_valid_observed` above, so the two cannot go blind independently.
-  // KEEP THE REMAINING FIVE PORT CONNECTIONS IDENTICAL TO THE MONITOR'S —
-  // rewiring one and not the other is the only way left for this to start
-  // counting retires the monitor never checked.
-  //
-  // A LOW SPEC-CHECKED COUNT IS EXPECTED, AND IS NOT A DEFECT. riscv-formal
-  // ships no spec model at all for `ecall`, `ebreak`, `mret` or the `csrr*`
-  // family at the pinned SHA (formal/pin.mk), so `spec_valid` is 0 for every
-  // one of those retires BY DESIGN and the monitor's whole semantic block is
-  // skipped for them — the behaviour M3 added is checked by test/asm/trap.S,
-  // test/csr_tb.v and test/decoder_tb.v instead, against assertions this repo
-  // wrote. csr.S, minstret.S and trap.S therefore show the widest gap between
-  // the two counts, and that gap is the pin's coverage boundary, not a bug.
-  // Only ZERO is a failure.
+  // A low spec-checked count is expected, since riscv-formal ships no spec
+  // model for `ecall`, `ebreak`, `mret` or `csrr*` at the pin. Only zero fails.
   logic       probe_spec_valid;
   logic       probe_spec_trap;
   logic [4:0] probe_spec_rs1_addr;
@@ -296,21 +208,9 @@ module testbench(
     .spec_mem_wdata(probe_spec_mem_wdata)
   );
 
-  // `(* keep *)` for the same reason `trap_to_zero` below carries one: these
-  // are read by debug-item name from test/cxxrtl.cc and nothing inside the
-  // design reads them, so without it yosys is free to optimise both away and
-  // the runner would report a setup error it cannot distinguish from a real
-  // one. 32 bits is far more than the 5000-cycle budget in test/run_tests.sh
-  // can ever need, so no wrap is possible.
-  //
-  // The gating mirrors the monitor's own outer condition exactly
-  // (`if (!reset && ch0_rvfi_valid) ... if (ch0_spec_valid)`), so these count
-  // the retires it looked at and the subset whose values it compared — not an
-  // approximation of them.
-  //
-  // Plain `always @(posedge clk)`, not `always_ff`, because the `initial`
-  // below assigns the same variables; that is the pattern every other
-  // bookkeeping block in this file uses and nothing here is synthesised.
+  // `(* keep *)` because nothing in the design reads these and yosys would
+  // otherwise optimise them away. The gating mirrors the monitor's own outer
+  // condition, so they count what it looked at rather than an approximation.
   (* keep *) logic [31:0] rvfi_retires;
   (* keep *) logic [31:0] rvfi_spec_retires;
   initial begin
@@ -327,9 +227,8 @@ module testbench(
   end
 
  `ifdef ICARUS
-  // A counter independent of the retire count below: a stalled pipeline
-  // can keep retiring instructions with no stores at all, which a
-  // retire-only floor would miss.
+  // Independent of the retire count: a pipeline can keep retiring with no
+  // stores at all, which a retire-only floor would miss.
   (* keep *) logic [31:0] mem_write_count;
   initial mem_write_count = 32'b0;
   always @(posedge clk) begin
@@ -338,17 +237,15 @@ module testbench(
     end
   end
 
-  // Measured on this program at 238a066: 20 writes, 79 retires. These
-  // floors sit a margin under both so a few extra stall cycles still
-  // pass; reverting `live_rs1`/`live_rs2` to ADR-0037's
-  // `live_producer(r)` function form gives 0 writes, 1 retire here.
+  // The baked-in program does 20 writes and 79 retires, so these sit a margin
+  // under both. They are what makes a deadlocked pipeline loud: reverting
+  // `live_rs1`/`live_rs2` to ADR-0037's `live_producer(r)` function form gives
+  // 0 writes and 1 retire.
   localparam int unsigned WRITE_FLOOR  = 15;
   localparam int unsigned RETIRE_FLOOR = 60;
 
-  // Owns dumpfile setup, reset and the whole run: the floor check below
-  // needs `rvfi_retires`/`mem_write_count`, declared earlier in this
-  // `ifdef RISCV_FORMAL` region, and iverilog will not bind a forward
-  // reference to a `logic` declared later in the same module.
+  // Owns reset and the whole run, because the floor check needs the counters
+  // above and iverilog will not bind a forward reference.
   initial begin
     $dumpfile("testbench.vcd");
     $dumpvars(0, testbench);
@@ -367,21 +264,12 @@ module testbench(
  `endif
  `endif
 `ifdef ICARUS
-  // `make waves`' program: the six-instruction increment loop this file used to
-  // carry in an `initial rom[...]` block, written straight into rtl/imemory.v's
-  // two banks (ADR-0054 -- word 2i is even, word 2i+1 is odd). It exercises
-  // fetch, a load, a store and a backward jump, which is what the waveform is
-  // for.
+  // `make waves`' program, written into rtl/imemory.v's two banks (word 2i is
+  // even, 2i+1 odd). It counts in RAM because an address in the text range
+  // would take the banks' write port and steal the fetch behind it.
   //
-  // It counts in RAM. An address in the text range would take the banks' write
-  // port and steal the fetch behind it, and nothing here drives the core's
-  // stall for that yet.
-  //
-  // A HIERARCHICAL REFERENCE, hence `ifdef ICARUS` -- the same guard the clock
-  // and reset generation above carries. yosys does not RESOLVE one of these: it
-  // implicitly declares the dotted name and carries on with an undriven wire,
-  // which CLAUDE.md records as a real hazard. The cxxrtl legs never take this
-  // path; they load their ROM through `debug_items`.
+  // `ifdef ICARUS` because it is a hierarchical reference, which yosys does not
+  // resolve (see the spec probe above).
   initial begin
     imem.rom_even[0] = 32'h000100b7; //       lui     x1, 0x10
     imem.rom_odd [0] = 32'h0000a023; //       sw      x0, 0(x1)
@@ -412,27 +300,11 @@ module testbench(
     end
   end
 
-  // ADR-0029: `mtvec` resets to 0 and test/asm/sections.lds links `.text`
-  // there, so a trap taken before a test installs its handler redirects to
-  // `_start` and the program silently RESTARTS. That failure mode looks like a
-  // livelock or a timeout, produces no error, and puts the actual cause -- a
-  // fault several instructions earlier -- nowhere near the symptom.
-  //
-  // This is a HARNESS assertion, not an RTL one: a real program is entitled to
-  // put a handler at 0, and it would need revisiting if sections.lds ever
-  // moved `.text`. It also needs no hierarchical reference into the CSR file.
-  // `trap` is ADR-0028's one-cycle "trap entry committed" pulse, and decode
-  // registers `pc <= mtvec` on that same edge, so the fetch address one cycle
-  // later IS mtvec (rtl/fetcher.v drives imem_addr straight off pc).
-  //
-  // `(* keep *)` because test/cxxrtl.cc reads `trap_to_zero` by debug-item
-  // name to turn this into a distinct process exit code; without it yosys is
-  // free to optimise away a register nothing in the design reads.
-  //
-  // Plain `always @(posedge clk)`, not `always_ff`, for the same reason every
-  // other diagnostic block in this file is: iverilog warns that a system task
-  // cannot be synthesised inside an `always_ff` process, and CLAUDE.md says
-  // warnings are errors. Nothing in this bench is synthesised.
+  // `mtvec` resets to 0 and sections.lds links `.text` there, so a trap taken
+  // before a test installs its handler restarts the program silently -- it
+  // looks like a livelock, with the real cause several instructions earlier
+  // (ADR-0029). A harness assertion, not an RTL one: a real program may
+  // legitimately put a handler at 0.
   logic trap_taken_d;
   (* keep *) logic trap_to_zero;
   initial begin
@@ -451,20 +323,10 @@ module testbench(
     end
   end
 
-  // ADR-0009: for every store, mem_wstrb is high for
-  // exactly one cycle. Direct regression for the divide-replay defect, where
-  // the accessor kept re-issuing the same store every cycle the executor sat
-  // busy in `divide` because nothing upstream defaulted back to zero in
-  // between. Two DIFFERENT consecutive real stores legitimately produce two
-  // adjacent high cycles, so this checks for the same request repeating
-  // (identical address, data, and strobe on back-to-back high cycles), not
-  // merely back-to-back nonzero cycles.
-  //
-  // $fatal is Icarus-only below: yosys's read_verilog (the write_cxxrtl leg
-  // this file also feeds, per the Makefile) doesn't implement it at all, so
-  // this stays inside `ifdef ICARUS` the same way the clock/reset generation
-  // above does. The $display fires unconditionally, so the violation is
-  // still visible under cxxrtl if it were ever encountered there.
+  // Two different consecutive stores legitimately produce two adjacent high
+  // cycles, so this looks for the same request repeating rather than for
+  // back-to-back nonzero ones. `$fatal` is Icarus-only because yosys's
+  // read_verilog does not implement it.
   logic [31:0] prev_wstrb_mem_addr, prev_wstrb_mem_wdata;
   logic [3:0]  prev_mem_wstrb;
   initial prev_mem_wstrb = 4'b0000;


### PR DESCRIPTION
Closes JEF-719.

Third and last batch of the comment cleanup, over the formal harness and the
benches. **927 comment lines become 334, −593, −64%**, and **no ADR number or
invariant number survives in any comment**.

## Comments only, proven two ways

The grep the ticket specifies prints nothing. It is weak in two directions here,
so neither claim rests on it: it cannot see a trailing comment appended to a
line of code, and in `test/asm/*.h` it discards `#define`/`#ifndef`, which are
**code**. Both are closed.

1. **Strip every comment — whole-line *and* trailing — and every blank line from
   each file at `origin/main` and here, and require byte equality.** `#` counts
   as a comment only in the assembly headers, since in Verilog it is a delay
   control (`#1;`); string literals are respected. All eight files: `IDENTICAL`.
2. **The two `.h` files are read by all 56 programs**, so they are checked at the
   object level: assemble and link every program with `origin/main`'s headers and
   with these, then `objcopy -O binary` `.text` and `.data`. **112 images,
   byte-for-byte identical.**

## References removed

| | count |
|---|---:|
| `ADR-00NN` and `invariant N` in these files at base | 20 |
| in comments now | **0** |
| remaining anywhere in these files | 1 |

The one remaining is `test/testbench.v:320`, inside a `$display` string:

```verilog
$display("TRAP TO ZERO: a trap was taken while mtvec == 0 (ADR-0029).");
```

That is a runtime diagnostic, so it is **code**, and editing it would break the
comments-only guarantee. Left in deliberately. Removing it is a one-line
follow-up for a change allowed to touch code.

## Per-file deltas

| file | before | after | delta |
|---|---:|---:|---:|
| `test/testbench.v` | 195 | 58 | **−137** |
| `formal/pcloop.sv` | 211 | 77 | **−134** |
| `test/decoder_tb.v` | 180 | 48 | **−132** |
| `test/imem_tb.v` | 82 | 35 | −47 |
| `formal/dmemcheck.sv` | 66 | 23 | −43 |
| `test/csr_tb.v` | 76 | 43 | −33 |
| `test/asm/test_macros.h` | 44 | 8 | −36 |
| `test/asm/riscv_test.h` | 73 | 42 | −31 |
| **total** | **927** | **334** | **−593 (−64%)** |

Four of the ticket's baselines were counted with a pattern that treats Verilog
`#1;` delay controls and `#define` directives as comments. Recounted with `#` as
code outside the assembly headers: `decoder_tb.v` is 180 not 229, `csr_tb.v` 76
not 85, `imem_tb.v` 82 not 83, `test_macros.h` 44 not 130, `riscv_test.h` 73 not
88. `riscv_test.h` had also **not** regressed since the first batch — it was
byte-identical to what `40a6ebb` shipped.

## Removing the citation found a wrong claim

`formal/pcloop.sv` said its fetch-lockstep assertion was the only thing holding
the core to that contract. **It is not.** `rtl/decoder.v`'s own `FORMAL` block
asserts `pc == past_next_pc`. What pcloop adds is that its assertion sits on the
*fetcher's output ports*, so it also covers the two word-alignment masks.

That came out of reading the RTL in order to replace the citation. Shortening the
sentence would not have found it.

Every other replaced claim was checked against the code before it was written:
`rtl/decoder.v`'s `next_pc` priority chain (`reset` → 0, `stall` → `pc`, jalr
reads `reg_rs1`, trap reads `mtvec`, mret reads `mepc`), the six branch `funct3`
values (000/001/100/101/110/111, so 010 and 011 match none), `instr_mret`'s
`funct3 == 0` and its place in `serialize`, the `instr[31:16]` mask,
`formal/wrapper.v` declaring `imem_addr_next` unread, and `formal/components.sby`
reading the RTL without `-formal`.

## Five before/after pairs

**1. The tripwire, as a mechanism.** No label to look up.

```diff
-  // `f_may_stall` must name every stall reason the decoder has -- six now. A
-  // missing one makes the sequential-advance assertion cover a cycle the
-  // decoder legitimately holds the pc on and the task goes red on correct RTL,
-  // which is how ADR-0042's operand-fetch cycle left it failing.
+  // List every reason decode can stall. Miss one and the assertion below covers
+  // a cycle where the pc is allowed to hold, then fails there instead of
+  // finding a real bug. This has happened before: the register file read became
+  // synchronous, that added a stall, and this list did not know about it.
```

**2. The corrected claim.**

```diff
-  // The fetch lockstep (ADR-0054). Nothing else holds the core to it: breaking
-  // it has one symptom, the SoC fetching the wrong instruction, with no
-  // elaboration error, no lint finding, and no ladder check in contact with the
-  // port -- formal/wrapper.v answers imem_data combinationally and never reads
-  // it.
+  // The memory latches its address a cycle early, so imem_addr_next this cycle
+  // must be imem_addr next cycle. rtl/decoder.v checks the same thing one level
+  // up, on pc and next_pc. This one is on the fetcher's output ports, so it
+  // also covers the two word-alignment masks: change one and forget the other
+  // and only this fails. Nothing on the riscv-formal ladder reads either port.
```

**3. The assume, as three plain facts.** The requirement is that it names the
fact it models, where it is discharged and its scope. Naming the ADR never
satisfied that.

```diff
-  // Assumed: reset is asserted before the first edge and never returns -- true
-  // of every harness in the tree, asserted by none of them, and unguarded, so
-  // it is in force over every assertion here rather than only the pc-history
-  // pair it was written for (ADR-0049).
+  // Assumed: reset is high before the first clock edge and low forever after.
+  // Every harness in this tree drives it that way. Nothing proves it, so this
+  // is a convention, not a fact.
+  //
+  // It is unguarded, so it holds over every assertion below, not just the two
+  // that compare pc across a cycle. Those two are why it is here. Reset sets
+  // next_pc to 0, so a solver free to raise reset again could zero pc between
+  // the two cycles and satisfy them for the wrong reason.
```

**4. Outright deletion — `test/csr_tb.v`.** The task names and bodies say all of
it. Three of these went, plus two more elsewhere in the file.

```diff
-  // Read `a` combinationally, without issuing anything.
   task automatic peek(input logic [11:0] a);
@@
-  // Commit one write on the next edge, the way rtl/decoder.v does.
   task automatic poke(input logic [11:0] a, input logic [31:0] d);
@@
-  // Commit one trap entry on the next edge, the way rtl/decoder.v does.
   task automatic take_trap(input logic [31:0] cause, input logic [31:0] epc);
```

**5. Outright deletion — `test/testbench.v` line 2.** Dead code left behind; the
Makefile passes `-D RISCV_FORMAL`.

```diff
 `timescale 1 ns / 1 ps
-//`define RISCV_FORMAL
 module testbench(
```

**Bonus — short sentences, fact first.**

```diff
-  // errcode is a one-cycle pulse (test/monitor.sim.v clears it every cycle), so
-  // it must be checked every cycle -- a read at the end of the run sees
-  // nothing. Matches test/cxxrtl.cc's exit 4.
+  // The error code is high for one cycle only; test/monitor.sim.v clears it
+  // every cycle. Check it every cycle -- reading it once at the end misses it.
+  // Same failure as test/cxxrtl.cc's exit 4.
```

## Tripwires

**Kept**, each restated as what actually goes wrong, with no label to look up:
`components.sby` must keep reading the RTL without `-formal`, or the decoder
assumes the echo this task asserts and a broken fetcher becomes unreachable
instead of a counterexample; do not write `decoder.uncompressed` — yosys makes a
new undriven wire with that name and the solver picks the value; list every
reason decode can stall; the fetch lockstep and which half each proof covers; the
error code is high for one cycle only; the 15-write/60-retire floor and the
function-call spelling that trips it; `rvfi_valid_observed` is the one wire all
three read; keep the spec probe's ports the same as the monitor's; `pc` has one
driver and a second puts the memory a cycle out of step; a steal coinciding with
a freeze must hold, and only the arm order decides it; `present_and_fetch`'s
parking nop; `csr_tb.v`'s carry-boundary vectors; `imem_tb.v`'s independent
reference; and `riscv_test.h`'s three trap constraints and the doubleword
`tohost`.

**One dropped**, named as required: `test/testbench.v`'s two notes on why the
diagnostic blocks use plain `always @(posedge clk)` rather than `always_ff`. Not
a tripwire by the stated test — iverilog refuses a system task inside `always_ff`
and the build fails loudly saying so.

## Gates

Load average 52–63 on 10 cores throughout (two sibling agents), so wall times are
contended.

| gate | result |
|---|---|
| `make -C formal check JOBS=4` | **85 checks: 85 pass, 0 fail**; both set equalities matched in both directions. 17m47s wall / 297% CPU |
| `make -C formal components_pcloop` | PASS by k-induction (re-run after every edit to the file) |
| `make -C formal components_decoder` / `components_executor` | PASS, both by k-induction |
| `make -C formal dmemcheck` | PASS (re-run after every edit to the file) |
| `make test` | **56/56**, `EXPECTED_FAIL` matched, suite shape matches `OBSERVED_FLOOR` |
| `make test-units` | **8 benches**, matching `test/*_tb.v` exactly |
| `make probe-gates` | 125 graded comparisons, every failure path executed |
| `make lint` | svlint clean in both passes |

The ladder ran before the comment edits, and `formal/checks.cfg` reads only
`formal/wrapper.v` and `rtl/` — neither is touched by this branch — so 85/85
stands for this tree. `components_pcloop` and `dmemcheck` are the two targets that
read the changed files and were re-run after each pass.

## One thing for the architect

`CLAUDE.md`'s comment rule still reads *"An ADR citation is an optional trailing
pointer, never the explanation."* This branch removes them entirely, which is
stricter. `CLAUDE.md` is out of scope here, so the rule text and the tree now
disagree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
