### PR TITLE
JEF-719: delete the comments in the five remaining RTL files

### DIFF
--- a/rtl/accessor.v
+++ b/rtl/accessor.v
@@ -9,30 +9,33 @@ module accessor(
     output logic [3:0]  mem_wstrb,
     output logic [31:0] mem_wdata,
     input  logic [31:0] mem_rdata,
-    // This stage has no fault signal to give: every trap is detected and
-    // committed in decode (invariant 2), and a trapping load or store arrives
-    // with every `is_l*`/`is_s*` flag clear.
+    // There is no fault output here on purpose. A misaligned load or store is
+    // caught in decode, which clears its `is_l*`/`is_s*` flags, so an access
+    // that gets this far cannot fail. Add one and an instruction could fail
+    // after decode had already let the ones behind it through, and there is no
+    // way to take those back.
     //
-    // The memory registers `mem_rdata` a cycle after the address is presented, a
-    // real round trip, so a load cannot be answered in the one cycle every other
-    // instruction takes through this stage (ADR-0015). `stalled` is high for
-    // exactly the request cycle; decode freezes and rtl/executor.v bubbles for
-    // it, so the completing load and a fresh instruction cannot collide over
-    // this stage's single output register.
+    // The memory registers `mem_rdata` a cycle after it is given an address, so
+    // a load takes two cycles here where everything else takes one. `stalled` is
+    // high for the first of them. Decode holds and the executor sends nothing,
+    // so the load finishing next cycle and a new instruction cannot both want
+    // `out` at once.
     output logic stalled,
-    // rtl/imemory.v needs this to tell a real read from the idle bus, which
-    // presents address 0 -- inside the text range, so an unqualified address
-    // would steal a fetch every idle cycle and the core would never run.
+    // The instruction memory shares one read port between fetch and data, and
+    // uses this to tell a real load from an idle bus. An idle bus shows address
+    // 0, which is a text address, so a memory looking only at the address would
+    // give up a fetch every idle cycle and the core would never get anywhere.
     output logic mem_ren,
-    // A load's result is a live producer from its request until write-through,
-    // one cycle later than decoder_out/executor_out alone can see (ADR-0004).
+    // A load has left `executor_out` and has not yet written the register file
+    // while it waits for memory. Decode watches these so it can wait on the load
+    // during that cycle, which none of its other checks cover.
     output logic       pending_valid,
     output logic [4:0] pending_rd,
     output accessor_output out
 );
-  // Selected out here because iverilog cannot build a precise sensitivity entry
-  // for a constant part-select taken inside an always_* block; prefer a
-  // continuous assign for any field read added later (ADR-0034).
+  // Pulled out here rather than read inside the always_* blocks below: iverilog
+  // cannot work out a precise sensitivity list for a field read taken inside
+  // one, and warns. Use a continuous assign for any field read added later.
   logic in_is_lb;
   logic in_is_lbu;
   logic in_is_lh;
@@ -76,9 +79,8 @@ module accessor(
   logic       pending_addr16;
   logic [1:0] pending_addr24;
  `ifdef RISCV_FORMAL
-  // These survive the request/response gap for the same reason `pending_rd`
-  // does: `in` is a guaranteed bubble on the response cycle, so nothing of this
-  // instruction is left to read off it then.
+  // Saved for the same reason `pending_rd` is. On the cycle the data comes back,
+  // `in` is empty, so nothing about this instruction can still be read from it.
   rvfi_shadow  pending_rvfi;
   logic [31:0] pending_rvfi_mem_addr;
  `endif
@@ -90,12 +92,12 @@ module accessor(
   assign word_aligned_addr = {in_mem_addr[31:2], 2'b00};
   assign store_halfword    = in_mem_data[15:0];
   assign store_byte        = in_mem_data[7:0];
-  // Must stay combinational, in lockstep with mem_addr/mem_wstrb: a registered
-  // `mem_wdata` lags them by a cycle, so the memory latches the previous cycle's
-  // data at the current cycle's address.
+  // Keep this off a register. It has to change on the same cycle mem_addr and
+  // mem_wstrb do. Registered, it arrives a cycle late, and the memory writes the
+  // last cycle's data to this cycle's address.
   assign mem_wdata = write_request;
-  // The zeroed defaults below are what stop the accessor re-issuing whatever
-  // request was last in `in` for every cycle the executor sits busy in `divide`.
+  // The zeros below are what stop this block sending the same request again on
+  // every cycle the executor spends dividing.
   always_comb begin
     mem_addr = 0;
     mem_wstrb = 0;
@@ -147,13 +149,13 @@ module accessor(
       pending_rvfi_mem_addr <= 0;
      `endif
     end else if (pending_valid) begin
-      // The request fired last cycle and mem_rdata now reflects it. `in` is
-      // guaranteed to be a bubble, so nothing competes for `out`.
+      // The read went out last cycle and mem_rdata now holds its answer. `in` is
+      // empty this cycle, so nothing else wants `out`.
       out.valid <= 1'b1;
       out.rd <= pending_rd;
      `ifdef RISCV_FORMAL
-      // A full rmask regardless of load width is a safe over-approximation: the
-      // monitor flags a missing bit against the spec, never an extra one.
+      // Always a full mask, whatever the load width. The monitor complains about
+      // a bit that should be set and is not, never the other way round.
       out.rvfi <= pending_rvfi;
       out.rvfi_mem_addr <= pending_rvfi_mem_addr;
       out.rvfi_mem_rmask <= 4'b1111;
@@ -201,7 +203,7 @@ module accessor(
     end else if (!in_valid) begin
       out <= 0;
     end else if (is_load) begin
-      // Bubble now, and remember what is needed to decode mem_rdata next cycle.
+      // Send nothing on, and keep what is needed to unpack mem_rdata next cycle.
       out <= 0;
       pending_valid <= 1'b1;
       pending_rd <= in_rd;

--- a/rtl/accessor.v
+++ b/rtl/accessor.v
@@ -4,58 +4,35 @@
 module accessor(
     input  logic clk,
     input  logic reset,
-    // inputs
     input  executor_output in,
-    // memory access
     output logic [31:0] mem_addr,
     output logic [3:0]  mem_wstrb,
     output logic [31:0] mem_wdata,
     input  logic [31:0] mem_rdata,
-    // No fault signal, and this stage has none to give: every trap is detected
-    // and committed in decode (CLAUDE.md invariant 2). Misalignment used to be
-    // detected HERE, which was post-decode and contradicted that invariant;
-    // ADR-0011 scoped the move to M3 and it has happened, in rtl/decoder.v,
-    // where the effective address is already computed. A trapping load or
-    // store never reaches this stage with any `is_l*`/`is_s*` flag set, so it
-    // issues no bus request at all.
-    // ADR-0009-style stall broadcast (ADR-0009): the memory (test/testbench.v,
-    // rtl/memory.v) registers mem_rdata one cycle after the address is
-    // presented — a real, unavoidable round trip, not a choice — so a load
-    // cannot be answered in the single cycle every other instruction takes
-    // through this stage. High for exactly the cycle a load's *request*
-    // fires; littlecpu.v folds this into the same global stall that already
-    // freezes decode for a divide, and rtl/executor.v freezes (emits a
-    // bubble) for that one cycle so nothing new arrives here while the
-    // response is still in flight — otherwise the completing load and a
-    // fresh instruction would collide over this stage's single output
-    // register and the single-port memory bus.
+    // This stage has no fault signal to give: every trap is detected and
+    // committed in decode (invariant 2), and a trapping load or store arrives
+    // with every `is_l*`/`is_s*` flag clear.
+    //
+    // The memory registers `mem_rdata` a cycle after the address is presented, a
+    // real round trip, so a load cannot be answered in the one cycle every other
+    // instruction takes through this stage (ADR-0015). `stalled` is high for
+    // exactly the request cycle; decode freezes and rtl/executor.v bubbles for
+    // it, so the completing load and a fresh instruction cannot collide over
+    // this stage's single output register.
     output logic stalled,
-    // High for the cycle a load's request is on the bus. rtl/imemory.v needs
-    // it to tell a real read from the idle bus, which presents address 0 --
-    // inside the text range, so an unqualified address would steal a fetch
-    // every idle cycle and the core would never run (ADR-0059). Same predicate
-    // as `stalled` above plus the reset term the request block below applies.
+    // rtl/imemory.v needs this to tell a real read from the idle bus, which
+    // presents address 0 -- inside the text range, so an unqualified address
+    // would steal a fetch every idle cycle and the core would never run.
     output logic mem_ren,
-    // ADR-0004 hazard scoreboard (ADR-0004): a load's result is a live
-    // producer from the moment its request is issued here until write-through
-    // makes it visible, which is one cycle later than decoder_out/executor_out
-    // alone can see (that's what `stalled` above is fixing). Decode also
-    // checks this — a third stage, but only for this specific one-cycle gap,
-    // not a general widening of the scoreboard.
+    // A load's result is a live producer from its request until write-through,
+    // one cycle later than decoder_out/executor_out alone can see (ADR-0004).
     output logic       pending_valid,
     output logic [4:0] pending_rd,
-    // outputs
     output accessor_output out
 );
-  // The incoming payload's fields, selected out once here. A struct field
-  // read is a constant part-select, and iverilog cannot build a precise
-  // sensitivity entry for one taken inside an always_* block -- it reports
-  // `sorry: constant selects in always_* processes are not fully supported`
-  // and conservatively makes the process sensitive to the whole struct.
-  // That is safe (over-sensitivity re-evaluates redundantly; only
-  // under-sensitivity can go stale) but CLAUDE.md says warnings are errors,
-  // and a continuous assign has an exact sensitivity. rtl/executor.v keeps
-  // the `in.` form deliberately -- see CLAUDE.md's documented exception.
+  // Selected out here because iverilog cannot build a precise sensitivity entry
+  // for a constant part-select taken inside an always_* block; prefer a
+  // continuous assign for any field read added later (ADR-0034).
   logic in_is_lb;
   logic in_is_lbu;
   logic in_is_lh;
@@ -95,58 +72,36 @@ module accessor(
   logic is_store;
   assign is_store = in_is_sw || in_is_sh || in_is_sb;
 
-  // pending_valid/pending_rd are declared as ports above (the hazard
-  // scoreboard needs them too); the rest of the pending-load state below is
-  // internal-only. All of it is latched at the request cycle below and
-  // consumed one cycle later once mem_rdata actually reflects this load —
-  // see `stalled` above.
   logic       pending_is_lb, pending_is_lbu, pending_is_lh, pending_is_lhu, pending_is_lw;
   logic       pending_addr16;
   logic [1:0] pending_addr24;
  `ifdef RISCV_FORMAL
-  // ADR-0006: a load's RVFI shadow payload (and the word-aligned
-  // request address, needed for rvfi_mem_addr) has to survive the same
-  // one-cycle request/response gap pending_rd does, for the same reason —
-  // `in` is a guaranteed bubble on the response cycle (see pending_valid
-  // below), so nothing of this instruction's is left to read off `in` then.
+  // These survive the request/response gap for the same reason `pending_rd`
+  // does: `in` is a guaranteed bubble on the response cycle, so nothing of this
+  // instruction is left to read off it then.
   rvfi_shadow  pending_rvfi;
   logic [31:0] pending_rvfi_mem_addr;
  `endif
   logic [31:0] write_request;
 
-  // Hoisted out of the always_comb below for the same reason as decoder.v's
-  // register-index fields: iverilog cannot build a precise sensitivity entry
-  // for a constant part-select taken inside an always_* block, so it warns
-  // and falls back to whole-signal sensitivity. Conservative and safe, but
-  // noise -- and CLAUDE.md says warnings are errors. A continuous assign has
-  // an exact sensitivity, so selecting out here silences it honestly.
   logic [31:0] word_aligned_addr;
   logic [15:0] store_halfword;
   logic [7:0]  store_byte;
   assign word_aligned_addr = {in_mem_addr[31:2], 2'b00};
   assign store_halfword    = in_mem_data[15:0];
   assign store_byte        = in_mem_data[7:0];
-  // mem_wdata must be combinational, in lockstep with mem_addr/mem_wstrb
-  // above: a registered mem_wdata (the original bug here) lags the address
-  // and strobe by one cycle, so the memory model latches the *previous*
-  // cycle's data at the *current* cycle's address — exactly the "address
-  // recovers before data" skew traced while landing the cxxrtl runner in `9cd0c67` (see
-  // test/EXPECTED_FAIL's history and ADR-0004).
+  // Must stay combinational, in lockstep with mem_addr/mem_wstrb: a registered
+  // `mem_wdata` lags them by a cycle, so the memory latches the previous cycle's
+  // data at the current cycle's address.
   assign mem_wdata = write_request;
-  // make the request. Defaults to no request every cycle — reset, a bubble,
-  // and a real non-memory instruction (e.g. add) all fall out of the same
-  // single default below rather than each re-stating "0, 0, 0" — and that's
-  // also the direct fix for the divide-replay defect, where the accessor
-  // used to keep re-issuing whatever request was last in `in` for every
-  // cycle the executor sat busy in `divide`, because nothing here defaulted
-  // back to zero in between.
+  // The zeroed defaults below are what stop the accessor re-issuing whatever
+  // request was last in `in` for every cycle the executor sits busy in `divide`.
   always_comb begin
     mem_addr = 0;
     mem_wstrb = 0;
     write_request = 0;
     if (!reset && in_valid) begin
       write_request = in_mem_data;
-      // request is synchronous
       (* parallel_case *)
       case (1'b1)
         in_is_lw || in_is_lh || in_is_lhu || in_is_lb || in_is_lbu: begin
@@ -163,7 +118,6 @@ module accessor(
             end
 
             in_is_sh: begin
-              // Offset to the right position
               mem_wstrb = addr16 ? 4'b1100 : 4'b0011;
               write_request = {2{store_halfword}};
             end
@@ -176,14 +130,11 @@ module accessor(
           mem_addr = word_aligned_addr;
         end // case: in_is_sw || in_is_sh || in_is_sb
 
-        // default: not a load or a store this cycle (e.g. an add) — the
-        // zeroed defaults above stand.
       endcase // case (1'b1)
     end // if (!reset && in_valid)
   end // always_comb
 
   always_ff @(posedge clk) begin
-    // response is registered
     if (reset) begin
       out <= 0;
       pending_valid <= 1'b0;
@@ -196,18 +147,13 @@ module accessor(
       pending_rvfi_mem_addr <= 0;
      `endif
     end else if (pending_valid) begin
-      // The request fired last cycle (`stalled` was high then); mem_rdata
-      // now reflects it. rtl/decoder.v froze upstream and rtl/executor.v
-      // bubbled for that one cycle, so `in` here is guaranteed to be a
-      // bubble right now — nothing else is competing for `out` this cycle.
+      // The request fired last cycle and mem_rdata now reflects it. `in` is
+      // guaranteed to be a bubble, so nothing competes for `out`.
       out.valid <= 1'b1;
       out.rd <= pending_rd;
      `ifdef RISCV_FORMAL
-      // Full read mask regardless of load width (byte/half/word): the
-      // monitor only flags a *missing* bit against what the spec expects,
-      // never an extra one, so an over-approximation is safe -- ported
-      // as-is from the serialized core's green run (ADR-0006 —
-      // notes), not re-derived.
+      // A full rmask regardless of load width is a safe over-approximation: the
+      // monitor flags a missing bit against the spec, never an extra one.
       out.rvfi <= pending_rvfi;
       out.rvfi_mem_addr <= pending_rvfi_mem_addr;
       out.rvfi_mem_rmask <= 4'b1111;
@@ -255,9 +201,7 @@ module accessor(
     end else if (!in_valid) begin
       out <= 0;
     end else if (is_load) begin
-      // Request just issued combinationally above; the response isn't back
-      // until next cycle (see `stalled`). Emit a bubble now and remember
-      // what's needed to decode mem_rdata once it arrives.
+      // Bubble now, and remember what is needed to decode mem_rdata next cycle.
       out <= 0;
       pending_valid <= 1'b1;
       pending_rd <= in_rd;
@@ -269,29 +213,19 @@ module accessor(
       pending_addr16 <= addr16;
       pending_addr24 <= addr24;
      `ifdef RISCV_FORMAL
-      // `mem_addr` here is this cycle's combinational request address (the
-      // always_comb block above), already word-aligned -- the same value
-      // driving the real bus this cycle. Captured now because `in` (and so
-      // this address) is gone by the response cycle above.
+      // `mem_addr` is this cycle's real bus address, already word-aligned.
       pending_rvfi <= in.rvfi;
       pending_rvfi_mem_addr <= mem_addr;
      `endif
     end else begin
-      // Not a load: stores and every other op settle in the one cycle every
-      // other pipeline stage takes.
+      // Stores and every other op settle in one cycle.
       out.valid <= 1'b1;
       out.rd_data <= in_rd_data;
       out.rd <= in_rd;
      `ifdef RISCV_FORMAL
       out.rvfi <= in.rvfi;
-      // `mem_addr`/`mem_wstrb`/`write_request` are this cycle's real bus
-      // values from the always_comb block above -- exact, not an
-      // approximation, so store bytes outside the byte-accurate wmask never
-      // get compared against something this instruction didn't actually
-      // write. Zeroed for every non-store op (including reads never reach
-      // this branch -- loads take the is_load branch above), so a plain ALU
-      // op never inherits a stale memory access from whatever last used
-      // this register.
+      // Zeroed for every non-store op, so a plain ALU op cannot inherit a stale
+      // memory access from whatever last used this register.
       out.rvfi_mem_addr <= is_store ? mem_addr : 32'b0;
       out.rvfi_mem_wmask <= is_store ? mem_wstrb : 4'b0;
       out.rvfi_mem_wdata <= is_store ? write_request : 32'b0;

--- a/rtl/decoder.v
+++ b/rtl/decoder.v
@@ -8,37 +8,37 @@ module decoder (
   input  logic [31:0] reg_rs1,
   input  logic [31:0] reg_rs2,
   input  executor_output executor_out,
-  // Decode bubbles its own output for the whole divide rather than holding it:
-  // the divider latches its operands at issue, and a held decoder_out would be
-  // misread as freshly issued the moment the executor returns to `init`.
+  // While a divide runs, decode zeroes `out` instead of holding it. The divider
+  // has already taken its operands, and a held `out` would be read as a new
+  // instruction when the executor goes back to `init`.
   input  logic divider_stall,
-  // Held, not bubbled, for exactly the cycle this is asserted. Nothing
-  // downstream has consumed this cycle's decoder_out when it fires, so bubbling
-  // would silently drop that instruction.
+  // This one holds `out` instead of zeroing it. Nothing downstream has taken
+  // this cycle's `out` yet, so zeroing it would lose that instruction.
   input  logic accessor_stall,
-  // The instruction memory took its read port for a data access, so the window
-  // presented this cycle is a data word rather than the instruction at `pc`
-  // (ADR-0059). A divider or accessor freeze on the same cycle outranks it.
+  // The instruction memory gave its read port to a load or store, so the window
+  // arriving this cycle holds a data word, not the instruction at `pc`. If a
+  // divide or a load stall lands on the same cycle, that one wins.
   input  logic fetch_stall,
-  // A load in the accessor's turnaround is a live producer for one cycle that
-  // neither decoder_out nor executor_out can see it in. That gap only.
+  // A load spends an extra cycle waiting for memory. During it the load has left
+  // `executor_out` and has not yet written the register file, so neither of the
+  // other two terms below sees it. These cover that one cycle.
   input  logic       accessor_pending_valid,
   input  logic [4:0] accessor_pending_rd,
-  // The drain predicate's fourth slot: a *store* in the accessor appears in none
-  // of the other three, and without it a CSR instruction issues early and
-  // `minstret` is wrong exactly when a store is in flight (ADR-0026).
+  // A store writes no register, so the hazard check ignores it. Serialization
+  // still has to wait for one. That is what this is for -- without it a CSR
+  // access can issue while a store is still in the accessor.
   input  logic       accessor_out_valid,
   output logic [31:0] pc,
-  // The value `pc` will hold next cycle, published combinationally this one so a
-  // synchronous instruction memory can latch it on the same edge `pc` takes it.
-  // That is how fetch stays combinational from decode's point of view on a part
-  // with no combinational-read memory (invariant 1, ADR-0054).
+  // The value `pc` takes next cycle, ready during this one. A memory that needs
+  // a cycle to answer latches this on the same edge `pc` moves, so its data is
+  // there when decode wants it. Without it decode would always be one
+  // instruction behind the address it is deciding from.
   output logic [31:0] next_pc,
   output logic [4:0] rs1,
   output logic [4:0] rs2,
-  // rtl/csrs.v is a sibling module, not a stage: it answers combinationally in
-  // time for the publish block, and commits on the edge the accessing
-  // instruction issues, so nothing downstream carries CSR state (ADR-0005).
+  // rtl/csrs.v is a sibling module, not a stage. It answers in the same cycle,
+  // and commits on the edge the instruction issues. No CSR value is ever held
+  // downstream, so there is nothing to forward and nothing to replay.
   output logic [11:0] csr_addr,
   output logic        csr_ren,
   output logic        csr_wen,
@@ -46,8 +46,8 @@ module decoder (
   input  logic [31:0] csr_rdata,
   input  logic        csr_implemented,
   output logic        instret,
-  // A trap is a branch: it redirects through the same `next_pc` chain every
-  // other branch uses, which is why nothing downstream needs a kill signal.
+  // A trap takes the same `next_pc` chain a branch does. Nothing downstream has
+  // to be told about it, so there is no kill signal anywhere.
   output logic        trap_entry,
   output logic [31:0] trap_cause,
   output logic [31:0] trap_epc,
@@ -61,16 +61,16 @@ module decoder (
  `endif
   output decoder_output out
 );
-  // Zero-extending a compressed instruction leaves no neighbouring-instruction
-  // garbage in the upper half for a decode path that forgets to gate on
-  // `uncompressed` to read (ADR-0021).
+  // The fetch window is always 32 bits. For a 16-bit instruction the upper half
+  // is the next instruction in memory. Zeroing it means a decode line that reads
+  // instr[31:16] without checking the width first sees zero, not its neighbour.
   logic [31:0] instr;
   assign instr = (in.instr[1:0] == 2'b11) ? in.instr : {16'b0, in.instr[15:0]};
 
-  // Base encodings (RISC-V unprivileged spec, Ch. 2.2). Hoisted out of the
-  // always_comb blocks below because iverilog cannot build a precise sensitivity
-  // entry for a constant part-select taken inside one; prefer a continuous
-  // assign for any field read added later (ADR-0034).
+  // Base encodings (RISC-V unprivileged spec, Ch. 2.2). Pulled out here rather
+  // than read inside the always_comb blocks below: iverilog cannot work out a
+  // precise sensitivity list for a bit-select taken inside one, and warns. Use a
+  // continuous assign for any field read added later.
   logic [4:0] rd_field, rs1_field, rs2_field;
   assign rd_field  = instr[11:7];
   assign rs1_field = instr[19:15];
@@ -273,9 +273,9 @@ module decoder (
   assign instr_rem = instr_m && funct3 == 3'b110;
   assign instr_remu = instr_m && funct3 == 3'b111;
 
-  // The Zicsr immediate forms stay named apart from the register forms: their
-  // rs1 field is a zimm, so `uses_rs1` must not interlock on it and `csr_arg`
-  // must read the encoding rather than the register file.
+  // Keep the immediate forms named apart from the register forms. Their rs1
+  // field holds a 5-bit constant, not a register number, so `uses_rs1` must not
+  // wait on it and `csr_arg` must read the encoding instead of the register.
   logic instr_csr, instr_csrrwi, instr_csrrsi, instr_csrrci;
   assign instr_csr = opcode == 5'b11100 && uncompressed;
   assign instr_csrrw = instr_csr && funct3 == 3'b001 || instr_csrrwi;
@@ -292,10 +292,10 @@ module decoder (
   logic [31:0] csr_arg;
   assign csr_arg = is_csr_imm ? {27'b0, rs1_field} : reg_rs1;
 
-  // Zicsr's suppression rules. Suppressing the write when the source is zero is
-  // what makes `csrr` legal against a read-only CSR rather than an
-  // illegal-instruction trap. The read-suppression rule already falls out of
-  // `rd` gating rtl/writeback.v's `wen`, and is named here only for RVFI.
+  // Skipping the write when the source is zero is what makes `csrr` legal on a
+  // read-only CSR instead of an illegal instruction. Skipping the read when rd
+  // is x0 already happens, because rd == 0 gates rtl/writeback.v's `wen`; it is
+  // named here only so RVFI reports the right read mask.
   logic csr_src_zero, csr_write_op, csr_read_op;
   assign csr_src_zero = rs1_field == 5'b0;
   assign csr_write_op = instr_csr_access && !((instr_csrrs || instr_csrrc) && csr_src_zero);
@@ -304,16 +304,14 @@ module decoder (
                      instr_csrrs ? (csr_rdata | csr_arg) :
                                    (csr_rdata & ~csr_arg);
 
-  // SYSTEM with funct3 == 0. An encoding missing from this group decodes to
-  // nothing, which now means an illegal-instruction trap rather than a silent
-  // NOP.
+  // SYSTEM with funct3 == 0. Leave one of these out and it decodes to nothing,
+  // which traps as an illegal instruction rather than being ignored.
   logic instr_error, instr_mret, instr_wfi, instr_cebreak;
   assign instr_error = opcode == 5'b11100 && uncompressed && funct3 == 0 && rs1 == 0 && rd == 0;
   assign instr_ecall = instr_error && instr[31:20] == 12'h0;
-  // C.EBREAK needs its own line because it is the rd == 0, rs2 == 0 corner of
-  // quadrant 2's funct4 == 4'b1001 row that `instr_cjalr` and `instr_cadd` each
-  // exclude by a different field. Without it the encoding decodes to nothing and
-  // traps as illegal rather than as a breakpoint.
+  // C.EBREAK needs its own line. It sits in the same row as `instr_cjalr` and
+  // `instr_cadd`, and each of those excludes it by a different field. Without
+  // this it decodes to nothing and traps as illegal instead of as a breakpoint.
   assign instr_cebreak = quadrant == 2'b10 && cfunct4 == 4'b1001 &&
     instr[11:7] == 5'b0 && instr[6:2] == 5'b0;
   assign instr_ebreak = (instr_error && instr[31:20] == 12'h1) || instr_cebreak;
@@ -341,8 +339,9 @@ module decoder (
     instr_fencei || (instr_csr_access && csr_implemented);
 
   // The effective address, used here to decide misalignment and again in the
-  // publish block as `out.mem_addr`. That it is available in decode for free is
-  // what makes invariant 2 affordable.
+  // publish block as `out.mem_addr`. Having it this early is what lets a
+  // misaligned access be turned into a trap before the instruction issues,
+  // rather than by the memory stage refusing it after the fact.
   logic [31:0] mem_addr_calc;
   assign mem_addr_calc = $signed(immediate) + $signed(reg_rs1);
 
@@ -370,11 +369,11 @@ module decoder (
   assign trap_pending = instr_illegal || instr_ebreak || instr_ecall ||
                         load_misaligned || store_misaligned;
 
-  // No `(* parallel_case *)`. The five causes cannot co-occur today, so this
-  // encoder is vacuous -- but claiming one-hot would turn that disjointness from
-  // something the `ifdef FORMAL` block asserts into something the RTL assumes,
-  // and a later cause that broke it would be a lie to synthesis rather than a
-  // failed proof (ADR-0030).
+  // No `(* parallel_case *)` here. No two of these five can be true at once
+  // today, so the priority never matters. But marking the case one-hot tells
+  // synthesis it may assume that. Add a sixth cause that overlaps an existing
+  // one and you get whatever the optimiser chose, instead of a failed
+  // assertion. The `ifdef FORMAL` block below checks it can't happen.
   always_comb begin
     case (1'b1)
       instr_illegal:    trap_cause = CAUSE_ILLEGAL_INSTRUCTION;
@@ -441,22 +440,22 @@ module decoder (
   logic [31:0] pc_inc;
   assign pc_inc = uncompressed ? 4 : 2;
 
-  // "Does this instruction really read rsN?" -- not a shift's shamt, not a
-  // U-type immediate's overlapping bit positions, not a zimm. Both the
-  // scoreboard and the operand-fetch stall key off these, so widening either
-  // predicate stalls on registers nothing reads and narrowing it reads stale
-  // ones (ADR-0004).
+  // Does this instruction really read rsN? Not a shift amount, not immediate
+  // bits that happen to sit where a register number would, not a Zicsr
+  // constant. Both `hazard_rs1`/`hazard_rs2` and `operand_stall` use these.
+  // Widen one and the core waits on registers nothing reads. Narrow one and an
+  // instruction issues before its operand has arrived.
   logic uses_rs1, uses_rs2;
   assign uses_rs1 = !(instr_lui || instr_jal || instr_auipc || is_csr_imm);
   assign uses_rs2 = (instr_math && !instr_math_immediate) || instr_sb || instr_sh || instr_sw ||
     instr_beq || instr_bne || instr_blt || instr_bltu || instr_bge || instr_bgeu;
 
-  // Do not factor these two into a shared `function automatic live_producer(r)`.
-  // iverilog builds a continuous assign's sensitivity list from the call's
-  // arguments, so a body that also reads `out`/`executor_out`/`accessor_pending_*`
-  // never re-evaluates when those change -- silent under-sensitivity, with no
-  // diagnostic, which froze the iverilog leg at the first RAW hazard of every
-  // program while cxxrtl and the ladder stayed green (ADR-0037).
+  // Do not fold these two into a shared function. iverilog builds a continuous
+  // assign's sensitivity list from the arguments at the call site. A function
+  // body that also read `out`, `executor_out` or `accessor_pending_*` would stop
+  // re-evaluating when any of those changed. `hazard_rs1` then sticks high at the
+  // first conflict and the core stops. iverilog gives no warning for this, and
+  // yosys gets the same function right, so every other check stays green.
   logic live_rs1, live_rs2;
   assign live_rs1 = (out.valid && out.rd == rs1) ||
     (executor_out.valid && executor_out.rd == rs1) ||
@@ -465,11 +464,18 @@ module decoder (
     (executor_out.valid && executor_out.rd == rs2) ||
     (accessor_pending_valid && accessor_pending_rd == rs2);
 
-  // Serialization holds these in decode until all four in-flight slots are empty
-  // (invariant 5). Two distinct reasons, so do not narrow it to suit one: a CSR
-  // instruction and `mret` are here for `minstret` exactness and not for hazard
-  // safety (ADR-0027), while `fence.i` needs the older store's write edge to have
-  // passed before the fetch a cycle ahead of it latches stale text (ADR-0061).
+  // These three wait until the pipeline is empty, for two different reasons.
+  // Narrowing the test to suit one of them breaks the other.
+  //
+  // A CSR access and `mret` are not waiting for an operand. `minstret` counts up
+  // when an instruction issues, not when it finishes, so it already includes
+  // instructions still moving down the pipeline. Waiting until they are done
+  // makes the count match what has actually finished.
+  //
+  // `fence.i` waits because text is writable and the fetch address goes out a
+  // cycle early. A store needs two edges to reach the memory array. By then the
+  // instruction after the `fence.i` has already been fetched, and it read the
+  // old text. An empty pipeline means the store has landed.
   logic pipe_drained, serialize;
   assign pipe_drained = !out.valid && !executor_out.valid && !accessor_out_valid &&
     !accessor_pending_valid;
@@ -481,20 +487,22 @@ module decoder (
   assign hazard = hazard_rs1 || hazard_rs2 || serialize;
 
  `ifdef RISCV_FORMAL
-  // These must stay exactly `uses_rs1`/`uses_rs2` and not a looser formula. The
-  // monitor's reordered-channel shadow-register check compares any reported
-  // address against its own last-write model unconditionally, so over-reporting
-  // one the instruction never read fails error 132 on a correct core.
+  // Report a register only if the instruction really reads one. The monitor
+  // keeps its own record of every register's last write and checks any address
+  // reported here against it. Name a register the instruction never read and the
+  // two disagree, on a core that is working correctly.
   logic rvfi_rs1_valid, rvfi_rs2_valid;
   assign rvfi_rs1_valid = !instr_lui && !instr_jal && !instr_auipc && !is_csr_imm;
   assign rvfi_rs2_valid = uses_rs2;
  `endif
-  // Register reads take one cycle, so an instruction presents its address pair,
-  // bubbles, and issues on the next cycle (invariant 9). The predicate states
-  // that rule directly rather than counting cycles: valid for exactly the pair
-  // presented last cycle, and only for the ports this instruction reads. The
-  // instructions that skip a fetch cycle all override out.rs1/out.rs2 in the
-  // publish block, so skipping cannot leak a stale operand.
+  // Register reads take one cycle. Decode presents rs1/rs2, waits a cycle, then
+  // issues. So reg_rs1/reg_rs2 hold the answer to whatever addresses went out
+  // last cycle, not this one.
+  //
+  // The test below says exactly that, and only for the ports this instruction
+  // reads. lui, jal and auipc read neither, so they never wait. Each writes its
+  // own operands into `out` further down instead of passing reg_rs1/reg_rs2
+  // through, so skipping the read cannot leak a stale value.
   logic [4:0] prev_rs1, prev_rs2;
   logic       read_taken, operand_stall;
   always_ff @(posedge clk) begin
@@ -511,14 +519,14 @@ module decoder (
   assign operand_stall = !read_taken || (uses_rs1 && prev_rs1 != rs1) ||
                                         (uses_rs2 && prev_rs2 != rs2);
 
-  // All six stall reasons, one broadcast. They freeze the PC alike; the publish
-  // block below is where they differ (ADR-0009).
+  // Every reason to stall, in one signal. They all hold the PC; the block that
+  // writes `out` below is where they differ.
   assign stall = hazard || operand_stall || divider_stall || accessor_stall || fetch_stall;
 
-  // Kept out of the `next_pc` chain below so each comparison is a
-  // self-determined expression with both operands explicitly `$signed`. Signed
-  // arithmetic buried in an arm of a conditional has silently gone unsigned in
-  // this repo twice.
+  // Kept out of the `next_pc` chain below so each comparison stands on its own
+  // with both sides marked `$signed`. A signed comparison written as one arm of
+  // a conditional takes its signedness from the other arms, and has quietly
+  // turned unsigned in this repo twice.
   logic branch_taken;
   always_comb begin
     (* parallel_case *)
@@ -533,9 +541,9 @@ module decoder (
     endcase
   end
 
-  // Every redirect this core takes, as one priority chain (ADR-0054). No
-  // `(* parallel_case *)`: `stall` and `trap_pending` do co-occur, so claiming
-  // one-hot would be a lie to synthesis.
+  // Every way the PC can change, in one priority chain. No `(* parallel_case *)`
+  // here: `stall` and `trap_pending` really can both be true, so the order
+  // matters and synthesis must not assume otherwise.
   always_comb begin
     case (1'b1)
       reset:                     next_pc = 32'b0;
@@ -550,10 +558,10 @@ module decoder (
     endcase
   end
 
-  // Must stay term-for-term identical to the publish block's `else` guard, and
-  // in particular must not gain `&& in.valid`: that arm does not test it either.
-  // The two disagreeing would apply a CSR write once per stall cycle rather than
-  // once per instruction, silently.
+  // Keep this exactly the same as the final `else` guard below, term for term.
+  // In particular do not add `&& in.valid`: that arm does not test it either. If
+  // the two ever disagree a CSR write fires once per stalled cycle instead of
+  // once per instruction, and nothing says so.
   logic issuing;
   assign issuing = !reset && !stall;
 
@@ -561,8 +569,8 @@ module decoder (
   assign committing = issuing && !trap_pending;
   assign csr_ren = committing && csr_read_op;
   assign csr_wen = committing && csr_write_op;
-  // A trapping instruction issues and retires in RVFI, but it did not retire
-  // architecturally, so it must not be counted (ADR-0027).
+  // A trapping instruction still issues, and RVFI still reports it, but it
+  // changed nothing. It must not be counted.
   assign instret = committing;
 
   assign trap_entry = issuing && trap_pending;
@@ -574,22 +582,24 @@ module decoder (
     if (reset) begin
       out <= '0;
     end else if (divider_stall || accessor_stall) begin
-      // Both fire a cycle behind their cause, so decoder_out holds an instruction
-      // nothing downstream has consumed and bubbling would drop it. This arm
-      // outranking a same-cycle `fetch_stall` is a ruling rather than a
-      // consequence of statement order (ADR-0060), and the `ifdef FORMAL` block
-      // asserts both directions because reordering these two arms is silent.
+      // Both of these fire a cycle after the thing that caused them, so `out`
+      // holds an instruction nothing downstream has taken yet. Zeroing it would
+      // lose that instruction. This arm has to come before the next one: if a
+      // `fetch_stall` lands on the same cycle, holding still wins. Swapping the
+      // two arms changes that and nothing would say so, which is why the
+      // `ifdef FORMAL` block below checks both cases.
       out <= out;
     end else if (hazard || operand_stall || fetch_stall) begin
-      // These bubble rather than hold: nothing stops the executor reading `in`
-      // every cycle here, so a held decoder_out would be reprocessed instead of
-      // the stalled instruction being retried.
+      // These zero `out` instead of holding it. The executor reads `in` every
+      // cycle, so a held `out` would be executed again and again while the
+      // stalled instruction waits.
       out <= '0;
     end else begin
-      // Trap commit lives at the bottom of this arm, which is what buys -- with
-      // no guard of its own -- no trap on a stalled cycle, none from a bubble,
-      // and no double commit. It also means the scoreboard has already cleared
-      // rs1, so the misalignment test reads its architectural value.
+      // This arm runs on exactly the cycles an instruction issues. Committing
+      // traps at the bottom of it is what makes the rest free: no trap on a
+      // stalled cycle, none from an empty cycle, and never twice for the same
+      // instruction. `hazard_rs1` has also already cleared by now, so the
+      // misalignment test reads the real value of rs1.
       out.valid <= 1'b1;
       out.mem_addr <= mem_addr_calc;
       out.rs1 <= instr_lui ? immediate : reg_rs1;
@@ -647,9 +657,9 @@ module decoder (
       case(1'b1)
         default: ;
         instr_auipc: begin
-          // AUIPC has no rs1/rs2 fields -- the bits the default selection reads
-          // are part of the U-type immediate -- so its operands are supplied
-          // directly here and added through the is_add pass-through.
+          // AUIPC has no rs1 or rs2 field. The bits the default selection reads
+          // are part of its immediate, so both operands are written here
+          // directly and added as if it were an add.
           out.rd <= rd;
           out.rs1 <= fetcher_pc;
           out.rs2 <= immediate;
@@ -681,12 +691,12 @@ module decoder (
         end
       endcase
 
-      // Last in the block so non-blocking last-write-wins beats every flag the
-      // arms above set, and no arm has to know traps exist. The instruction
-      // still retires with `out.valid` high, having architecturally done nothing
-      // but redirect (ADR-0028) -- clearing these flags is the whole mechanism,
-      // since rtl/accessor.v issues no bus request without one and `out.rd` of 0
-      // gates rtl/writeback.v's `wen`.
+      // Last in the block, so these writes win over every flag set above and no
+      // arm has to know traps exist. `out.valid` stays high: the instruction
+      // still reaches the end of the pipeline, having done nothing but change
+      // the PC. Clearing the flags is the whole of that. rtl/accessor.v starts
+      // no memory access with none of them set, and rd of 0 stops
+      // rtl/writeback.v writing a register.
       if (trap_pending) begin
         out.is_add <= 0; out.is_sub <= 0; out.is_xor <= 0; out.is_or <= 0; out.is_and <= 0;
         out.is_mul <= 0; out.is_mulh <= 0; out.is_mulhu <= 0; out.is_mulhsu <= 0;
@@ -704,31 +714,31 @@ module decoder (
   logic clocked;
   initial clocked = 0;
   always_ff @(posedge clk) clocked <= 1;
-  // Assumes reset before the first edge. Discharged nowhere -- it is structural,
-  // true of every harness in the tree -- and in force over the whole task,
-  // because before that edge `out` and the history registers below have no
-  // defined value.
+  // Assume reset is high before the first edge. Nothing proves this; every
+  // harness in the tree happens to do it. Before that edge `out` and the history
+  // registers below hold no defined value, so nothing here means anything
+  // without it.
   initial assume(reset);
   always_comb if(!clocked) assume(reset);
-  // Assumes reset never returns. Discharged nowhere, same reason. Written for
-  // the pc-increment assertions below, which would otherwise have to account for
-  // every point reset could jump pc back to 0; being unguarded it also covers
-  // the trap-arm assertions, harmlessly, since those carry `!prev_reset`.
+  // Assume reset never comes back. Nothing proves this either. The pc-increment
+  // assertions below would otherwise have to allow for reset forcing pc to 0 at
+  // any point. It is unguarded, so it also covers the trap assertions further
+  // down; those already test `!prev_reset`, so it costs nothing there.
   always_comb if (clocked) assume(!reset);
 
-  // Assumes the fetcher echoes this module's own pc, which it does
-  // combinationally in rtl/fetcher.v. Discharged by formal/pcloop.sv, which
-  // instantiates the real fetcher and asserts the echo instead; that task is on
-  // CI. In force over the whole task, wider than the pc-increment pair it was
-  // written for -- inert only because nothing else below reads `in.pc`.
+  // Assume the fetcher hands back the pc this module gave it. rtl/fetcher.v does
+  // that with a wire. formal/pcloop.sv builds the real fetcher and asserts it
+  // instead of assuming it, so this is checked somewhere; that task runs on CI.
+  // This assume covers the whole file, not just the assertions it was written
+  // for, and nothing else below reads `in.pc`.
   always_comb assume(in.pc == pc);
 
-  // Every "previous cycle" signal below is its own registered copy rather than a
-  // $past() on a free input: $past() chained across another register adds a cycle
-  // of history the solver can fill with a pre-reset value this standalone proof
-  // cannot rule out. `trap_pending` and `instr_mret` belong in `branch_jump`
-  // because both override `pc` -- forgetting either is how "a trap is a branch"
-  // stops being true in the proof while staying true in the RTL.
+  // Each of these keeps its own copy of last cycle's value instead of using
+  // $past(). `in.pc` and `instr` are free inputs here, and $past() through
+  // another register would let the solver fill in a value from before reset that
+  // this proof cannot rule out. `trap_pending` and `instr_mret` belong in
+  // `branch_jump` because both change the pc. Leave either out and the proof
+  // stops believing a trap is a branch while the RTL still treats it as one.
   logic branch_jump;
   always_ff @(posedge clk) if (reset) branch_jump <= 1'b0;
     else branch_jump <= instr_jal || instr_jalr || instr_beq || instr_bne || instr_blt || instr_bltu || instr_bge || instr_bgeu || trap_pending || instr_mret;
@@ -745,10 +755,10 @@ module decoder (
 
   always_ff @(posedge clk) if (clocked && prev_stall && !prev_reset) assert(pc == past_pc);
 
-  // Both directions of ADR-0060's ruling, because the publish block's arm order
-  // is all that decides which happens and each failure is silent: bubbling on
-  // the coincidence drops an unconsumed instruction, holding on a plain steal
-  // republishes one the executor reads every cycle.
+  // Both halves of the arm order above. Nothing else enforces it and both ways
+  // of getting it wrong are silent: zeroing `out` when a stall and a freeze
+  // coincide loses an instruction, and holding it on a plain stall hands the
+  // executor the same instruction twice.
   decoder_output past_out;
   logic prev_hold_and_steal, prev_steal_only;
   always_ff @(posedge clk) begin
@@ -759,16 +769,16 @@ module decoder (
   always_comb if (clocked && !prev_reset && prev_hold_and_steal) assert(out == past_out);
   always_comb if (clocked && !prev_reset && prev_steal_only)     assert(out == '0);
 
-  // A tautology one flip-flop wide, which is the point: it is what fails if a
-  // later edit gives `pc` a second driver, and that would put the instruction
-  // memory a cycle out of step with decode with no symptom but wrong
-  // instructions (ADR-0054).
+  // Obviously true one flip-flop apart, and that is the point. It fails the
+  // moment something else also writes `pc`. A second writer puts the
+  // instruction memory a cycle out of step with decode, and the only symptom is
+  // that every instruction executed is the wrong one.
   logic [31:0] past_next_pc;
   always_ff @(posedge clk) past_next_pc <= next_pc;
   always_comb if (clocked) assert(pc == past_next_pc);
 
-  // A bubble is fully zeroed, never a partial one that could sneak an rd
-  // through.
+  // An empty `out` is zeroed all the way through, so it can never carry an rd
+  // that writes a register.
   always_comb if (clocked && !out.valid) assert(out.rd == 0);
 
   always_comb if (rs1 == 0) assert(!hazard_rs1);
@@ -782,22 +792,21 @@ module decoder (
     instr_mul, instr_mulh, instr_mulhu, instr_mulhsu, instr_div, instr_divu, instr_rem,
     instr_remu, instr_sll, instr_slt, instr_sltu, instr_srl, instr_sra, instr_lui, instr_lb,
     instr_lbu, instr_lh, instr_lhu, instr_lw, instr_sb, instr_sh, instr_sw, instr_ecall,
-    // Every encoding `instr_valid` admits has to appear here, and the forms that
-    // differ only in funct3 or funct12 stay listed one per term, so a decode
-    // change that made two of them true at once is still caught.
+    // Everything `instr_valid` accepts has to appear here too. Keep the forms
+    // that differ only in funct3 or funct12 on separate terms, so a decode
+    // change that makes two of them true at once still trips this.
     instr_ebreak, instr_csrrw, instr_csrrs, instr_csrrc,
     instr_mret, instr_wfi, instr_fence, instr_fencei});
 
   always_comb if (instr_valid) assert(one_of);
 
-  // What makes the trap-cause encoder above safe to leave un-parallel_case'd.
-  // Add a sixth cause that overlaps an existing one and this fails, rather than
-  // the behaviour quietly becoming whatever the encoder produced.
+  // This is what makes the trap-cause case above safe without a one-hot marking.
+  // Add a sixth cause that overlaps an existing one and this fails here.
   always_comb assert($onehot0({instr_illegal, instr_ebreak, instr_ecall,
                                load_misaligned, store_misaligned}));
 
-  // Written per cause rather than as a restatement of the case statement, so a
-  // reordering of the arms is caught rather than mirrored.
+  // One line per cause, not a copy of the case statement, so reordering its arms
+  // trips these instead of changing them to match.
   always_comb if (instr_illegal)    assert(trap_cause == CAUSE_ILLEGAL_INSTRUCTION);
   always_comb if (instr_ebreak)     assert(trap_cause == CAUSE_BREAKPOINT);
   always_comb if (instr_ecall)      assert(trap_cause == CAUSE_ECALL_M);
@@ -816,9 +825,9 @@ module decoder (
     prev_mepc       <= mepc;
   end
 
-  // That the redirect went to mtvec is something no ladder check can see:
-  // `rvfi_insn_check` drops every value assertion under `spec_trap`, and
-  // pc_fwd/pc_bwd accept any target that is honestly reported.
+  // No riscv-formal check can see that the trap went to mtvec. Its instruction
+  // check drops every value comparison once an instruction traps, and its pc
+  // checks accept any target so long as the core reports the one it took.
   always_comb if (clocked && !prev_reset && prev_trap_entry) assert(pc == prev_mtvec);
   always_comb if (clocked && !prev_reset && prev_mret_entry) assert(pc == prev_mepc);
 
@@ -828,8 +837,8 @@ module decoder (
     assert(!out.is_sb && !out.is_sh && !out.is_sw);
   end
 
-  // Asserted so that an edit re-gating either on `instr_valid` -- the weaker
-  // pre-M3 spelling -- fails (ADR-0027).
+  // Gating these on `instr_valid` instead would look right and be weaker: an
+  // instruction can decode fine and still trap. This catches that.
   always_comb if (trap_pending) assert(!instret && !csr_wen && !csr_ren);
   always_comb assert(!(trap_entry && mret_entry));
  `endif

--- a/rtl/decoder.v
+++ b/rtl/decoder.v
@@ -4,89 +4,50 @@
 module decoder (
   input  logic clk,
   input  logic reset,
-  // inputs
   input  fetcher_output in,
   input  logic [31:0] reg_rs1,
   input  logic [31:0] reg_rs2,
-  // ADR-0004 hazard scoreboard: the other two producer stages (write-through
-  // in the regfile already covers writeback, CLAUDE.md invariant 6).
   input  executor_output executor_out,
-  // ADR-0009: the executor's multi-cycle-divide busy signal. The divider
-  // latches everything it needs internally at issue (rtl/executor.v), so
-  // decode is free to bubble its own output for the whole divide — and must:
-  // holding it unchanged instead would have the executor misread the same
-  // stale instruction as freshly issued the moment it returns to `init`
-  // (worked through in detail on rtl/executor.v).
+  // Decode bubbles its own output for the whole divide rather than holding it:
+  // the divider latches its operands at issue, and a held decoder_out would be
+  // misread as freshly issued the moment the executor returns to `init`.
   input  logic divider_stall,
-  // ADR-0009: the accessor's one-cycle load-response stall. Unlike the
-  // divider, nothing downstream has captured *this* cycle's decoder_out yet
-  // when this fires — the executor freezes for that one cycle too (see
-  // rtl/executor.v), so bubbling here would silently drop the very
-  // instruction sitting in decoder_out. Decode must hold it unchanged
-  // instead, for exactly the one cycle this is asserted.
+  // Held, not bubbled, for exactly the cycle this is asserted. Nothing
+  // downstream has consumed this cycle's decoder_out when it fires, so bubbling
+  // would silently drop that instruction.
   input  logic accessor_stall,
-  // ADR-0059: the instruction memory took its read port for a data access this
-  // cycle, so the fetch window presented now holds the data word instead of the
-  // instruction at `pc`. Bubble-shaped like a RAW hazard -- nothing issued, so
-  // the PC holds and the same instruction is presented again next cycle. A
-  // divider or accessor freeze on the same cycle outranks it; see the publish
-  // block below for why the order is that way round.
+  // The instruction memory took its read port for a data access, so the window
+  // presented this cycle is a data word rather than the instruction at `pc`
+  // (ADR-0059). A divider or accessor freeze on the same cycle outranks it.
   input  logic fetch_stall,
-  // ADR-0004 hazard scoreboard, third producer: a load in the accessor's
-  // one-cycle turnaround (see accessor_stall and rtl/accessor.v) is a live
-  // producer for that one extra cycle neither decoder_out nor executor_out
-  // can see it in. Narrow, not a general widening of the scoreboard to a
-  // third pipeline stage.
+  // A load in the accessor's turnaround is a live producer for one cycle that
+  // neither decoder_out nor executor_out can see it in. That gap only.
   input  logic       accessor_pending_valid,
   input  logic [4:0] accessor_pending_rd,
-  // ADR-0026: the fourth stall reason (CSR serialization, CLAUDE.md
-  // invariant 5) needs a genuine drain predicate, and
-  // `accessor_pending_valid` above covers LOADS ONLY. A store sitting in the
-  // accessor appears in none of the other three producer slots, so "the pipe
-  // is drained" and "no load is pending" are different questions and this
-  // input is the difference. Missing it produces a `minstret` that is wrong
-  // only when a store happens to be in flight.
+  // The drain predicate's fourth slot: a *store* in the accessor appears in none
+  // of the other three, and without it a CSR instruction issues early and
+  // `minstret` is wrong exactly when a store is in flight (ADR-0026).
   input  logic       accessor_out_valid,
-  // outputs
   output logic [31:0] pc,
-  // ADR-0054: the value `pc` will hold NEXT cycle, published combinationally
-  // this cycle. A synchronous instruction memory latches its address off this
-  // on the same edge `pc` takes it, so its data is available for the whole of
-  // the cycle in which `pc` names that address -- which is how fetch stays
-  // combinational from decode's point of view (CLAUDE.md invariant 1) on a
-  // part with no combinational-read memory primitive (ADR-0044).
-  //
-  // Nothing speculative rides on it: it is the same value, computed by the
-  // same expression, that the register below takes. `formal/pcloop.sv` and the
-  // `ifdef FORMAL` block at the bottom of this file both assert that
-  // relationship rather than leaving it to be read off the code.
+  // The value `pc` will hold next cycle, published combinationally this one so a
+  // synchronous instruction memory can latch it on the same edge `pc` takes it.
+  // That is how fetch stays combinational from decode's point of view on a part
+  // with no combinational-read memory (invariant 1, ADR-0054).
   output logic [31:0] next_pc,
-  // rs1 and rs2 are synchronous outputs
   output logic [4:0] rs1,
   output logic [4:0] rs2,
-  // ADR-0005: the CSR file (rtl/csrs.v) is a sibling module, read and
-  // written here in decode. `csr_rdata`/`csr_implemented` answer `csr_addr`
-  // combinationally, in time for the publish block below to register the
-  // read value; `csr_wen`/`csr_wdata` commit on the same edge the accessing
-  // instruction issues, so the whole access is one cycle wide and nothing
-  // downstream carries CSR state.
+  // rtl/csrs.v is a sibling module, not a stage: it answers combinationally in
+  // time for the publish block, and commits on the edge the accessing
+  // instruction issues, so nothing downstream carries CSR state (ADR-0005).
   output logic [11:0] csr_addr,
   output logic        csr_ren,
   output logic        csr_wen,
   output logic [31:0] csr_wdata,
   input  logic [31:0] csr_rdata,
   input  logic        csr_implemented,
-  // ADR-0027: minstret counts non-trapping issues, and issue happens here.
   output logic        instret,
-  // ---- trap entry (CLAUDE.md invariant 2 / ADR-0005 / ADR-0030) ----------
-  // Every trap this core takes is detected AND committed here, in decode, on
-  // the edge the trapping instruction issues. `trap_entry` is high for exactly
-  // that cycle; rtl/csrs.v commits mepc/mcause/mstatus off it and rtl/
-  // littlecpu.v exports it as the top-level `trap` pulse (ADR-0028).
-  // `mtvec`/`mepc` come back the other way because decode owns the PC
-  // (invariant 1) -- a trap is a branch, and it is taken by the same
-  // mechanism every other branch here uses. There is no flush and there is
-  // nothing to flush: nothing downstream of this stage can fault.
+  // A trap is a branch: it redirects through the same `next_pc` chain every
+  // other branch uses, which is why nothing downstream needs a kill signal.
   output logic        trap_entry,
   output logic [31:0] trap_cause,
   output logic [31:0] trap_epc,
@@ -94,45 +55,29 @@ module decoder (
   input  logic [31:0] mtvec,
   input  logic [31:0] mepc,
  `ifdef RISCV_FORMAL
-  // ADR-0006: the CSR file's shadow payload for the access being presented
-  // this cycle, latched below into the issuing instruction's shadow.
   input  rvfi_csr64   csr_rvfi_mcycle,
   input  rvfi_csr64   csr_rvfi_minstret,
   input  rvfi_csr32   csr_rvfi_mscratch,
  `endif
-  // forwards
   output decoder_output out
 );
-  // ADR-0003/ADR-0021: instr[31:16] is only ever meaningful for a genuinely
-  // 32-bit instruction (quadrant == 2'b11). Masking it here is the defence
-  // behind the immediate mux's own fix (instr_jalr_op, not instr_jalr, at
-  // the immediate-select case below): even if some future decode path
-  // forgets to gate on `uncompressed`, there is no neighbouring-instruction
-  // garbage left in the upper half to read. quadrant is derived from
-  // instr[1:0] below, which this mask never touches.
+  // Zero-extending a compressed instruction leaves no neighbouring-instruction
+  // garbage in the upper half for a decode path that forgets to gate on
+  // `uncompressed` to read (ADR-0021).
   logic [31:0] instr;
   assign instr = (in.instr[1:0] == 2'b11) ? in.instr : {16'b0, in.instr[15:0]};
 
-  // Register-index fields, named and hoisted out of the always_comb blocks
-  // below. Two reasons. First, `rd_field` reads better than `instr[11:7]` at
-  // every use site, which is the point of this core. Second, iverilog cannot
-  // build a precise sensitivity entry for a constant part-select taken inside
-  // an always_* block -- it reports `sorry: constant selects in always_*
-  // processes are not fully supported` and conservatively makes the process
-  // sensitive to all 32 bits. That is safe (over-sensitivity re-evaluates
-  // more than necessary; it can never produce a stale value) but it is noise,
-  // and CLAUDE.md says warnings are errors. Selecting out here, where a
-  // continuous assign has an exact sensitivity, silences it honestly.
-  //
-  // Base encodings (RISC-V unprivileged spec, Ch. 2.2).
+  // Base encodings (RISC-V unprivileged spec, Ch. 2.2). Hoisted out of the
+  // always_comb blocks below because iverilog cannot build a precise sensitivity
+  // entry for a constant part-select taken inside one; prefer a continuous
+  // assign for any field read added later (ADR-0034).
   logic [4:0] rd_field, rs1_field, rs2_field;
   assign rd_field  = instr[11:7];
   assign rs1_field = instr[19:15];
   assign rs2_field = instr[24:20];
 
-  // Compressed encodings (Ch. 16). The 3-bit "prime" fields index x8-x15;
-  // instr[11:7] doubles as rd/rs1 in CI/CR formats, so `rd_field` is reused
-  // there rather than aliased under a second name.
+  // Compressed encodings (Ch. 16). instr[11:7] doubles as rd/rs1 in CI/CR
+  // formats, so `rd_field` is reused there rather than aliased.
   logic [2:0] c_rd_rs1_prime, c_rs2_prime;
   logic [4:0] c_rs2_field;
   assign c_rd_rs1_prime = instr[9:7];
@@ -159,10 +104,9 @@ module decoder (
   logic [6:0] funct7;
   assign funct7 = instr[31:25];
 
-  // Forward declarations: the immediate-select and rd-select blocks below reference
-  // these before their own assign groups (further down) come into scope. iverilog
-  // (unlike yosys) requires every identifier declared before its first use, so the
-  // bare declarations live here; each signal's driving `assign` stays with its group.
+  // Forward declarations: the blocks below read these before their own assign
+  // groups come into scope, and iverilog (unlike yosys) requires every
+  // identifier declared before its first use.
   logic instr_lui_op, instr_jal_op, instr_jalr_op, instr_cj, instr_cjal, instr_cjr, instr_cjalr,
     instr_clui;
   logic instr_branch_op, instr_cbeqz, instr_cbnez;
@@ -283,7 +227,6 @@ module decoder (
   assign instr_caddi16sp = quadrant == 2'b01 && cfunct3 == 3'b011 && instr[11:7] == 2 &&
     caddi16sp_immediate != 0;
   assign instr_caddi4spn = quadrant == 2'b00 && cfunct3 == 3'b000 && caddi4spn_immediate != 0;
-  // c.li is addi in disguise
   assign instr_cli = quadrant == 2'b01 && cfunct3 == 3'b010;
   assign instr_slti = instr_math_immediate_op && funct3 == 3'b010;
   assign instr_sltiu = instr_math_immediate_op && funct3 == 3'b011;
@@ -330,12 +273,9 @@ module decoder (
   assign instr_rem = instr_m && funct3 == 3'b110;
   assign instr_remu = instr_m && funct3 == 3'b111;
 
-  // Zicsr (ADR-0005). The immediate forms stay separately named -- they used
-  // to be folded straight into the register forms, which lost the
-  // zimm-vs-rs1 distinction entirely. That distinction is load-bearing
-  // twice: `uses_rs1` below must not interlock on a zimm (it is not a
-  // register index), and `csr_arg` must read the encoding rather than the
-  // register file.
+  // The Zicsr immediate forms stay named apart from the register forms: their
+  // rs1 field is a zimm, so `uses_rs1` must not interlock on it and `csr_arg`
+  // must read the encoding rather than the register file.
   logic instr_csr, instr_csrrwi, instr_csrrsi, instr_csrrci;
   assign instr_csr = opcode == 5'b11100 && uncompressed;
   assign instr_csrrw = instr_csr && funct3 == 3'b001 || instr_csrrwi;
@@ -349,20 +289,13 @@ module decoder (
   assign is_csr_imm = instr_csrrwi || instr_csrrsi || instr_csrrci;
 
   assign csr_addr = instr[31:20];
-  // The operand: a zero-extended 5-bit zimm out of the rs1 field for the
-  // immediate forms, the register itself otherwise.
   logic [31:0] csr_arg;
   assign csr_arg = is_csr_imm ? {27'b0, rs1_field} : reg_rs1;
 
-  // Zicsr's two suppression rules (ADR-0005). Both are tests on the
-  // *encoding*, not on a value: CSRRS/CSRRC suppress the write when rs1 is
-  // x0 -- which is what makes `csrr` (a CSRRS with rs1 == x0) legal against
-  // a read-only CSR rather than an illegal-instruction trap -- and the
-  // immediate forms suppress it when zimm is 0. Those are the same five bits
-  // either way, so one test covers both forms. CSRRW/CSRRWI suppress the
-  // read when rd is x0; that falls out of `rd` below being 0, which already
-  // gates rtl/writeback.v's `wen`, so it only has to be said here for the
-  // RVFI rmask report.
+  // Zicsr's suppression rules. Suppressing the write when the source is zero is
+  // what makes `csrr` legal against a read-only CSR rather than an
+  // illegal-instruction trap. The read-suppression rule already falls out of
+  // `rd` gating rtl/writeback.v's `wen`, and is named here only for RVFI.
   logic csr_src_zero, csr_write_op, csr_read_op;
   assign csr_src_zero = rs1_field == 5'b0;
   assign csr_write_op = instr_csr_access && !((instr_csrrs || instr_csrrc) && csr_src_zero);
@@ -371,43 +304,27 @@ module decoder (
                      instr_csrrs ? (csr_rdata | csr_arg) :
                                    (csr_rdata & ~csr_arg);
 
-  // The SYSTEM instructions with funct3 == 0, distinguished from each other by
-  // funct12 alone -- which is why each one has to be spelled out exactly.
-  // Before trap entry existed, `mret` and `wfi` fell through to
-  // "unrecognised", which was harmless because unrecognised meant "execution
-  // flags suppressed, no trap". It stops being harmless the moment
-  // unrecognised means illegal-instruction.
+  // SYSTEM with funct3 == 0. An encoding missing from this group decodes to
+  // nothing, which now means an illegal-instruction trap rather than a silent
+  // NOP.
   logic instr_error, instr_mret, instr_wfi, instr_cebreak;
   assign instr_error = opcode == 5'b11100 && uncompressed && funct3 == 0 && rs1 == 0 && rd == 0;
   assign instr_ecall = instr_error && instr[31:20] == 12'h0;
-  // C.EBREAK (16'h9002) expands to EBREAK, so it raises a BREAKPOINT (cause 3)
-  // and not an illegal instruction. It is the rd == 0, rs2 == 0 corner of
-  // quadrant 2's funct4 == 4'b1001 row, which its two neighbours each exclude
-  // by a different field -- `instr_cjalr` needs instr[11:7] != 0 and
-  // `instr_cadd` needs instr[6:2] != 0 -- so without this line the encoding
-  // decodes to NOTHING, `instr_valid` is low, and the trap comes out cause 2:
-  // a wrong-but-plausible answer that still traps, still records an mepc and
-  // still resumes. test/asm/cebreak.S is what catches it, at both alignments.
+  // C.EBREAK needs its own line because it is the rd == 0, rs2 == 0 corner of
+  // quadrant 2's funct4 == 4'b1001 row that `instr_cjalr` and `instr_cadd` each
+  // exclude by a different field. Without it the encoding decodes to nothing and
+  // traps as illegal rather than as a breakpoint.
   assign instr_cebreak = quadrant == 2'b10 && cfunct4 == 4'b1001 &&
     instr[11:7] == 5'b0 && instr[6:2] == 5'b0;
   assign instr_ebreak = (instr_error && instr[31:20] == 12'h1) || instr_cebreak;
-  // ADR-0005: `mret` restores MIE <- MPIE, sets MPIE, and jumps to mepc.
-  // Committed in the publish block below, alongside trap entry, and serialized
-  // on the same drain predicate CSR instructions use (CLAUDE.md invariant 5).
   assign instr_mret = instr_error && instr[31:20] == 12'h302;
-  // `wfi` executes as a NOP, which is spec-legal. With `mie`/`mip` read-only
-  // zero there is no interrupt that could ever resume it, so "wait" and
-  // "continue" are the same instruction on this core.
+  // `wfi` is a NOP, which is spec-legal: `mie`/`mip` are read-only zero, so no
+  // interrupt could ever resume it.
   assign instr_wfi = instr_error && instr[31:20] == 12'h105;
 
-  // MISC-MEM. `fence` is a NOP: one hart, one bus, and one access in flight at
-  // a time, so there is nothing to order. `fence.i` is a NOP in its cache half
-  // for the same reason -- no icache -- but it also has to wait, which is the
-  // serialization term below rather than anything here. Same story as `wfi`
-  // above: merely unrecognised until trap entry landed, at which point a legal
-  // `fence` would have faulted. Only funct3 is tested -- `fence`'s fm/pred/succ
-  // fields and `fence.i`'s reserved immediate are legal-value fields with
-  // nothing to act on here.
+  // Both MISC-MEM forms are NOPs here -- one hart and no icache -- so only
+  // funct3 is tested; their other fields are legal-value fields with nothing to
+  // act on. `fence.i`'s ordering half is the serialization term below.
   logic instr_miscmem, instr_fence, instr_fencei;
   assign instr_miscmem = opcode == 5'b00011 && uncompressed;
   assign instr_fence  = instr_miscmem && funct3 == 3'b000;
@@ -423,45 +340,26 @@ module decoder (
     || instr_sw || instr_ecall || instr_ebreak || instr_mret || instr_wfi || instr_fence ||
     instr_fencei || (instr_csr_access && csr_implemented);
 
-  // ---- trap detection (CLAUDE.md invariant 2, ADR-0005, ADR-0030) ---------
-  //
-  // The effective address, computed once and used twice: here, to decide
-  // whether the access is misaligned, and in the publish block below as
-  // `out.mem_addr`. Misalignment was detected in rtl/accessor.v until this
-  // change -- post-decode, contradicting invariant 2. ADR-0011 scoped the move
-  // to M3 and this is it. That the address is already available here for free
-  // is the whole reason invariant 2 is affordable.
+  // The effective address, used here to decide misalignment and again in the
+  // publish block as `out.mem_addr`. That it is available in decode for free is
+  // what makes invariant 2 affordable.
   logic [31:0] mem_addr_calc;
   assign mem_addr_calc = $signed(immediate) + $signed(reg_rs1);
 
-  // Word accesses need 4-byte alignment, halfword accesses 2-byte; byte
-  // accesses are always aligned. That is why `lb`/`lbu`/`sb` appear nowhere
-  // here -- and why every one of the nine misalignment checks that used to sit
-  // in formal/EXPECTED_FAIL was a word or halfword access while every
-  // byte-granularity one already passed.
   logic load_misaligned, store_misaligned;
   assign load_misaligned  = (instr_lw && mem_addr_calc[1:0] != 2'b00) ||
                             ((instr_lh || instr_lhu) && mem_addr_calc[0] != 1'b0);
   assign store_misaligned = (instr_sw && mem_addr_calc[1:0] != 2'b00) ||
                             (instr_sh && mem_addr_calc[0] != 1'b0);
 
-  // ADR-0005's two illegal-CSR rules. Both are tests on the ENCODING plus the
-  // CSR file's own address decode, never on a value:
-  //
-  //   * an access to a CSR rtl/csrs.v does not implement, which reaches this
-  //     through `instr_valid` above exactly as it did before traps existed;
-  //   * a WRITE to a read-only CSR, which the privileged spec encodes in the
-  //     address itself (addr[11:10] == 2'b11). `csr_write_op` already has
-  //     Zicsr's suppression rules applied, so `csrr misa` -- a CSRRS with
-  //     rs1 == x0, write suppressed -- stays legal while `csrw misa` does not.
-  //     That rule was architecturally unobservable until this change, which is
-  //     recorded next to formal/checks.cfg's `[csrs]` list.
+  // `csr_write_op` already has Zicsr's suppression rules applied, so `csrr misa`
+  // stays legal while `csrw misa` does not.
   logic csr_readonly_write, instr_illegal;
   assign csr_readonly_write = instr_csr_access && csr_write_op && csr_addr[11:10] == 2'b11;
   assign instr_illegal = !instr_valid || csr_readonly_write;
 
-  // Cause codes (ADR-0005). Instruction-address-misaligned (0) is unreachable
-  // -- C makes 2-byte targets legal (ADR-0002) -- and is deliberately absent.
+  // Instruction-address-misaligned (0) is absent because C makes 2-byte targets
+  // legal, so it is unreachable.
   localparam logic [31:0] CAUSE_ILLEGAL_INSTRUCTION = 32'd2;
   localparam logic [31:0] CAUSE_BREAKPOINT          = 32'd3;
   localparam logic [31:0] CAUSE_LOAD_MISALIGNED     = 32'd4;
@@ -472,21 +370,11 @@ module decoder (
   assign trap_pending = instr_illegal || instr_ebreak || instr_ecall ||
                         load_misaligned || store_misaligned;
 
-  // ADR-0030's priority order: illegal (2) -> breakpoint (3) -> environment
-  // call (11) -> load misaligned (4) -> store misaligned (6). An instruction
-  // that is not legal cannot meaningfully be said to have a misaligned
-  // operand: the address computation is only defined for an instruction the
-  // decoder recognises.
-  //
-  // Deliberately NOT `(* parallel_case *)`, and that is the point of ADR-0030.
-  // The five cases cannot co-occur today -- an illegal instruction has every
-  // execution flag suppressed and so has no memory operand; `ecall` and
-  // `ebreak` differ in funct12 and are SYSTEM rather than LOAD/STORE; a load
-  // and a store are different opcodes -- which makes this priority encoder
-  // vacuous. Claiming one-hot to synthesis would turn that disjointness from
-  // something the `ifdef FORMAL` block below ASSERTS into something the RTL
-  // silently assumes, so a later cause that broke it would be a lie to
-  // synthesis rather than a failed proof.
+  // No `(* parallel_case *)`. The five causes cannot co-occur today, so this
+  // encoder is vacuous -- but claiming one-hot would turn that disjointness from
+  // something the `ifdef FORMAL` block asserts into something the RTL assumes,
+  // and a later cause that broke it would be a lie to synthesis rather than a
+  // failed proof (ADR-0030).
   always_comb begin
     case (1'b1)
       instr_illegal:    trap_cause = CAUSE_ILLEGAL_INSTRUCTION;
@@ -498,10 +386,8 @@ module decoder (
     endcase
   end
 
-  // mepc is the address of the FAULTING instruction, not of the next one --
-  // that is what lets a handler fix up and resume, and it is asserted directly
-  // in test/asm/trap.S rather than inferred from the fact that the test
-  // resumed.
+  // The faulting instruction's address, not the next one's -- that is what lets
+  // a handler fix up and resume.
   assign trap_epc = fetcher_pc;
 
   always_comb begin
@@ -555,46 +441,22 @@ module decoder (
   logic [31:0] pc_inc;
   assign pc_inc = uncompressed ? 4 : 2;
 
-  // ADR-0004 stall-only hazard scoreboard. Stall only when THIS instruction
-  // actually consumes rs1/rs2 as a register operand — not, say, a shift's
-  // shamt or a U-type/J-type immediate's overlapping bit position — and that
-  // register has a live (non-x0) producer still in flight at decoder_out (the
-  // module's own `out`, i.e. the instruction decode issued last cycle),
-  // executor_out, or (ADR-0015) a load still in the accessor's one-cycle
-  // memory turnaround. Write-through in the regfile covers the writeback
-  // stage itself; the accessor check exists only because a load specifically
-  // needs one more cycle there than every other instruction (see
-  // accessor_stall/rtl/accessor.v) — not a general widening to a third stage.
-  // `is_csr_imm` is excluded because instr[19:15] is a 5-bit zimm for those
-  // three encodings, not a register index -- interlocking on it would stall
-  // on a register the instruction never reads (ADR-0005).
+  // "Does this instruction really read rsN?" -- not a shift's shamt, not a
+  // U-type immediate's overlapping bit positions, not a zimm. Both the
+  // scoreboard and the operand-fetch stall key off these, so widening either
+  // predicate stalls on registers nothing reads and narrowing it reads stale
+  // ones (ADR-0004).
   logic uses_rs1, uses_rs2;
   assign uses_rs1 = !(instr_lui || instr_jal || instr_auipc || is_csr_imm);
   assign uses_rs2 = (instr_math && !instr_math_immediate) || instr_sb || instr_sh || instr_sw ||
     instr_beq || instr_bne || instr_blt || instr_bltu || instr_bge || instr_bgeu;
 
-  // Is this operand's register the destination of a live (not-yet-retired)
-  // producer at any of the three checked points? Spelled out twice rather than
-  // shared through a `function automatic live_producer(r)` called from the two
-  // continuous assigns below, and THAT IS A CORRECTNESS REQUIREMENT, not a
-  // style preference:
-  //
-  //   iverilog builds a continuous assign's sensitivity list from the function
-  //   CALL's arguments. A function whose body additionally reads module-level
-  //   signals -- `out`, `executor_out`, `accessor_pending_*` -- therefore never
-  //   re-evaluates when any of those change, only when `r` does. That is
-  //   UNDER-sensitivity, which is the one direction CLAUDE.md's documented
-  //   `sorry:` exception says is a real bug rather than harmless noise, and it
-  //   is silent: iverilog issues no diagnostic for it at all.
-  //
-  // Measured, not theorised. With the function form, the iverilog leg froze at
-  // the FIRST RAW hazard of every program -- `hazard_rs1` latched high and
-  // never fell -- so `make waves`' own baked-in program executed two
-  // instructions and then span, and no `.S` program could reach `tohost`. The
-  // cxxrtl and formal legs were unaffected (yosys evaluates the function
-  // correctly), which is exactly why it went unnoticed: the leg CLAUDE.md's
-  // verification table calls the microscope was reporting nothing, and nothing
-  // it reported was wrong.
+  // Do not factor these two into a shared `function automatic live_producer(r)`.
+  // iverilog builds a continuous assign's sensitivity list from the call's
+  // arguments, so a body that also reads `out`/`executor_out`/`accessor_pending_*`
+  // never re-evaluates when those change -- silent under-sensitivity, with no
+  // diagnostic, which froze the iverilog leg at the first RAW hazard of every
+  // program while cxxrtl and the ladder stayed green (ADR-0037).
   logic live_rs1, live_rs2;
   assign live_rs1 = (out.valid && out.rd == rs1) ||
     (executor_out.valid && executor_out.rd == rs1) ||
@@ -603,41 +465,11 @@ module decoder (
     (executor_out.valid && executor_out.rd == rs2) ||
     (accessor_pending_valid && accessor_pending_rd == rs2);
 
-  // CLAUDE.md invariant 5 / ADR-0005: a CSR instruction is held in decode
-  // until execute, access and writeback have drained. ADR-0026: this is a
-  // fourth stall *reason* on an existing mechanism, not a fourth mechanism.
-  // It is bubble-shaped -- the CSR instruction has NOT issued, and the
-  // executor reads `in` every cycle, so holding decoder_out would have it
-  // reprocess whatever is sitting there -- which is exactly the scoreboard's
-  // shape, so it folds into `hazard` rather than growing the stall protocol.
-  //
-  // All four in-flight slots are needed. `out`/`executor_out` are the two the
-  // scoreboard already watches; `accessor_pending_valid` is ADR-0015's
-  // load-response turnaround; `accessor_out_valid` is the one that is easy to
-  // miss, because a store in the accessor shows up in none of the other
-  // three (ADR-0026).
-  //
-  // What this buys is `minstret` exactness, NOT hazard safety (ADR-0027
-  // amends ADR-0005 on exactly this point): the CSR read result reaches rd
-  // through the ordinary `is_add` pass-through, where the scoreboard above
-  // already covers RAW. Delete this stall and no hazard appears -- what
-  // appears is a `csrr minstret` inflated by whatever is in flight behind it.
-  //
-  // `mret` joins the CSR instructions on this stall for the reason CLAUDE.md
-  // invariant 5 names them together: it reads mepc and writes mstatus in
-  // decode, the same one-cycle-wide architectural update a CSR instruction
-  // makes, and holding it until the pipe drains keeps that update from being
-  // interleaved with instructions that issued before it.
-  //
-  // `fence.i` joins them because text is writable (ADR-0059) and the fetch
-  // address is published a cycle early (ADR-0054). Waiting for all four slots
-  // is what makes the ordering it promises true: an older store is still in
-  // `accessor_out` for the cycle after its write edge, so a drained pipe means
-  // that edge has passed, and the address published on `fence.i`'s own issue
-  // edge is therefore latched against the written array. Without the wait,
-  // `fence.i` at cycle D+1 after a store at D issues while the fetch of its
-  // successor happened at edge D+1 -- before the write at edge D+2 -- and the
-  // successor executes stale text (ADR-0061).
+  // Serialization holds these in decode until all four in-flight slots are empty
+  // (invariant 5). Two distinct reasons, so do not narrow it to suit one: a CSR
+  // instruction and `mret` are here for `minstret` exactness and not for hazard
+  // safety (ADR-0027), while `fence.i` needs the older store's write edge to have
+  // passed before the fetch a cycle ahead of it latches stale text (ADR-0061).
   logic pipe_drained, serialize;
   assign pipe_drained = !out.valid && !executor_out.valid && !accessor_out_valid &&
     !accessor_pending_valid;
@@ -649,82 +481,20 @@ module decoder (
   assign hazard = hazard_rs1 || hazard_rs2 || serialize;
 
  `ifdef RISCV_FORMAL
-  // ADR-0006: rs1_valid/rs2_valid decide whether rvfi_rs{1,2}_addr
-  // and _rdata report the real register or are masked to 0, per RVFI
-  // convention (an instruction with no rsN field must report addr/rdata as
-  // 0, not whatever bits of the encoding happen to alias a register index).
-  // rvfi_rs1_valid is the serialized core's green-run formula, ported as-is
-  // (`git show 1709433^:rtl/riscv.v`): LUI/JAL/AUIPC have no rs1 field.
-  //
-  // rvfi_rs2_valid is `uses_rs2` above, not the serialized core's broader
-  // formula (which additionally excludes only JALR/loads, leaving it true
-  // for e.g. ADDI) — that broader version looked safe the same way the
-  // over-reported case above is (the monitor's channel-0 check only
-  // compares rs2_addr against spec when spec_rs2_addr != 0, so a garbage
-  // address for an instruction with no real rs2 field looked harmless) but
-  // is not: the monitor's *reordered*-channel shadow-register check
-  // (errors 131/132) compares whatever rs2_addr/rs2_rdata is reported
-  // against its own last-write model for that address unconditionally,
-  // with no such exemption. ADDI's I-type encoding has no rs2 field, but
-  // decode's default rs2 selection (`rs2 = instr[24:20]`) reads immediate
-  // bits there regardless — for `addi x2, x0, 1` those bits are 1, so the
-  // broader formula reports rs2_addr=x1 with rs2_addr's *current* value,
-  // which the shadow model (tracking x1's last real write) can legitimately
-  // disagree with. Caught empirically: the `make test` run failed
-  // error 132 ("mismatch with shadow rs2") on a correct core. `uses_rs2` is
-  // exactly "does this instruction have a real rs2 operand", so it doesn't
-  // have this hole.
-  //
-  // `is_csr_imm` is excluded for the same reason `uses_rs1` excludes it: the
-  // three immediate CSR encodings have a zimm where rs1 would be, so
-  // reporting instr[19:15] as an rs1 address (with that register's current
-  // contents as rdata) would hand the monitor's shadow-register check a
-  // register read this instruction never performed -- the rs1 twin of the
-  // ADDI rs2 hole described above. riscv-formal's own rvfi_csrw_check reads
-  // the zimm straight out of rvfi_insn for these, so it needs nothing here.
+  // These must stay exactly `uses_rs1`/`uses_rs2` and not a looser formula. The
+  // monitor's reordered-channel shadow-register check compares any reported
+  // address against its own last-write model unconditionally, so over-reporting
+  // one the instruction never read fails error 132 on a correct core.
   logic rvfi_rs1_valid, rvfi_rs2_valid;
   assign rvfi_rs1_valid = !instr_lui && !instr_jal && !instr_auipc && !is_csr_imm;
   assign rvfi_rs2_valid = uses_rs2;
  `endif
-  // ADR-0042: THE OPERAND-FETCH CYCLE. rtl/regfile.v's read is registered, so
-  // the operands for the address pair presented in cycle N are on
-  // reg_rs1/reg_rs2 in cycle N+1. Decode needs them in the cycle it issues --
-  // it computes branch targets, jalr targets and load/store addresses from them
-  // (and, per CLAUDE.md invariant 2, commits misalignment traps from them) --
-  // so an instruction spends one cycle presenting its address pair and issues
-  // on the next.
-  //
-  // The predicate is the direct statement of the rule: the registered read is
-  // valid for exactly the address pair that was presented last cycle, and only
-  // the ports this instruction actually reads have to be valid. It is NOT a
-  // cycle counter, and both refinements are paid for in measurement -- ADR-0042
-  // records these, over the 52-program suite:
-  //
-  //   every instruction waits one cycle    (not built)
-  //   address pair unchanged               +27.8% cycles
-  //   ...and only the ports it reads       +18.0% cycles   <- this
-  //
-  // `uses_rs1`/`uses_rs2` are the scoreboard's own predicates, reused verbatim,
-  // so this reads the same shape as `hazard_rs1` a few lines up -- on purpose.
-  // lui, jal, auipc and the zimm CSR forms have no register operand, and every
-  // one of them OVERRIDES out.rs1/out.rs2 in the publish block below rather
-  // than passing reg_rs1/reg_rs2 through, so skipping their fetch cycle cannot
-  // leak a stale operand. Narrowing `uses_rs1` to exclude a memory operation
-  // would break this exactly the way the publish block already warns it breaks
-  // misalignment detection: the two now share a reason.
-  //
-  // `rvfi_rs1_valid` is byte-identical to `uses_rs1` and `rvfi_rs2_valid` IS
-  // `uses_rs2`, so RVFI reports zero for exactly the operands whose fetch is
-  // skipped. That is also what keeps this clear of ADR-0020: no `ifdef
-  // RISCV_FORMAL` value reaches this predicate.
-  //
-  // THERE IS NO FLUSH HERE AND NONE IS NEEDED (invariant 1). The stalled
-  // instruction is not speculative and is never killed: the publish block below
-  // simply holds `pc`, so rtl/fetcher.v re-presents the same instruction next
-  // cycle and the bubble carries no work. That is the whole reason this lands
-  // as a stall rather than as a fetch-ahead pipeline register.
-  //
-  // `read_taken` covers reset, where `prev_rs1`/`prev_rs2` hold no read at all.
+  // Register reads take one cycle, so an instruction presents its address pair,
+  // bubbles, and issues on the next cycle (invariant 9). The predicate states
+  // that rule directly rather than counting cycles: valid for exactly the pair
+  // presented last cycle, and only for the ports this instruction reads. The
+  // instructions that skip a fetch cycle all override out.rs1/out.rs2 in the
+  // publish block, so skipping cannot leak a stale operand.
   logic [4:0] prev_rs1, prev_rs2;
   logic       read_taken, operand_stall;
   always_ff @(posedge clk) begin
@@ -741,39 +511,14 @@ module decoder (
   assign operand_stall = !read_taken || (uses_rs1 && prev_rs1 != rs1) ||
                                         (uses_rs2 && prev_rs2 != rs2);
 
-  // ADR-0009: a single global stall, combining the local RAW hazard and the
-  // operand-fetch cycle with whatever's busy downstream (the divider, the
-  // accessor's one-cycle load turnaround, or the instruction memory's stolen
-  // fetch window). Any reason freezes the PC; see below for why the two
-  // downstream reasons freeze decoder_out differently.
+  // All six stall reasons, one broadcast. They freeze the PC alike; the publish
+  // block below is where they differ (ADR-0009).
   assign stall = hazard || operand_stall || divider_stall || accessor_stall || fetch_stall;
 
-  // ---- the next PC (ADR-0054) ---------------------------------------------
-  //
-  // Every redirect in this module used to be a `pc <= ...` inside the publish
-  // block below -- one per arm, with Verilog's last-non-blocking-write-wins
-  // giving the priority order. The order is unchanged and is written out here
-  // as a priority chain; what changed is that the value is now NAMED before the
-  // edge instead of existing only after it, because the instruction memory
-  // needs it a cycle early (see the `next_pc` port comment above).
-  //
-  // Two consequences worth stating, because both remove a class of edit that
-  // used to be silent:
-  //
-  //   * the three stall arms below each said `pc <= pc` separately; `stall` is
-  //     exactly their disjunction, so there is now one statement of "a stalled
-  //     cycle does not advance the PC" (ADR-0009) rather than three;
-  //   * `out.rvfi.pc_wdata` is assigned from this signal, once. It used to be
-  //     re-derived at every redirect site, by hand, in lockstep with the `pc`
-  //     assignment beside it -- and decode owns the PC (CLAUDE.md invariant 1),
-  //     so those two disagreeing would have been a core that reported one
-  //     target to RVFI and took another.
-  //
-  // The branch comparisons are broken out into `branch_taken` rather than left
-  // as ternaries so that each one is a self-determined relational expression
-  // with both operands explicitly `$signed`. CLAUDE.md's rule about signed
-  // arithmetic inside a conditional arm is about reference models, but the
-  // shape is the same one that has caught this repo twice.
+  // Kept out of the `next_pc` chain below so each comparison is a
+  // self-determined expression with both operands explicitly `$signed`. Signed
+  // arithmetic buried in an arm of a conditional has silently gone unsigned in
+  // this repo twice.
   logic branch_taken;
   always_comb begin
     (* parallel_case *)
@@ -788,20 +533,13 @@ module decoder (
     endcase
   end
 
-  // Deliberately NOT `(* parallel_case *)`: this IS a priority encoder, and
-  // its order is the order the publish block's overlapping `pc <=` writes used
-  // to impose. Claiming one-hot here would be a lie to synthesis -- `stall` and
-  // `trap_pending` can and do co-occur.
+  // Every redirect this core takes, as one priority chain (ADR-0054). No
+  // `(* parallel_case *)`: `stall` and `trap_pending` do co-occur, so claiming
+  // one-hot would be a lie to synthesis.
   always_comb begin
     case (1'b1)
-      // Reset forces the PC to 0 rather than advancing it.
       reset:                     next_pc = 32'b0;
-      // ADR-0009: any stall reason freezes the PC, so the stalled instruction
-      // re-presents next cycle. There is no flush and nothing to flush.
       stall:                     next_pc = pc;
-      // ADR-0028/ADR-0030: a trap is a branch, and it outranks every other
-      // redirect -- it was the last `pc <=` in the publish block for exactly
-      // this reason.
       trap_pending:              next_pc = mtvec;
       instr_mret:                next_pc = mepc;
       instr_jalr:                next_pc = ($signed(immediate) + $signed(reg_rs1)) & 32'hfffffffe;
@@ -812,149 +550,69 @@ module decoder (
     endcase
   end
 
-  // The one cycle an instruction actually issues: the publish block's `else`
-  // arm below runs on exactly these edges, so everything that commits
-  // architectural state OUTSIDE the pipeline registers -- the CSR write and
-  // the minstret increment -- is gated on it. Getting this wrong is silent:
-  // a CSR write that fired on a stalled cycle would apply once per stall
-  // cycle instead of once per instruction.
-  // Deliberately the publish block's own guard restated, term for term, and
-  // NOT `... && in.valid`: the publish arm does not test `in.valid` either,
-  // because rtl/fetcher.v drives it to exactly `!reset` (CLAUDE.md invariant
-  // 1 -- fetch is combinational and never presents a wrong-path
-  // instruction), so there is no third case. Adding the term would make this
-  // stricter than the arm it is supposed to shadow, and the two disagreeing
-  // is precisely the bug this signal exists to avoid.
+  // Must stay term-for-term identical to the publish block's `else` guard, and
+  // in particular must not gain `&& in.valid`: that arm does not test it either.
+  // The two disagreeing would apply a CSR write once per stall cycle rather than
+  // once per instruction, silently.
   logic issuing;
   assign issuing = !reset && !stall;
 
-  // The one cycle an instruction actually takes architectural effect: it
-  // issued AND it did not trap. Everything that commits state outside the
-  // pipeline registers hangs off this.
   logic committing;
   assign committing = issuing && !trap_pending;
   assign csr_ren = committing && csr_read_op;
   assign csr_wen = committing && csr_write_op;
-  // ADR-0027: increment at issue, for NON-TRAPPING issues only. A trapping
-  // instruction issues, and retires in RVFI with `rvfi_trap = 1`, but it did
-  // not retire architecturally, so it must not be counted. `!trap_pending`
-  // implies `instr_valid` (an unrecognised instruction is now cause 2), so
-  // this is strictly the rule ADR-0027 states, not an approximation of it.
+  // A trapping instruction issues and retires in RVFI, but it did not retire
+  // architecturally, so it must not be counted (ADR-0027).
   assign instret = committing;
 
-  // ADR-0028: the trap-entry pulse. rtl/csrs.v commits mepc/mcause/mstatus off
-  // it and rtl/littlecpu.v exports it as the top-level `trap` port. High for
-  // exactly one cycle per trap because `issuing` is, and no trap can be
-  // committed twice: the publish block's `else` arm below runs on exactly the
-  // same condition, so the redirect and the CSR update are the same edge.
   assign trap_entry = issuing && trap_pending;
-  // `mret` is not a trap, so it commits on the ordinary non-trapping path.
   assign mret_entry = committing && instr_mret;
 
-  // The PC register, and the whole of it: every redirect this core takes is
-  // already resolved into `next_pc` above (ADR-0054).
   always_ff @(posedge clk) pc <= next_pc;
 
-  // publish the decoded results
   always_ff @(posedge clk) begin
     if (reset) begin
-      // bubble the output
       out <= '0;
     end else if (divider_stall || accessor_stall) begin
-      // ADR-0009: PC holds like any other freeze, but decoder_out must hold
-      // too, unchanged — not bubble. Decode gets exactly one free cycle to
-      // issue the instruction *after* the one that made the executor or
-      // accessor busy before either of these stalls exists (they both fire
-      // one cycle behind their cause); that next instruction is sitting in
-      // decoder_out, genuinely not yet consumed by anything downstream, and
-      // bubbling it here would silently drop it. It's safe to hold rather
-      // than bubble specifically because nothing downstream can reprocess it
-      // while held: the executor's own `case (state)` is mutually exclusive
-      // (it only ever reads `in` from its `init` branch, never while
-      // `state == divide`) and, for the accessor case, the executor is
-      // itself frozen the same cycle (see rtl/executor.v's accessor_stall).
-      // Takes priority over a same-cycle hazard for the same reason — that
-      // hazard is about the *next* instruction, which isn't decode's problem
-      // yet since decoder_out hasn't advanced.
-      //
-      // It takes priority over a same-cycle `fetch_stall` too, and that is a
-      // ruling rather than a consequence of the arm order (ADR-0060). A steal
-      // says the window presented this cycle is not an instruction, so there is
-      // nothing to publish; a freeze says the instruction already sitting in
-      // decoder_out has not been consumed yet. Bubbling on the coincidence
-      // would drop that instruction, so holding wins. The `ifdef FORMAL` block
-      // at the bottom asserts it: the arm order is the only thing enforcing it,
-      // and reordering these two arms would otherwise be silent.
+      // Both fire a cycle behind their cause, so decoder_out holds an instruction
+      // nothing downstream has consumed and bubbling would drop it. This arm
+      // outranking a same-cycle `fetch_stall` is a ruling rather than a
+      // consequence of statement order (ADR-0060), and the `ifdef FORMAL` block
+      // asserts both directions because reordering these two arms is silent.
       out <= out;
     end else if (hazard || operand_stall || fetch_stall) begin
-      // ADR-0009: upstream of the stalling stage freezes — the PC (and so
-      // the fetch window) holds, so the stalled instruction re-presents next
-      // cycle. ADR-0042's operand-fetch cycle shares this arm exactly: holding
-      // the PC is what keeps rs1/rs2 pointed at the same pair for the second
-      // cycle, so the bubble and the read are the same act.
-      // Bubbles rather than holds: unlike divider_stall/accessor_stall
-      // above, nothing stops the executor from reading `in` every cycle here,
-      // so holding decoder_out unchanged would have it reprocess the same
-      // instruction repeatedly instead of retrying the *hazarded* one.
+      // These bubble rather than hold: nothing stops the executor reading `in`
+      // every cycle here, so a held decoder_out would be reprocessed instead of
+      // the stalled instruction being retried.
       out <= '0;
     end else begin
-      // THIS ARM IS THE ONE CYCLE AN INSTRUCTION ISSUES, and every trap is
-      // committed in it, at the bottom -- deliberately, because that single
-      // placement gives four things for free that would otherwise each need
-      // their own guard, and each of which a later edit can break silently:
-      //
-      //   * no trap on a stalled cycle -- this arm does not run then;
-      //   * no trap from a bubble -- a bubble is the arm above, not this one;
-      //   * no double commit -- an instruction reaches this arm exactly once;
-      //   * `reg_rs1` is hazard-clear, so the misalignment test below is
-      //     computed from the ARCHITECTURAL value of rs1 rather than a stale
-      //     one. That holds because `uses_rs1` is true for every load and
-      //     every store (it excludes only lui/jal/auipc and the zimm CSR
-      //     forms), so the ADR-0004 scoreboard has already stalled this
-      //     instruction on any live producer of rs1 before it can get here.
-      //     Narrow `uses_rs1` to exclude a memory op and misalignment
-      //     detection silently starts reading the wrong register.
-      //
-      // Every redirect this arm used to make is resolved in `next_pc` above
-      // (ADR-0054); nothing below writes the PC any more.
+      // Trap commit lives at the bottom of this arm, which is what buys -- with
+      // no guard of its own -- no trap on a stalled cycle, none from a bubble,
+      // and no double commit. It also means the scoreboard has already cleared
+      // rs1, so the misalignment test reads its architectural value.
       out.valid <= 1'b1;
       out.mem_addr <= mem_addr_calc;
-      // forwards
       out.rs1 <= instr_lui ? immediate : reg_rs1;
       out.rs2 <= instr_math ? math_arg : reg_rs2;
       out.rd <= rd;
      `ifdef RISCV_FORMAL
-      // ADR-0006 shadow capture: everything RVFI needs that only decode
-      // knows. `rvfi.pc_wdata` IS the next PC, and since ADR-0054 that value
-      // has a name before the edge -- so this is one assignment rather than a
-      // second copy of the redirect chain kept in lockstep with it by hand.
-      // (Reading `pc` back here would not work: the non-blocking assignment
-      // above is not visible until next cycle. `next_pc` is combinational and
-      // is.) This arm runs only when `stall` is low, so `next_pc` here is the
-      // real target of the instruction being published, never a held PC.
+      // `next_pc` rather than `pc`: the non-blocking assignment above is not
+      // visible until next cycle. This arm runs only when `stall` is low, so it
+      // is the real target and never a held PC.
       out.rvfi.pc_wdata <= next_pc;
-      // `instr` is already zero-extended for a compressed instruction (the
-      // mask above), so this is RVFI's required zero-extended 16-bit report
-      // for free -- no separate ternary needed.
       out.rvfi.insn <= instr;
       out.rvfi.pc_rdata <= fetcher_pc;
-      // ADR-0028. Decode is the only stage that knows this, because decode is
-      // the only stage that can fault (CLAUDE.md invariant 2).
       out.rvfi.trap <= trap_pending;
       out.rvfi.rs1_addr <= rvfi_rs1_valid ? rs1 : 5'b0;
       out.rvfi.rs2_addr <= rvfi_rs2_valid ? rs2 : 5'b0;
       out.rvfi.rs1_rdata <= rvfi_rs1_valid ? reg_rs1 : 32'b0;
       out.rvfi.rs2_rdata <= rvfi_rs2_valid ? reg_rs2 : 32'b0;
-      // rtl/csrs.v builds these combinationally off the access being
-      // presented this cycle (its `ren`/`wen` are this module's, gated on
-      // `issuing`), so on this edge they describe exactly the instruction
-      // being published -- and a non-CSR instruction gets all-zero masks for
-      // free, because `csr_ren`/`csr_wen` are low for it.
+      // A non-CSR instruction gets all-zero masks for free, because
+      // `csr_ren`/`csr_wen` are low for it.
       out.rvfi.csr_mcycle   <= csr_rvfi_mcycle;
       out.rvfi.csr_minstret <= csr_rvfi_minstret;
       out.rvfi.csr_mscratch <= csr_rvfi_mscratch;
      `endif
-      // outputs
       out.is_add <= instr_add;
       out.is_sub <= instr_sub;
       out.is_xor <= instr_xor;
@@ -985,17 +643,13 @@ module decoder (
       out.is_ecall <= instr_ecall;
       out.is_ebreak <= instr_ebreak;
       out.is_valid_instr <= instr_valid;
-      // calculate branch
       (* parallel_case *)
       case(1'b1)
         default: ;
         instr_auipc: begin
-          // AUIPC has no rs1/rs2 fields at all (U-type: imm[31:12] | rd |
-          // opcode) — the bit positions decode.v's default rs1/rs2 selection
-          // reads are part of the immediate here, not a register index. The
-          // result is pc + immediate, computed the same way jal/jalr compute
-          // their return address: through is_add with the operands supplied
-          // directly rather than through reg_rs1/reg_rs2.
+          // AUIPC has no rs1/rs2 fields -- the bits the default selection reads
+          // are part of the U-type immediate -- so its operands are supplied
+          // directly here and added through the is_add pass-through.
           out.rd <= rd;
           out.rs1 <= fetcher_pc;
           out.rs2 <= immediate;
@@ -1003,23 +657,15 @@ module decoder (
         end
 
         instr_csr_access: begin
-          // ADR-0005: the CSR read result rides the pass-through the decoder
-          // already uses for lui/jal/auipc -- the value goes out as rs1 with
-          // rs2 zeroed and the executor adds them. The *write* has already
-          // been committed this same edge, by rtl/csrs.v off `csr_wen`; the
-          // whole access is one cycle wide.
-          //
-          // `rd` is the ordinary rd field, so CSRRW's read-suppression when
-          // rd == x0 needs nothing extra: rd == 0 already gates
-          // rtl/writeback.v's `wen`.
+          // Only the read result needs the datapath; rtl/csrs.v committed the
+          // write on this same edge.
           out.rs1 <= csr_rdata;
           out.rs2 <= 32'b0;
           out.is_add <= 1;
         end
 
         instr_jal || instr_jalr: begin
-          // The jump TARGET is `next_pc` above; what is left here is the
-          // return address, which is a datapath value like any other.
+          // The target is `next_pc`; what is left is the return address.
           out.rs1 <= fetcher_pc;
           out.rs2 <= pc_inc;
           out.rd <= rd;
@@ -1027,49 +673,20 @@ module decoder (
         end
 
         instr_beq || instr_bne || instr_blt || instr_bltu || instr_bge || instr_bgeu: begin
-          // The comparison and the target both live in `branch_taken` /
-          // `next_pc` above. A branch writes no register and carries no
-          // operand past decode, so all that is left is zeroing the payload.
+          // A branch is resolved entirely in `branch_taken`/`next_pc` and carries
+          // nothing past decode.
           out.rs1 <= 0;
           out.rs2 <= 0;
           out.rd <= 0;
         end
       endcase
 
-      // ---- mret ------------------------------------------------------------
-      // `mret` is a branch, taken exactly like every other branch here -- in
-      // `next_pc` above. The mstatus half (MIE <- MPIE, MPIE <- 1) is committed
-      // by rtl/csrs.v off `mret_entry` on this same edge. Nothing else about it
-      // reaches the pipeline: rd is x0 in its encoding, so `out.rd` is already
-      // 0 and no execution flag is set for it -- which is why it has no arm in
-      // the case above and nothing to do here.
-
-      // ---- trap entry (ADR-0028 / ADR-0030) -------------------------------
-      // A TRAP IS A BRANCH. `next_pc = mtvec` above is the same redirect the
-      // jump and branch arms take, on the same edge, through the same register
-      // -- which is why no flush exists and none is needed (CLAUDE.md
-      // invariant 1): the trapping instruction is the newest one in the
-      // machine, and everything behind it is already correct.
-      //
-      // Last in the block on purpose. Non-blocking assignments take the last
-      // write, so the suppression below beats every flag the arms above set --
-      // no arm has to know about traps and no ordering rule has to be
-      // remembered. The PC half of that priority now lives in `next_pc`'s
-      // chain, where `trap_pending` sits above every other redirect.
-      //
-      // The instruction still RETIRES (`out.valid` is 1, set at the top of
-      // this arm): ADR-0028's convention is that a trapping instruction
-      // retires having architecturally done nothing except redirect. Clearing
-      // every execution flag is what makes `rvfi_mem_rmask`/`wmask` zero --
-      // rtl/accessor.v builds them from the real bus, and with no flag set it
-      // issues no request at all, so a trapping store never reaches memory.
-      // That is the property `dmemcheck` catches (its environment shadow comes
-      // from the real `mem_wstrb`/`mem_wdata` while `rvfi_dmem_check`'s comes
-      // from `rvfi_mem_*`, so a suppressed-but-executed store desynchronises
-      // them), and `rvfi_insn_check` explicitly does not.
-      //
-      // Forcing `out.rd` to 0 does the same job for the register file: it
-      // gates rtl/writeback.v's `wen` and makes `rvfi_rd_addr`/`rd_wdata` zero.
+      // Last in the block so non-blocking last-write-wins beats every flag the
+      // arms above set, and no arm has to know traps exist. The instruction
+      // still retires with `out.valid` high, having architecturally done nothing
+      // but redirect (ADR-0028) -- clearing these flags is the whole mechanism,
+      // since rtl/accessor.v issues no bus request without one and `out.rd` of 0
+      // gates rtl/writeback.v's `wen`.
       if (trap_pending) begin
         out.is_add <= 0; out.is_sub <= 0; out.is_xor <= 0; out.is_or <= 0; out.is_and <= 0;
         out.is_mul <= 0; out.is_mulh <= 0; out.is_mulhu <= 0; out.is_mulhsu <= 0;
@@ -1087,85 +704,31 @@ module decoder (
   logic clocked;
   initial clocked = 0;
   always_ff @(posedge clk) clocked <= 1;
-  // FACT       reset is asserted before the first clock edge.
-  // DISCHARGED NOWHERE. Structural: every harness that instantiates this core
-  //            drives reset high initially. No check asserts it (ADR-0049).
-  // SCOPE      the whole task. Unguarded, and that is what it was written for:
-  //            before the first edge `out` and the pc history registers have
-  //            no defined value, so nothing below is meaningful without it.
-  // assume we've reset at clk 0
+  // Assumes reset before the first edge. Discharged nowhere -- it is structural,
+  // true of every harness in the tree -- and in force over the whole task,
+  // because before that edge `out` and the history registers below have no
+  // defined value.
   initial assume(reset);
   always_comb if(!clocked) assume(reset);
-  // Reset is a once-at-the-start pulse everywhere in this design (matches
-  // rtl/executor.v's identical assumption); without this, the solver can
-  // reassert it on an arbitrary later cycle and the pc-increment assertions
-  // below — which reason about "pc advanced by pc_inc since last cycle" —
-  // would have to separately account for every point reset could jump pc
-  // back to 0.
-  //
-  // FACT       reset never returns after the first cycle.
-  // DISCHARGED NOWHERE. True of every harness in the tree; asserted by none.
-  // SCOPE      the whole task -- LARGER than what it was written for. The
-  //            paragraph above is about the pc-increment assertions; this is
-  //            an unguarded `always_comb assume`, so it is equally in force
-  //            over the ADR-0028 / ADR-0030 trap-arm assertions added to this
-  //            block two milestones later. Harmless (those already carry their
-  //            own `!prev_reset` guards) but written down rather than left to
-  //            be inferred from proximity (ADR-0049 clause 3).
+  // Assumes reset never returns. Discharged nowhere, same reason. Written for
+  // the pc-increment assertions below, which would otherwise have to account for
+  // every point reset could jump pc back to 0; being unguarded it also covers
+  // the trap-arm assertions, harmlessly, since those carry `!prev_reset`.
   always_comb if (clocked) assume(!reset);
 
-  // This component proof stands alone (no real fetcher instantiated), so
-  // `in` is otherwise a free input. In the real pipeline the decoder owns
-  // pc and the fetcher only echoes it straight back combinationally
-  // (rtl/fetcher.v's `out.pc = pc;`, wired pc->pc in littlecpu.v) — without
-  // pinning that down here, the solver can present a `fetcher_pc` that
-  // bears no relation to what this decoder itself last drove, and the
-  // pc-increment assertions below are unprovable against a fetcher that
-  // isn't behaving like this design's actual one.
-  //
-  // FACT       the fetcher echoes the decoder's own pc combinationally --
-  //            rtl/fetcher.v's `out.pc = pc;`, wired pc -> pc in
-  //            rtl/littlecpu.v.
-  // DISCHARGED formal/pcloop.sv, which instantiates the real fetcher and
-  //            ASSERTS the echo (`assert(fetcher_out.pc == pc)`) instead of
-  //            assuming it. ADR-0017 relocated this obligation to M2's
-  //            full-core wrapper; pcloop.sv now discharges it directly and at
-  //            component level, which is better. This is a REAL, RUNNING
-  //            discharge as of `bb6e228` (ADR-0046): `make -C formal
-  //            components_pcloop` is a target, it is in CI's `components` job,
-  //            and it passes by k-induction in 2.7s. It was red and unrun
-  //            while this audit was in flight -- see ADR-0049 F2 for what that
-  //            looked like and why it went unnoticed, which is worth reading
-  //            before adding another assume whose discharge is a task nothing
-  //            invokes.
-  // SCOPE      the whole task -- LARGER than what it was written for.
-  //            ADR-0017 analysed its effect on the pc-increment pair; it is
-  //            also in force over the bubble, hazard, `one_of`, trap-cause and
-  //            trap-arm assertions below, all of which were written after it.
-  //            None of those reason about `in.pc`, so the widening is inert
-  //            today; it is recorded so that an assertion added later that
-  //            DOES read `in.pc` is not silently handed a fetcher it never
-  //            asked for.
+  // Assumes the fetcher echoes this module's own pc, which it does
+  // combinationally in rtl/fetcher.v. Discharged by formal/pcloop.sv, which
+  // instantiates the real fetcher and asserts the echo instead; that task is on
+  // CI. In force over the whole task, wider than the pc-increment pair it was
+  // written for -- inert only because nothing else below reads `in.pc`.
   always_comb assume(in.pc == pc);
 
-  // pc increment logic. Skipped for a cycle whose *previous* cycle was
-  // stalled (the PC held instead of advancing by pc_inc that edge — checked
-  // separately below) or reset (pc is forced to 0 on reset, not advanced by
-  // pc_inc from wherever it was). Every "previous cycle" signal here
-  // (branch_jump, past_pc, prev_stall, prev_reset, prev_uncompressed) is
-  // deliberately its own directly-registered copy of a real (reset-gated)
-  // signal rather than routed through $past() on a free input (in.pc/instr
-  // are unconstrained beyond the in.pc == pc assumption above) — $past()
-  // chained across another register adds an extra cycle of history the
-  // solver can fill with a pre-reset garbage value that this component
-  // proof, standing alone, has no way to rule out.
-  //
-  // `trap_pending` and `instr_mret` join the jumps and branches here because
-  // they are jumps: both override `pc` in the publish block above, so a cycle
-  // whose predecessor took one did not advance sequentially. That is the same
-  // exclusion the six branches get, for the same reason, and forgetting it is
-  // how "a trap is a branch" stops being true in the proof while staying true
-  // in the RTL.
+  // Every "previous cycle" signal below is its own registered copy rather than a
+  // $past() on a free input: $past() chained across another register adds a cycle
+  // of history the solver can fill with a pre-reset value this standalone proof
+  // cannot rule out. `trap_pending` and `instr_mret` belong in `branch_jump`
+  // because both override `pc` -- forgetting either is how "a trap is a branch"
+  // stops being true in the proof while staying true in the RTL.
   logic branch_jump;
   always_ff @(posedge clk) if (reset) branch_jump <= 1'b0;
     else branch_jump <= instr_jal || instr_jalr || instr_beq || instr_bne || instr_blt || instr_bltu || instr_bge || instr_bgeu || trap_pending || instr_mret;
@@ -1180,15 +743,12 @@ module decoder (
   always_ff @(posedge clk) if(clocked && !branch_jump && !prev_stall && !prev_reset && prev_uncompressed) assert(past_pc + 4 == pc);
   always_ff @(posedge clk) if(clocked && !branch_jump && !prev_stall && !prev_reset && !prev_uncompressed) assert(past_pc + 2 == pc);
 
-  // ADR-0009: a stalled cycle never advances pc.
   always_ff @(posedge clk) if (clocked && prev_stall && !prev_reset) assert(pc == past_pc);
 
-  // ADR-0060: a steal and a divider/accessor freeze on the same cycle hold
-  // decoder_out; a steal on its own bubbles it. Both directions are asserted,
-  // because the publish block's arm order is all that decides which happens and
-  // each failure is silent -- bubbling on the coincidence drops an instruction
-  // nothing downstream has consumed, and holding on a plain steal republishes
-  // one the executor reads every cycle.
+  // Both directions of ADR-0060's ruling, because the publish block's arm order
+  // is all that decides which happens and each failure is silent: bubbling on
+  // the coincidence drops an unconsumed instruction, holding on a plain steal
+  // republishes one the executor reads every cycle.
   decoder_output past_out;
   logic prev_hold_and_steal, prev_steal_only;
   always_ff @(posedge clk) begin
@@ -1199,71 +759,45 @@ module decoder (
   always_comb if (clocked && !prev_reset && prev_hold_and_steal) assert(out == past_out);
   always_comb if (clocked && !prev_reset && prev_steal_only)     assert(out == '0);
 
-  // ADR-0054: the contract the instruction memory rests on -- what this module
-  // publishes as `next_pc` in cycle N is what `pc` holds in cycle N+1. One
-  // flip-flop away from a tautology today, and that is exactly the point: it is
-  // what fails if a later edit gives `pc` a second driver, which is the shape
-  // the redirect chain had before it was lifted out of the publish block. A
-  // second driver would put the memory one cycle out of step with decode with
-  // no other symptom than wrong instructions.
+  // A tautology one flip-flop wide, which is the point: it is what fails if a
+  // later edit gives `pc` a second driver, and that would put the instruction
+  // memory a cycle out of step with decode with no symptom but wrong
+  // instructions (ADR-0054).
   logic [31:0] past_next_pc;
   always_ff @(posedge clk) past_next_pc <= next_pc;
   always_comb if (clocked) assert(pc == past_next_pc);
 
-  // ADR-0004: valid == 0 implies out.rd == 0 (a bubble is fully
-  // zeroed, never a partial one that could sneak a spurious rd through).
-  // Gated on `clocked`: before the first clock edge applies `reset`, `out`
-  // is a free, uninitialized register as far as the solver is concerned, so
-  // the property only holds once the design has actually been reset.
+  // A bubble is fully zeroed, never a partial one that could sneak an rd
+  // through.
   always_comb if (clocked && !out.valid) assert(out.rd == 0);
 
-  // ADR-0004: rs1 == 0 / rs2 == 0 never cause a stall — x0 has no
-  // producer to wait on (write-through already special-cases it to 0).
   always_comb if (rs1 == 0) assert(!hazard_rs1);
   always_comb if (rs2 == 0) assert(!hazard_rs2);
 
   logic one_of;
-  // Use $onehot() so pairwise overlaps (even count of flags) are detected rather than
-  // cancelling out as they would with XOR.
+  // $onehot() rather than XOR, so a pairwise overlap is detected instead of
+  // cancelling out.
   assign one_of = $onehot({instr_auipc, instr_jal, instr_jalr, instr_beq, instr_bne, instr_blt,
     instr_bltu, instr_bge, instr_bgeu, instr_add, instr_sub, instr_xor, instr_or, instr_and,
     instr_mul, instr_mulh, instr_mulhu, instr_mulhsu, instr_div, instr_divu, instr_rem,
     instr_remu, instr_sll, instr_slt, instr_sltu, instr_srl, instr_sra, instr_lui, instr_lb,
     instr_lbu, instr_lh, instr_lhu, instr_lw, instr_sb, instr_sh, instr_sw, instr_ecall,
-    // The three Zicsr forms join the list rather than being exempted from
-    // it: `instr_valid` now admits a CSR access (when csr_implemented, a
-    // free input in this standalone task), so leaving them out would make
-    // the assertion below fail on every legal `csrr`. Listed separately, not
-    // folded into one term, so a decode change that made two of them true at
-    // once would still be caught -- they are distinguished only by funct3.
+    // Every encoding `instr_valid` admits has to appear here, and the forms that
+    // differ only in funct3 or funct12 stay listed one per term, so a decode
+    // change that made two of them true at once is still caught.
     instr_ebreak, instr_csrrw, instr_csrrs, instr_csrrc,
-    // The four M3 additions. `mret` and `wfi` are SYSTEM/funct3==0 forms told
-    // apart from ecall/ebreak (and from each other) by funct12 alone; `fence`
-    // and `fence.i` are MISC-MEM and differ only in funct3. All four are now
-    // in `instr_valid`, so omitting them here would fail this assertion on
-    // every legal one of them -- which is exactly what makes the omission
-    // catchable rather than silent.
     instr_mret, instr_wfi, instr_fence, instr_fencei});
 
-  // we should only get one type of instruction
   always_comb if (instr_valid) assert(one_of);
 
-  // ---- ADR-0030: the trap causes, and why the priority encoder is vacuous --
-  //
-  // The disjointness argument written out as an assertion, which is what keeps
-  // the ADR honest as the core grows: an illegal instruction has no memory
-  // operand (`instr_valid` is what admits a load or a store in the first
-  // place, and `csr_readonly_write` is a SYSTEM encoding), `ecall`/`ebreak`
-  // differ in funct12 and are neither LOAD nor STORE, and a load and a store
-  // are different opcodes in both the 32-bit and the compressed forms. Add a
-  // sixth cause that overlaps an existing one and this fails rather than the
-  // behaviour quietly becoming whatever the encoder happened to produce.
+  // What makes the trap-cause encoder above safe to leave un-parallel_case'd.
+  // Add a sixth cause that overlaps an existing one and this fails, rather than
+  // the behaviour quietly becoming whatever the encoder produced.
   always_comb assert($onehot0({instr_illegal, instr_ebreak, instr_ecall,
                                load_misaligned, store_misaligned}));
 
-  // ...and the committed cause is the one ADR-0030's order names. Written per
-  // cause rather than as a restatement of the case statement, so a reordering
-  // of the arms is caught rather than mirrored.
+  // Written per cause rather than as a restatement of the case statement, so a
+  // reordering of the arms is caught rather than mirrored.
   always_comb if (instr_illegal)    assert(trap_cause == CAUSE_ILLEGAL_INSTRUCTION);
   always_comb if (instr_ebreak)     assert(trap_cause == CAUSE_BREAKPOINT);
   always_comb if (instr_ecall)      assert(trap_cause == CAUSE_ECALL_M);
@@ -1271,11 +805,8 @@ module decoder (
   always_comb if (store_misaligned) assert(trap_cause == CAUSE_STORE_MISALIGNED);
   always_comb if (!trap_pending)    assert(trap_cause == 32'b0);
 
-  // ---- ADR-0028: what a trapping retire is allowed to have done ------------
-  // `mtvec`/`mepc` are free inputs in this standalone task (rtl/csrs.v is not
-  // instantiated), so these are registered copies rather than reads of the
-  // live input -- the same technique the pc-increment history above uses, and
-  // for the same reason.
+  // `mtvec`/`mepc` are free inputs here, so these are registered copies rather
+  // than reads of the live input.
   logic        prev_trap_entry, prev_mret_entry;
   logic [31:0] prev_mtvec, prev_mepc;
   always_ff @(posedge clk) begin
@@ -1285,30 +816,21 @@ module decoder (
     prev_mepc       <= mepc;
   end
 
-  // The redirect actually happened, and it went to mtvec -- which is the one
-  // thing ADR-0028 records that NO check on the riscv-formal ladder can see:
+  // That the redirect went to mtvec is something no ladder check can see:
   // `rvfi_insn_check` drops every value assertion under `spec_trap`, and
-  // pc_fwd/pc_bwd are satisfied by any target so long as it is honestly
-  // reported. This is the check that says it must be `mtvec`.
+  // pc_fwd/pc_bwd accept any target that is honestly reported.
   always_comb if (clocked && !prev_reset && prev_trap_entry) assert(pc == prev_mtvec);
   always_comb if (clocked && !prev_reset && prev_mret_entry) assert(pc == prev_mepc);
 
-  // A trapping instruction writes no register and issues no memory access. The
-  // executor and accessor read these flags off `out`, so clearing them here is
-  // the whole mechanism -- there is no downstream kill signal and CLAUDE.md
-  // invariant 1 forbids adding one.
   always_comb if (clocked && !prev_reset && prev_trap_entry) begin
     assert(out.rd == 5'b0);
     assert(!out.is_lb && !out.is_lbu && !out.is_lh && !out.is_lhu && !out.is_lw);
     assert(!out.is_sb && !out.is_sh && !out.is_sw);
   end
 
-  // ADR-0027: a trapping issue does not increment minstret, and does not
-  // commit a CSR write either. Both fall out of `committing`, asserted here so
-  // that a future edit that re-gated one of them on `instr_valid` (the
-  // pre-M3 spelling, which is weaker) fails.
+  // Asserted so that an edit re-gating either on `instr_valid` -- the weaker
+  // pre-M3 spelling -- fails (ADR-0027).
   always_comb if (trap_pending) assert(!instret && !csr_wen && !csr_ren);
-  // A trap and an mret are different instructions; nothing may commit both.
   always_comb assert(!(trap_entry && mret_entry));
  `endif
 endmodule

--- a/rtl/imemory.v
+++ b/rtl/imemory.v
@@ -1,17 +1,23 @@
 `timescale 1 ns / 1 ps
 `default_nettype none
-// A ROM in block RAM, banked by *word* parity so ADR-0003's two-word fetch
-// window comes out of one copy. ADR-0044 names the technique at halfword
-// granularity, which suits a memory that windows the 32 bits itself; this core
-// windows them in rtl/fetcher.v, so halfword banks would need two reads a bank.
+// A ROM in block RAM. Fetch asks for two neighbouring words every cycle, so an
+// instruction sitting across a word boundary costs nothing extra. Two banks
+// split by word parity serve both from one copy of the ROM: neighbouring words
+// are always in different banks, so each bank supplies one of them.
 //
-// Block RAM rather than `SB_SPRAM256KA` because SPRAM has no INIT capability, so
-// a ROM there would need an SPI-flash boot path. BRAM's 15 KB ceiling is
-// therefore the ceiling on program size (ADR-0054).
+// Splitting by halfword would suit a memory that picks the 32 bits out itself.
+// rtl/fetcher.v does that part, and asks for whole words, so halfword banks
+// would mean two reads from each bank instead of one.
 //
-// The read is synchronous, so the address register is loaded with the *next*
-// fetch address, in lockstep with the PC. That is what keeps invariant 1 true on
-// a part with no combinational-read memory; `formal/pcloop.sv` asserts it.
+// Block RAM rather than `SB_SPRAM256KA` because SPRAM cannot be filled from the
+// bitstream. A ROM there could only be written by code already running. So the
+// block RAM on the part is the limit on how big a program can be.
+//
+// The read takes a cycle. So the address register is loaded with the address
+// fetch wants *next*, on the same edge the PC moves to it. Decode still sees the
+// instruction at `pc` in the cycle it works out where to go next. If those two
+// ever slip apart, every instruction the core runs is the wrong one, and nothing
+// else would show it -- `formal/pcloop.sv` checks it.
 module imemory #(
   // Must be even, and each bank a whole number of `SB_RAM40_4K` depths (256
   // words), or the mapping picks up leftover logic.
@@ -70,8 +76,8 @@ module imemory #(
   assign data_odd   = data_word[0];
   assign text_range = data_word < 30'(ROM_WORDS);
 
-  // A store steals as well as a load: it holds the write port, and a fetch read
-  // of the word being written is a collision the part does not define.
+  // A store takes the port too, not just a load. Reading a word while it is
+  // being written gives an answer the part does not define.
   logic text_access, text_write_even, text_write_odd;
   assign text_access     = (mem_ren || |mem_wstrb) && text_range;
   assign text_write_even = |mem_wstrb && text_range && !data_odd;
@@ -81,18 +87,19 @@ module imemory #(
   assign even_raddr = text_access ? data_index : even_index;
   assign odd_raddr  = text_access ? data_index : odd_index;
 
-  // Out of range reads as zero, which decodes to an illegal instruction, so a
-  // wild PC faults instead of aliasing back into the ROM through truncation.
+  // Out of range reads as zero. Zero is an illegal instruction, so a PC that
+  // runs off the end traps instead of wrapping round and reading real code.
   //
-  // Keep `in_range2` as `< ROM_WORDS - 1` rather than `word + 1 < ROM_WORDS`.
-  // The address arriving here is the freshly computed next PC, so an incrementer
-  // in front of the comparator puts a second carry chain in series with the one
-  // that produced it -- `make soc-timing`'s first run found exactly that at the
-  // end of the critical path. It also faults both words at the top of the
-  // address space, where `word + 1` wraps and answers from word 0.
+  // Keep `in_range2` as `< ROM_WORDS - 1`. Written the obvious way, `word + 1 <
+  // ROM_WORDS`, the adder sits in front of the comparator -- and the address
+  // arriving here is the next PC, which was itself just computed by an adder.
+  // That puts two carry chains in a row on the longest path in the design.
+  // `make soc-timing`'s first run found exactly that. The form here also handles
+  // the top of the address space, where `word + 1` wraps round to 0 and would
+  // read word 0 back.
   //
-  // The unconditional read plus a separately addressed write is the shape yosys
-  // maps to an EBR's own two ports.
+  // Read every cycle, with the write on its own address: that is the shape yosys
+  // turns into a block RAM's two ports.
   logic [31:0] even_data, odd_data;
   logic        odd_first, in_range, in_range2;
   logic        data_hit, data_hit_odd;

--- a/rtl/imemory.v
+++ b/rtl/imemory.v
@@ -1,90 +1,43 @@
 `timescale 1 ns / 1 ps
 `default_nettype none
-// The instruction memory: two interleaved banks of 32-bit words, read
-// synchronously off the fetch address published one cycle early (ADR-0054).
-// The data bus reaches it too, through the banks' own write port and by
-// borrowing their read port for a cycle.
+// A ROM in block RAM, banked by *word* parity so ADR-0003's two-word fetch
+// window comes out of one copy. ADR-0044 names the technique at halfword
+// granularity, which suits a memory that windows the 32 bits itself; this core
+// windows them in rtl/fetcher.v, so halfword banks would need two reads a bank.
 //
-// It is a ROM in BLOCK RAM, and both halves of that are decisions
-// (ADR-0054 §"ROM in BRAM"). `SB_SPRAM256KA` is the only large memory on this
-// part and it has NO INIT capability at all, so a ROM there needs a runtime
-// boot path copying from external SPI flash -- a different product. BRAM is
-// initialisable from the bitstream, and its 15 KB ceiling is therefore the
-// ceiling on program size.
+// Block RAM rather than `SB_SPRAM256KA` because SPRAM has no INIT capability, so
+// a ROM there would need an SPI-flash boot path. BRAM's 15 KB ceiling is
+// therefore the ceiling on program size (ADR-0054).
 //
-// ---- why two banks, and why they are 32 bits wide and not 16 --------------
-//
-// ADR-0003's fetch window reads the word at `pc` AND the word after it, every
-// cycle, so a 32-bit instruction straddling a 4-byte boundary costs nothing.
-// The previous placeholder got the second word by instantiating the whole ROM
-// TWICE (rtl/littlesoc.v), which doubles storage to add a port and is most of
-// the 43 KB overage ADR-0044 measured.
-//
-// Banking replaces the duplication: consecutive words live in different banks,
-// so `word W` and `word W+1` are always one read from each. Storage is the ROM
-// size, once.
-//
-// ADR-0044 names this technique at 16-BIT granularity -- even halfwords in one
-// bank, odd in the other. That is the right split for a memory that returns the
-// 32-bit window itself. This core's fetch interface asks for two adjacent
-// WORDS and does its own windowing (rtl/fetcher.v), so the parity that matters
-// here is word parity, and 16-bit banks would need two reads from each bank
-// rather than one -- duplication again, one level down. Word-granularity
-// interleaving is the same technique against the interface this core actually
-// has, and it is also the one that leaves `imem_data`/`imem_data2` meaning
-// exactly what `formal/imemcheck.sv` checks them to mean.
-//
-// ---- why the address arrives a cycle early --------------------------------
-//
-// There is no combinational-read memory primitive on this part (ADR-0044), and
-// invariant 1 requires decode to see the instruction at `pc` in the same cycle
-// it decides the next one. So the address register is loaded with the NEXT
-// fetch address at every posedge, in lockstep with the PC itself: during the
-// cycle in which `imem_addr` names a word, this module's registered outputs
-// already hold it. `formal/pcloop.sv` asserts that lockstep rather than
-// leaving it to be read off two files.
+// The read is synchronous, so the address register is loaded with the *next*
+// fetch address, in lockstep with the PC. That is what keeps invariant 1 true on
+// a part with no combinational-read memory; `formal/pcloop.sv` asserts it.
 module imemory #(
-  // Total 32-bit words of ROM. Split evenly across the two banks below, so
-  // this must be even and each bank must be a whole number of `SB_RAM40_4K`
-  // depths (256 words) for the mapping to be free of leftover logic.
-  //
-  // 2048 words = 8 KB = 16 EBRs, which with rtl/regfile.v's 4 leaves 10 of the
-  // part's 30 spare. See ADR-0054 for what that ceiling costs: it holds 55 of
-  // this repo's 56 test programs, and `test/asm/rvc.S` (12,232 bytes, almost
-  // all of it `.skip` padding for a page-boundary straddle) is the one it does
-  // not. test/testbench.v overrides it, because simulation has no EBRs.
+  // Must be even, and each bank a whole number of `SB_RAM40_4K` depths (256
+  // words), or the mapping picks up leftover logic.
   parameter integer ROM_WORDS = 2048,
-  // Bank image files, in `$readmemh` format: even-indexed words in the first,
-  // odd-indexed in the second. Two files rather than one plus a de-interleaving
-  // loop, because a loop copying between arrays in an `initial` block is not
-  // something yosys turns into memory init -- it would elaborate and then
-  // synthesise to an empty ROM. soc/rom_banks.py writes the pair.
+  // Two files rather than one plus a de-interleaving loop: yosys does not turn a
+  // loop copying between arrays in an `initial` block into memory init, so that
+  // would elaborate and then synthesise to an empty ROM.
   parameter INIT_EVEN = "",
   parameter INIT_ODD  = ""
 ) (
   input  logic        clk,
-  // ADR-0054: the word address rtl/fetcher.v will present as `imem_addr` on
-  // the NEXT edge. This module latches it, so its outputs answer that cycle.
   input  logic [31:0] imem_addr_next,
   output logic [31:0] imem_data,
   output logic [31:0] imem_data2,
-  // The data bus, so text is readable and writable from a store or a load.
-  // The range decode and the arbitration between the two buses live here
-  // rather than in each consumer: rtl/littlesoc.v and test/testbench.v run
-  // different `ROM_WORDS`, so a range test written outside this module would
-  // put the two legs on different maps.
+  // The range decode lives here because rtl/littlesoc.v and test/testbench.v run
+  // different `ROM_WORDS`, so a range test written outside this module would put
+  // the two legs on different maps.
   input  logic [31:0] mem_addr,
   input  logic [31:0] mem_wdata,
   input  logic [3:0]  mem_wstrb,
-  // High on the cycle a load's request is on the bus. The idle bus presents
-  // address 0, which is inside the text range, so without it every idle cycle
-  // would steal a fetch.
+  // The idle bus presents address 0, which is inside the text range, so without
+  // this every idle cycle would steal a fetch.
   input  logic        mem_ren,
-  // Zero unless the previous cycle was a text-range load, so a consumer can
-  // OR this with the data RAM's answer.
+  // Zero unless the previous cycle was a text-range load, so a consumer can OR
+  // this with the data RAM's answer.
   output logic [31:0] mem_rdata,
-  // High for the cycle whose fetch window was taken by a data access. The
-  // fetch that lost the read port has to be repeated.
   output logic        fetch_stall
 );
   localparam int BANK_WORDS = ROM_WORDS / 2;
@@ -92,19 +45,13 @@ module imemory #(
 
   logic [31:0] rom_even[0:BANK_WORDS-1];
   logic [31:0] rom_odd [0:BANK_WORDS-1];
-  // Guarded, so a consumer that fills the banks some other way -- the cxxrtl
-  // runner pokes them through `debug_items` -- can leave the pair empty rather
-  // than pointing at a file that has to exist. `$readmemh("")` is an error, not
-  // a no-op, in both frontends.
+  // Guarded because `$readmemh("")` is an error rather than a no-op in both
+  // frontends, and the cxxrtl runner fills the banks through `debug_items`.
   generate if (INIT_EVEN != "") begin : l_rom_init
     initial $readmemh(INIT_EVEN, rom_even);
     initial $readmemh(INIT_ODD,  rom_odd);
   end endgenerate
 
-  // Word index W of the next fetch, and the two bank indices it selects.
-  // Word W lives in bank W[0] at index W >> 1; word W+1 lives in the other
-  // bank, at the SAME index if W is even and at one past it if W is odd.
-  // That "+ W[0]" is the entire cost of banking.
   logic [29:0]          next_word;
   logic [BANK_BITS:0]   word_index;
   logic [BANK_BITS-1:0] even_index, odd_index;
@@ -113,13 +60,8 @@ module imemory #(
   assign odd_index  = word_index[BANK_BITS:1];
   assign even_index = odd_index + {{(BANK_BITS-1){1'b0}}, word_index[0]};
 
-  // The data side. One word, so it needs one bank -- the one its word parity
-  // names -- at the index that parity strips off.
-  //
-  // The range test is the same shape as the fetch one below: a word index
-  // against a constant, with no adder in front of it. `mem_addr` is
-  // word-aligned for every load and store (rtl/accessor.v), so the low two
-  // bits carry nothing the byte strobes do not.
+  // The low two bits are dropped because rtl/accessor.v word-aligns every load
+  // and store, so they carry nothing the byte strobes do not.
   logic [29:0]          data_word;
   logic [BANK_BITS-1:0] data_index;
   logic                 data_odd, text_range;
@@ -128,11 +70,8 @@ module imemory #(
   assign data_odd   = data_word[0];
   assign text_range = data_word < 30'(ROM_WORDS);
 
-  // The steal. A text access takes the banks' single read port for the edge,
-  // so the fetch presented that cycle is answered with the data word instead
-  // and has to be repeated -- `fetch_stall` below says so. A store steals too:
-  // it holds the write port, and a fetch read of the word being written is a
-  // collision the part does not define.
+  // A store steals as well as a load: it holds the write port, and a fetch read
+  // of the word being written is a collision the part does not define.
   logic text_access, text_write_even, text_write_odd;
   assign text_access     = (mem_ren || |mem_wstrb) && text_range;
   assign text_write_even = |mem_wstrb && text_range && !data_odd;
@@ -143,27 +82,17 @@ module imemory #(
   assign odd_raddr  = text_access ? data_index : odd_index;
 
   // Out of range reads as zero, which decodes to an illegal instruction, so a
-  // wild PC faults instead of silently aliasing back into the ROM through bit
-  // truncation. Both words are tested: the last word of ROM is in range while
-  // the word after it is not. Registered alongside the data they mask, because
-  // the address they are computed from is a cycle ahead of it.
+  // wild PC faults instead of aliasing back into the ROM through truncation.
   //
-  // BOTH TESTS ARE ON THE WORD INDEX, and the second is `< ROM_WORDS - 1`
-  // rather than `word + 1 < ROM_WORDS`. That is a timing decision, measured:
-  // the address arriving here is the freshly computed next PC, so an
-  // incrementer in front of the comparator puts a second 32-bit carry chain in
-  // series with the one that produced it -- and `make soc-timing`'s first run
-  // found exactly that chain at the END of the critical path. Comparing against
-  // a constant one lower is the same predicate with no adder.
+  // Keep `in_range2` as `< ROM_WORDS - 1` rather than `word + 1 < ROM_WORDS`.
+  // The address arriving here is the freshly computed next PC, so an incrementer
+  // in front of the comparator puts a second carry chain in series with the one
+  // that produced it -- `make soc-timing`'s first run found exactly that at the
+  // end of the critical path. It also faults both words at the top of the
+  // address space, where `word + 1` wraps and answers from word 0.
   //
-  // It also removes a corner: `word + 1` wraps at the top of the address space,
-  // so the old form called the second word of a fetch at 0xfffffffc "in range"
-  // and answered it from word 0. This form faults both words there.
-  //
-  // The read below is unconditional and the write is a second, separately
-  // addressed port: that is the shape yosys maps to an EBR's own read and write
-  // ports. Both buses are answered from these registers, so a data read arrives
-  // a cycle after its address the same way a fetch does.
+  // The unconditional read plus a separately addressed write is the shape yosys
+  // maps to an EBR's own two ports.
   logic [31:0] even_data, odd_data;
   logic        odd_first, in_range, in_range2;
   logic        data_hit, data_hit_odd;
@@ -198,7 +127,5 @@ module imemory #(
   assign imem_data  = in_range  ? window_lo : 32'b0;
   assign imem_data2 = in_range2 ? window_hi : 32'b0;
 
-  // Zero out of range, and zero on the cycle after a store, so a consumer can
-  // OR this with the data RAM's `mem_rdata` instead of decoding the map twice.
   assign mem_rdata = data_hit ? (data_hit_odd ? odd_data : even_data) : 32'b0;
 endmodule

--- a/rtl/littlecpu.v
+++ b/rtl/littlecpu.v
@@ -8,13 +8,16 @@ module littlecpu(
   input  logic [31:0] imem_data,
   output logic [31:0] imem_addr2,
   input  logic [31:0] imem_data2,
-  // The value `imem_addr` takes on the next edge, so a synchronous memory can
-  // latch it early (ADR-0054). A combinational one -- test benches,
-  // formal/wrapper.v -- leaves it unread and drives `imem_data` off `imem_addr`.
+  // The value `imem_addr` takes on the next edge. A synchronous memory latches
+  // this on the same edge the PC moves, so its data is ready for the whole of
+  // the cycle that needs it; a combinational memory -- test benches,
+  // formal/wrapper.v -- leaves it unread and answers `imem_addr` directly.
   output logic [31:0] imem_addr_next,
-  // The fetch and data buses share one address space and the instruction memory
-  // arbitrates between them (ADR-0059). A memory that cannot steal ties
-  // `fetch_stall` low and leaves `mem_ren` unread.
+  // The fetch and data buses share one address space, and the instruction
+  // memory arbitrates: a load or store to the text range takes the read port
+  // for that cycle and the fetch that lost it comes back as `fetch_stall`.
+  // A memory that keeps its two buses separate ties `fetch_stall` low and
+  // leaves `mem_ren` unread.
   output logic [31:0] mem_addr,
   output logic [31:0] mem_wdata,
   output logic [3:0]  mem_wstrb,
@@ -59,20 +62,22 @@ module littlecpu(
   output logic [31:0] rvfi_csr_mscratch_wdata
   `endif //  `ifdef RISCV_FORMAL
   );
-  // Declared here rather than beside their producers: the pipeline's feedback
-  // paths mean each is read by a module instantiated above the one that drives
-  // it, and iverilog requires declare-before-use.
+  // Declared up here rather than next to the module that drives each one. Later
+  // stages feed signals back to earlier ones, so each of these is read by a
+  // module written above its driver, and iverilog wants the name first.
   decoder_output decoder_out;
   executor_output executor_out;
   logic divider_stalled, accessor_stalled;
   logic       accessor_pending_valid;
   logic [4:0] accessor_pending_rd;
-  // The serialization drain predicate has to see a *store* in the accessor,
-  // which `accessor_pending_valid` (loads only) cannot show it (ADR-0026).
+  // `accessor_pending_valid` only goes high for loads. The decoder needs this as
+  // well, so it can tell a store is still in the accessor before it lets a CSR
+  // access issue.
   logic accessor_out_valid;
-  // A one-cycle pulse, not a level. Its consumer is ADR-0029's harness check: a
-  // trap taken with mtvec == 0 is a silent restart at `_start`, because
-  // test/asm/sections.lds links .text at 0.
+  // High for one cycle per trap, not a level. The test benches watch it to catch
+  // a trap taken before the handler address is installed: mtvec resets to 0 and
+  // test/asm/sections.lds links .text at 0, so such a trap restarts the program
+  // silently and would otherwise look like a timeout.
   logic decoder_trap_entry;
   assign trap = decoder_trap_entry;
   logic  [31:0] pc;
@@ -249,8 +254,9 @@ module littlecpu(
   );
 
  `ifdef RISCV_FORMAL
-  // Constants rather than per-retire data: M-mode only, XLEN=32, no interrupts
-  // and no halt are properties of the design, not of an instruction.
+  // These four never change. There is one privilege mode, registers are 32 bits
+  // wide, there are no interrupts and the core cannot be halted, so none of them
+  // depends on which instruction just finished.
   assign rvfi_halt = 1'b0;
   assign rvfi_intr = 1'b0;
   assign rvfi_mode = 2'd3;

--- a/rtl/littlecpu.v
+++ b/rtl/littlecpu.v
@@ -6,34 +6,15 @@ module littlecpu(
   input  logic reset,
   output logic [31:0] imem_addr,
   input  logic [31:0] imem_data,
-  // ADR-0003: the second word of the dual-word combinational fetch window,
-  // read at imem_addr + 4 so a 32-bit instruction straddling a 4-byte
-  // boundary (pc % 4 == 2) can be fetched in the same cycle -- no aligner
-  // FSM, no stall.
   output logic [31:0] imem_addr2,
   input  logic [31:0] imem_data2,
-  // ADR-0054: the value `imem_addr` will take on the next edge, published
-  // combinationally this cycle so a SYNCHRONOUS instruction memory can latch
-  // it and have `imem_data`/`imem_data2` ready for the whole of the cycle that
-  // needs them. Every memory primitive on the target part is synchronous
-  // (ADR-0044); this port is what keeps invariant 1 intact against that fact
-  // without a fetch buffer, a stall or a flush.
-  //
-  // A memory that is genuinely combinational (test benches, the formal
-  // environment) may leave it unread and drive `imem_data` off `imem_addr`
-  // directly -- which is exactly what formal/wrapper.v does, so the riscv-formal
-  // ladder sees this change as one extra, unread output port.
+  // The value `imem_addr` takes on the next edge, so a synchronous memory can
+  // latch it early (ADR-0054). A combinational one -- test benches,
+  // formal/wrapper.v -- leaves it unread and drives `imem_data` off `imem_addr`.
   output logic [31:0] imem_addr_next,
-  // ADR-0059: the fetch and data buses share one address space and the
-  // instruction memory owns the arbitration between them. `mem_ren` is what
-  // tells a real load from the idle bus, which presents address 0 -- inside the
-  // text range, so without it every idle cycle would steal a fetch.
-  // `fetch_stall` comes back high for the cycle whose fetch window a data
-  // access took, and is the sixth stall reason (CLAUDE.md invariant 8).
-  //
-  // A memory that cannot steal -- the formal environments answer `imem_data`
-  // freely, and any Harvard consumer -- ties `fetch_stall` low and leaves
-  // `mem_ren` unread.
+  // The fetch and data buses share one address space and the instruction memory
+  // arbitrates between them (ADR-0059). A memory that cannot steal ties
+  // `fetch_stall` low and leaves `mem_ren` unread.
   output logic [31:0] mem_addr,
   output logic [31:0] mem_wdata,
   output logic [3:0]  mem_wstrb,
@@ -78,56 +59,32 @@ module littlecpu(
   output logic [31:0] rvfi_csr_mscratch_wdata
   `endif //  `ifdef RISCV_FORMAL
   );
-  // Declared here (ahead of the decoder instantiation below) because the trap
-  // assignment below references it; iverilog requires declare-before-use.
+  // Declared here rather than beside their producers: the pipeline's feedback
+  // paths mean each is read by a module instantiated above the one that drives
+  // it, and iverilog requires declare-before-use.
   decoder_output decoder_out;
-  // Declared here, ahead of the decoder/executor/accessor instantiations,
-  // because decoder's scoreboard reads executor_out and accessor's pending
-  // load, executor's stalled output feeds decoder's divider_stall, and
-  // accessor's stalled output feeds both decoder's accessor_stall and
-  // executor's accessor_stall (ADR-0004/ADR-0009); iverilog requires
-  // declare-before-use.
   executor_output executor_out;
   logic divider_stalled, accessor_stalled;
   logic       accessor_pending_valid;
   logic [4:0] accessor_pending_rd;
-  // ADR-0026: the CSR serialization drain predicate needs to see a *store*
-  // in the accessor, which accessor_pending_valid (loads only) cannot show
-  // it. accessor_out is declared further down, next to its instantiation, so
-  // this carries its valid bit up to the decoder's port list.
+  // The serialization drain predicate has to see a *store* in the accessor,
+  // which `accessor_pending_valid` (loads only) cannot show it (ADR-0026).
   logic accessor_out_valid;
-  // ADR-0028: `trap` is redefined, not deleted -- it is now a one-cycle "trap
-  // entry committed this cycle" pulse, driven straight from the decode stage
-  // that commits it (CLAUDE.md invariant 2). It used to be a combinational OR
-  // of "the decoded instruction was unrecognised" with the accessor's
-  // POST-DECODE misalignment signal, and nothing consumed it. Both halves of
-  // that are gone: the accessor no longer detects misalignment (ADR-0011's
-  // debt, discharged in rtl/decoder.v), and an unrecognised instruction is now
-  // a real illegal-instruction trap rather than a silently suppressed one.
-  //
-  // It is kept rather than removed because deleting it would change the port
-  // list in formal/wrapper.v, formal/dmemcheck.sv, formal/imemcheck.sv,
-  // formal/cover.sv, formal/complete.sv and test/testbench.v for no functional
-  // gain -- and because ADR-0029's harness check (a trap taken with mtvec == 0
-  // is a silent restart at `_start`, since test/asm/sections.lds links .text
-  // at 0) needs exactly this signal.
+  // A one-cycle pulse, not a level. Its consumer is ADR-0029's harness check: a
+  // trap taken with mtvec == 0 is a silent restart at `_start`, because
+  // test/asm/sections.lds links .text at 0.
   logic decoder_trap_entry;
   assign trap = decoder_trap_entry;
   logic  [31:0] pc;
-  // ADR-0054: decode owns the PC, so decode is where the NEXT one is known.
-  // Declared here, ahead of both instantiations, because the fetcher reads it
-  // and the decoder drives it; iverilog requires declare-before-use.
   logic  [31:0] next_pc;
   fetcher_output fetcher_out;
   fetcher fetcher(
     .clk(clk),
     .reset(reset),
-    // inputs
     .pc(pc),
     .next_pc(next_pc),
     .imem_data(imem_data),
     .imem_data2(imem_data2),
-    // outputs
     .out(fetcher_out),
     .imem_addr(imem_addr),
     .imem_addr2(imem_addr2),
@@ -140,7 +97,6 @@ module littlecpu(
   logic        wen;
   regfile regfile(
     .clk(clk),
-    // from the decoder
     .rs1(rs1),
     .rs2(rs2),
     .reg_rs1(reg_rs1),
@@ -150,17 +106,11 @@ module littlecpu(
     .wdata(wdata)
   );
 
-  // ADR-0005: the CSR file is a sibling of the decoder, read and written in
-  // decode. Everything between them is combinational within the cycle the
-  // accessing instruction issues.
   logic [11:0] csr_addr;
   logic        csr_ren, csr_wen;
   logic [31:0] csr_wdata, csr_rdata;
   logic        csr_implemented;
   logic        csr_instret;
-  // ADR-0005 / ADR-0028: the trap-entry side of the same decode/CSR pair. The
-  // decoder detects and commits; the CSR file records mepc/mcause/mstatus and
-  // hands back the two registers the decoder redirects the PC through.
   logic        csr_trap_entry, csr_mret_entry;
   logic [31:0] csr_trap_cause, csr_trap_epc;
   logic [31:0] csr_mtvec, csr_mepc;
@@ -172,7 +122,6 @@ module littlecpu(
   decoder decoder(
     .clk(clk),
     .reset(reset),
-    // inputs
     .in(fetcher_out),
     .reg_rs1(reg_rs1),
     .reg_rs2(reg_rs2),
@@ -192,7 +141,6 @@ module littlecpu(
     .csr_rvfi_minstret(csr_rvfi_minstret),
     .csr_rvfi_mscratch(csr_rvfi_mscratch),
    `endif
-    // outputs
     .pc(pc),
     .next_pc(next_pc),
     .rs1(rs1),
@@ -212,7 +160,6 @@ module littlecpu(
   csrs csrs(
     .clk(clk),
     .reset(reset),
-    // inputs
     .addr(csr_addr),
     .ren(csr_ren),
     .wen(csr_wen),
@@ -222,7 +169,6 @@ module littlecpu(
     .trap_cause(csr_trap_cause),
     .trap_epc(csr_trap_epc),
     .mret_entry(csr_mret_entry),
-    // outputs
     .rdata(csr_rdata),
     .implemented(csr_implemented),
     .mtvec_value(csr_mtvec),
@@ -238,10 +184,8 @@ module littlecpu(
   executor executor(
     .clk(clk),
     .reset(reset),
-    // inputs
     .in(decoder_out),
     .accessor_stall(accessor_stalled),
-    // outputs
     .out(executor_out),
     .stalled(divider_stalled)
   );
@@ -251,9 +195,7 @@ module littlecpu(
   accessor accessor(
     .clk(clk),
     .reset(reset),
-    // inputs
     .in(executor_out),
-    // memory access
     .mem_addr(mem_addr),
     .mem_wstrb(mem_wstrb),
     .mem_wdata(mem_wdata),
@@ -262,16 +204,13 @@ module littlecpu(
     .stalled(accessor_stalled),
     .pending_valid(accessor_pending_valid),
     .pending_rd(accessor_pending_rd),
-    // forwards
     .out(accessor_out)
   );
 
   writeback writeback(
     .clk(clk),
     .reset(reset),
-    // inputs
     .in(accessor_out),
-    // outputs
     .wen(wen),
     .waddr(waddr),
     .wdata(wdata)
@@ -310,13 +249,8 @@ module littlecpu(
   );
 
  `ifdef RISCV_FORMAL
-  // The CSR fields are per-retire data (rtl/csrs.v, threaded through the shadow
-  // to rtl/writeback.v), and so is `rvfi_trap` now -- rtl/decoder.v computes it
-  // where every trap is committed (CLAUDE.md invariant 2) and rtl/writeback.v
-  // drives it at retire. These four are not per-retire data and stay constants:
-  // M-mode only / XLEN=32 / no interrupts (mie and mip are read-only zero) and
-  // no halt makes mode/ixl/intr/halt properties of the design rather than of an
-  // instruction.
+  // Constants rather than per-retire data: M-mode only, XLEN=32, no interrupts
+  // and no halt are properties of the design, not of an instruction.
   assign rvfi_halt = 1'b0;
   assign rvfi_intr = 1'b0;
   assign rvfi_mode = 2'd3;

--- a/rtl/littlesoc.v
+++ b/rtl/littlesoc.v
@@ -1,64 +1,30 @@
 `timescale 1 ns / 1 ps
 `default_nettype none
-// The SoC: the core, the two memories it talks to, a power-on reset, and two
-// LEDs. It PLACES on an up5k in an sg48 package, which is what makes the first
-// real timing measurement this project has ever had possible (ADR-0054).
+// The design that places, measured by `make soc-timing`. `make fit` measures
+// `littlecpu` with its memories external; the two numbers are separate on
+// purpose and must not be merged (ADR-0038).
 //
-// `make fit` does NOT synthesise this module and must not start: ADR-0038
-// decision 1 measures `littlecpu` with its memories external, because that is
-// the thing the core's own work changes. `make soc-timing` is this module's
-// measurement, and the two numbers are separate on purpose -- the SoC's
-// includes the ROM's depth mux, the RAM's range decode and the LED tap, none of
-// which are the core.
+// Nothing on either bus is ever refused -- out of range reads as zero -- which
+// is what keeps every trap in decode (invariant 2).
 //
-// ---- the memory map --------------------------------------------------------
-//
-// ADR-0008's addresses, unchanged: text from 0, RAM from RAM_BASE. The data
-// bus now reaches both -- a store into the text range writes it and a load
-// from it is answered by `imemory` -- so the two memories are one address
-// space, and `mem_rdata` is the OR of their two answers. Fetch still reaches
-// text only. Everything out of range on either bus reads as zero and no
-// access is ever refused, which is what keeps every trap in decode
-// (CLAUDE.md invariant 2).
-//
-// ---- what this cannot do yet, stated rather than discovered -----------------
-//
-// The ROM is initialised from the bitstream; the RAM CANNOT BE. `SB_SPRAM256KA`
-// has no INIT capability at all, so a program's `.data` is not there at
-// power-on. Every `.S` program in test/asm has a `.data` section, so a
-// bitstream built from one would run against zeroed data. Fixing that means a
-// copy stub in `.text` (a crt0 that copies an image linked into ROM) or the
-// SPI-flash boot path ADR-0044 describes; both are out of scope here and
-// ADR-0054 records the gap rather than leaving it to be found on hardware.
+// The ROM is initialised from the bitstream and the SPRAM cannot be, so a
+// program's `.data` is not there at power-on and every `.S` program in test/asm
+// has one. Running a real program needs a copy stub in `.text` or ADR-0044's
+// SPI-flash boot path.
 module littlesoc (
-  // 12 MHz on an iCEBreaker (ADR-0038 declares Fmax at 12 MHz as an INTENT;
-  // `make soc-timing` measures what the design actually closes at, and
-  // reconciling the two is a decision rather than a consequence).
   input  logic clk,
-  // Active-low user button. Held down, it resets the core.
   input  logic btn_n,
-  // Active-low LEDs. They exist because a design with no observable output is
-  // a design yosys is entitled to delete -- which is exactly what happened to
-  // the previous version of this module, and it reported 4 logic cells and 0%
-  // utilisation while doing it (ADR-0038's consequences). Both are passive taps
-  // on signals the core already drives; neither adds an MMIO region, so the
-  // memory map and the bus are unchanged (ADR-0044's `causal_io_ch0` /
-  // `bus_dmem_io_*` questions stay exactly where they were).
+  // A design with no observable output is one yosys deletes: the previous
+  // version of this module reported 4 logic cells and 0% utilisation while doing
+  // exactly that. These two are passive taps that reach every stage of the core,
+  // and neither adds an MMIO region.
   output logic ledr_n,
   output logic ledg_n
 );
-  // ---- power-on reset, and the button ---------------------------------------
-  // The FPGA comes out of configuration with no reset pulse of its own, and the
-  // core needs one: rtl/decoder.v only forces pc to 0 while `reset` is high.
-  // 16 cycles, counted once and then never again -- the counter saturates.
-  //
-  // `reset` IS REGISTERED, and that is a timing decision as much as a
-  // metastability one. `btn_n` arrives asynchronously, so the two-flop
-  // synchroniser below is the ordinary correctness requirement -- but it also
-  // keeps the pad out of the fabric's timing paths, and `make soc-timing`'s
-  // first run measured a critical path that STARTED at the `btn_n` pad and ran
-  // through reset's fanout into decode. 1.105 ns of pad delay plus four routing
-  // hops, on the longest path in the design, bought by a wire.
+  // The FPGA comes out of configuration with no reset pulse of its own.
+  // Registering `reset` is a timing decision as well as a metastability one:
+  // `make soc-timing`'s first run measured the design's longest path starting at
+  // the `btn_n` pad.
   logic [3:0] por_count = 4'b0;
   logic       por_done  = 1'b0;
   logic [1:0] btn_sync  = 2'b0;
@@ -72,7 +38,6 @@ module littlesoc (
     reset    <= !por_done || !btn_sync[1];
   end
 
-  // ---- the core ------------------------------------------------------------
   logic        trap;
   logic [31:0] mem_addr, mem_wdata, mem_rdata;
   logic [31:0] imem_mem_rdata, dmem_mem_rdata;
@@ -98,19 +63,11 @@ module littlesoc (
     .trap(trap)
   );
 
-  // ---- instruction ROM -----------------------------------------------------
-  // ONE instance, not two. The previous version of this module instantiated
-  // `imemory` TWICE to get ADR-0003's second fetch port, which doubles storage
-  // to add a port and was most of the 43 KB overage ADR-0044 measured; the
-  // banking inside rtl/imemory.v replaces it.
-  //
-  // `imem_addr`/`imem_addr2` are left unread here, deliberately: the ROM is
-  // synchronous, so it is addressed off `imem_addr_next` a cycle early
-  // (ADR-0054), and `imem_addr` is the same value one edge later. The two ports
-  // stay on the core because that is the bus the riscv-formal ladder speaks.
+  // `imem_addr`/`imem_addr2` are deliberately unread: the ROM is synchronous, so
+  // it is addressed off `imem_addr_next` a cycle early. Both ports stay on the
+  // core because that is the bus the riscv-formal ladder speaks.
   //
   // 2048 words = 8 KB = 16 EBRs of the part's 30, with rtl/regfile.v taking 4.
-  // See ADR-0054 for what that ceiling holds and what it does not.
   imemory #(
     .ROM_WORDS(2048),
     .INIT_EVEN("soc/rom_even.hex"),
@@ -128,7 +85,6 @@ module littlesoc (
     .fetch_stall(fetch_stall)
   );
 
-  // ---- data RAM ------------------------------------------------------------
   // 16384 words = 64 KB = two `SB_SPRAM256KA` of the part's four.
   memory #(.BASE(32'h0001_0000), .RAM_WORDS(16384)) dmem (
     .clk(clk),
@@ -138,19 +94,12 @@ module littlesoc (
     .mem_rdata(dmem_mem_rdata)
   );
 
-  // Both memories answer zero outside their own range, so the two buses join
-  // with an OR rather than a select -- one less level on the data path. The
-  // ranges do not overlap, and a store leaves the RAM's registered read data
-  // unchanged (rtl/memory.v) while the ROM answers zero, so the OR can never
-  // mix two live values.
+  // An OR rather than a select, one less level on the data path. The ranges do
+  // not overlap, and a store leaves the RAM's registered read data unchanged
+  // (rtl/memory.v) while the ROM answers zero, so this cannot mix two live
+  // values.
   assign mem_rdata = imem_mem_rdata | dmem_mem_rdata;
 
-  // ---- the two observable bits --------------------------------------------
-  // A tap on the store bus and a sticky trap flag. Between them they keep every
-  // stage of the core reachable from an output pin, which is what stops
-  // synthesis from deleting it: a store's data comes from the register file,
-  // which comes from writeback, which comes from loads and the executor, which
-  // come from decode, which comes from the fetch window.
   logic store_bit, trap_seen;
   always_ff @(posedge clk) begin
     if (reset) begin

--- a/rtl/littlesoc.v
+++ b/rtl/littlesoc.v
@@ -1,30 +1,32 @@
 `timescale 1 ns / 1 ps
 `default_nettype none
-// The design that places, measured by `make soc-timing`. `make fit` measures
-// `littlecpu` with its memories external; the two numbers are separate on
-// purpose and must not be merged (ADR-0038).
+// The whole chip: core, both memories, four pins. `make soc-timing` measures
+// this. `make fit` measures the core on its own with the memories outside it, so
+// its cell count is a different design's and the two do not compare.
 //
-// Nothing on either bus is ever refused -- out of range reads as zero -- which
-// is what keeps every trap in decode (invariant 2).
+// Neither memory can turn an access down. Anything out of range reads as zero.
+// So no memory error can turn up after decode has already let an instruction
+// through, and there is no path for one to come back on if it did.
 //
 // The ROM is initialised from the bitstream and the SPRAM cannot be, so a
 // program's `.data` is not there at power-on and every `.S` program in test/asm
-// has one. Running a real program needs a copy stub in `.text` or ADR-0044's
-// SPI-flash boot path.
+// has one. Running a real program needs a stub in `.text` that copies the data
+// image out of ROM, or a boot path that reads it from external SPI flash.
 module littlesoc (
   input  logic clk,
   input  logic btn_n,
-  // A design with no observable output is one yosys deletes: the previous
-  // version of this module reported 4 logic cells and 0% utilisation while doing
-  // exactly that. These two are passive taps that reach every stage of the core,
-  // and neither adds an MMIO region.
+  // Give yosys a design whose output nothing can see and it deletes the lot. An
+  // earlier version of this module did exactly that and reported 4 logic cells.
+  // These two only watch signals the core already drives, so they add no
+  // registers to the memory map and change nothing about how it runs.
   output logic ledr_n,
   output logic ledg_n
 );
-  // The FPGA comes out of configuration with no reset pulse of its own.
-  // Registering `reset` is a timing decision as well as a metastability one:
-  // `make soc-timing`'s first run measured the design's longest path starting at
-  // the `btn_n` pad.
+  // The FPGA comes out of configuration with no reset of its own, so this makes
+  // one. Keep `reset` registered. The button is asynchronous and needs the two
+  // flops anyway, but the register also keeps the pin out of the logic behind
+  // it: `make soc-timing`'s first run found the longest path in the whole design
+  // starting at `btn_n`.
   logic [3:0] por_count = 4'b0;
   logic       por_done  = 1'b0;
   logic [1:0] btn_sync  = 2'b0;
@@ -63,11 +65,11 @@ module littlesoc (
     .trap(trap)
   );
 
-  // `imem_addr`/`imem_addr2` are deliberately unread: the ROM is synchronous, so
-  // it is addressed off `imem_addr_next` a cycle early. Both ports stay on the
-  // core because that is the bus the riscv-formal ladder speaks.
+  // `imem_addr` and `imem_addr2` are left unconnected on purpose. The ROM needs
+  // its address a cycle early, so it takes `imem_addr_next` instead. The core
+  // keeps both ports because the formal checks read them.
   //
-  // 2048 words = 8 KB = 16 EBRs of the part's 30, with rtl/regfile.v taking 4.
+  // 2048 words = 8 KB = 16 block RAMs of the part's 30. rtl/regfile.v takes 4.
   imemory #(
     .ROM_WORDS(2048),
     .INIT_EVEN("soc/rom_even.hex"),
@@ -94,10 +96,9 @@ module littlesoc (
     .mem_rdata(dmem_mem_rdata)
   );
 
-  // An OR rather than a select, one less level on the data path. The ranges do
-  // not overlap, and a store leaves the RAM's registered read data unchanged
-  // (rtl/memory.v) while the ROM answers zero, so this cannot mix two live
-  // values.
+  // An OR instead of a mux, which is one less level of logic here. The two
+  // ranges do not overlap. On a store the RAM holds its last read value and the
+  // ROM gives zero, so this can never mix two real values together.
   assign mem_rdata = imem_mem_rdata | dmem_mem_rdata;
 
   logic store_bit, trap_seen;


### PR DESCRIPTION
Comments only, in the five RTL files. Closes JEF-719.

The third and last batch, covering what PR #97 and PR #99 did not reach. `rtl/decoder.v` was the worst file in the tree at 670 comment lines on 577 of code, and it had *grown* since the ticket opened.

Two rules, applied together:

**Delete by default.** A comment survives only if it says something the code does not, in plain words, understandable without leaving the file. Otherwise it goes — not shortened, gone.

**No document references.** Every `(ADR-00NN)` and every `invariant N` is struck. A citation cannot be understood without leaving the file, so it fails the rule's own test by construction. Worse, it lets the sentence beside it off the hook: the reference carries the explanation and nobody has to understand the mechanism. **The count is 0 in all five files.**

## Per-file deltas (comment lines)

| File | before | after | delta | deleted |
|---|---|---|---|---|
| `rtl/decoder.v` | 670 | 202 | **-468** | **70%** |
| `rtl/imemory.v` | 115 | 49 | -66 | 57% |
| `rtl/accessor.v` | 101 | 37 | -64 | 63% |
| `rtl/littlecpu.v` | 82 | 22 | -60 | **73%** |
| `rtl/littlesoc.v` | 80 | 30 | -50 | 63% |
| **total** | **1048** | **340** | **-708** | **68%** |

ADR/invariant references: **37 → 0**. Some individual comments got *longer*, because removing the citation forced the sentence to state the mechanism. The total still falls because more comments were deleted outright.

## Comments-only proof, both ways

**1. The diff contains no non-comment, non-blank line.**

```
$ git diff -U0 origin/main | grep '^[+-]' | grep -v '^[+-][+-]' | grep -vE '^[+-]\s*(//|$)'
$ echo $?
1
```

**2. Each file hashes identically either side, once `//` comments and blank lines are stripped.**

```
da8d05b6886054630621451a0de2d8c180b64ca9197fcc36fc819a9e4196ebe7  rtl/decoder.v
513b42d721950397a074f0c7ce50dc34f9195cf7b6bec35cda9831f7ecc2524f  rtl/imemory.v
9b64247036883244914399faa07e14022f70b62dba204be1bdb786006c82b926  rtl/accessor.v
bccc324624b215dcfa04394e36c2257de34f2ab2f7d3e1a5cb06df948465b41c  rtl/littlecpu.v
3b34e0d5d5840affa7d88407f97285dfcce0ca07ea3f900e2325dabb5788737a  rtl/littlesoc.v
```

Identical on `origin/main` and on this branch. Counted in code with comments stripped, across the five files: **`parallel_case` 9, `full_case` 5, `$onehot` 2 — the same on both sides.** Those look like comments and are not, which is what proof 2 is for. No string literal in these files contains `//`, so neither check can be fooled.

## Five before/after pairs

**1. Outright deletion — `rtl/littlecpu.v`'s port narration.** Three paragraphs re-deriving one fact, plus `// inputs` / `// outputs` / `// memory access` / `// forwards` at every instantiation. 73% of this file's comments went.

```diff
-  // Declared here (ahead of the decoder instantiation below) because the trap
-  // assignment below references it; iverilog requires declare-before-use.
   decoder_output decoder_out;
-  // Declared here, ahead of the decoder/executor/accessor instantiations,
-  // because decoder's scoreboard reads executor_out and accessor's pending
-  // load, executor's stalled output feeds decoder's divider_stall, and
-  // accessor's stalled output feeds both decoder's accessor_stall and
-  // executor's accessor_stall (ADR-0004/ADR-0009); iverilog requires
-  // declare-before-use.
+  // Declared up here rather than next to the module that drives each one. Later
+  // stages feed signals back to earlier ones, so each of these is read by a
+  // module written above its driver, and iverilog wants the name first.
   executor_output executor_out;
```

**2. Outright deletion — three in `rtl/decoder.v` with nothing left after.**

```diff
-  // rs1 and rs2 are synchronous outputs        <- also wrong: they are always_comb
-  // c.li is addi in disguise                   <- the assign beside it says so
-  // The PC register, and the whole of it: every redirect this core takes is
-  // already resolved into `next_pc` above (ADR-0054).
   always_ff @(posedge clk) pc <= next_pc;
```

Nothing lost on the third: the single-driver property it gestured at is *asserted*, in this file's `FORMAL` block, in `formal/pcloop.sv` and in `test/decoder_tb.v`. Also gone outright across the five files: `// calculate branch`, `// publish the decoded results`, `// bubble the output`, `// make the request.`, `// request is synchronous`, `// response is registered`, `// Offset to the right position`, and every `// ---- section ----` banner.

**3. The citation was carrying the explanation** — `rtl/decoder.v`'s serialization. The old comment said `minstret` would be "inflated" and pointed at an ADR for why. Removing the pointer forced the actual mechanism out, and it is worth knowing: the counter increments at *issue*, so it runs ahead of what has finished until the pipeline empties.

```diff
-  // What this buys is `minstret` exactness, NOT hazard safety (ADR-0027
-  // amends ADR-0005 on exactly this point): the CSR read result reaches rd
-  // through the ordinary `is_add` pass-through, where the scoreboard above
-  // already covers RAW. Delete this stall and no hazard appears -- what
-  // appears is a `csrr minstret` inflated by whatever is in flight behind it.
-  // ... 16 more lines, including `fence.i`'s reason ...
+  // These three wait until the pipeline is empty, for two different reasons.
+  // Narrowing the test to suit one of them breaks the other.
+  //
+  // A CSR access and `mret` are not waiting for an operand. `minstret` counts up
+  // when an instruction issues, not when it finishes, so it already includes
+  // instructions still moving down the pipeline. Waiting until they are done
+  // makes the count match what has actually finished.
+  //
+  // `fence.i` waits because text is writable and the fetch address goes out a
+  // cycle early. A store needs two edges to reach the memory array. By then the
+  // instruction after the `fence.i` has already been fetched, and it read the
+  // old text. An empty pipeline means the store has landed.
```

**4. A tripwire kept, 22 lines to 6** — `rtl/decoder.v`'s `live_producer`. The old one opened by arguing it was not a style preference and closed with the incident report. The new one opens with the instruction and names the symptom.

```diff
-  // Is this operand's register the destination of a live (not-yet-retired)
-  // producer at any of the three checked points? Spelled out twice rather than
-  // shared through a `function automatic live_producer(r)` called from the two
-  // continuous assigns below, and THAT IS A CORRECTNESS REQUIREMENT, not a
-  // style preference:
-  // ... 17 more lines ...
+  // Do not fold these two into a shared function. iverilog builds a continuous
+  // assign's sensitivity list from the arguments at the call site. A function
+  // body that also read `out`, `executor_out` or `accessor_pending_*` would stop
+  // re-evaluating when any of those changed. `hazard_rs1` then sticks high at the
+  // first conflict and the core stops. iverilog gives no warning for this, and
+  // yosys gets the same function right, so every other check stays green.
```

**5. `FACT / DISCHARGED / SCOPE` label blocks become sentences** in `rtl/decoder.v`'s `FORMAL` section, the treatment `rtl/executor.v` got in PR #99. Each assume still names the fact it models, where that fact is checked, and how far it reaches. 33 lines to 5:

```diff
-  // FACT       the fetcher echoes the decoder's own pc combinationally --
-  //            rtl/fetcher.v's `out.pc = pc;`, wired pc -> pc in
-  //            rtl/littlecpu.v.
-  // DISCHARGED formal/pcloop.sv, which instantiates the real fetcher and
-  //            ASSERTS the echo ... This is a REAL, RUNNING discharge as of
-  //            `bb6e228` (ADR-0046) ... see ADR-0049 F2 for what that looked
-  //            like and why it went unnoticed ...
-  // SCOPE      the whole task -- LARGER than what it was written for. ...
+  // Assume the fetcher hands back the pc this module gave it. rtl/fetcher.v does
+  // that with a wire. formal/pcloop.sv builds the real fetcher and asserts it
+  // instead of assuming it, so this is checked somewhere; that task runs on CI.
+  // This assume covers the whole file, not just the assertions it was written
+  // for, and nothing else below reads `in.pc`.
   always_comb assume(in.pc == pc);
```

## Two claims corrected by reading the code

Stripping a citation means you have to understand the mechanism to replace it. Twice a first draft did not, and produced a confident sentence that was wrong. Both were fixed against `rtl/decoder.v` rather than against the ADR:

- **There are two separate checks, not one.** `live_rs1`/`live_rs2` read three places (`out`, `executor_out`, `accessor_pending`). `pipe_drained` reads four — those three plus `accessor_out_valid`. An early draft merged them. `accessor_pending_valid` goes high for loads only, so the hazard check is right to ignore a store and serialization is not; that is exactly why `accessor_out_valid` exists as a separate input.
- **Why a CSR access waits.** Not "so it counts correctly" in the abstract: `assign instret = committing` fires on the *issue* cycle, so `minstret` already includes instructions that have not finished. Waiting for the pipeline to empty is what makes the two equal at the moment of the read.

## Tripwires

**None dropped**, and each is now stated as a mechanism rather than a citation: `decoder.v`'s `live_producer`; `operand_stall`'s one-cycle rule; the `uses_rs1`/`uses_rs2` warning; trap commit in decode; the `$onehot` assertion; the `next_pc` chain and why it is not `(* parallel_case *)`; the freeze-beats-stall arm order; the `issuing`/guard identity. Plus `imemory.v`'s `< ROM_WORDS - 1` timing decision, its two-port block RAM shape, the two-files-not-a-loop init rule and the `$readmemh("")` guard; `accessor.v`'s combinational `mem_wdata`, its zeroed defaults and the two-cycle load; `littlesoc.v`'s `make fit` / `make soc-timing` separation and the LED tap that stops yosys deleting the core.

Two explanations were consolidated rather than dropped, both found by `/simplify`: the "idle bus shows address 0" argument stood in three places and now stands at the producer (`accessor.v`) and the consumer (`imemory.v`); the `uses_rs1` warning stood twice in `decoder.v` and now stands once.

## Gates, all on this tree

| Gate | Result |
|---|---|
| `make -C formal check JOBS=4` | **85 checks: 85 pass, 0 fail**; both set equalities matching in both directions. 21m31s wall at host load ~30 on 10 cores (two sibling agents running) |
| `make test` | **56/56 passed**, failure list matches `test/EXPECTED_FAIL` exactly; suite shape matches `OBSERVED_FLOOR` (56 programs) |
| `make test-units` | **8 unit benches**, matching `test/*_tb.v` exactly |
| `make probe-gates` | **125 graded comparisons, every failure path executed** |
| `make lint` | svlint clean in both passes |
| `make fit` | **3899 of 4100 cells — OK**, unchanged |
| `make soc-timing` | **10.44 MHz against a 10.00 MHz floor — OK**, unchanged |

The ladder was run once, per the concurrency budget, against a tree with the same five code hashes as this commit. `make test`, `make lint`, `make fit` and `make soc-timing` were re-run after the final round of edits and reproduced their numbers exactly.

`/soundcheck:pr-review`: **no Critical or High findings.** The diff contains no executable statement.

`/simplify`: ran as a **single-pass inline review**, not the 4-agent fan-out — the Agent tool was unavailable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
