### PR TITLE
JEF-726: the programs that prove writable text

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -254,12 +254,26 @@ it** — `insn 19`, `ill 19`, `reg 15 22` — off a re-measured **F = 6, G = 4 �
 wall time roughly doubled. Two things about the change are worth knowing before touching it. The
 **coincidence of `fetch_stall` with a divider or accessor freeze is a ruling, not statement order**:
 holding wins, and it is asserted in two places because reordering two `else if` arms is otherwise
-silent. And **the suite does not exercise any of this end to end**: no program in `test/asm` does a
-text-region data access (`.data` is at `0x10000`, the bench's text ends at `0x4000`), so retire
-counts are identical program by program and the steal never fires there. `formal/wrapper.v` models
-the arbiter and is where the ladder meets it; `imemcheck`/`dmemcheck`/`cover`/`complete` tie
-`fetch_stall` low and say so. `selfmod.S` and `textload.S` are the programs that would close this,
-and they are not written yet.
+silent. `formal/wrapper.v` models the arbiter and is where the ladder meets it;
+`imemcheck`/`dmemcheck`/`cover`/`complete` tie `fetch_stall` low and say so.
+
+**Three programs exercise all of that end to end now, and the suite is 59** (ADR-0063).
+`test/asm/selfmod.S` stores into `.text`, fences and runs the stored word; `test/asm/textload.S`
+carries a handler that reads the faulting instruction out of `.text`, works out two bytes or four
+and resumes past it — so none of its four trapping instructions is wrapped in `.option norvc` and
+two of them are `c.ebreak`, which is the discipline that hid ADR-0048's defect no longer being the
+only way to write a resuming trap test; `test/asm/contend.S` puts loads and stores in `.text` at
+both word-address parities with byte and halfword strobes. **Twenty-six stolen fetch windows across
+the three (6 / 4 / 16), against zero anywhere in the tree before**, counted with a throwaway
+`fetch_stall` counter. `make test` is 59/59 and `make cosim-suite` is 59/59, both baselines empty,
+and `test/sail/rv32imc_zicsr.json` needed no change — its one `MainMemory` region is already
+executable, readable and writable across the megabyte. **The one thing to know before editing
+`selfmod.S`**: test 2's store has to be `sw t1, %lo(patch_adjacent)(x0)`, because `fence.i` waits
+for its own rs1 field to have been presented and so can only issue one cycle behind a store that
+also presented `rs1 = x0`. Written the way anyone would write it (`la t0, site; sw t1, 0(t0)`) the
+program **passes with the serialization term deleted** — measured, both ways. `.data`'s load address
+and the crt0 copy loop are deliberately not in that change; the SoC still cannot run a program that
+reads its own `.data`.
 
 **Every graded comparison in the grading layer now has a probe of its own red direction, and two of
 them had never been executed** (ADR-0053). Five of this repo's recorded defects were in that layer
@@ -1255,12 +1269,12 @@ longer quietly widen.
   rejected the shifter merge at 19 cells *saved* on legibility grounds, and accepting a hygiene
   change at 37 cells *spent* would cut against that ruling. Read this before proposing the
   narrowing again — it is measured and declined, not overlooked.
-- Decisions: [`docs/adr/`](docs/adr/) — **fifty-six ADRs, fifty-five of them accepted**, plus a
-  deferred list. Re-derived by counting: `ls docs/adr/*.md | wc -l` is 57, one of which is
+- Decisions: [`docs/adr/`](docs/adr/) — **sixty-three ADRs, sixty-two of them accepted**, plus a
+  deferred list. Re-derived by counting: `ls docs/adr/*.md | wc -l` is 64, one of which is
   `README.md`, and the status column in that README carries exactly one non-accepted entry
-  (ADR-0016, superseded by ADR-0018). This line has now been behind twice — it said "forty-five
-  accepted" and then "forty-seven" — so **re-derive it with the two commands rather than
-  incrementing it**, which is what missed ADR-0049 through ADR-0051 in one go.
+  (ADR-0016, superseded by ADR-0018). This line has now been behind three times — it said
+  "forty-five accepted", then "forty-seven", then "fifty-six" — so **re-derive it with the two
+  commands rather than incrementing it**, which is what missed ADR-0049 through ADR-0051 in one go.
 - Reference text from the old core: `git show 1709433^:rtl/riscv.v` (RVFI retire block),
   `git show e67875c^:rtl/alu.v` (arithmetic)
 - Work is tracked in Linear, project **Little CPU** (team JEF). Named here so you know where the

--- a/docs/adr/0063-the-suite-runs-programs-that-use-writable-text.md
+++ b/docs/adr/0063-the-suite-runs-programs-that-use-writable-text.md
@@ -1,0 +1,134 @@
+# ADR-0063: The suite runs programs that use writable text
+
+**Status:** Accepted · 2026-08-02 · *Builds step 5 of
+[`docs/ideas/one-address-space-over-two-memories.md`](../ideas/one-address-space-over-two-memories.md),
+minus its `.data` half. Discharges
+[ADR-0061](0061-fence-i-has-to-serialize.md)'s "argued fix with a unit test" and
+[ADR-0060](0060-the-steal-reaches-decode-as-the-sixth-stall-reason.md)'s "the suite does not yet
+exercise this change end to end". Closes the blind spot
+[ADR-0048](0048-what-an-independent-read-of-the-no-oracle-rtl-found.md) named.*
+
+## Context
+
+ADR-0059 made text writable, ADR-0060 routed the stolen fetch window into decode as the sixth stall
+reason, and ADR-0061 made `fence.i` serialize. Both of the latter two recorded the same gap: no
+program in `test/asm` does a text-region data access, so every retire count in the suite was
+identical program by program and the whole feature was reachable from nothing the merge gate runs.
+ADR-0061 was blunter still — what covers its decision is a decoder bench and a component proof, and
+what would cover the *behaviour* is a program that stores to text, fences, and executes the result.
+
+Separately, the shared trap handler in `test/asm/riscv_test.h` resumes at `mepc + 4` and cannot read
+the faulting instruction, so every trapping instruction in a resuming test is wrapped in
+`.option norvc`. That discipline is what hid the `c.ebreak` cause defect ADR-0048 found.
+
+## Decision 1 — three programs, and the suite goes 56 to 59
+
+- **`test/asm/selfmod.S`** stores into `.text`, fences, and runs the stored word. Three cases: the
+  instruction immediately after `fence.i`, a stub patched and then called, and the original word
+  written back and the stub called again — the third so a ROM image that already held the patched
+  word could not pass the second.
+- **`test/asm/textload.S`** carries its own handler, which reads the faulting instruction out of
+  `.text`, decides two bytes or four from its low two bits, and resumes past it. None of its four
+  trapping instructions is wrapped in `.option norvc`, and two of them are `c.ebreak`.
+- **`test/asm/contend.S`** puts loads and stores in `.text` at both word-address parities, with byte
+  and halfword strobes, a store and a load of the same word back to back, and a text load
+  immediately behind a RAM store.
+
+Each has a `test/OBSERVED_FLOOR` line, so `test/check_suite_shape.sh` matches in both directions
+from both runners. `make test` is 59/59 and `make cosim-suite` is 59/59, both baselines empty.
+
+Every text address any of them touches is under `0x200`, far inside the 8 KB the SoC's ROM covers.
+Past that boundary the simulation's 16 KB ROM and the part's 8 KB one disagree about which addresses
+are text at all, and a program that straddled it would mean different things on the two legs.
+
+## Decision 2 — the store before `fence.i` uses x0 as its base, and that is what makes the test able to fail
+
+This is the finding, and it is the reason this change has an ADR rather than being three test files.
+
+`operand_stall` makes decode present rs1/rs2 one cycle and issue the next, and `fence.i` reads
+neither register — but `uses_rs1` is true for it, so it still waits for its own rs1 field, which is
+zero, to have been presented. It can therefore only issue one cycle behind a store that presented
+`rs1 = x0` as well. Behind `la t0, site; sw t1, 0(t0)` it issues one cycle later than that, by which
+time the store's write edge has already passed, and the stale fetch ADR-0061 describes is
+unreachable.
+
+Measured, with `instr_fencei` dropped from `rtl/decoder.v`'s serialization term:
+
+| test 2's store | verdict |
+|---|---|
+| `la t0, patch_adjacent; sw t1, 0(t0)` | **PASS**, 49 retires |
+| `sw t1, %lo(patch_adjacent)(x0)` | **FAIL 2**, 17 retires |
+
+The first is the form anyone would write and it checks nothing. The second is what ships, with the
+reasoning at the top of the file, because rewriting it back is a one-line tidy-up that leaves the
+program passing.
+
+The `%lo` form needs the patch site inside the first 2 KB of `.text`. Past that the immediate's sign
+bit is set, the store address comes out negative, the write is dropped and test 2 fails — loud, not
+silent.
+
+## Decision 3 — `test/asm/riscv_test.h` is not touched
+
+`textload.S` defines its own `trap_handler` and installs it with the existing
+`RVTEST_INSTALL_TRAP_HANDLER`, reusing `RVTEST_TRAP_DATA`'s three words in RAM. One program needs the
+length-decoding handler, so a shared macro would be a second surface for one caller.
+
+That also settles the byte-identity question the brief raised: no shared header, linker script or
+macro file changed, so the other 56 programs assemble to exactly the bytes they did before. The
+suite tables confirm it — every one of their retire and spec-checked counts is unchanged.
+
+## Decision 4 — `test/sail/rv32imc_zicsr.json` needs no change, and this is the confirmation
+
+Its single `MainMemory` region is `0x0000_0000` for `0x0010_0000`, with `executable`, `readable` and
+`writable` all true, so the reference model already answers a load or a store in the text region the
+way this core does. Verified by running rather than by reading: `make cosim-suite` is 59/59 with
+`test/COSIM_EXPECTED_FAIL` empty, and `selfmod.S` — where the two machines would have to disagree
+about what instruction is at an address — agrees. The file is a complete `--config` and is rejected
+outright if a key is missing, so editing it on a guess is the one thing that cannot be done cheaply
+here.
+
+## The measurement
+
+Steals counted with a throwaway `fetch_stall` counter in `test/testbench.v`, read out through
+`test/cxxrtl.cc`; the instrumentation is not part of this change.
+
+| program | retires | steals |
+|---|---|---|
+| `selfmod.S` | 47 | **6** |
+| `textload.S` | 197 | **4** |
+| `contend.S` | 113 | **16** |
+| `add.S`, `sw.S`, `trap.S`, `rvc.S` | unchanged | **0** |
+
+Twenty-six stolen fetch windows, against zero anywhere in the tree before this change.
+
+Two mutations, each against the whole 59-program table:
+
+- **`fetch_stall` tied low in `rtl/imemory.v`.** `selfmod.S` goes 47 retires to 6 and `contend.S`
+  113 to 25, both `TRAP-TO-ZERO`. Every other line of the table is byte-identical, including
+  `textload.S`.
+- **`instr_fencei` dropped from the serialization term.** `selfmod.S` alone goes red, `FAIL 2`, 47
+  retires to 17. `fencenop.S` — the only other program that executes a `fence.i` — does not move,
+  which is the measurement behind saying it checks that the instruction retires and nothing about
+  ordering.
+
+## Consequences
+
+- **`textload.S` does not go red when the steal is tied low**, and that is worth knowing rather than
+  hiding. Its four text loads all sit in the handler, where the corrupted fetch window lands on a
+  cycle decode was going to bubble anyway. It exercises the text *read* path and the compressed
+  trap; `contend.S` and `selfmod.S` are what the steal itself hangs on.
+- **The `.data` half of the brief's step 5 is not here.** A load address in the text region for
+  `.data` plus a copy loop in `riscv_test.h` changes shared infrastructure every program reads, and
+  it cannot be checked without the SoC synthesis flow. It is its own change. Until it lands the SoC
+  still cannot run a program that reads its own `.data`, which is what the deferred-bootloader entry
+  already says.
+- **No test may jump into the data region, and none does.** The core fetches zero there and traps in
+  decode; the reference model's single region is executable across the whole megabyte. Such a test
+  would diverge by construction, and the divergence would be the model's permissiveness.
+- **`c.ebreak`'s cause is now asserted by a test that lets the assembler compress freely.**
+  `cebreak.S` already covered the cause at both alignments, but only by padding each faulting
+  instruction with a `c.nop` so the shared `mepc + 4` handler landed on a boundary. `textload.S`
+  needs no padding and no `.option norvc`, so the discipline that hid the defect is no longer the
+  only way to write a resuming trap test here.
+- **`fence.i` costs a drain and now has a program that says so.** ADR-0061's own closing description
+  of itself — an argued fix with a unit test — no longer applies.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -67,6 +67,7 @@ and what it costs. Reversing one is fine — write a new ADR that supersedes it.
 | [0060](0060-the-steal-reaches-decode-as-the-sixth-stall-reason.md) | The steal reaches decode, as the sixth stall reason | Accepted · builds 0057's step 3 and lands its condition 1; amends 0026, 0009 |
 | [0061](0061-fence-i-has-to-serialize.md) | `fence.i` has to serialize | Accepted · amends 0002; lands with 0060 |
 | [0062](0062-twelve-megahertz-is-reachable-and-the-bypass-select-is-the-cost.md) | Twelve megahertz is reachable, and the write-through bypass select is the cost | Accepted · corrects 0058's decode-head attribution and its second-path cap |
+| [0063](0063-the-suite-runs-programs-that-use-writable-text.md) | The suite runs programs that use writable text | Accepted · builds 0057's step 5 less its `.data` half; discharges 0061 |
 
 0001–0007 came from the design brief
 ([`docs/ideas/finish-the-rewrite.md`](../ideas/finish-the-rewrite.md)). 0008–0011 came out of

--- a/test/OBSERVED_FLOOR
+++ b/test/OBSERVED_FLOOR
@@ -99,6 +99,7 @@ blt.S               255    255
 bltu.S              280    280
 bne.S               255    255
 cebreak.S            161    138
+contend.S           113    113
 csr.S               108     82
 csrset.S              72     62
 div.S                60     60
@@ -124,6 +125,7 @@ rem.S                60     60
 remu.S               60     60
 rvc.S               184    184
 sb.S                394    394
+selfmod.S            47     44
 sh.S                447    447
 simple.S              5      5
 sll.S               457    457
@@ -139,6 +141,7 @@ srli.S              214    214
 straddle.S           18     18
 sub.S               421    421
 sw.S                454    454
+textload.S          197    177
 trap.S              303    259
 xor.S               451    451
 xori.S              171    171

--- a/test/asm/contend.S
+++ b/test/asm/contend.S
@@ -1,0 +1,120 @@
+#include "riscv_test.h"
+#include "test_macros.h"
+
+// Loads and stores that land in .text, where the fetch is reading. The
+// instruction memory has one read port per bank, so a data access there takes
+// the port and the fetch behind it is dropped and asked for again.
+//
+// Neighbouring words live in different banks, so every access below is done at
+// both word-address parities: the cells start at an 8-byte boundary, which
+// makes tw_even and tw_scratch_even even word addresses and the two `_odd`
+// cells odd ones. A bank select that ignored the low bit would answer the
+// wrong cell rather than fail to answer.
+//
+// The cells sit after TEST_PASSFAIL's infinite loop, so nothing ever executes
+// them, and they stay well under 8 KB -- the size of the ROM on the part,
+// which is smaller than the one the simulation builds. Past that boundary the
+// two would disagree about which addresses are text at all.
+
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # Reads, both parities.
+  #-------------------------------------------------------------
+
+  TEST_CASE( 2, a4, 0x0000babe, la a3, tw_even; lw a4, 0(a3); )
+  TEST_CASE( 3, a4, 0x0000cafe, la a3, tw_odd;  lw a4, 0(a3); )
+
+  # Narrower than a word, so the accessor picks bytes out of a text answer the
+  # same way it does out of a RAM one.
+  TEST_CASE( 4, a4, 0xcafe, la a3, tw_odd; lhu a4, 0(a3); )
+  TEST_CASE( 5, a4, 0xbe,   la a3, tw_even; lbu a4, 0(a3); )
+
+  #-------------------------------------------------------------
+  # A store and a load of the same word back to back, both parities. One `la`,
+  # so the two accesses are adjacent and each one takes a fetch window.
+  #-------------------------------------------------------------
+
+  la    a3, tw_scratch_even
+  li    a4, 0x11112222
+  sw    a4, 0(a3)
+  lw    a5, 0(a3)
+  TEST_CASE( 6, a5, 0x11112222, nop; )
+
+  la    a3, tw_scratch_odd
+  li    a4, 0x33334444
+  sw    a4, 0(a3)
+  lw    a5, 0(a3)
+  TEST_CASE( 7, a5, 0x33334444, nop; )
+
+  #-------------------------------------------------------------
+  # Byte and halfword strobes, so a write that reached the right bank with the
+  # wrong strobes is caught rather than passing on a whole-word rewrite.
+  #-------------------------------------------------------------
+
+  la    a3, tw_scratch_odd
+  li    a4, 0xa5
+  sb    a4, 1(a3)
+  lw    a5, 0(a3)
+  TEST_CASE( 8, a5, 0x3333a544, nop; )
+
+  la    a3, tw_scratch_even
+  li    a4, 0xbeef
+  sh    a4, 2(a3)
+  lw    a5, 0(a3)
+  TEST_CASE( 9, a5, 0xbeef2222, nop; )
+
+  #-------------------------------------------------------------
+  # A text store, then a load of the neighbouring word out of the other bank.
+  #-------------------------------------------------------------
+
+  la    a3, tw_scratch_even
+  li    a4, 0x0f0f0f0f
+  sw    a4, 0(a3)
+  lw    a5, 4(a3)
+  TEST_CASE( 10, a5, 0x3333a544, nop; )
+  TEST_CASE( 11, a5, 0x0f0f0f0f, la a3, tw_scratch_even; lw a5, 0(a3); )
+
+  #-------------------------------------------------------------
+  # A text load right behind a RAM store. The data RAM's read port does not
+  # change on a write cycle, so it is still holding the word the load before it
+  # returned -- and the two memories' answers are ORed together on their way
+  # back to the core.
+  #-------------------------------------------------------------
+
+  la    a3, rdat
+  lw    a4, 0(a3)
+  li    a5, -1
+  sw    a5, 0(a3)
+  la    a3, tw_even
+  lw    a4, 0(a3)
+  TEST_CASE( 12, a4, 0x0000babe, nop; )
+
+  # ...and the store did reach RAM, so test 12 was not reading past a store
+  # that never happened.
+  TEST_CASE( 13, a4, -1, la a3, rdat; lw a4, 0(a3); )
+
+  TEST_PASSFAIL
+
+  .align 3
+tw_even:
+  .word 0x0000babe
+tw_odd:
+  .word 0x0000cafe
+tw_scratch_even:
+  .word 0
+tw_scratch_odd:
+  .word 0
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+  .align 2
+rdat:
+  .word 0x0000f00d
+
+RVTEST_DATA_END

--- a/test/asm/selfmod.S
+++ b/test/asm/selfmod.S
@@ -1,0 +1,100 @@
+#include "riscv_test.h"
+#include "test_macros.h"
+
+// A store into .text, a fence.i, and then the stored word runs as an
+// instruction. Text and data share one address space, so `sw` can reach the
+// instruction memory.
+//
+// Test 2 is the case the fence has to cover. Decode publishes the fetch address
+// a cycle early, so the word for the instruction after `fence.i` is read out of
+// the banks on the edge `fence.i` issues. `fence.i` waits for the pipeline to
+// empty, which puts a store still in flight ahead of that read.
+//
+// The store in test 2 has to use x0 as its base. Decode presents rs1 one cycle
+// and issues the next, and `fence.i`'s rs1 field is zero, so it can only issue
+// one cycle behind a store that presented rs1 = x0 too. Behind any other store
+// it issues a cycle later, the write has already landed, and the test passes
+// with the wait taken out of the decoder. Writing it as
+// `la t0, patch_adjacent; sw t1, 0(t0)` reads better and checks nothing. The
+// `%lo` form needs the patch site inside the first 2 KB of .text; past that the
+// store address comes out negative and test 2 fails.
+//
+// Every patch site is `.option norvc`, so it is exactly the four bytes the
+// `sw` writes, and follows an `.align 2` so the store address is word aligned.
+// The replacement encodings are assembled as templates and loaded out of .text
+// rather than written as hex here.
+
+RVTEST_CODE_BEGIN
+
+  li    a0, 0
+
+  la    t0, tmpl_bump_a0
+  lw    t1, 0(t0)
+
+  .align 2
+  .option push
+  .option norvc
+  sw    t1, %lo(patch_adjacent)(x0)
+  fence.i
+patch_adjacent:
+  nop
+  .option pop
+
+  TEST_CASE( 2, a0, 1, nop; )
+
+  #-------------------------------------------------------------
+  # The same thing at a distance: patch a stub, fence, then call it.
+  #-------------------------------------------------------------
+
+  la    t0, tmpl_set_a1
+  lw    t1, 0(t0)
+  la    t0, patch_stub
+  sw    t1, 0(t0)
+  fence.i
+
+  li    a1, 0
+  jal   ra, patch_stub
+
+  TEST_CASE( 3, a1, 0x2a, nop; )
+
+  #-------------------------------------------------------------
+  # Writing the original word back and calling the stub again. Without this a
+  # ROM image that already held the patched word would pass test 3.
+  #-------------------------------------------------------------
+
+  la    t0, tmpl_nop
+  lw    t1, 0(t0)
+  la    t0, patch_stub
+  sw    t1, 0(t0)
+  fence.i
+
+  li    a1, 0
+  jal   ra, patch_stub
+
+  TEST_CASE( 4, a1, 0, nop; )
+
+  TEST_PASSFAIL
+
+  # Control cannot fall in here: every path above ends in TEST_PASSFAIL's
+  # infinite loop. The stub is only ever entered by the `jal` above.
+  .align 2
+  .option push
+  .option norvc
+patch_stub:
+  nop
+  ret
+
+tmpl_bump_a0:
+  addi  a0, a0, 1
+tmpl_set_a1:
+  li    a1, 0x2a
+tmpl_nop:
+  nop
+  .option pop
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+  TEST_DATA
+RVTEST_DATA_END

--- a/test/asm/textload.S
+++ b/test/asm/textload.S
@@ -1,0 +1,173 @@
+#include "riscv_test.h"
+#include "test_macros.h"
+
+// The handler reads the faulting instruction out of .text, works out whether
+// it was two bytes or four, and resumes past it.
+//
+// That is why none of the trapping instructions below is wrapped in
+// `.option norvc`. riscv_test.h's shared handler resumes at mepc+4 and has no
+// way to tell the two lengths apart, so every other trapping test in this
+// suite has to keep the assembler from compressing the instruction that
+// faults. Text and data share one address space here, so a load can reach the
+// encoding and the wrapper is not needed.
+//
+// mepc can sit two bytes past a word boundary, so the handler word-aligns it
+// before the load and takes the upper halfword when bit 1 is set. A word load
+// at an odd halfword would fault inside the handler.
+//
+// The handler clobbers t0, t1 and t2, so nothing here holds a live value in
+// any of them across a fault.
+
+RVTEST_CODE_BEGIN
+
+  # mtvec resets to 0, which is _start -- install before faulting.
+  RVTEST_INSTALL_TRAP_HANDLER
+
+  #-------------------------------------------------------------
+  # A compressed breakpoint at pc % 4 == 0. The `c.li` behind it is two bytes,
+  # so a handler that resumed at mepc+4 would step over it and leave a0 at 0.
+  #-------------------------------------------------------------
+
+  li    a0, 0
+
+  .option push
+  .option rvc
+  .align 2
+cebrk_aligned:
+  c.ebreak
+  c.li  a0, 5
+  .option pop
+
+  TEST_CASE( 2, a4, 3, la a3, trap_cause; lw a4, 0(a3); )
+  TEST_CASE( 3, a0, 5, nop; )
+
+test_4:
+  la    a3, trap_epc
+  lw    a4, 0(a3)
+  la    x29, cebrk_aligned
+  li    TESTNUM, 4
+  bne   a4, x29, fail
+
+  #-------------------------------------------------------------
+  # The same at pc % 4 == 2, which is the halfword the handler has to shift
+  # down before it looks at the low two bits.
+  #-------------------------------------------------------------
+
+  li    a1, 0
+
+  .option push
+  .option rvc
+  .align 2
+  c.nop
+cebrk_odd:
+  c.ebreak
+  c.li  a1, 6
+  .option pop
+
+  TEST_CASE( 5, a4, 3, la a3, trap_cause; lw a4, 0(a3); )
+  TEST_CASE( 6, a1, 6, nop; )
+  TEST_CASE( 7, a4, 2, la a3, cebrk_odd; andi a4, a3, 3; )
+
+test_8:
+  la    a3, trap_epc
+  lw    a4, 0(a3)
+  la    x29, cebrk_odd
+  li    TESTNUM, 8
+  bne   a4, x29, fail
+
+  #-------------------------------------------------------------
+  # A four-byte fault, so the other arm of the length decision runs. Resuming
+  # two bytes early here would land inside `ecall`'s upper halfword, which is
+  # zero and decodes to nothing, and the cause and the count would both move.
+  #-------------------------------------------------------------
+
+  li    a2, 0
+  ecall
+  li    a2, 7
+
+  TEST_CASE(  9, a4, 11, la a3, trap_cause; lw a4, 0(a3); )
+  TEST_CASE( 10, a2, 7, nop; )
+
+  #-------------------------------------------------------------
+  # A compressed instruction whose cause comes from its operand address rather
+  # than from its encoding, so the length decision is exercised apart from the
+  # breakpoint path.
+  #-------------------------------------------------------------
+
+  la    a0, tdat
+  addi  a0, a0, 1
+  li    a1, 0x5a5
+
+  .option push
+  .option rvc
+  .align 2
+mis_clw:
+  c.lw  a1, 0(a0)
+  c.li  a2, 9
+  .option pop
+
+  TEST_CASE( 11, a4, 4, la a3, trap_cause; lw a4, 0(a3); )
+  TEST_CASE( 12, a1, 0x5a5, nop; )
+  TEST_CASE( 13, a2, 9, nop; )
+
+test_14:
+  la    a3, trap_epc
+  lw    a4, 0(a3)
+  la    x29, mis_clw
+  li    TESTNUM, 14
+  bne   a4, x29, fail
+
+  TEST_CASE( 15, a4, 4, la a3, trap_count; lw a4, 0(a3); )
+
+  TEST_PASSFAIL
+
+  # Reached only through mtvec. RVTEST_INSTALL_TRAP_HANDLER installs this
+  # label, so the name has to be trap_handler.
+  .align 2
+trap_handler:
+  .option push
+  .option norvc
+  la    t0, trap_count
+  lw    t1, 0(t0)
+  addi  t1, t1, 1
+  sw    t1, 0(t0)
+  csrr  t1, mcause
+  la    t0, trap_cause
+  sw    t1, 0(t0)
+  csrr  t0, mepc
+  la    t1, trap_epc
+  sw    t0, 0(t1)
+
+  # The load that this test exists for: the faulting instruction, read back out
+  # of .text.
+  andi  t1, t0, -4
+  lw    t1, 0(t1)
+  andi  t2, t0, 2
+  beqz  t2, 1f
+  srli  t1, t1, 16
+1:
+  # Both low bits set means four bytes; anything else is two.
+  andi  t1, t1, 3
+  li    t2, 3
+  addi  t0, t0, 2
+  bne   t1, t2, 2f
+  addi  t0, t0, 2
+2:
+  csrw  mepc, t0
+  mret
+  .option pop
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+  RVTEST_TRAP_DATA
+
+  # Only its address is used. The `c.lw` one byte past it traps before reading.
+  .align 2
+tdat:
+  .word 0x0ff0
+
+RVTEST_DATA_END


### PR DESCRIPTION
Closes JEF-726.

Three programs, each with a `test/OBSERVED_FLOOR` line, taking the suite from 56 to 59. Nothing in
the tree did a text-region data access before this, so every retire count was identical program by
program and ADR-0059/0060/0061's whole feature was reachable from nothing the merge gate runs.
ADR-0061 said so about itself: "an argued fix with a unit test, and that is the honest description
of it."

- **`test/asm/selfmod.S`** — stores into `.text`, fences, runs the stored word. Three cases: the
  instruction immediately after `fence.i`, a stub patched and called, and the original word written
  back and the stub called again (so a ROM image that already held the patched word could not pass
  the second).
- **`test/asm/textload.S`** — its own handler reads the faulting instruction out of `.text`, decides
  two bytes or four from the low two bits, and resumes past it. **None of its four trapping
  instructions is wrapped in `.option norvc`, and two of them are `c.ebreak`** — the discipline that
  hid ADR-0048's defect is no longer the only way to write a resuming trap test here.
- **`test/asm/contend.S`** — loads and stores in `.text` at both word-address parities, byte and
  halfword strobes, a store and a load of the same word back to back, and a text load right behind a
  RAM store.

`docs/adr/0063` records it.

## The finding: test 2's store has to use x0 as its base

`operand_stall` makes decode present rs1/rs2 one cycle and issue the next. `fence.i` reads neither
register but `uses_rs1` is true for it, so it still waits for its own rs1 field — zero — to have been
presented, and can only issue one cycle behind a store that presented `rs1 = x0` too. Behind the form
anyone would write it issues a cycle later, by which time the write has landed and the stale fetch
ADR-0061 describes is unreachable.

Measured, with `instr_fencei` dropped from `rtl/decoder.v`'s serialization term:

| test 2's store | verdict |
|---|---|
| `la t0, patch_adjacent; sw t1, 0(t0)` | **PASS**, 49 retires |
| `sw t1, %lo(patch_adjacent)(x0)` (ships) | **FAIL 2**, 17 retires |

The first checks nothing. The reasoning is at the top of the file, because rewriting it back is a
one-line tidy-up that leaves the program green.

## The steal fires

Counted with a throwaway `fetch_stall` counter in `test/testbench.v` read out through
`test/cxxrtl.cc`; the instrumentation is not in this change.

| program | retires | steals |
|---|---|---|
| `selfmod.S` | 47 | **6** |
| `textload.S` | 197 | **4** |
| `contend.S` | 113 | **16** |
| `add.S`, `sw.S`, `trap.S`, `rvc.S` | unchanged | **0** |

Twenty-six stolen fetch windows, against zero anywhere in the tree before.

## Both red directions, against the whole 59-program table

- **`fetch_stall` tied low in `rtl/imemory.v`** — `selfmod.S` 47 retires → 6 and `contend.S` 113 →
  25, both `TRAP-TO-ZERO`. Every other line of the table byte-identical, `textload.S` included.
- **`instr_fencei` dropped from the serialization term** — `selfmod.S` alone red, `FAIL 2`, 47 → 17.
  `fencenop.S`, the only other program that executes a `fence.i`, does not move, which is the
  measurement behind saying it checks that the instruction retires and nothing about ordering.

## Checks

- `make test` — **59/59**, `test/EXPECTED_FAIL` empty, `test/check_suite_shape.sh` matching both
  ways. Includes `make probe-gates` (125 probes) and `make test-units` (8 benches, all green).
- `make cosim-suite` — **59/59 agreed**, `test/COSIM_EXPECTED_FAIL` empty. `selfmod.S` agrees, which
  is where the two machines would have to disagree about what instruction is at an address.
- `test/sail/rv32imc_zicsr.json` **needs no change and was not edited** — its one `MainMemory` region
  is `0x0` for `0x0010_0000` with `executable`/`readable`/`writable` all true. Confirmed by running,
  not by reading; it is a complete `--config` and is rejected outright if a key is missing.
- **No `rtl/` file changed and no shared test infrastructure changed.** `riscv_test.h`,
  `sections.lds` and `test_macros.h` are byte-identical to `main`, so the 56 existing programs
  assemble to exactly the bytes they did before and their retire/spec-checked counts are unchanged
  in the table. `lint`, `elaborate`, `formal`, `fit`, `nonperturbation` and `soc-timing` are all out
  of contact with this diff, so they were not re-run locally.
- Every text address any of the three touches is under `0x200`, far inside the SoC's 8 KB ROM, so the
  16 KB simulation and the 8 KB part agree about which addresses are text.
- No test jumps into the data region.

## Split, as the ticket allows

**The `.data` half is not here.** A load address in the text region for `.data` plus a crt0 copy loop
in `riscv_test.h` changes shared infrastructure every program reads — the ticket's own "risky part" —
and cannot be checked without the SoC synthesis flow, which is off this diff entirely. It wants its
own ticket. Until it lands the SoC still cannot run a program that reads its own `.data`, which is
what the deferred-bootloader entry already says.

## One thing worth the architect's eye

`textload.S` does **not** go red when the steal is tied low, and the PR says so rather than hiding
it: its four text loads all sit in the handler, where the corrupted fetch window lands on a cycle
decode was going to bubble anyway. It exercises the text read path and the compressed trap;
`contend.S` and `selfmod.S` are what the steal itself hangs on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
