### PR TITLE
12 MHz becomes a requirement (JEF-749)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,7 +277,9 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
   # `make soc-timing` -- the SoC place-and-route and the only timing figure this
-  # project has (ADR-0054). Non-required for the same reason as `fit`.
+  # project has (ADR-0054). It is in main's required set, unlike `fit`: the
+  # floor it grades is the clock the board runs at, so missing it means the
+  # design does not run on the target part.
   #
   # Unlike `fit` it needs the cross compiler as well as the OSS CAD Suite,
   # because it assembles a real ROM image before synthesising, and it expects
@@ -320,9 +322,9 @@ jobs:
             cat "$RUNNER_TEMP/soc-timing.txt"
             echo '```'
             echo "Critical path over the whole SoC (core + ROM + RAM), with the"
-            echo "logic/routing split. This job ratchets against \`SOC_MIN_MHZ\`,"
-            echo "a floor set below the measurement rather than at ADR-0038's"
-            echo "declared 12 MHz, and it is NOT in main's required set."
+            echo "logic/routing split. This job grades \`SOC_MIN_MHZ\`, which is"
+            echo "the 12 MHz board clock rather than a margin under the last"
+            echo "measurement (ADR-0066), and it is in main's required set."
           } >> "$GITHUB_STEP_SUMMARY"
           exit "$status"
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,8 +208,10 @@ silently, failing later in nextpnr with a message about BELs. Measured both ways
 **4041/5280 LC (76%), 20/30 EBR, 2/4 SPRAM, 4/39 IO, 8/8 GB**, and
 **88.51 ns = 11.30 MHz — 34.20 ns logic (38.7%) + 54.29 ns routing (61.3%), 41 logic levels**, on
 `imem.in_range → decode → next PC → imem.in_range2`. That is the loop invariant 1 puts in one cycle,
-measured rather than argued. **The design does NOT meet ADR-0038's declared 12 MHz**, and the 12 MHz
-intent is deliberately left where it stands. **Two findings came out of the first run and are fixed**:
+measured rather than argued. **The design did NOT meet ADR-0038's 12 MHz at that commit**, and the
+12 MHz declaration was deliberately left where it stood. It is met now, and 12 MHz is a
+**requirement** rather than an intent — see the bypass change below and ADR-0066.
+**Two findings came out of the first run and are fixed**:
 the path started at the `btn_n` *pad* (the button is synchronised now) and ended in a 32-bit
 incrementer feeding the ROM's range check (both range tests compare a word index against a constant
 now). 9.60 → 11.30 MHz for those two. **The SoC would still not RUN a program in `test/asm`**: SPRAM
@@ -283,12 +285,20 @@ comparators behind it sat **after** the instruction rather than beside it, and e
 the whole chain before the next PC could be chosen. It compares against a **registered copy** of the
 address pair now. Measured on this tree, four placements each: **95.74 – 99.47 ns (10.05 – 10.44
 MHz) → 74.34 – 78.80 ns (12.69 – 13.45 MHz)**, 29 LUT levels → 23, distributions not overlapping and
-the move six times the 3.6% edit band. `SOC_MIN_MHZ` goes **10.0 → 10.9**, keeping the 11.5% margin
-it was derived with and taking it below ADR-0062's lower 12.32 MHz sample rather than this tree's
-better one. `make fit` is 3899 → **3880**, inside the ±50 churn floor and meaning nothing; the SoC
+the move six times the 3.6% edit band. `SOC_MIN_MHZ` went **10.0 → 10.9** there and is **12.0** now
+(ADR-0066). `make fit` is 3899 → **3880**, inside the ±50 churn floor and meaning nothing; the SoC
 top's LC is 4314 → 4383. **12 is the board crystal, not a round number** — the part's oscillator
-divides 48 to 48/24/12/6, so the step below 12 is 6, and ADR-0038's intent is met rather than missed
-by 6%.
+divides 48 to 48/24/12/6, so the step below 12 is 6, and missing it costs half the clock rather than
+a percentage.
+
+**So 12 MHz is a REQUIREMENT, and `SOC_MIN_MHZ` stopped being a regression floor** (ADR-0066). A
+regression floor sits under the current measurement and slides every time the design moves; a
+requirement sits at the number the hardware asks for and does not move at all. 12.0 leaves **5.75%**
+against the worst local placement (12.69 MHz), which is tighter than any other ratchet here and
+against a 3.6% edit-churn band — accepted deliberately, because a design at 11.9 MHz has stopped
+meeting its requirement and the honest report of that is a red gate. **When it trips, the fix is the
+design, not the floor.** `soc-timing` is a **required** check on `main` as of the same decision, and
+CI measured 12.72 MHz on its own hardware.
 
 **What that change costs is a coupling, and it is the part to remember.** The bypass used to be
 correct for *any* address pair; it is now correct **because** `operand_stall` guarantees that on an
@@ -336,9 +346,11 @@ branches are probed by invoking the real target against the real `test/*_tb.v` t
 `UNIT_BENCHES`/`UNIT_BENCH_SRC_*` overridden on the command line, which is what its own comment
 already commits to being possible. `test/probe_gates.sh` is **125** probes now, up from 108
 (ADR-0058 added three for `soc/timing_split.py`'s LUT-versus-carry depth split).
-**`make soc-timing` joins CI in the `soc-timing` job**, mirroring `fit`: non-required, for the same
-reason (ADR-0036) — it publishes the census and the logic/routing split to the step summary whether
-it passes or fails. It is the first job needing both the RISC-V cross compiler and the OSS CAD
+**`make soc-timing` joins CI in the `soc-timing` job**, mirroring `fit`: non-required at the time,
+for the same reason (ADR-0036) — it publishes the census and the logic/routing split to the step
+summary whether it passes or fails. **It is required now** (ADR-0066): the floor it grades is the
+board clock, so a red there means the design does not run on the part. It is the first job needing
+both the RISC-V cross compiler and the OSS CAD
 Suite, so the toolchain assertion moved into `.github/actions/verify-toolchain` rather than being
 copied from the `test` job — the duplication shape that broke `elaborate` once already.
 
@@ -679,13 +691,15 @@ too: `ci.yml`'s `elaborate` job runs and checks this same `testbench.vvp` direct
 baked-in program, not the `.S` suite (see the second bullet under "what does not work" above for
 what stays open). CI (`.github/workflows/ci.yml`) runs **nine** jobs on every PR:
 elaborate, test, components, lint, fit, soc-timing, nonperturbation, monitor-freshness and formal —
-the last of which also carries `complete` and `complete_cover` as hard gates (M2 term 5). **Six of
-the nine are required** — `elaborate`, `test`, `components`, `monitor-freshness`, `lint`, `formal`,
-read live from `gh api repos/thejefflarson/little-cpu/branches/main/protection -q
+the last of which also carries `complete` and `complete_cover` as hard gates (M2 term 5). **Seven of
+the nine are required** — `elaborate`, `test`, `components`, `monitor-freshness`, `lint`, `formal`
+and, since ADR-0066, `soc-timing`, read live from
+`gh api repos/thejefflarson/little-cpu/branches/main/protection -q
 '.required_status_checks.contexts'` rather than from any comment in the workflow — and
-`nonperturbation`, `fit` and `soc-timing` are the three that run without gating, each deliberately
-(ADR-0047, ADR-0052; `soc-timing` for the same reason as `fit` — area and timing are design
-constraints, not correctness ones, ADR-0036). **There is no `continue-on-error` anywhere in the
+`nonperturbation` and `fit` are the two that run without gating, each deliberately
+(ADR-0047, ADR-0052). **`soc-timing` was one of them until 12 MHz became a requirement**: area is
+still a design constraint, but a clock the board cannot supply is not one. **There is no
+`continue-on-error` anywhere in the
 file**, in any job: the `formal` job carried the last one until ADR-0052 struck it. This line named
 four jobs and stopped there until the gate inventory; `lint` and `formal` had both been promoted to
 required in the meantime,
@@ -919,30 +933,32 @@ make soc-timing     # THE SoC PLACE-AND-TIME FLOW (ADR-0054), and NOT `make fit`
                     # 2/4 SPRAM; 74.34 - 78.80 ns = 12.69 - 13.45 MHz over four
                     # placements as of ADR-0064, which addressed the regfile's
                     # write-through bypass from a registered copy of rs1/rs2.
-                    # THAT MEETS ADR-0038's DECLARED 12 MHz at every placement,
-                    # and 12 is the board crystal rather than a round number
-                    # (ADR-0062). It was 88.51 ns = 11.30 MHz, 38.7% logic /
+                    # THAT MEETS 12 MHz at every placement, and 12 is the board
+                    # crystal rather than a round number -- the step below it
+                    # is 6 (ADR-0062). It was 88.51 ns = 11.30 MHz, 38.7% logic /
                     # 61.3% routing, over
                     # imem.in_range -> decode -> next PC -> imem.in_range2
                     # at ADR-0054, whose 41 levels were 25 LUT + 17 CARRY at
                     # 3.31 ns and 0.34 ns each; read those apart (ADR-0058).
-                    # Ratchets on SOC_MIN_MHZ (10.9, 11.5% under the worst
-                    # placement -- ADR-0064; it was 10.0, and this line said
-                    # 10.5 while the Makefile never did, ADR-0057), a
-                    # regression floor set below the measurement, not at the
-                    # intent.
+                    # Grades SOC_MIN_MHZ, which is 12.0 as of ADR-0066: the
+                    # board clock itself, NOT a margin under the measurement.
+                    # It was 10.9 (ADR-0064) and 10.0 before that, both
+                    # regression floors that slid as the design moved. This one
+                    # does not slide, and the margin against the worst local
+                    # placement is 5.75% -- tighter than any other ratchet
+                    # here, accepted on purpose. WHEN IT TRIPS, FIX THE DESIGN.
                     # soc/timing_sweep.sh runs four placements and prints the
                     # spread. One placement is a sample; compare distributions.
                     # Needs the RISC-V toolchain (it builds a real ROM image).
-                    # ON CI as of the `soc-timing` job (non-required, same
-                    # reasoning as `fit`: area and timing are design
-                    # constraints, not correctness ones, ADR-0036). The
+                    # ON CI in the `soc-timing` job, REQUIRED as of ADR-0066
+                    # (it was non-required, mirroring `fit`). The
                     # census (soc/cell_census.py) and the ratchet
                     # (soc/timing_split.py) are both probed hermetically in
                     # test/probe_gates.sh. `SOC_PROG=lw.S` picks the program,
                     # `SOC_SEED=3` places it differently -- one placement is a
                     # sample, and main's own spread is 1.2% (ADR-0058).
-                    # Probe: `make soc-timing SOC_MIN_MHZ=99` exits 1.
+                    # Probe: `make soc-timing SOC_MIN_MHZ=99` exits 2 (the
+                    # script exits 1 and make reports its own status).
 
 make -C formal components_decoder   # component proofs. THREE tasks, all with real assertions:
 make -C formal components_executor  # decoder, executor, pcloop -- the assertion-free fetcher /
@@ -1273,9 +1289,11 @@ longer quietly widen.
 - **Timing**: `make soc-timing`, and `soc/timing_sweep.sh` for the four-placement spread that is
   the only honest form of the number. **74.34 · 75.81 · 76.88 · 78.80 ns = 12.69 – 13.45 MHz**
   (ADR-0064, local Homebrew yosys 0.67+post), against 95.74 – 99.47 ns on the same tree before it.
-  **ADR-0038's declared 12 MHz is met at every placement**, and ADR-0062 is where 12 stops being a
+  **12 MHz is met at every placement, and it is a REQUIREMENT rather than an intent** (ADR-0066):
+  `SOC_MIN_MHZ` is 12.0, `soc-timing` is a required check, and CI's own hardware measures 12.72 MHz.
+  ADR-0062 is where 12 stops being a
   round number: the board crystal is 12 MHz and the part oscillator divides 48 to 48/24/12/6, so the
-  step below 12 is 6. The one change that did it addressed `rtl/regfile.v`'s write-through bypass
+  step below 12 is 6. **A red `soc-timing` is a design problem, not a floor to lower.** The one change that did it addressed `rtl/regfile.v`'s write-through bypass
   from a registered copy of the address pair — read invariant 6 before touching `operand_stall`.
   The earlier figure was 88.51 ns = 11.30 MHz, 38.7% logic / 61.3% routing, on
   `imem.in_range → decode → next PC → imem.in_range2` (ADR-0054); the comparable one before that is
@@ -1311,9 +1329,12 @@ longer quietly widen.
   critical path** — give **88.51 ns / 41 logic levels** and **91.67 ns / 53**, on 11 logic cells'
   difference in the netlist; 11 cells anywhere is enough for nextpnr to redistribute placement. Each
   figure is reproducible run to run (nextpnr is seeded); it is the *edit* the number is unstable
-  under. So **a `make soc-timing` delta of a couple of percent is not evidence of anything**, and
-  `SOC_MIN_MHZ` (10.0) sits ~11.5% under the measurement for the same reason `FIT_MAX_LC` sits above
-  the ±50-cell floor. `rtl/memory.v` therefore ships the FLAT spelling of its arms and says so at
+  under. So **a `make soc-timing` delta of a couple of percent is not evidence of anything** — but
+  `SOC_MIN_MHZ` no longer buys margin against that band. It is 12.0, the board clock, and the worst
+  local placement is 12.69, so there is **5.75%** between them against a 3.6% churn band and a 1–2%
+  placement band (ADR-0066). That is accepted: a regression floor may sit below the measurement so
+  noise does not cry wolf, and a requirement floor may not — an edit that lands at 11.9 MHz has
+  stopped meeting the requirement, whatever moved it. `rtl/memory.v` therefore ships the FLAT spelling of its arms and says so at
   the site — the tidier nested one costs 11 cells and 3.6% of the only timing number this project
   has, which is the trade ADR-0038 already made twice in the other direction.
 - **`make fit` has a churn floor of roughly ±50 cells, and a ratchet has to sit above it.**
@@ -1347,8 +1368,9 @@ longer quietly widen.
 **Deferred behind future ADRs** — forwarding network, radix-4 divider, interrupts, and the
 **bootloader** (SPRAM cannot be initialised, so the SoC ADR-0054 builds cannot get a program's
 `.data` into RAM at power-on; that needs a `.text` copy stub or ADR-0044's SPI-flash path). FPGA
-timing closure came off this list at ADR-0054, which took the measurement — and the design misses
-ADR-0038's declared 12 MHz by 6%, with that declaration deliberately left standing. (The negedge-BRAM regfile came off this list in ADR-0042, **decided
+timing closure came off this list at ADR-0054, which took the measurement — and the design **meets
+12 MHz at every placement** (ADR-0064), which is a **requirement** rather than a declaration as of
+ADR-0066. (The negedge-BRAM regfile came off this list in ADR-0042, **decided
 against**: it is 99 cells cheaper and costs no cycles, but the generated ladder cannot model a
 mixed-polarity design at all, so `reg_ch0` would never again run against `rtl/regfile.v`.) Each trades away simplicity the current design depends on; none are
 safe to build while the core is unverified. (Sail co-sim came off this list in ADR-0032: the

--- a/Makefile
+++ b/Makefile
@@ -465,11 +465,12 @@ soc.json: $(SOC_SRCS) soc-rom
 	@python3 soc/cell_census.py soc.synth.log SB_RAM40_4K $(SOC_EXPECT_EBR) \
 	  "rtl/imemory.v or rtl/regfile.v has stopped inferring block RAM, or the ROM size changed"
 
-# nextpnr's exit status is deliberately not the signal: it defaults to a 12 MHz
-# target and exits nonzero when the design misses it, which this one does, having
-# already written the `.asc`. Honouring the status would mean no icetime report
-# at all because the design is 6% slow. `.DELETE_ON_ERROR` is why the `||` is
-# needed rather than merely tidy — without it make deletes that `.asc`.
+# nextpnr's exit status is deliberately not the signal: it grades its own 12 MHz
+# default with its own estimator, and what this repo grades is icetime's report
+# of the `.asc` nextpnr has already written. When it does fail it writes that
+# file first, so honouring the status would leave nothing to measure.
+# `.DELETE_ON_ERROR` is why the `||` is needed rather than merely tidy — without
+# it make deletes that `.asc`.
 #
 # `SOC_SEED=<n>` places the same design differently. One placement is a sample,
 # not a measurement — compare a few seeds before believing a change helped.
@@ -493,14 +494,13 @@ soc.asc: soc.json soc/littlesoc.pcf
 	  exit 1; \
 	}
 
-# A floor to catch regressions, deliberately set below what the design measures.
-# The measured number moves by a few percent on edits that change no hardware,
-# because the placer lays everything out again, so a floor at the current
-# measurement would go red for no reason. The margin is 11.5%, which is what the
-# 10.0 floor was derived with, taken below the worst of four placements. The
-# design now clears 12 MHz at every placement, so a red here means a real
-# regression rather than the old shortfall.
-SOC_MIN_MHZ := 10.9
+# 12 MHz is the board crystal, and the part's own oscillator divides 48 by 1, 2,
+# 4 or 8 -- so the step below 12 is 6, and missing it costs half the clock.
+# This sits at what the hardware asks for rather than under the last
+# measurement, so unlike a regression floor it does not slide as the design
+# moves. When it trips, fix the design: lowering the number gives up the board
+# clock.
+SOC_MIN_MHZ := 12.0
 
 .PHONY: soc-timing
 soc-timing: soc.asc
@@ -517,10 +517,10 @@ soc-timing: soc.asc
 	@echo
 	@echo 'READ ADR-0054 BEFORE QUOTING ANY OF THIS. It is a static estimate for'
 	@echo 'one placement of one build at the worst-case corner, and it is'
-	@echo 'toolchain-dependent the same way `make fit` is. ADR-0038 declares Fmax'
-	@echo 'at 12 MHz as an INTENT; this measurement does not move it in either'
-	@echo 'direction. The design clears it at four placements as of ADR-0063.'
-	@echo 'One placement is a sample: soc/timing_sweep.sh prints the spread.'
+	@echo 'toolchain-dependent the same way `make fit` is. 12 MHz is a'
+	@echo 'REQUIREMENT as of ADR-0066: it is the board clock, and the step below'
+	@echo 'it is 6 MHz. One placement is a sample: soc/timing_sweep.sh prints the'
+	@echo 'spread, and a requirement has to hold at all of them.'
 	@# The ratchet is applied by the thing that already parses the report. It
 	@# was a `python3 -c` here, i.e. a SECOND parser of the same file -- and the
 	@# second one was the one holding the gate.

--- a/docs/adr/0038-area-is-measured-in-logic-cells-and-two-levers-are-rejected.md
+++ b/docs/adr/0038-area-is-measured-in-logic-cells-and-two-levers-are-rejected.md
@@ -79,6 +79,14 @@ design places. At 12 MHz a half-period is 41 ns — enormous relative to any pat
 > unchanged** — reconciling it with a measurement is a decision, not a consequence, and this
 > paragraph's own test still applies to anyone proposing to close the gap.
 
+> **The word "declare" is struck and 12 MHz is a REQUIREMENT as of
+> [ADR-0066](0066-twelve-megahertz-is-a-requirement.md).** It was written as an intent because the
+> design missed it; it does not miss it any more (ADR-0062, ADR-0064). 12 is the board crystal and
+> the part's oscillator divides 48 by 1, 2, 4 or 8, so the step below 12 is 6 — missing it costs
+> half the clock rather than a percentage. `SOC_MIN_MHZ` is **12.0** and no longer slides with the
+> design: it is what the hardware asks for, not a margin under the last measurement. Lowering it is
+> a decision to stop targeting the board clock and needs its own ADR.
+
 **Anyone proposing to raise Fmax is proposing to break invariant 1 or invariant 6, and must bring an
 ADR that says which.** This is recorded so that a future performance complaint is answered with the
 design's own reasoning rather than a reflexive optimization.

--- a/docs/adr/0066-twelve-megahertz-is-a-requirement.md
+++ b/docs/adr/0066-twelve-megahertz-is-a-requirement.md
@@ -1,0 +1,108 @@
+# ADR-0066: Twelve megahertz is a requirement
+
+**Status:** Accepted · 2026-08-02 · *Amends
+[ADR-0038](0038-area-is-measured-in-logic-cells-and-two-levers-are-rejected.md) decision 2, which
+declared 12 MHz an intent. Cashes
+[ADR-0062](0062-twelve-megahertz-is-reachable-and-the-bypass-select-is-the-cost.md)'s divider
+argument and [ADR-0064](0064-the-write-through-bypass-is-addressed-from-the-held-pair.md)'s
+measurement; ADR-0064 explicitly left this question open. No `rtl/` change ships from this ADR.*
+
+## Context
+
+ADR-0038 declared Fmax at 12 MHz before this project could place a design, and every ADR since has
+measured against it as an aspiration: 11.30 MHz at ADR-0054, 10.18–10.32 at ADR-0059, 12.32–12.91 at
+ADR-0062's spike, 12.69–13.45 at ADR-0064 where the change landed.
+
+**It was written as an intent because the design missed it.** That is no longer true, and an intent
+that is met is a requirement nobody has agreed to enforce.
+
+## Why 12 is a number and not a target
+
+`soc/littlesoc.pcf` targets the iCEBreaker up5k/sg48. Its board crystal is 12 MHz and the part's own
+oscillator is 48 MHz nominal with a divider of 1, 2, 4 or 8 — 48, 24, 12, 6. Twelve is native from
+either source and **the step below it is six**.
+
+So a design at 11.9 MHz does not run 1% slower than one at 12.0. It runs at half the clock, because
+6 MHz is the next thing the board can supply. This is ADR-0062's argument and it is the whole reason
+the number is not negotiable downward by small amounts.
+
+## Decision
+
+1. **`SOC_MIN_MHZ` is 12.0**, up from 10.9 (ADR-0064) and 10.0 before that.
+2. **The convention changes with the number.** 10.0 and 10.9 were *regression* floors: each sat
+   about 11.5% below the then-current measurement so that placement noise and edit churn could not
+   turn a working design red. A regression floor slides every time the design moves. **A requirement
+   floor does not slide.** It sits at the number the hardware demands, and tripping it means the
+   design no longer runs on the board.
+3. **ADR-0038's declaration becomes a requirement**, amended in place there.
+4. **`soc-timing` is a required status check** on `main`. The required set is seven: `elaborate`,
+   `test`, `components`, `monitor-freshness`, `lint`, `formal`, `soc-timing`. That was done in the
+   repository settings before this ADR landed, after CI measured 12.72 MHz on its own hardware.
+   `fit` stays non-required: area is a design constraint, and 3880 of 5280 cells is not a cliff.
+
+## What it measures
+
+`soc/timing_sweep.sh`, four placements — the default plus `nextpnr-ice40 --seed 1/2/3` — on the
+branch with `SOC_MIN_MHZ = 12.0`. **Homebrew Yosys 0.67+post (`b8e7da6f`)**,
+nextpnr-0.10-108-g68c1acd8, `icetime` from the same install. Machine load 7.4–9.7 with two sibling
+agents building; `icetime` is a static analysis and nextpnr is seeded, so load moves the wall time
+(2m47s for the four) and not the numbers.
+
+| seed | ns | MHz |
+|---|---|---|
+| default | 76.88 | 13.01 |
+| 1 | 78.80 | 12.69 |
+| 2 | 75.81 | 13.19 |
+| 3 | 74.34 | 13.45 |
+
+All four clear 12.0 and the target exits 0. This reproduces ADR-0064's sweep to the hundredth of a
+nanosecond, which is what a seeded placer on an unchanged netlist should do — **no timing
+measurement is re-derived here**, and none should be: the measurements are ADR-0062's and
+ADR-0064's.
+
+nextpnr's own estimator now reports `13.72 MHz (PASS at 12.00 MHz)`, which is worth knowing because
+the Makefile's comment about its exit status said the opposite. Its status is still not the signal:
+it grades its own default with its own estimator, and what this repo grades is `icetime`'s report of
+the `.asc`.
+
+Probe, re-run: `make soc-timing SOC_MIN_MHZ=99` exits 2 (the script exits 1) with
+`13.01 MHz is under the 99.00 MHz floor`.
+
+## The consequence, accepted deliberately
+
+At 12.0 the margin against the worst local placement (12.69) is **5.75%**, against a measured
+**3.6% edit-churn band** (ADR-0054) and a 1–2% placement band (ADR-0057). CI's pinned OSS CAD Suite
+is a third axis that has never been measured for timing; it reported 12.72 MHz on the same tree,
+which is 6.0%.
+
+**That is tighter than any other ratchet in this repo, and it is correct anyway.** A regression floor
+buys margin so that noise does not cry wolf, because a design that regressed by 2% is still a working
+design. A requirement floor has no such licence. If an edit lands the design at 11.9 MHz, the honest
+report is that it stopped meeting its requirement — whether the cause was the edit's logic or the
+placer's mood, the part still has to be clocked at 6.
+
+**When it trips, the fix is the design, not the floor.** That sentence is written at the site, in the
+Makefile and in `soc/timing_split.py`'s failure message. Lowering `SOC_MIN_MHZ` later is a decision
+to stop targeting the board clock and needs its own ADR.
+
+## What this does not say
+
+- **It is not a claim that the design is fast.** 12 MHz on a part whose oscillator offers 48 is a
+  consequence of a combinational fetch window in one cycle, which is invariant 1 and is the design.
+- **It does not raise the bar above 12.** Nothing here asks for 24. The next divider step up is a
+  different project, and ADR-0038's test still applies: anyone proposing it is proposing to change
+  invariant 1 or invariant 6 and must say which.
+- **It is one placement flow on one toolchain.** `make soc-timing` is a static estimate at the
+  worst-case corner; no silicon has been clocked. What the requirement gates is the estimate.
+
+## Consequences
+
+- `Makefile`, `soc/timing_split.py`, `.github/workflows/ci.yml` and `CLAUDE.md` stop describing the
+  floor as a margin under the measurement. `test/probe_gates.sh` keeps the same probe, relabelled.
+- **A red `soc-timing` now blocks merge.** Before this, a change that cost 15% of the clock reached
+  `main` with a green summary and a number in a step report nobody had to read.
+- **Every future timing ADR has a pass/fail, not a trend.** The last four each reported a percentage
+  against a moving reference; the question now is whether the sweep clears 12.0.
+- `make fit`'s `FIT_MAX_LC` is untouched and stays a regression ratchet with margin over its ±50-cell
+  churn floor. The two ratchets now have different characters on purpose, and that difference is the
+  thing to carry: area has no cliff at 5280 minus one cell, and the clock has one at 12 MHz.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -42,7 +42,7 @@ and what it costs. Reversing one is fine — write a new ADR that supersedes it.
 | [0035](0035-the-baseline-pins-the-failure-mode.md) | `test/EXPECTED_FAIL` pins the failure mode, not just the file name | Accepted |
 | [0036](0036-three-gate-hardening-decisions-ratified-at-integration.md) | Three gate-hardening decisions ratified at integration, and a correction to ADR-0031 | Accepted |
 | [0037](0037-an-empty-baseline-is-not-m2.md) | An empty formal baseline is not M2, and the milestone criterion said it was | Accepted · amended by 0045, 0047 |
-| [0038](0038-area-is-measured-in-logic-cells-and-two-levers-are-rejected.md) | Area is measured in logic cells, Fmax is declared at 12 MHz, and two area levers are rejected | Accepted |
+| [0038](0038-area-is-measured-in-logic-cells-and-two-levers-are-rejected.md) | Area is measured in logic cells, Fmax is declared at 12 MHz, and two area levers are rejected | Accepted · decision 2 amended by 0066, which makes 12 MHz a requirement |
 | [0039](0039-co-simulation-runs-the-whole-suite-against-a-baseline.md) | Co-simulation runs the whole suite against a baseline, and `tohost` becomes a doubleword | Accepted |
 | [0040](0040-the-ladder-refuses-a-negedge-regfile-and-make-check-was-re-grading.md) | The ladder refuses a negedge regfile rather than mis-modelling one, and `make check` had been re-grading the previous run | Accepted |
 | [0041](0041-integration-decisions-from-the-fit-cosim-and-negedge-wave.md) | Integration decisions from the fit / co-simulation / negedge wave | Accepted |
@@ -70,6 +70,7 @@ and what it costs. Reversing one is fine — write a new ADR that supersedes it.
 | [0063](0063-the-suite-runs-programs-that-use-writable-text.md) | The suite runs programs that use writable text | Accepted · builds 0057's step 5 less its `.data` half; discharges 0061 |
 | [0064](0064-the-write-through-bypass-is-addressed-from-the-held-pair.md) | The write-through bypass is addressed from the held pair, and invariant 6 now leans on invariant 9 | Accepted · implements 0062; moves `SOC_MIN_MHZ` |
 | [0065](0065-the-ladder-speaks-the-writable-text-bus.md) | The ladder speaks the writable-text bus, and `imemcheck` stops at the first store | Accepted · builds 0057's step 4; pays off 0060 decision 3 |
+| [0066](0066-twelve-megahertz-is-a-requirement.md) | Twelve megahertz is a requirement | Accepted · amends 0038 decision 2; answers the question 0064 left open |
 
 0001–0007 came from the design brief
 ([`docs/ideas/finish-the-rewrite.md`](../ideas/finish-the-rewrite.md)). 0008–0011 came out of

--- a/soc/timing_split.py
+++ b/soc/timing_split.py
@@ -63,9 +63,9 @@ def main():
     parser.add_argument(
         "--min-mhz",
         type=float,
-        help="fail if the critical path is slower than this (the regression "
-        "ratchet; see SOC_MIN_MHZ in the Makefile for why it sits below the "
-        "measurement rather than at ADR-0038's declared 12 MHz)",
+        help="fail if the critical path is slower than this (SOC_MIN_MHZ in "
+        "the Makefile, which sits at the board clock rather than below the "
+        "last measurement)",
     )
     args = parser.parse_args()
 
@@ -156,9 +156,10 @@ def main():
         if mhz < args.min_mhz:
             sys.exit(
                 f"\n*** {mhz:.2f} MHz is under the {args.min_mhz:.2f} MHz floor.\n"
-                f"*** This is a ratchet (ADR-0054), not a suggestion. Find what\n"
-                f"*** lengthened the fetch -> decode -> next-PC loop; raising\n"
-                f"*** SOC_MIN_MHZ in the Makefile needs a reason in the commit."
+                f"*** That floor is the clock the board runs at, so the design\n"
+                f"*** no longer meets its requirement. Find what lengthened the\n"
+                f"*** path and shorten it. Lowering SOC_MIN_MHZ is a decision to\n"
+                f"*** stop targeting the board clock and needs its own ADR."
             )
         print(f"\nRATCHET: {mhz:.2f} MHz against a {args.min_mhz:.2f} MHz floor -- OK")
 

--- a/test/probe_gates.sh
+++ b/test/probe_gates.sh
@@ -877,7 +877,7 @@ probe "control: a report clearing the floor is green" 0 "RATCHET:" \
   "$TS $d/report.rpt --min-mhz 10.0"
 
 d=$(ts_fixture)
-probe "a report missing the floor is a ratchet, not a suggestion" 1 \
+probe "a report under the floor fails, because the floor is the board clock" 1 \
   "is under the" "$TS $d/report.rpt --min-mhz 9999"
 
 d=$(ts_fixture); sed -i.bak '/^Total path delay:/d' "$d/report.rpt"


### PR DESCRIPTION
Closes JEF-749.

`SOC_MIN_MHZ` goes **10.9 -> 12.0**, and the convention goes with it.

## What changed

- **`Makefile`: `SOC_MIN_MHZ := 12.0`**, with the requirement-versus-regression distinction at the site. 10.0 and 10.9 were regression floors, each about 11.5% under the then-current measurement so churn could not cry wolf; a regression floor slides every time the design moves. This one sits at the clock the board supplies and does not slide. **When it trips, the fix is the design, not the floor** — written in the Makefile and in `soc/timing_split.py`'s failure message.
- **`docs/adr/0038`** decision 2 amended in place: the 12 MHz *declaration* becomes a *requirement*.
- **`docs/adr/0066-twelve-megahertz-is-a-requirement.md`** records the decision, the divider argument and the accepted noise risk.
- **`soc/timing_split.py`**, **`.github/workflows/ci.yml`** and **`CLAUDE.md`** stop describing the floor as a margin under the measurement, and stop calling `soc-timing` non-required — it is a required check now, so the required set is seven.
- **`test/probe_gates.sh`**: same probe, relabelled.

No `rtl/` file changed. **No timing measurement is re-derived here** — the numbers are ADR-0062's and ADR-0064's.

## Why 12 and not 11

12 MHz is the iCEBreaker crystal, and the part's own oscillator divides 48 by 1, 2, 4 or 8 — 48/24/12/6. **The step below 12 is 6.** A design at 11.9 MHz does not run 1% slower; it runs at half the clock.

## The consequence, accepted deliberately

At 12.0 the margin against the worst local placement (12.69) is **5.75%**, against a measured **3.6% edit-churn band** and a 1-2% placement band. That is tighter than any other ratchet in this repo. A regression floor buys margin so noise does not cry wolf; a requirement floor has no such licence. If an edit lands at 11.9 MHz, the honest report is that the design stopped meeting its requirement. **Lowering this number later is a decision to stop targeting the board clock and needs its own ADR.**

## How it was tested

`soc/timing_sweep.sh`, four placements with the new floor in place. Homebrew **Yosys 0.67+post (`b8e7da6f`)**, nextpnr-0.10-108-g68c1acd8, `icetime` from the same install. **Machine load 7.4-9.7** with two sibling agents building; 2m47s wall for the four, and `icetime` is a static analysis against a seeded placer, so load moves the wall time and not the numbers.

| seed | ns | MHz |
|---|---|---|
| default | 76.88 | 13.01 |
| 1 | 78.80 | 12.69 |
| 2 | 75.81 | 13.19 |
| 3 | 74.34 | 13.45 |

All four clear 12.0; the sweep exits 0. This reproduces ADR-0064's sweep to the hundredth of a nanosecond, which is what a seeded placer on an unchanged netlist should do.

Other gates, same tree:

- **Probe**: `make soc-timing SOC_MIN_MHZ=99` exits **2** (the script exits 1, make reports its own) with `*** 13.01 MHz is under the 99.00 MHz floor.` CLAUDE.md said "exits 1" and is corrected.
- `make fit` — **3880 / 4100 cells, 73%**, unchanged.
- `make test` — **59/59**, `test/EXPECTED_FAIL` empty, set equality both ways.
- `make probe-gates` — **125 graded comparisons, every failure path executed.**
- nextpnr's own estimator now prints `13.72 MHz (PASS at 12.00 MHz)`. The Makefile comment claiming it exits nonzero because the design is 6% slow is corrected — its status is still not the signal, for a different reason.

## Notes for review

- **`docs/adr/README.md` touches one row plus one new row**; sibling PRs are taking 0065 and 0067, so the ADR-count line in `CLAUDE.md`'s Pointers is deliberately left alone — it should be re-derived once, after the three land, per its own instruction.
- Branch protection was updated outside this PR (soc-timing added to the required set after CI measured 12.72 MHz on its own hardware); nothing here can change it.