### PR TITLE
Strike the stale Fmax claims in the two design briefs

### DIFF
--- a/docs/ideas/fast-simple-small-formally-verified.md
+++ b/docs/ideas/fast-simple-small-formally-verified.md
@@ -128,8 +128,20 @@ and every `[depth]` line is a function of them (ADR-0046, ADR-0057). Bet 2's pre
 no reorder buffer. Retire needs no filter. And `pcloop`'s k-induction never has to invent an
 invariant over speculative state.
 
-**What it costs:** the fetch loop is the critical path — 28 LUT levels at ~3.3 ns each — and
-the design sits at 10.2–10.4 MHz against a 12 MHz crystal whose next divider step is 6.
+**What it costs:** the fetch loop is the critical path, and everything on it is paid once per
+cycle.
+
+~~the design sits at 10.2–10.4 MHz against a 12 MHz crystal whose next divider step is 6.~~
+**Struck.** The design reaches **12.7–13.5 MHz** across four placements, and 12 MHz is a
+requirement now rather than an intent. It got there by finding one comparator on the wrong side of
+the instruction — the write-through bypass selected on a live combinational `rs1` when the contract
+already said the answer belongs to the previous cycle's pair. Six LUT levels for four lines.
+
+**That changes the bar for reopening the bet, and it is the more useful correction.** This section
+was written when the bet looked like it was costing the board clock. It was not. A flush can no
+longer justify itself by reaching 12, because 12 is met without wrong-path state — the next thing
+worth wanting is 24, which needs roughly 11 of the remaining 23 levels. Whether that is reachable
+at all is measured separately, and it may not be.
 
 ## Reopening bet 1
 

--- a/docs/ideas/fit-the-core-on-the-up5k.md
+++ b/docs/ideas/fit-the-core-on-the-up5k.md
@@ -470,11 +470,18 @@ Invariant 1 (combinational fetch) and invariant 6 put `pc → imem_addr → imem
 decode → regfile read → branch compare → next pc` in one cycle **by design**. A low Fmax is a
 consequence of a stated value, not a defect.
 
-The regfile read alone measured 14.82 ns on faster silicon; the full loop plausibly lands at
-50–70 ns on up5k, ~15–20 MHz. Declare **12 MHz** (the iCEBreaker oscillator) and record `icetime`
-in `make fit` once the design places. At 12 MHz a half-period is 41 ns, which is enormous relative
-to the negedge discipline's budget. Anyone proposing to raise Fmax later is proposing to break
-invariant 1 or 6, and must bring an ADR.
+~~The regfile read alone measured 14.82 ns on faster silicon; the full loop plausibly lands at
+50–70 ns on up5k, ~15–20 MHz.~~ **Both halves of that guess are struck.** The loop measured
+88.5 ns — worse than the guess — and then reached **76.9 ns, 12.7–13.5 MHz** across four
+placements. 12 MHz is a requirement now, `soc-timing` is a required check, and `make soc-timing`
+is where it is measured, not `make fit`.
+
+**The last sentence is the one that was most wrong.** Raising Fmax did not mean breaking invariant 1
+or 6. It meant noticing that the write-through bypass compared against a live combinational `rs1`
+when the regfile's own contract already said the answer belongs to the previous cycle's address
+pair — six LUT levels for four lines, no invariant touched. The lesson worth keeping: a low Fmax
+was assumed to be the price of a stated value, and most of it turned out to be an accident nobody
+had looked for.
 
 ## Risks
 


### PR DESCRIPTION
Both briefs said the design misses 12 MHz. It reaches **12.7–13.5 MHz** across four placements, 12 MHz is a requirement now, and `soc-timing` is a required check.

## The one worth reading

`fit-the-core-on-the-up5k.md`'s "Fmax: declare 12 MHz and stop" said:

> A low Fmax is a consequence of a stated value, not a defect. […] Anyone proposing to raise Fmax later is proposing to break invariant 1 or 6, and must bring an ADR.

**Raising it needed neither.** The write-through bypass selected on a live combinational `rs1` when the regfile's own contract already said the answer belongs to the previous cycle's address pair. Six LUT levels for four lines, no invariant touched.

Its numeric guess was wrong in both directions too — it predicted 50–70 ns, the loop measured 88.5, and it now sits at 76.9.

**Most of the missing frequency was not a design cost. It was an accident nobody had looked for, sitting behind an assumption that it was a design cost.**

That also moves the bar for the no-flush bet, which is now being priced separately: a flush can no longer justify itself by reaching 12, because 12 is met without wrong-path state.

Struck in place rather than deleted, per the convention for briefs. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJ77ZZJ6pDiL3vj3Qw9hKs