### PR TITLE
JEF-725: Commit to the non-faulting bus and rule on the eleven declined checks

### DIFF
--- a/docs/adr/0044-what-the-memory-system-has-to-be.md
+++ b/docs/adr/0044-what-the-memory-system-has-to-be.md
@@ -7,10 +7,14 @@ ADR-0008; the design it enables is post-M4 and needs its own ADR.*
 > ahead of the post-M4 slot below. It adopts the next-PC-clocked address and the negedge rejection
 > verbatim, banks at **word** granularity rather than the halfword split named here (this core's
 > fetch interface asks for two adjacent words and windows them itself), and puts the ROM in BRAM
-> with the SPI-flash boot path still unbuilt. **Everything in the ladder section below still
-> stands**: no faulting bus and no IO region were added, so all eleven checks stay `[BLOCKED]` and
-> invariant 2 stays unpressured. The four constraints and the 43 KB arithmetic above are the
-> starting point ADR-0054 was written from; they are kept as written.
+> with the SPI-flash boot path still unbuilt. The four constraints and the 43 KB arithmetic above are
+> the starting point ADR-0054 was written from; they are kept as written.
+>
+> **The ladder section below is discharged by
+> [ADR-0067](0067-the-bus-never-refuses-and-the-eleven-are-ruled.md)**, which takes option 1 as a
+> permanent commitment and rules on all eleven checks by name — seven `[DESIGN]`, four `[BLOCKED]`.
+> Invariant 2 is settled there rather than unpressured. Read the table and the blocker sort below as
+> the analysis that ruling was made from; read `formal/checks.cfg` for the rulings themselves.
 
 ## Context
 

--- a/docs/adr/0067-the-bus-never-refuses-and-the-eleven-are-ruled.md
+++ b/docs/adr/0067-the-bus-never-refuses-and-the-eleven-are-ruled.md
@@ -1,0 +1,206 @@
+# ADR-0067: The bus never refuses a transaction, and the eleven declined checks are ruled
+
+**Status:** Accepted · 2026-08-02 · *Pays off
+[ADR-0044](0044-what-the-memory-system-has-to-be.md)'s closing obligation — a ruling on each of its
+eleven declined ladder checks by name. Adopts its option 1 as a permanent commitment. Reads
+`formal/imemcheck.sv` as [ADR-0065](0065-the-ladder-speaks-the-writable-text-bus.md) left it.
+Settles invariant 2's open question. No `rtl/` file changed and no gate changed verdict.*
+
+## Context
+
+ADR-0044 ended with a debt, stated precisely: the eventual memory ADR owes a ruling on each of
+eleven checks **by name**, with each `#omit` line either deleted, re-tagged `[DESIGN]`, or left
+`[BLOCKED]` with what it is still blocked on.
+
+ADR-0054 built the memory system and deliberately did not take that ruling. It was right not to: at
+that point the SoC had two disjoint buses, one initialisable ROM, no way to load a program, and no
+address map a real product would have. Declaring the bus permanently non-faulting from there would
+have been a guess dressed as a decision — the thing ADR-0038 refused to do about the regfile and
+ADR-0042 then did properly, with data.
+
+The map is real now. Text is writable and the data bus reaches it (ADR-0059), the stolen fetch
+window reaches decode (ADR-0060), and every formal harness speaks the same bus the RTL does
+(ADR-0065). The question the ruling turns on — can this system's memory say *no* to an access? — has
+a settled answer for the first time.
+
+## Decision 1 — the bus never refuses a transaction, and that is permanent
+
+`rtl/imemory.v` and `rtl/memory.v` answer every address the core can present. Read from the RTL
+rather than from intent:
+
+- An **in-range** load or store is served.
+- An **out-of-range load** reads zero. `rtl/memory.v` drives `32'b0` when `in_range` is false, and
+  `rtl/imemory.v` drives `32'b0` unless the previous cycle was a text-range load. The two are joined
+  with an OR (ADR-0059 decision 2), so an address in neither region reads zero.
+- An **out-of-range store** is dropped. Every write arm in both files is gated on its own range
+  test, and `rtl/memory.v` indexes off a subtracted offset rather than truncated address bits, so a
+  dropped store cannot alias a mapped word either. `test/mem_tb.v` checks that at the boundary and
+  far away.
+- An **out-of-range fetch** reads zero. Zero is an illegal instruction, so a PC that runs off the
+  end of text traps in decode instead of wrapping round.
+
+There is no fault line, no handshake and no way to signal refusal on either bus. **This ADR adopts
+ADR-0044 option 1 as a commitment, not as a description of what happens to be built.** A future
+kernel that wants access faults needs its own ADR, and that ADR has to answer invariant 2, not
+merely note it.
+
+Option 2 (faults resolved in decode from a static range decode) and option 3 (change invariant 2)
+are both declined. Option 2 buys reachable `ifault` at the cost of a second copy of the memory map
+inside `rtl/decoder.v`, on the loop `make soc-timing` reports as critical, for a fault no program in
+this repo can raise. Option 3 trades away the property that makes CSR commit precise with no reorder
+buffer, and buys nothing until there is protection to enforce.
+
+## Decision 2 — invariant 2 is settled, not merely unpressured
+
+ADR-0044's sharpest paragraph is that invariant 2 and an access fault only coexist because nothing
+on this core can raise one — the two propositions were not reconciled, they were *unreached*, and
+the memory system would force a ruling.
+
+It is reached now and the ruling is the conservative one: **nothing faults after decode, because
+nothing after decode can fault.** That is a property of the memory system as designed, not an
+accident of what is not built yet, and the five checks that put the question are declined
+permanently rather than parked.
+
+The two words are not interchangeable. "Unpressured" leaves someone free to add a faulting
+peripheral and meet the conflict at synthesis time; "settled" says the non-faulting bus is part of
+the design, and widening it is an ADR-sized change.
+
+## Decision 3 — the eleven, by name
+
+| check | ruling | why |
+|---|---|---|
+| `fault_ch0` | `[DESIGN]` | no access fault can be raised |
+| `bus_imem_fault_ch0` | `[DESIGN]` | no fault line on the fetch bus |
+| `bus_dmem_fault_ch0` | `[DESIGN]` | no fault line on the data bus |
+| `bus_dmem_io_read_fault_ch0` | `[DESIGN]` | same, and the fault half is what settles it |
+| `bus_dmem_io_write_fault_ch0` | `[DESIGN]` | same |
+| `bus_imem_ch0` | `[DESIGN]` | `formal/imemcheck.sv` holds this against the real fetch ports |
+| `bus_dmem_ch0` | `[DESIGN]` | `formal/dmemcheck.sv` holds this against the real data port |
+| `bus_dmem_io_read_ch0` | `[BLOCKED]` | no MMIO region exists |
+| `bus_dmem_io_write_ch0` | `[BLOCKED]` | no MMIO region exists |
+| `causal_io_ch0` | `[BLOCKED]` | no MMIO region exists |
+| `bus_dmem_io_order_ch0` | `[BLOCKED]` **on the core** | one access is outstanding at a time |
+
+The two `io_*_fault` forms need both a faulting bus and an MMIO region. They are `[DESIGN]` because
+one of their two conditions is now permanently unmeetable; an MMIO region would not reopen them.
+
+`bus_dmem_io_order_ch0` is the one whose blocker moved rather than closed. ADR-0044 already said its
+real obstacle is the core and not the memory, and its `#omit` line said "no ordering to check" while
+its stated need was `RISCV_FORMAL_BUS` and `rvformal_addr_io`. The line now leads with the core:
+`rtl/accessor.v` has one access outstanding at a time, so a second one is a pipeline change with
+everything the stall protocol would have to say about it, and no memory design touches that.
+
+**Unification unblocks none of the eleven.** That is the correct outcome and not a disappointment.
+The whole point of one address space over two memories was to make text reachable from the data bus,
+and none of these checks is about reachability — five are about refusal, four about a region this
+map does not have, one about ordering the pipeline cannot produce, and two about restating
+properties two hand-authored tasks already hold. A change that unblocked some of them would have
+been a change that added a fault line or an MMIO window, and neither was in scope.
+
+## Decision 4 — the `imemcheck` argument survives, and it is stronger than ADR-0044's version
+
+ADR-0044 tagged `bus_imem_ch0` and `bus_dmem_ch0` "expect `[DESIGN]` on review", on the argument
+that `formal/imemcheck.sv` and `formal/dmemcheck.sv` already hold the property. That argument was
+written before ADR-0065 replaced `rvfi_imem_check` with this repo's own shadow-halfword assertion,
+and ADR-0065 records a real narrowing: **the retire assertion stops at the first store to the
+watched halfword and does not resume.** So the argument had to be re-read rather than inherited.
+
+It holds, and the reason is worth writing down because it points the other way from the obvious
+worry. `checks/rvfi_bus_imem_check.sv` at the pin pins a `rand_const` halfword for the whole trace
+and **has no write path at all**: it walks the instruction-fetch bus channels and assumes each read
+of the watched address returns the fixed value. On a core whose text is writable, that assumption
+does not preserve the stored-then-fetched case — it constrains it out of the model entirely, and
+silently.
+
+So adopting `bus_imem_ch0` would not recover what `formal/imemcheck.sv` gave up. It never had it.
+What this repo's version does instead is model the store explicitly and stop asserting where the
+answer is genuinely ambiguous, which is the same coverage stated honestly rather than assumed away.
+
+`bus_dmem_ch0` is the easier half: `checks/rvfi_bus_dmem_check.sv` carries a shadow and a write path,
+and it re-derives against `rvfi_bus_*` what `formal/dmemcheck.sv` already derives against the real
+`mem_addr`/`mem_wstrb`/`mem_rdata` port. Both would additionally cost driving nine `rvfi_bus_*`
+outputs from `rtl/`, which is new instrumentation for `make -C formal nonperturbation` to prove
+unread, for a property already held.
+
+### What no check on this ladder asserts
+
+**That a store to text becomes visible to a later fetch.** `formal/imemcheck.sv` assumes it — the
+fetch data is a free input its shadow constrains, because that task models no memory — and no other
+task on the ladder looks at fetch data against a memory model at all. Adopting either bus check
+would not change that.
+
+`test/asm/selfmod.S`, `test/asm/textload.S` and `test/asm/contend.S` (ADR-0063) are the only things
+in the tree that test it, under `make test` and `make cosim-suite`. That is a simulation-only
+guarantee about the property the whole writable-text theme exists to create, and it should be read
+as one.
+
+## The consequence ADR-0008 gave up: address 0 is writable text
+
+`test/asm/sections.lds` puts `.text` at `0x0000_0000` and `_start` is its first bytes.
+`rtl/imemory.v` treats every word below `ROM_WORDS` as writable from the data bus. **So a store
+through a null pointer overwrites the first instructions of `_start`.**
+
+`rtl/memory.v`'s `BASE` parameter is `0x0001_0000` and its own comment says why: RAM sits at a
+non-zero base so a null store lands outside it rather than silently on real data. That protection
+still holds for RAM and is now beside the point, because the null store lands on text instead.
+
+This is inherent to the theme and not avoidable within it. Making text unreachable from the data bus
+is exactly what ADR-0059 undid; moving text off zero costs the reset vector, the linker script and
+every `OBSERVED_FLOOR` line, for a guard against one bug class in a repo with no memory protection of
+any kind. It is recorded here so it is found in a decision record rather than on hardware, and so
+the eventual protection ADR starts from a known address rather than a discovery.
+
+Two things follow that are cheap to state and worth stating:
+
+- The failure is **loud, not silent**, in the common case. A store of zero over `_start` leaves an
+  illegal instruction, which traps to `mtvec`, and `test/run_tests.sh` already labels a trap
+  redirected to address 0 as `TRAP-TO-ZERO` (ADR-0029) rather than letting it time out.
+- It arrived with ADR-0059, not here. Before text was reachable from the data bus the same store was
+  dropped by an address decode that no longer exists, and nothing in `test/asm` does it either way.
+
+## What did not change
+
+**Nothing generated, and nothing ran differently.** The `#omit` lines are read by
+`formal/genchecks-audit.py`, which captures only the check name; `genchecks`' own cfg parser drops
+every `#` line before it sees a section. The generated ladder was captured before the edit and
+regenerated after it: **`diff -r` over the two directories is empty — 85 `.sby` files plus the
+emitted makefile, byte-identical.** This change alters reasons and class tags and nothing else.
+
+The declined count is derived rather than asserted. `formal/genchecks-audit.py` reports
+`85 generated, 14 declined for want of a [depth] line` and set-equalities that set against the
+`#omit` declarations in both directions, so the eleven above plus the three that were already
+`[DESIGN]` are counted by the generator, not by this ADR.
+
+The gate that could have moved was run rather than reasoned about. Machine: 10 cores, two sibling
+agents live, load 13–43 across the run, `JOBS=4`, so the wall time is not comparable with a quiet
+box.
+
+| gate | result |
+|---|---|
+| `make -C formal check JOBS=4` | **85 checks, 85 pass**, 11m39s; both set equalities exact in both directions |
+| `formal/EXPECTED_FAIL` | empty, matched by name and status |
+| `formal/checks/*.sby` before vs after | byte-identical, all 85, compared twice |
+
+The `#omit` region is a graded comparison, so both of its red directions were forced rather than
+assumed. Deleting the `fault_ch0` line gives exit 1 and
+`in dropped but not #omit: fault_ch0`; adding a line for a check that *is* generated gives exit 1
+and `in #omit but not dropped: insn_add_ch0`. Both took about a second, and `checks.cfg` was
+restored and re-run green after each.
+
+## Consequences
+
+- **Every `#omit` line now reads as a decision or as a burn-down item, and the two are
+  distinguishable.** That was the whole reason the `[BLOCKED]`/`[DESIGN]` tags exist; until now
+  eleven of the fourteen carried the tag that means "come back to this" and nobody could tell which
+  ones ever would.
+- **The remaining burn-down is four checks, and it turns on two things.** An MMIO region and a
+  second outstanding access are both out of scope and both need their own ADR, so the honest reading
+  of `checks.cfg` is that the declined set is now stable rather than shrinking.
+- **A pin bump that adds a check still fails generation until someone rules on it.** That mechanism
+  is untouched, and it is what keeps this list from going stale the way ADR-0044's did.
+- **`formal/EXPECTED_CHECKS`, `formal/EXPECTED_FAIL` and every depth line are untouched.** The
+  ladder is 85 checks, 85 pass, both set equalities exact in both directions, re-run on this branch.
+- **The next memory-shaped change inherits a contract instead of a question.** SPI flash boot, a
+  bigger text region, a bootloader — each of them has to keep the bus non-faulting or replace this
+  ADR, and the second option now has a name and a cost rather than being an open option nobody
+  chose.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -71,6 +71,7 @@ and what it costs. Reversing one is fine — write a new ADR that supersedes it.
 | [0064](0064-the-write-through-bypass-is-addressed-from-the-held-pair.md) | The write-through bypass is addressed from the held pair, and invariant 6 now leans on invariant 9 | Accepted · implements 0062; moves `SOC_MIN_MHZ` |
 | [0065](0065-the-ladder-speaks-the-writable-text-bus.md) | The ladder speaks the writable-text bus, and `imemcheck` stops at the first store | Accepted · builds 0057's step 4; pays off 0060 decision 3 |
 | [0066](0066-twelve-megahertz-is-a-requirement.md) | Twelve megahertz is a requirement | Accepted · amends 0038 decision 2; answers the question 0064 left open |
+| [0067](0067-the-bus-never-refuses-and-the-eleven-are-ruled.md) | The bus never refuses a transaction, and the eleven declined checks are ruled | Accepted · pays off 0044's closing obligation; settles invariant 2 |
 
 0001–0007 came from the design brief
 ([`docs/ideas/finish-the-rewrite.md`](../ideas/finish-the-rewrite.md)). 0008–0011 came out of

--- a/formal/checks.cfg
+++ b/formal/checks.cfg
@@ -69,28 +69,30 @@ mscratch any
 # perturb generation.
 #
 #   [BLOCKED]  the property is wanted and there is no hardware here to state it
-#              about -- a burn-down owned by the memory-system ADR (ADR-0044,
-#              which tabulates all eleven).
+#              about.
 #   [DESIGN]   declined on the merits; no hardware change reopens it.
 #
 # The tag is free-form to the audit script, which captures only the check name.
 #
-# fault_ch0 and the four *_fault forms are the five that put invariant 2 in
-# question: a bus fault is raised by the memory, i.e. after decode, and
-# invariant 2 says every trap is committed in decode. The two coexist today only
-# because no access fault is reachable on this core. ADR-0044 records the
-# options and deliberately picks none, so do not read these lines as that
-# ruling having been made.
-#omit fault_ch0                   [BLOCKED] needs a bus that can refuse, rvfi_mem_fault{,_rmask,_wmask}, and mcause in [csrs]; and it puts invariant 2 in question -- ADR-0044
-#omit bus_imem_ch0                [BLOCKED] needs RISCV_FORMAL_BUS; property already held by formal/imemcheck.sv, so expect [DESIGN] on review
-#omit bus_imem_fault_ch0          [BLOCKED] needs RISCV_FORMAL_BUS and a bus that can refuse a transaction
-#omit bus_dmem_ch0                [BLOCKED] needs RISCV_FORMAL_BUS; property already held by formal/dmemcheck.sv, so expect [DESIGN] on review
-#omit bus_dmem_fault_ch0          [BLOCKED] needs RISCV_FORMAL_BUS and a bus that can refuse a transaction
+# The bus never refuses a transaction, and that is decided rather than pending.
+# An in-range access is answered, an out-of-range load reads zero, an
+# out-of-range store is dropped, and a fetch past the end of text reads zero,
+# which decode raises as an illegal instruction. There is no access fault for
+# the five fault checks to be about.
+#
+# bus_imem_ch0 and bus_dmem_ch0 would restate what formal/imemcheck.sv and
+# formal/dmemcheck.sv already hold against the real fetch and data ports, and
+# taking them means driving nine more RVFI outputs that nothing else needs.
+#omit fault_ch0                   [DESIGN] the bus never refuses a transaction, so no access fault can be raised
+#omit bus_imem_ch0                [DESIGN] formal/imemcheck.sv holds this against the real fetch ports
+#omit bus_imem_fault_ch0          [DESIGN] no fault line on the fetch bus, and none is coming
+#omit bus_dmem_ch0                [DESIGN] formal/dmemcheck.sv holds this against the real data port
+#omit bus_dmem_fault_ch0          [DESIGN] no fault line on the data bus, and none is coming
 #omit bus_dmem_io_read_ch0        [BLOCKED] needs RISCV_FORMAL_BUS and rvformal_addr_io; no MMIO region exists
-#omit bus_dmem_io_read_fault_ch0  [BLOCKED] needs RISCV_FORMAL_BUS, rvformal_addr_io, and a faulting bus
+#omit bus_dmem_io_read_fault_ch0  [DESIGN] no fault line on the data bus, and none is coming
 #omit bus_dmem_io_write_ch0       [BLOCKED] needs RISCV_FORMAL_BUS and rvformal_addr_io; no MMIO region exists
-#omit bus_dmem_io_write_fault_ch0 [BLOCKED] needs RISCV_FORMAL_BUS, rvformal_addr_io, and a faulting bus
-#omit bus_dmem_io_order_ch0       [BLOCKED] needs RISCV_FORMAL_BUS and rvformal_addr_io; one outstanding access, no ordering to check
+#omit bus_dmem_io_write_fault_ch0 [DESIGN] no fault line on the data bus, and none is coming
+#omit bus_dmem_io_order_ch0       [BLOCKED] on the core, not the memory: one access is outstanding at a time, so there is nothing to order
 #omit causal_io_ch0               [BLOCKED] needs rvformal_addr_io; no MMIO region exists
 #omit csrc_inc_mcycle_ch0         [DESIGN] rvfi_csrc_inc_check.sv is red on a CORRECT core here; measured, see [csrs]
 #omit csrc_inc_minstret_ch0       [DESIGN] rvfi_csrc_inc_check.sv is red on a CORRECT core here; measured, see [csrs]


### PR DESCRIPTION
Closes JEF-725.

ADR-0044 tabulated eleven declined ladder checks and said the eventual memory ADR owed each of them a ruling **by name**. ADR-0054 built the memory system and deliberately did not take it, because the SoC had no address map a real product would have. It does now — text is writable, the steal reaches decode, and #111 makes the ladder speak the new bus — so this takes the ruling.

**Pure declaration plus an ADR. No `rtl/` file changed, no `[depth]` line moved, no gate changed verdict.**

## The commitment

ADR-0044 option 1, adopted permanently: **the bus never refuses a transaction.** Read out of the RTL rather than from intent — an in-range access is answered, an out-of-range load reads zero, an out-of-range store is dropped and cannot alias a mapped word, and a fetch past the end of text reads zero, which decode raises as an illegal instruction. There is no fault line on either bus.

**Invariant 2 is settled, not merely unpressured.** ADR-0044's point was that the invariant and an access fault coexisted only because nothing could raise one — unreached, not reconciled. It is reached now, and the conservative answer is taken: nothing faults after decode because nothing after decode can fault.

## The eleven rulings

| check | ruling | why |
|---|---|---|
| `fault_ch0` | `[DESIGN]` | no access fault can be raised |
| `bus_imem_fault_ch0` | `[DESIGN]` | no fault line on the fetch bus |
| `bus_dmem_fault_ch0` | `[DESIGN]` | no fault line on the data bus |
| `bus_dmem_io_read_fault_ch0` | `[DESIGN]` | the fault half settles it; an MMIO region would not reopen it |
| `bus_dmem_io_write_fault_ch0` | `[DESIGN]` | same |
| `bus_imem_ch0` | `[DESIGN]` | `formal/imemcheck.sv` holds this against the real fetch ports |
| `bus_dmem_ch0` | `[DESIGN]` | `formal/dmemcheck.sv` holds this against the real data port |
| `bus_dmem_io_read_ch0` | `[BLOCKED]` | no MMIO region exists |
| `bus_dmem_io_write_ch0` | `[BLOCKED]` | no MMIO region exists |
| `causal_io_ch0` | `[BLOCKED]` | no MMIO region exists |
| `bus_dmem_io_order_ch0` | `[BLOCKED]` **on the core** | one access outstanding at a time, so there is nothing to order |

**Unification unblocks none of them**, which is the right outcome and is written into the ADR as one. None of the eleven is about reachability, and the one thing this theme changed was reachability.

## The `imemcheck` question — re-read, not inherited

#111 drops `rvfi_imem_check` for this repo's own shadow-halfword check, whose retire assertion stops at the first store to the watched halfword. So ADR-0044's "`imemcheck` already holds the property" argument had to be re-derived.

**It survives, and for a stronger reason than ADR-0044 gave.** `checks/rvfi_bus_imem_check.sv` at the pin pins a `rand_const` halfword for the whole trace and **has no write path at all** — it assumes every instruction-fetch bus read of the watched address returns the fixed value. On a writable-text core that does not preserve the stored-then-fetched case, it constrains it out of the model silently. Adopting `bus_imem_ch0` would not recover what `imemcheck` gave up; it never had it. Both would additionally cost driving nine `rvfi_bus_*` outputs (count re-derived from `checks/rvfi_macros.py`, not quoted) for a property two hand-authored tasks already hold.

Recorded alongside it: **the property writable text creates — a store becoming visible to a later fetch — is asserted nowhere on this ladder.** It is an assumption in `imemcheck`, because that task models no memory, and adopting either bus check would not change that. `selfmod.S` / `textload.S` / `contend.S` are the only things testing it.

## The consequence ADR-0008 gave up

**Address 0 is writable text, so a null-pointer store overwrites `_start`.** `rtl/memory.v`'s `BASE` is non-zero for exactly this reason and that protection is now beside the point. Inherent to the theme and not avoidable within it; written down so it is found in a decision record rather than on hardware.

## Gates

10 cores, two sibling agents live, load 13–43 across the run, `JOBS=4` — wall time is not comparable with a quiet box.

| gate | result |
|---|---|
| `make -C formal check JOBS=4` | **85 checks, 85 pass**, 11m39s; both set equalities exact in both directions |
| `formal/EXPECTED_FAIL` | empty, matched by name and status |
| `formal/genchecks-audit.py` | `85 generated, 14 declined for want of a [depth] line`; `#omit` 14 names, exact match |
| generated `.sby` set, before vs after | **byte-identical**, all 85 plus the emitted makefile, `diff -r` empty — verified rather than assumed |

The declined count is derived from the generator, not asserted in prose — the number above is the audit's own output line.

### Both red directions of the `#omit` set, forced

| probe | verdict |
|---|---|
| delete the `fault_ch0` `#omit` line | exit 1, `in dropped but not #omit: fault_ch0` |
| add an `#omit` line for a generated check | exit 1, `in #omit but not dropped: insn_add_ch0` |

`checks.cfg` restored and re-run green after each.

## For the architect

- **ADR is 0067** per the coordinator's renumbering note; 0065 is #111 and 0066 is a sibling. The README row is appended after 0064, so it will conflict trivially with #111's row.
- **Merge after #111.** ADR-0067 links `docs/adr/0065-the-ladder-speaks-the-writable-text-bus.md`, which does not exist until that PR lands, and Decision 4 reads `formal/imemcheck.sv` as #111 leaves it. The `formal/checks.cfg` edits do not overlap — #111 touches `[script-sources]`, this touches the `#omit` region.
- **`CLAUDE.md` is not touched and two lines in it are now stale.** Flagging rather than editing, same as #111, since it is a three-way conflict surface this sprint. Invariant 2's text says "five of the fourteen checks `formal/checks.cfg` declines are declined against it, and why ADR-0044 records the three options without picking one" — the option is picked now and those five are `[DESIGN]`. It wants one sentence.
- **`make test` was not run.** Nothing under `test/` reads `checks.cfg`, and the mechanised test for this change is `genchecks-audit.py`'s two-way set equality, which ran inside `make -C formal check` and was probed in both red directions above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJ77ZZJ6pDiL3vj3Qw9hKs
