### PR TITLE
JEF-747: license the decoder's one-hot markings with a proof

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -770,6 +770,23 @@ divide defect — all three since fixed, and the last two no longer have bullets
 the struck bullet above), and everything ran under `RISCV_FORMAL_ALTOPS`, so
 a green `insn_mul` says nothing whatever about multiplication (ADR-0010). **M2 is not reached.**
 
+**Four of `rtl/decoder.v`'s six `(* parallel_case *)` markings were spent against nobody's proof,
+and the two statements that lack the marking must keep lacking it** (ADR-0068). The immediate,
+`rd`, `rs1` and `rs2` muxes select on opcode-group and **compressed** flags — `instr_load_op`,
+`instr_clw`, `instr_cswsp` — and the `$onehot` assertion in that file covers the 45 *architectural*
+flags (`instr_lw`, `instr_add`) and names none of them. A compressed flag widened to overlap a
+sibling leaves every architectural flag one-hot, so the existing check stays green while two arms of
+a marked mux match at once and synthesis picks either; **measured** — widening `instr_clw` to
+quadrant 2 passed `components_decoder` before this change. Five `$onehot0` assertions, one per arm
+list, close it, and the same mutation now fails on exactly the two of them it should. The two
+**unmarked** statements were the ticket's actual ask and both are declined: `next_pc` selects on
+`stall` and `trap_pending`, which are both true whenever a trapping instruction is held, and
+`trap_cause` is ADR-0030's recorded priority order, whose first stated failure mode is someone
+flattening it. There are **eight** such statements in the file, not six — two are written
+`case(1'b1)` with no space and a space-sensitive grep is what missed them. The change is
+`ifdef FORMAL`-only and that is proven, not argued: the two `fit.json` netlists differ in one line,
+the module's recorded end line.
+
 ## Invariants — do not break these
 
 These are the design. Violating one is a bug even if tests pass.

--- a/docs/adr/0068-a-one-hot-marking-is-spent-against-an-assertion.md
+++ b/docs/adr/0068-a-one-hot-marking-is-spent-against-an-assertion.md
@@ -1,0 +1,90 @@
+# ADR-0068: A one-hot marking is spent against an assertion, not against inspection
+
+**Status:** Accepted · 2026-08-02 · *Supplements
+[ADR-0030](0030-trap-cause-priority-and-why-the-causes-are-disjoint.md), which is what declines one
+of the two statements this audit was asked to mark.*
+
+## Context
+
+`(* parallel_case *)` tells synthesis that at most one arm of a `case (1'b1)` can match, turning a
+priority chain roughly N deep into a flat mux roughly log N deep. On flags that really can overlap
+it is a synthesis/simulation mismatch: the simulator takes the first matching arm and the gates take
+whichever the optimiser preferred. `rtl/structs.v` already records one instance of that hazard —
+three CSR flags were removed from `decoder_output` because they would have made two arms of the
+executor's op select match at once alongside `is_add`.
+
+The audit that produced this ADR started from a count: six `case (1'b1)` statements in
+`rtl/decoder.v`, four marked and two not, with the two unmarked ones described as paying for a
+priority the decoder's `$onehot` assertion proves cannot happen. Both halves of that count turned
+out to be wrong, and the second half is the useful finding.
+
+## What the audit found
+
+**There are eight such statements, not six.** The count came from a grep for `case (1'b1)`; two of
+them are written `case(1'b1)` with no space, and both of those already carry the attribute. Six of
+the eight are marked.
+
+**The two unmarked ones must stay unmarked**, and each already says so at the site.
+
+- The `next_pc` chain selects on `reset`, `stall`, `trap_pending`, `instr_mret`, `instr_jalr`,
+  `instr_jal` and `branch_taken`. Four of those are not instruction flags at all, and `stall` and
+  `trap_pending` are both true on any cycle where a trapping instruction is held — which is a normal
+  cycle, not a corner. Marking it would be the mismatch above, on the one signal that owns the PC.
+- The `trap_cause` chain selects on `instr_illegal`, `instr_ebreak`, `instr_ecall`,
+  `load_misaligned` and `store_misaligned`. Three of those five are outside the instruction one-hot
+  set, and mutual exclusivity comes from a separate `$onehot0` assertion instead. That assertion
+  would license the attribute — but ADR-0030 records the priority order deliberately, and its whole
+  first reason is that someone reading the encoder concludes the order is dead and simplifies it
+  away. Flattening it is that simplification. The five arms are constants feeding `mcause`, so there
+  is nothing to win.
+
+**The interesting half is the four that were already marked.** The immediate, `rd`, `rs1` and `rs2`
+muxes select on opcode-group flags (`instr_load_op`, `instr_branch_op`) and on compressed flags
+(`instr_clw`, `instr_cswsp`, `instr_candi`). The `$onehot` assertion in `rtl/decoder.v` covers 45
+*architectural* flags — `instr_lw`, `instr_add`, `instr_jal` — and names none of those. So four
+attributes were spent against reading the encodings and finding them disjoint, which is true and was
+proved by nobody. A compressed flag that widened to overlap a sibling would keep every architectural
+flag one-hot, so the existing assertion would stay green while two arms of a marked mux matched at
+once.
+
+## Decision
+
+**Add the missing proof rather than the missing attribute.** `rtl/decoder.v`'s `FORMAL` block gains
+five `$onehot0` assertions, one per marked statement whose arms the instruction check does not
+reach — the four muxes above plus the operand overrides in the publish block. Each assertion is that
+statement's arm list, so it holds exactly the condition the attribute claims.
+
+Neither statement the finding named gets the attribute.
+
+## Evidence
+
+`make -C formal components_decoder` passes by k-induction with the five assertions in, 6s.
+
+The red direction was measured. Widening `instr_clw` to match quadrant 2 as well as quadrant 0 makes
+it overlap `instr_clwsp` — both feed `instr_lw`, so the architectural flags stay one-hot — and the
+task fails on exactly two of the new assertions, the immediate mux and the `rs1` mux, and on nothing
+else. Before this change that mutation passed.
+
+**The change is not visible to synthesis, and that is proven rather than argued.** Neither
+`make fit` nor `make soc-timing` defines `FORMAL`, and the two `fit.json` netlists differ in one
+line: the module's recorded end line, `rtl/decoder.v:4.1-845.10` against `4.1-882.10`. No cell, net
+or connection moves. `make fit` is 3880 of 4100 either way, and the four-placement sweep reproduces
+the shipping numbers to the digit: 74.34 / 75.81 / 76.88 / 78.80 ns, 12.69 – 13.45 MHz, against a
+`SOC_MIN_MHZ` of 10.9.
+
+## Consequences
+
+- The six marked statements in `rtl/decoder.v` are each licensed by an assertion the required
+  `components` job proves. A future one has to bring its own.
+- The rule generalises past this file: an optimisation attribute is a claim about the design, and
+  the place to put a claim is next to the thing that checks it.
+- Nothing here changes what the core computes, so there is no simulation-side test. The proof is the
+  test, and the mutation above is how to re-run its red direction.
+- **Each assertion transcribes its arm list rather than sharing it**, which is the known weakness:
+  an arm added to a marked statement and not added here leaves that arm unlicensed, and the
+  assertion stays green. Sharing the lists through named wires would close it and would move code
+  that is `FORMAL`-only today into the synthesized part of the file, so the transcription is
+  deliberate. The site says so.
+- Two statements are now declined in three places at once — at the site, here, and in ADR-0030 for
+  the trap causes. That is deliberate; the finding has been raised once already from a reading of
+  the file alone.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -72,6 +72,7 @@ and what it costs. Reversing one is fine — write a new ADR that supersedes it.
 | [0065](0065-the-ladder-speaks-the-writable-text-bus.md) | The ladder speaks the writable-text bus, and `imemcheck` stops at the first store | Accepted · builds 0057's step 4; pays off 0060 decision 3 |
 | [0066](0066-twelve-megahertz-is-a-requirement.md) | Twelve megahertz is a requirement | Accepted · amends 0038 decision 2; answers the question 0064 left open |
 | [0067](0067-the-bus-never-refuses-and-the-eleven-are-ruled.md) | The bus never refuses a transaction, and the eleven declined checks are ruled | Accepted · pays off 0044's closing obligation; settles invariant 2 |
+| [0068](0068-a-one-hot-marking-is-spent-against-an-assertion.md) | A one-hot marking is spent against an assertion, not against inspection | Accepted · supplements 0030, which declines one of the two statements it was asked to mark |
 
 0001–0007 came from the design brief
 ([`docs/ideas/finish-the-rewrite.md`](../ideas/finish-the-rewrite.md)). 0008–0011 came out of

--- a/rtl/decoder.v
+++ b/rtl/decoder.v
@@ -800,6 +800,45 @@ module decoder (
 
   always_comb if (instr_valid) assert(one_of);
 
+  // Five case statements above are marked one-hot for synthesis, and the check
+  // just above does not reach them -- their arms are opcode groups and
+  // compressed flags, which it does not name. Each assertion below is one of
+  // those arm lists. Without it an encoding change that made two arms match at
+  // once would leave synthesis free to pick either, and nothing would say so.
+  // Each list is transcribed, not shared with the statement it describes, so
+  // adding an arm to one means adding it here too.
+  // immediate
+  always_comb assert($onehot0({instr_load_op || instr_jalr_op, instr_store_op,
+    instr_lui_op || instr_auipc, instr_jal_op, instr_branch_op, instr_math_immediate_op,
+    instr_clwsp, instr_cswsp, instr_csw, instr_clw, instr_cj || instr_cjal,
+    instr_cbeqz || instr_cbnez, instr_cli, instr_clui, instr_caddi, instr_caddi16sp,
+    instr_caddi4spn, instr_candi}));
+  // rd
+  always_comb assert($onehot0({
+    instr_beq || instr_bne || instr_blt || instr_bge || instr_bltu || instr_bgeu ||
+      instr_sb || instr_sh || instr_sw || instr_cj || instr_cjr,
+    instr_cjal || instr_cjalr,
+    instr_clw || instr_caddi4spn,
+    instr_csrai || instr_csrli || instr_candi || instr_cand ||
+      instr_cor || instr_cxor || instr_csub}));
+  // rs1
+  always_comb assert($onehot0({
+    instr_clwsp || instr_cswsp || instr_caddi4spn,
+    instr_clw || instr_csw || instr_cbeqz || instr_cbnez ||
+      instr_csrai || instr_csrli || instr_candi || instr_cand ||
+      instr_cor || instr_cxor || instr_csub,
+    instr_cjr || instr_cjalr || instr_cslli,
+    instr_cli || instr_cmv,
+    instr_caddi || instr_caddi16sp || instr_cadd}));
+  // rs2
+  always_comb assert($onehot0({
+    instr_cswsp || instr_cslli || instr_csrai || instr_csrli || instr_cmv || instr_cadd,
+    instr_csw || instr_cand || instr_cor || instr_cxor || instr_csub,
+    instr_cbeqz || instr_cbnez}));
+  // the operand overrides in the publish block
+  always_comb assert($onehot0({instr_auipc, instr_csr_access, instr_jal || instr_jalr,
+    instr_beq || instr_bne || instr_blt || instr_bltu || instr_bge || instr_bgeu}));
+
   // This is what makes the trap-cause case above safe without a one-hot marking.
   // Add a sixth cause that overlaps an existing one and this fails here.
   always_comb assert($onehot0({instr_illegal, instr_ebreak, instr_ecall,


### PR DESCRIPTION
Closes JEF-747.

The ticket asked me to mark two `case (1'b1)` statements in `rtl/decoder.v` with
`(* parallel_case *)`, licensed by the file's `$onehot` assertion. Criterion 2
fails for both, which the ticket anticipated. The audit it asked for found
something else instead, and that is what this PR ships.

## The count is eight, not six

`grep "case (1'b1)"` finds six. Two more are written `case(1'b1)` with no space,
and both of those already carry the attribute. **Six of the eight are marked.**

## Criterion 2, element by element

The proven set is `rtl/decoder.v`'s `one_of`: `$onehot` over 45 flags, asserted
under `if (instr_valid)` — `instr_auipc jal jalr beq bne blt bltu bge bgeu add
sub xor or and mul mulh mulhu mulhsu div divu rem remu sll slt sltu srl sra lui
lb lbu lh lhu lw sb sh sw ecall ebreak csrrw csrrs csrrc mret wfi fence fencei`.

**`trap_cause`, line 378** — selects on `instr_illegal`, `instr_ebreak`,
`instr_ecall`, `load_misaligned`, `store_misaligned`. `instr_ebreak` ✓ in set,
`instr_ecall` ✓ in set, `instr_illegal` ✗, `load_misaligned` ✗,
`store_misaligned` ✗. **Three of five outside.** A separate `$onehot0` over
exactly those five *would* license it — but ADR-0030 records the priority order
deliberately, and its first stated failure mode is "someone reading the priority
encoder concludes it is dead code and simplifies it away". Flattening it is that
simplification, on five arms of constants feeding `mcause`. **Declined.**

**`next_pc`, line 548** — selects on `reset`, `stall`, `trap_pending`,
`instr_mret`, `instr_jalr`, `instr_jal`, `branch_taken`. `instr_mret` ✓,
`instr_jalr` ✓, `instr_jal` ✓; `reset` ✗, `stall` ✗, `trap_pending` ✗,
`branch_taken` ✗. **Four of seven outside, and two of them genuinely overlap** —
`stall` and `trap_pending` are both true on every cycle a trapping instruction
is held, which is a normal cycle. Marking it is the synthesis/simulation
mismatch `rtl/structs.v` already records, on the signal that owns the PC.
**Declined.**

Both statements already say this at the site. No RTL behaviour changed.

## What the audit actually found

**Four of the six markings were spent against nobody's proof.** The immediate,
`rd`, `rs1` and `rs2` muxes select on opcode-group flags (`instr_load_op`,
`instr_branch_op`) and compressed flags (`instr_clw`, `instr_cswsp`,
`instr_candi`). `one_of` covers the *architectural* flags and names none of
them.

The gap is reachable, not theoretical: **a compressed flag widened to overlap a
sibling that feeds the same architectural flag leaves `one_of` one-hot**, so the
existing check stays green while two arms of a marked mux match at once.

So this adds the missing proof rather than the missing attribute: five
`$onehot0` assertions in the `ifdef FORMAL` block, one per marked statement
whose arms `one_of` does not reach (the four muxes plus the operand overrides in
the publish block). Each is that statement's arm list.

**Red direction, measured.** Widen `instr_clw` to match quadrant 2 as well as
quadrant 0 — it then overlaps `instr_clwsp`, and both feed `instr_lw`:

| | before this PR | after |
|---|---|---|
| `make -C formal components_decoder` | **PASS** | **FAIL** on exactly the immediate and `rs1` assertions, nothing else |

## Criterion 3 — timing, four placements

**The diff changes no synthesized hardware, and that is proven rather than
argued.** Neither `make fit` nor `soc.json` passes `-D FORMAL`. The two
`fit.json` netlists differ in exactly one line:

```
< "module_src": "rtl/decoder.v:4.1-845.10"
> "module_src": "rtl/decoder.v:4.1-882.10"
```

The module's recorded end line. No cell, net or connection moves, so
**before == after, 0.00%, by construction** — well inside the 3.6% band.

`soc/timing_sweep.sh`, four placements, local Homebrew yosys 0.67+post,
`nextpnr-ice40`, machine load 22 → 17 (two sibling agents building concurrently):

| seed | ns | MHz |
|---|---|---|
| default | 76.88 | 13.01 |
| 1 | 78.80 | 12.69 |
| 2 | 75.81 | 13.19 |
| 3 | 74.34 | 13.45 |

**12.69 – 13.45 MHz**, reproducing main's recorded sweep to the digit.
`SOC_MIN_MHZ` **in my tree is 10.9**, not the 12.0 a sibling is raising it to —
every placement clears both.

## Criterion 4 — fit

`make fit`: **3880 of 4100 cells (73%), RATCHET OK**, local Homebrew yosys. Same
number before and after, as the netlist diff above requires.

## Criterion 5 — formal

- `make -C formal check JOBS=4`: **85 checks: 85 pass, 0 fail.** Failure list
  matches `EXPECTED_FAIL` exactly (name and status); generated check set matches
  `EXPECTED_CHECKS` exactly (85). `checks.cfg #omit`: 14 names, exact match.
  ~7 min wall at load 40-60 (two sibling agents concurrent), JOBS=4 of 10 cores.
- `make -C formal components_decoder`: **PASS, successful proof by k-induction**,
  6s — the one-hot assertion that licenses all of this still holds, now with five
  more beside it.
- `make -C formal components_executor`: **PASS by k-induction**, 30s.

## Criterion 6 — simulation and lint

- `make test`: **59/59 passed**, failure list matches `test/EXPECTED_FAIL` exactly.
- `make test-units`: **all eight benches pass**.
- `make lint`: **svlint clean in both passes**.

## Known weakness, written down rather than hidden

Each assertion **transcribes** its arm list rather than sharing it. An arm added
to a marked statement and not added here leaves that arm unlicensed, and the
assertion stays green. Sharing through named wires would close it and would move
`FORMAL`-only code into the synthesized part of the file, losing the netlist
argument above. The transcription is deliberate and the site says so.

## ADR

**ADR-0068** (0065 is claimed, 0066/0067 taken by siblings), supplementing
ADR-0030. `docs/adr/README.md` and `CLAUDE.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
