### PR TITLE
Bump riscv-formal pin to c992aa61fdfe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,6 @@ on:
   pull_request:
   push:
     branches: [main]
-  # Lets .github/workflows/riscv-formal-pin-bump.yml force a run on a PR it
-  # opened with the default GITHUB_TOKEN: GitHub does not fire pull_request
-  # for events caused by that token (recursion prevention), but does attach
-  # workflow_dispatch check runs to the PR by commit SHA.
-  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/riscv-formal-pin-bump.yml
+++ b/.github/workflows/riscv-formal-pin-bump.yml
@@ -8,6 +8,10 @@ name: riscv-formal pin bump
 # this workflow only notices and proposes. No auto-merge: ADR-0018's
 # dependabot-automerge.yml is scoped to `dependabot[bot]` and does not apply
 # here, and this workflow does not enable auto-merge on the PRs it opens.
+#
+# Without a PIN_BUMP_TOKEN secret it pushes the branch and opens an issue rather
+# than a pull request, because a PR the default GITHUB_TOKEN opens gets no CI
+# and so can never merge. formal/propose-pin-bump.sh has the measurement.
 on:
   schedule:
     - cron: "17 6 * * 1" # weekly, Monday
@@ -16,7 +20,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  actions: write # gh workflow run, needed only under the default GITHUB_TOKEN -- see the script
+  issues: write
 
 jobs:
   check-and-bump:
@@ -32,3 +36,4 @@ jobs:
         run: formal/bump-riscv-formal-pin.sh
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PIN_BUMP_TOKEN: ${{ secrets.PIN_BUMP_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -375,8 +375,15 @@ test-units: check-unit-benches test/monitor.sim.v
 probe-gates:
 	@./test/probe_gates.sh
 
+# Hangs off `test` for the same reason `probe-gates` does: it is bash and a stub
+# `gh`, so it runs anywhere, and the pin-bump path is otherwise exercised once a
+# week by a workflow nobody watches.
+.PHONY: pin-bump-test
+pin-bump-test:
+	@./formal/test-propose-pin-bump.sh
+
 .PHONY: test
-test: sim test-units probe-gates
+test: sim test-units probe-gates pin-bump-test
 	@./test/run_tests.sh ./sim test/asm test/EXPECTED_FAIL test/OBSERVED_FLOOR
 
 # Count logic cells from nextpnr, never cell counts from yosys. A flip-flop that

--- a/docs/adr/0069-a-dispatched-run-does-not-reach-the-merge-gate.md
+++ b/docs/adr/0069-a-dispatched-run-does-not-reach-the-merge-gate.md
@@ -1,0 +1,89 @@
+# ADR-0069: A dispatched run does not reach the merge gate
+
+**Status:** Accepted · 2026-08-03 · *Amends
+[ADR-0013](0013-the-riscv-formal-pin-is-an-enforced-control.md), whose pin-bump workflow opened a
+pull request that could never merge. No `rtl/` change ships from this ADR.*
+
+## Context
+
+`formal/bump-riscv-formal-pin.sh` opened a pull request with the Actions default `GITHUB_TOKEN` and
+then ran `gh workflow run ci.yml --ref "$BRANCH"`. The dispatch was there because GitHub does not
+fire `pull_request` for a PR that token opens, and `workflow_dispatch` was added to `ci.yml` for
+exactly that call.
+
+It does not work, and the way it fails is the part worth keeping: **the dispatched run is green
+everywhere a human looks and invisible to the only place that decides.**
+
+## What was measured
+
+On a scratch branch cut from `main`, so **not** conflicting with it — the earlier observations of
+this were on branches that were also conflicting, which independently suppresses `pull_request` CI
+and had to be ruled out first.
+
+1. Push the branch. `ci.yml`'s `push` trigger is `branches: [main]`, so nothing runs: the commit
+   has **0** check runs.
+2. `gh workflow run ci.yml --ref <branch>`. Nine check runs appear on that commit.
+3. Open a pull request from it. Five seconds after opening: `statusCheckRollup` is **0** while
+   those nine check runs are on the head commit. Ten seconds after opening: **11**, and grouping
+   the rollup entries by the workflow run in their `detailsUrl` gives three run ids, **none of them
+   the dispatched one**. The commit itself carries 20 check runs across four runs; the rollup
+   carries 11 across three.
+
+The pull request was `MERGEABLE` throughout, so the conflicting-branch explanation is out.
+`gh pr checks` listed the rollup's eleven and read entirely green.
+
+A second run measured the recursion guard directly, from a real workflow using the default token: it
+opened a pull request and then pushed an empty commit to the same branch. **Neither SHA has a single
+check run**, and the PR's rollup is 0. So GitHub suppresses `push` from that token as well as
+`pull_request` — which rules out pushing an empty commit as a fix, no secret required or not.
+
+## Decision
+
+**1. Open the pull request with a token that is not the Actions default.**
+`formal/propose-pin-bump.sh` reads `PIN_BUMP_TOKEN` and passes it to `gh pr create`. A PR opened by
+any other identity fires `pull_request` normally and needs no dispatch.
+
+**2. With no such secret, do not open a pull request at all.** The branch is pushed either way, so
+the regenerated `test/monitor.v` and the pre-graded diff — the whole value of the automation — are
+on disk. The script opens an issue naming that branch, linking a compare page, and saying which
+secret makes future bumps open their own PR. A human opens the PR in one click and the checks run.
+
+**3. Remove `workflow_dispatch` from `ci.yml`.** Its only stated purpose was the call above.
+Leaving a trigger whose documented reason is measurably false invites the same misreading; a manual
+re-run is `gh run rerun` on any past run.
+
+`actions: write` comes off the pin-bump workflow with the dispatch, and `issues: write` goes on.
+
+## What a human has to do
+
+Add a repository secret named `PIN_BUMP_TOKEN` holding a fine-grained PAT or a GitHub App
+installation token with contents and pull-requests write on this repository. Until then pin bumps
+arrive as issues. That is a settings action and no workflow can take it.
+
+## Evidence
+
+`formal/test-propose-pin-bump.sh` drives the script against a stub `gh` and pins both modes: 14
+checks, hermetic, on `make test` and so in CI's required `test` job. The stub refuses
+`gh workflow run` outright and refuses `pr create` unless the supplied token reached it.
+
+The red direction was run. Making the script take the pull-request arm unconditionally and dispatch
+CI alongside it turns **10 of the 14 green**.
+
+The token path itself was demonstrated end to end rather than argued: the pin pointed at an older
+SHA in a throwaway clone, `formal/bump-riscv-formal-pin.sh` run with `PIN_BUMP_TOKEN` set, and the
+pull request it opened reached a populated `statusCheckRollup` and a mergeable state. The
+no-secret path was demonstrated on the real scheduled workflow, dispatched from the branch: it
+pushed the branch and opened an issue, and opened no pull request. Every scratch branch, pull
+request and issue those runs created was deleted.
+
+## Consequences
+
+- A pin bump can merge, or it says plainly that it cannot and why. It could do neither before.
+- There is a repository setting the automation depends on, and it degrades to a slower path rather
+  than to a broken one when the setting is absent.
+- **`gh workflow run` is not a way to satisfy branch protection**, and that is now written where
+  someone would reach for it: in `formal/propose-pin-bump.sh`'s header and as two checks in the
+  test. The failure is silent in the direction that matters — the Actions tab is green.
+- The pin-bump workflow still enables auto-merge nowhere. A pin bump is reviewed.
+- The check that a proposal already exists reads open issues as well as open pull requests, so the
+  weekly schedule does not stack up duplicates while a bump waits for a human.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -73,6 +73,7 @@ and what it costs. Reversing one is fine — write a new ADR that supersedes it.
 | [0066](0066-twelve-megahertz-is-a-requirement.md) | Twelve megahertz is a requirement | Accepted · amends 0038 decision 2; answers the question 0064 left open |
 | [0067](0067-the-bus-never-refuses-and-the-eleven-are-ruled.md) | The bus never refuses a transaction, and the eleven declined checks are ruled | Accepted · pays off 0044's closing obligation; settles invariant 2 |
 | [0068](0068-a-one-hot-marking-is-spent-against-an-assertion.md) | A one-hot marking is spent against an assertion, not against inspection | Accepted · supplements 0030, which declines one of the two statements it was asked to mark |
+| [0069](0069-a-dispatched-run-does-not-reach-the-merge-gate.md) | A dispatched run does not reach the merge gate | Accepted · amends 0013; adds a repository secret the automation degrades without |
 
 0001–0007 came from the design brief
 ([`docs/ideas/finish-the-rewrite.md`](../ideas/finish-the-rewrite.md)). 0008–0011 came out of

--- a/formal/bump-riscv-formal-pin.sh
+++ b/formal/bump-riscv-formal-pin.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
-# Opens a PR bumping formal/pin.mk's riscv-formal SHA when upstream's `main`
-# has moved past it, regenerating test/monitor.v so monitor-freshness is a
-# real verdict on the bump rather than a guaranteed failure. Does nothing --
-# no branch, no commit, no PR -- if the pin is already current, or if a PR
-# already proposes the SHA upstream is at.
+# Proposes bumping formal/pin.mk's riscv-formal SHA when upstream's `main` has
+# moved past it, regenerating test/monitor.v so monitor-freshness is a real
+# verdict on the bump rather than a guaranteed failure. Does nothing -- no
+# branch, no commit, no proposal -- if the pin is already current, or if a pull
+# request or issue already proposes the SHA upstream is at.
+#
+# formal/propose-pin-bump.sh does the proposing and decides between a pull
+# request and an issue; read its header before changing how CI reaches this.
 #
 # The existing gates (monitor-freshness, formal/check-genchecks.py,
 # formal/check-complete-exclusions.py, the ladder itself) decide whether the
@@ -41,10 +44,20 @@ if [ "$PIN_SHA" = "$UPSTREAM_SHA" ]; then
 fi
 
 BRANCH="riscv-formal-pin/bump-${UPSTREAM_SHA:0:12}"
+TITLE="Bump riscv-formal pin to ${UPSTREAM_SHA:0:12}"
 
 OPEN_COUNT=$(gh pr list --state open --head "$BRANCH" --json number --jq 'length')
 if [ "$OPEN_COUNT" -gt 0 ]; then
   echo "a PR already proposes $UPSTREAM_SHA (branch $BRANCH); nothing to do"
+  exit 0
+fi
+
+# Titles are compared exactly rather than handed to `--search`, whose matching
+# is fuzzy: a near miss there would open a fresh issue every week.
+ISSUE_COUNT=$(gh issue list --state open --limit 200 --json title \
+  --jq "[.[] | select(.title == \"$TITLE\")] | length")
+if [ "$ISSUE_COUNT" -gt 0 ]; then
+  echo "an issue already proposes $UPSTREAM_SHA; nothing to do"
   exit 0
 fi
 
@@ -86,7 +99,7 @@ fi
 git config user.name "github-actions[bot]"
 git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 git add formal/pin.mk test/monitor.v
-git commit --quiet -m "Bump riscv-formal pin to ${UPSTREAM_SHA:0:12}
+git commit --quiet -m "$TITLE
 
 $DIFFSTAT"
 
@@ -129,15 +142,4 @@ BODY_FILE="$CLONE_DIR/pr-body.md"
   fi
 } > "$BODY_FILE"
 
-PR_URL=$(gh pr create --title "Bump riscv-formal pin to ${UPSTREAM_SHA:0:12}" \
-  --body-file "$BODY_FILE" --head "$BRANCH" --base main)
-echo "opened $PR_URL"
-
-# A PR opened with the Actions default GITHUB_TOKEN does not trigger
-# pull_request-triggered workflows -- GitHub suppresses events caused by that
-# token to prevent recursive runs -- so without this, ci.yml's required checks
-# would never run on this PR. workflow_dispatch is exempt, and GitHub attaches
-# check runs to a PR by commit SHA regardless of which event asked for them.
-if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
-  gh workflow run ci.yml --ref "$BRANCH"
-fi
+formal/propose-pin-bump.sh "$BRANCH" "$TITLE" "$BODY_FILE"

--- a/formal/pin.mk
+++ b/formal/pin.mk
@@ -9,7 +9,7 @@
 # from a script or CI job: this is a supply-chain control, not a knob. The
 # repo executes Python straight out of this clone (checks/rvfi_macros.py,
 # monitor/generate.py) and commits its stdout as tracked, compiled source.
-override RISCV_FORMAL_SHA := c992aa61fdfe0846c5ed90324c596202a1c69b76
+override RISCV_FORMAL_SHA := 2bd7410cdb515d851a9d9f810ccfebd25b162709
 override RISCV_FORMAL_URL := https://github.com/YosysHQ/riscv-formal.git
 
 ifeq ($(shell printf '%s' '$(RISCV_FORMAL_SHA)' | grep -cE '^[0-9a-f]{40}$$'),0)

--- a/formal/pin.mk
+++ b/formal/pin.mk
@@ -9,7 +9,7 @@
 # from a script or CI job: this is a supply-chain control, not a knob. The
 # repo executes Python straight out of this clone (checks/rvfi_macros.py,
 # monitor/generate.py) and commits its stdout as tracked, compiled source.
-override RISCV_FORMAL_SHA := 2bd7410cdb515d851a9d9f810ccfebd25b162709
+override RISCV_FORMAL_SHA := c992aa61fdfe0846c5ed90324c596202a1c69b76
 override RISCV_FORMAL_URL := https://github.com/YosysHQ/riscv-formal.git
 
 ifeq ($(shell printf '%s' '$(RISCV_FORMAL_SHA)' | grep -cE '^[0-9a-f]{40}$$'),0)

--- a/formal/propose-pin-bump.sh
+++ b/formal/propose-pin-bump.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# Proposes a pin bump whose branch has already been committed and pushed.
+# Opens a pull request when PIN_BUMP_TOKEN is set, and an issue naming the
+# branch when it is not.
+#
+# The token is what makes the pull request mergeable, and this is measured on
+# this repository rather than assumed. GitHub fires no `pull_request` event for
+# a PR the Actions default GITHUB_TOKEN opens, and no `push` event for a commit
+# it pushes, so such a PR collects no checks at all and branch protection blocks
+# it forever. Asking for a run with `gh workflow run` does not rescue it: those
+# check runs land on the commit and are visible in `gh pr checks`, but they
+# never enter the pull request's statusCheckRollup, which is the only thing the
+# merge gate reads. Do not put that call back.
+#
+# Usage: propose-pin-bump.sh <branch> <title> <body-file>
+set -euo pipefail
+
+if [ "$#" -ne 3 ]; then
+  echo "usage: propose-pin-bump.sh <branch> <title> <body-file>" >&2
+  exit 2
+fi
+
+BRANCH=$1
+TITLE=$2
+BODY_FILE=$3
+
+if [ ! -r "$BODY_FILE" ]; then
+  echo "propose-pin-bump.sh: cannot read body file '$BODY_FILE'" >&2
+  exit 2
+fi
+
+if [ -n "${PIN_BUMP_TOKEN:-}" ]; then
+  URL=$(GH_TOKEN="$PIN_BUMP_TOKEN" GITHUB_TOKEN="$PIN_BUMP_TOKEN" \
+    gh pr create --title "$TITLE" --body-file "$BODY_FILE" \
+    --head "$BRANCH" --base main)
+  echo "opened pull request $URL"
+  exit 0
+fi
+
+COMPARE=""
+if [ -n "${GITHUB_REPOSITORY:-}" ]; then
+  SERVER=${GITHUB_SERVER_URL:-https://github.com}
+  COMPARE="$SERVER/$GITHUB_REPOSITORY/compare/main...$BRANCH?expand=1"
+fi
+
+ISSUE_BODY=$(mktemp "${TMPDIR:-/tmp}/pin-bump-issue.XXXXXX") || {
+  echo "propose-pin-bump.sh: could not create a temporary file" >&2
+  exit 1
+}
+trap 'rm -f "$ISSUE_BODY"' EXIT
+
+{
+  echo "No PIN_BUMP_TOKEN secret is configured, so this run pushed the branch"
+  echo "and opened this issue instead of a pull request. A PR opened with the"
+  echo "Actions default GITHUB_TOKEN gets no CI and can never merge."
+  echo
+  echo "The work is done and is on \`$BRANCH\`: the pin is bumped and"
+  echo "\`test/monitor.v\` is regenerated against it. Open a pull request from"
+  echo "that branch yourself and the checks will run normally."
+  if [ -n "$COMPARE" ]; then
+    echo
+    echo "$COMPARE"
+  fi
+  echo
+  echo "To make future bumps open their own pull request, add a repository"
+  echo "secret named \`PIN_BUMP_TOKEN\` holding a token that is not the Actions"
+  echo "default one -- a fine-grained PAT or a GitHub App installation token"
+  echo "with contents and pull-requests write on this repository."
+  echo
+  cat "$BODY_FILE"
+} > "$ISSUE_BODY"
+
+URL=$(gh issue create --title "$TITLE" --body-file "$ISSUE_BODY")
+echo "opened issue $URL"

--- a/formal/test-propose-pin-bump.sh
+++ b/formal/test-propose-pin-bump.sh
@@ -1,0 +1,162 @@
+#!/bin/bash
+# Drives formal/propose-pin-bump.sh against a stub `gh` and pins what it does
+# in each of its two modes. The defect this replaces reported success on a pull
+# request that could never merge, so "it opened something" is not the property
+# worth checking: which thing it opened, and with which token, is.
+#
+# The stub refuses `gh workflow run` outright. Asking CI for a run that way puts
+# check runs on the commit and none of them in the pull request's
+# statusCheckRollup, so a script that reached for it again would go red here.
+#
+# Hermetic: no network, no toolchain, nothing but bash.
+#
+# Usage: formal/test-propose-pin-bump.sh
+set -euo pipefail
+
+HERE=$(cd "$(dirname "$0")" && pwd)
+REPO=$(cd "$HERE/.." && pwd)
+SCRIPT="$REPO/formal/propose-pin-bump.sh"
+
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/propose-pin-bump.XXXXXX") || {
+  echo "error: could not create a temporary directory." >&2
+  exit 1
+}
+if [ -z "$tmp" ] || [ ! -d "$tmp" ]; then
+  echo "error: mktemp -d produced no usable directory." >&2
+  exit 1
+fi
+trap 'rm -rf "$tmp"' EXIT
+
+mkdir -p "$tmp/bin"
+cat > "$tmp/bin/gh" <<'STUB'
+#!/bin/bash
+# Records every call, answers `pr create` and `issue create`, and rejects
+# anything else. STUB_EXPECT_TOKEN pins which token the caller used.
+printf '%s\n' "$*" >> "$GH_LOG"
+sub="$1 $2"
+body=""
+prev=""
+for a in "$@"; do
+  if [ "$prev" = "--body-file" ]; then body=$a; fi
+  prev=$a
+done
+case "$sub" in
+  "pr create")
+    if [ "${GH_TOKEN:-}" != "${STUB_EXPECT_TOKEN:-}" ]; then
+      echo "stub gh: pr create ran with token '${GH_TOKEN:-}'" >&2
+      exit 8
+    fi
+    if [ -n "${STUB_PR_FAIL:-}" ]; then
+      echo "stub gh: pull request creation refused" >&2
+      exit 1
+    fi
+    [ -n "$body" ] && cp "$body" "$GH_BODY"
+    echo "https://github.com/o/r/pull/1"
+    ;;
+  "issue create")
+    if [ -n "${STUB_ISSUE_FAIL:-}" ]; then
+      echo "stub gh: issue creation refused" >&2
+      exit 1
+    fi
+    [ -n "$body" ] && cp "$body" "$GH_BODY"
+    echo "https://github.com/o/r/issues/1"
+    ;;
+  *)
+    echo "stub gh: refusing '$sub'" >&2
+    exit 9
+    ;;
+esac
+STUB
+chmod +x "$tmp/bin/gh"
+
+printf 'body from the caller\n' > "$tmp/body.md"
+
+cases=0
+failed=0
+
+# check <label> <expected-exit> <expected-text> <shell-snippet>
+#
+# Both the status and a fragment of the output are pinned. A status alone would
+# be satisfied by a script that died on a typo before doing anything.
+check() {
+  local label=$1 want_exit=$2 want_text=$3 snippet=$4
+  cases=$((cases + 1))
+  local out rc why=""
+  set +e
+  out=$(eval "$snippet" 2>&1)
+  rc=$?
+  set -e
+  if [ "$rc" -ne "$want_exit" ]; then
+    why="exited $rc, expected $want_exit"
+  elif ! grep -qF -- "$want_text" <<< "$out"; then
+    why="output does not contain $want_text"
+  fi
+  if [ -z "$why" ]; then
+    printf '  ok   %s\n' "$label"
+  else
+    printf '  RED  %s\n     -> %s\n' "$label" "$why" >&2
+    printf '%s\n' "$out" | sed -e 's|^|        |' >&2
+    failed=1
+  fi
+}
+
+run() {  # run <case-name> [env assignments...] -- runs the script under test
+  local name=$1; shift
+  local dir="$tmp/$name"
+  mkdir -p "$dir"
+  : > "$dir/log"
+  : > "$dir/body"
+  env PATH="$tmp/bin:$PATH" GH_LOG="$dir/log" GH_BODY="$dir/body" "$@" \
+    "$SCRIPT" pin/branch "Bump riscv-formal pin to abc123abc123" "$tmp/body.md"
+}
+
+echo "== formal/propose-pin-bump.sh"
+
+check "a token opens a pull request" 0 "opened pull request" \
+  'run withtoken PIN_BUMP_TOKEN=sekrit STUB_EXPECT_TOKEN=sekrit'
+check "the pull request carries the supplied token" 8 \
+  "pr create ran with token 'sekrit'" \
+  'run wrongtoken PIN_BUMP_TOKEN=sekrit STUB_EXPECT_TOKEN=the-default-one'
+
+check "no token opens an issue" 0 "opened issue" \
+  'run notoken GITHUB_REPOSITORY=o/r'
+check "no token never opens a pull request" 0 "no pr create in the log" \
+  '! grep -q "pr create" "$tmp/notoken/log" && echo "no pr create in the log"'
+check "the issue names the branch" 0 "pin/branch" \
+  'cat "$tmp/notoken/body"'
+check "the issue says what a human must do" 0 "secret named" \
+  'cat "$tmp/notoken/body"'
+check "the issue links a compare page" 0 \
+  "https://github.com/o/r/compare/main...pin/branch" \
+  'cat "$tmp/notoken/body"'
+check "the issue carries the caller's body" 0 "body from the caller" \
+  'cat "$tmp/notoken/body"'
+
+check "a refused pull request is not reported as opened" 1 \
+  "pull request creation refused" \
+  'run prfail PIN_BUMP_TOKEN=sekrit STUB_EXPECT_TOKEN=sekrit STUB_PR_FAIL=1'
+check "a refused issue is not reported as opened" 1 "issue creation refused" \
+  'run issuefail STUB_ISSUE_FAIL=1'
+
+check "too few arguments" 2 "usage: propose-pin-bump.sh" \
+  'PATH="$tmp/bin:$PATH" "$SCRIPT" only-a-branch'
+check "an unreadable body file" 2 "cannot read body file" \
+  'PATH="$tmp/bin:$PATH" "$SCRIPT" pin/branch title "$tmp/absent.md"'
+
+# A tripwire, not a style rule. Dispatching CI is the thing that looks like it
+# works: the run is green in the Actions tab and the merge gate never sees it.
+echo
+echo "== no script reaches for gh workflow run"
+check "propose-pin-bump.sh does not dispatch CI" 0 "no dispatch call" \
+  '! grep -q "^ *gh workflow run" "$REPO/formal/propose-pin-bump.sh" \
+     && echo "no dispatch call"'
+check "bump-riscv-formal-pin.sh does not dispatch CI" 0 "no dispatch call" \
+  '! grep -q "^ *gh workflow run" "$REPO/formal/bump-riscv-formal-pin.sh" \
+     && echo "no dispatch call"'
+
+echo
+if [ "$failed" -ne 0 ]; then
+  echo "$cases checks, at least one RED." >&2
+  exit 1
+fi
+echo "$cases checks, all green."


### PR DESCRIPTION
Upstream riscv-formal moved.

- pinned:   `2bd7410cdb515d851a9d9f810ccfebd25b162709`
- upstream: `c992aa61fdfe0846c5ed90324c596202a1c69b76`
- compare:  https://github.com/YosysHQ/riscv-formal/compare/2bd7410cdb515d851a9d9f810ccfebd25b162709...c992aa61fdfe0846c5ed90324c596202a1c69b76

`test/monitor.v` is regenerated against the new pin in this commit.
The existing gates decide whether the bump is safe: monitor-freshness,
`formal/check-genchecks.py`, `formal/check-complete-exclusions.py`,
and the riscv-formal ladder itself.

### Diff under checks/, insns/, monitor/

None -- this bump only touches other directories (e.g. cores/).
