### PR TITLE
Propose the riscv-formal pin bump by issue, not by a PR nothing can merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,6 @@ on:
   pull_request:
   push:
     branches: [main]
-  # Lets .github/workflows/riscv-formal-pin-bump.yml force a run on a PR it
-  # opened with the default GITHUB_TOKEN: GitHub does not fire pull_request
-  # for events caused by that token (recursion prevention), but does attach
-  # workflow_dispatch check runs to the PR by commit SHA.
-  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/riscv-formal-pin-bump.yml
+++ b/.github/workflows/riscv-formal-pin-bump.yml
@@ -1,22 +1,26 @@
 name: riscv-formal pin bump
 
 # Notices when upstream YosysHQ/riscv-formal's `main` has moved past
-# formal/pin.mk's SHA and opens a PR bumping it, with test/monitor.v
-# regenerated against the new pin (ADR-0013). The existing gates --
+# formal/pin.mk's SHA, pushes a branch bumping it with test/monitor.v
+# regenerated against the new pin (ADR-0013), and opens an issue asking a human
+# to open the pull request from that branch. The existing gates --
 # monitor-freshness, formal/check-genchecks.py,
 # formal/check-complete-exclusions.py, the ladder itself -- grade the bump;
-# this workflow only notices and proposes. No auto-merge: ADR-0018's
-# dependabot-automerge.yml is scoped to `dependabot[bot]` and does not apply
-# here, and this workflow does not enable auto-merge on the PRs it opens.
+# this workflow only notices and proposes.
+#
+# It opens an issue rather than a pull request because a PR opened by this
+# workflow would get no CI and could never merge; formal/propose-pin-bump.sh has
+# the mechanism. No auto-merge either: ADR-0018's dependabot-automerge.yml is
+# scoped to `dependabot[bot]` and does not apply here.
 on:
   schedule:
     - cron: "17 6 * * 1" # weekly, Monday
   workflow_dispatch:
 
 permissions:
-  contents: write
-  pull-requests: write
-  actions: write # gh workflow run, needed only under the default GITHUB_TOKEN -- see the script
+  contents: write # git push, for the branch carrying the bump
+  issues: write # gh issue list, then gh issue create
+  pull-requests: read # gh pr list, to notice a bump a human has already opened
 
 jobs:
   check-and-bump:

--- a/Makefile
+++ b/Makefile
@@ -375,8 +375,15 @@ test-units: check-unit-benches test/monitor.sim.v
 probe-gates:
 	@./test/probe_gates.sh
 
+# Hangs off `test` for the same reason `probe-gates` does: it is bash and a stub
+# `gh`, so it runs anywhere, and the pin-bump path is otherwise exercised once a
+# week by a workflow nobody watches.
+.PHONY: pin-bump-test
+pin-bump-test:
+	@./formal/test-propose-pin-bump.sh
+
 .PHONY: test
-test: sim test-units probe-gates
+test: sim test-units probe-gates pin-bump-test
 	@./test/run_tests.sh ./sim test/asm test/EXPECTED_FAIL test/OBSERVED_FLOOR
 
 # Count logic cells from nextpnr, never cell counts from yosys. A flip-flop that

--- a/docs/adr/0069-a-dispatched-run-does-not-reach-the-merge-gate.md
+++ b/docs/adr/0069-a-dispatched-run-does-not-reach-the-merge-gate.md
@@ -1,0 +1,107 @@
+# ADR-0069: A dispatched run does not reach the merge gate
+
+**Status:** Accepted · 2026-08-02 · *Amends
+[ADR-0013](0013-the-riscv-formal-pin-is-an-enforced-control.md), whose pin-bump workflow opened a
+pull request that could never merge. No `rtl/` change ships from this ADR.*
+
+## Context
+
+`formal/bump-riscv-formal-pin.sh` opened a pull request with the Actions default `GITHUB_TOKEN` and
+then ran `gh workflow run ci.yml --ref "$BRANCH"`. The dispatch was there because GitHub does not
+fire `pull_request` for a PR that token opens, and `workflow_dispatch` was added to `ci.yml` for
+exactly that call.
+
+It does not work, and the way it fails is the part worth keeping: **the dispatched run is green
+everywhere a human looks and invisible to the only place that decides.**
+
+## What was measured
+
+On a scratch branch cut from `main`, so **not** conflicting with it — the earlier observations of
+this were on branches that were also conflicting, which independently suppresses `pull_request` CI
+and had to be ruled out first.
+
+1. Push the branch. `ci.yml`'s `push` trigger is `branches: [main]`, so nothing runs: the commit
+   has **0** check runs.
+2. `gh workflow run ci.yml --ref <branch>`. Nine check runs appear on that commit.
+3. Open a pull request from it. Five seconds after opening: `statusCheckRollup` is **0** while
+   those nine check runs are on the head commit. Ten seconds after opening: **11**, and grouping
+   the rollup entries by the workflow run in their `detailsUrl` gives three run ids, **none of them
+   the dispatched one**. The commit itself carries 20 check runs across four runs; the rollup
+   carries 11 across three.
+
+The pull request was `MERGEABLE` throughout, so the conflicting-branch explanation is out.
+`gh pr checks` listed the rollup's eleven and read entirely green.
+
+A second run measured the recursion guard directly, from a real workflow using the default token: it
+opened a pull request and then pushed an empty commit to the same branch. **Neither SHA has a single
+check run**, and the PR's rollup is 0. So GitHub suppresses `push` from that token as well as
+`pull_request` — which rules out pushing an empty commit as a fix, no secret required or not.
+
+## Decision
+
+**Propose the bump by issue, never by a pull request this workflow opens.** There is one code path
+and no secret.
+
+`formal/bump-riscv-formal-pin.sh` still does the work: bump `formal/pin.mk`, regenerate
+`test/monitor.v` at the new pin, commit, push the branch. `formal/propose-pin-bump.sh` then opens an
+issue naming that branch, linking a compare page that opens the pull request in one click, and
+saying that a human has to be the one to open it. A PR opened under a human account fires
+`pull_request` normally, so its checks count.
+
+**Remove `workflow_dispatch` from `ci.yml`.** Its only stated purpose was the call above, and its
+comment stated a mechanism that is measurably false. `gh run rerun` covers a manual re-run.
+
+The workflow's permissions become exactly what the four operations need: `contents: write` for the
+push, `issues: write` for `gh issue list` and `gh issue create`, and `pull-requests: read` for the
+`gh pr list` that notices a bump a human has already opened. `actions: write` goes with the
+dispatch.
+
+## Rejected: a PAT or GitHub App token
+
+A token that is not the Actions default would make a bot-opened PR fire `pull_request` and merge
+normally. **This repository is public, and that settles it.** The pin-bump workflow carries
+`workflow_dispatch`, so anyone with write access can run it at an arbitrary ref — and the script at
+that ref would read the secret. A token with contents and pull-requests write, reachable that way,
+buys one click.
+
+The measurement above holds either way; what changes is only who opens the pull request.
+
+## Evidence
+
+`formal/test-propose-pin-bump.sh` drives the script against a stub `gh`: 13 checks, hermetic, on
+`make test` and so in CI's required `test` job. The stub refuses `gh pr create` and
+`gh workflow run` outright, and two checks per script assert that neither string appears outside a
+comment.
+
+The red direction was run twice. Replacing the issue with a bot-opened PR **and** a dispatch turns
+**9 of the 13 red**; replacing it with the bot-opened PR alone — no dispatch, the subtler
+mistake — turns **8 of the 13 red**.
+
+The path was demonstrated end to end on the real scheduled workflow, dispatched at a branch whose
+pin was one commit behind: it pushed the branch, opened an issue, and opened no pull request. A
+second dispatch printed `an issue already proposes …; nothing to do`. Separately, a pull request
+opened from such a branch under a human account reached `statusCheckRollup = 11`,
+`mergeable = MERGEABLE` and `mergeStateStatus = CLEAN`, with all seven required checks green — which
+is the whole claim about who opens it. Every scratch branch, pull request and issue those runs
+created was deleted.
+
+## Consequences
+
+- A pin bump arrives as an issue with a one-click link, and the pull request a human opens from it
+  merges normally. Before this it arrived as a pull request that could never merge.
+- **CI does not run on the bump until a human opens the PR.** The weekly schedule notices upstream
+  moving; it no longer even appears to grade it. That is a real reduction against the intent, and
+  the intent never worked.
+- The commit message carries both SHAs and the compare link, so `gh pr create --fill` produces a
+  pull request body with them. The diffstat and the full diff under `checks/`, `insns/` and
+  `monitor/` are in the issue rather than in the PR description.
+- A branch whose issue nobody acts on stays behind: next week upstream has moved again, the script
+  computes a new branch name and opens a second issue, and the first branch is left. Nothing
+  deletes it.
+- **`gh workflow run` is not a way to satisfy branch protection**, and neither is a bot-opened PR.
+  Both are written where someone would reach for them: in `formal/propose-pin-bump.sh`'s header and
+  as four checks in the test. The failure is silent in the direction that matters — the Actions tab
+  is green.
+- The pin-bump workflow enables auto-merge nowhere. A pin bump is reviewed.
+- The check that a proposal already exists reads open issues as well as open pull requests, so the
+  weekly schedule does not stack up duplicates while a bump waits for a human.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -73,6 +73,7 @@ and what it costs. Reversing one is fine — write a new ADR that supersedes it.
 | [0066](0066-twelve-megahertz-is-a-requirement.md) | Twelve megahertz is a requirement | Accepted · amends 0038 decision 2; answers the question 0064 left open |
 | [0067](0067-the-bus-never-refuses-and-the-eleven-are-ruled.md) | The bus never refuses a transaction, and the eleven declined checks are ruled | Accepted · pays off 0044's closing obligation; settles invariant 2 |
 | [0068](0068-a-one-hot-marking-is-spent-against-an-assertion.md) | A one-hot marking is spent against an assertion, not against inspection | Accepted · supplements 0030, which declines one of the two statements it was asked to mark |
+| [0069](0069-a-dispatched-run-does-not-reach-the-merge-gate.md) | A dispatched run does not reach the merge gate | Accepted · amends 0013; the pin bump proposes by issue, and a PAT is rejected on public-repo grounds |
 
 0001–0007 came from the design brief
 ([`docs/ideas/finish-the-rewrite.md`](../ideas/finish-the-rewrite.md)). 0008–0011 came out of

--- a/formal/bump-riscv-formal-pin.sh
+++ b/formal/bump-riscv-formal-pin.sh
@@ -1,9 +1,13 @@
 #!/bin/bash
-# Opens a PR bumping formal/pin.mk's riscv-formal SHA when upstream's `main`
-# has moved past it, regenerating test/monitor.v so monitor-freshness is a
-# real verdict on the bump rather than a guaranteed failure. Does nothing --
-# no branch, no commit, no PR -- if the pin is already current, or if a PR
+# Bumps formal/pin.mk's riscv-formal SHA on a branch when upstream's `main` has
+# moved past it, regenerating test/monitor.v so monitor-freshness is a real
+# verdict on the bump rather than a guaranteed failure, and then opens an issue
+# asking a human to open the pull request. Does nothing -- no branch, no commit,
+# no issue -- if the pin is already current, or if a pull request or issue
 # already proposes the SHA upstream is at.
+#
+# formal/propose-pin-bump.sh opens that issue. Read its header before changing
+# how CI reaches the bump; opening the PR here does not work.
 #
 # The existing gates (monitor-freshness, formal/check-genchecks.py,
 # formal/check-complete-exclusions.py, the ladder itself) decide whether the
@@ -41,10 +45,20 @@ if [ "$PIN_SHA" = "$UPSTREAM_SHA" ]; then
 fi
 
 BRANCH="riscv-formal-pin/bump-${UPSTREAM_SHA:0:12}"
+TITLE="Bump riscv-formal pin to ${UPSTREAM_SHA:0:12}"
 
 OPEN_COUNT=$(gh pr list --state open --head "$BRANCH" --json number --jq 'length')
 if [ "$OPEN_COUNT" -gt 0 ]; then
   echo "a PR already proposes $UPSTREAM_SHA (branch $BRANCH); nothing to do"
+  exit 0
+fi
+
+# Titles are compared exactly rather than handed to `--search`, whose matching
+# is fuzzy: a near miss there would open a fresh issue every week.
+ISSUE_COUNT=$(gh issue list --state open --limit 200 --json title \
+  --jq "[.[] | select(.title == \"$TITLE\")] | length")
+if [ "$ISSUE_COUNT" -gt 0 ]; then
+  echo "an issue already proposes $UPSTREAM_SHA; nothing to do"
   exit 0
 fi
 
@@ -83,17 +97,25 @@ if git diff --quiet -- formal/pin.mk test/monitor.v; then
   exit 1
 fi
 
+COMPARE_URL="https://github.com/YosysHQ/riscv-formal/compare/${PIN_SHA}...${UPSTREAM_SHA}"
+
 git config user.name "github-actions[bot]"
 git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 git add formal/pin.mk test/monitor.v
-git commit --quiet -m "Bump riscv-formal pin to ${UPSTREAM_SHA:0:12}
+# A human opens the pull request from this branch, and `gh pr create --fill`
+# fills its body from this message, so the two SHAs and the compare link belong
+# here rather than only in the issue.
+git commit --quiet -m "$TITLE
+
+pinned:   $PIN_SHA
+upstream: $UPSTREAM_SHA
+compare:  $COMPARE_URL
 
 $DIFFSTAT"
 
 git push --quiet origin "$BRANCH"
 
-COMPARE_URL="https://github.com/YosysHQ/riscv-formal/compare/${PIN_SHA}...${UPSTREAM_SHA}"
-BODY_FILE="$CLONE_DIR/pr-body.md"
+BODY_FILE="$CLONE_DIR/issue-body.md"
 {
   echo "Upstream riscv-formal moved."
   echo
@@ -129,15 +151,4 @@ BODY_FILE="$CLONE_DIR/pr-body.md"
   fi
 } > "$BODY_FILE"
 
-PR_URL=$(gh pr create --title "Bump riscv-formal pin to ${UPSTREAM_SHA:0:12}" \
-  --body-file "$BODY_FILE" --head "$BRANCH" --base main)
-echo "opened $PR_URL"
-
-# A PR opened with the Actions default GITHUB_TOKEN does not trigger
-# pull_request-triggered workflows -- GitHub suppresses events caused by that
-# token to prevent recursive runs -- so without this, ci.yml's required checks
-# would never run on this PR. workflow_dispatch is exempt, and GitHub attaches
-# check runs to a PR by commit SHA regardless of which event asked for them.
-if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
-  gh workflow run ci.yml --ref "$BRANCH"
-fi
+formal/propose-pin-bump.sh "$BRANCH" "$TITLE" "$BODY_FILE"

--- a/formal/propose-pin-bump.sh
+++ b/formal/propose-pin-bump.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Opens an issue naming a pin-bump branch that has already been committed and
+# pushed. A human opens the pull request from that branch.
+#
+# It must not open the pull request itself. GitHub fires no `pull_request` event
+# for a PR the Actions default GITHUB_TOKEN opens, and no `push` for a commit it
+# pushes, so such a PR gets no checks and branch protection blocks it forever.
+# `gh workflow run` does not rescue it: those check runs land on the commit and
+# show up in `gh pr checks`, but never in the pull request's statusCheckRollup,
+# which is what the merge gate reads. Do not put that call back.
+#
+# Usage: propose-pin-bump.sh <branch> <title> <body-file>
+set -euo pipefail
+
+if [ "$#" -ne 3 ]; then
+  echo "usage: propose-pin-bump.sh <branch> <title> <body-file>" >&2
+  exit 2
+fi
+
+BRANCH=$1
+TITLE=$2
+BODY_FILE=$3
+
+if [ ! -r "$BODY_FILE" ]; then
+  echo "propose-pin-bump.sh: cannot read body file '$BODY_FILE'" >&2
+  exit 2
+fi
+
+ISSUE_BODY=$(mktemp "${TMPDIR:-/tmp}/pin-bump-issue.XXXXXX") || {
+  echo "propose-pin-bump.sh: could not create a temporary file" >&2
+  exit 1
+}
+trap 'rm -f "$ISSUE_BODY"' EXIT
+
+{
+  echo "The work is done and is on \`$BRANCH\`: the pin is bumped and"
+  echo "\`test/monitor.v\` is regenerated against it. **Open a pull request from"
+  echo "that branch** and the checks will run on it normally."
+  if [ -n "${GITHUB_REPOSITORY:-}" ]; then
+    echo
+    echo "${GITHUB_SERVER_URL:-https://github.com}/$GITHUB_REPOSITORY/compare/main...$BRANCH?expand=1"
+  fi
+  echo
+  echo "This is an issue rather than a pull request because a PR opened by the"
+  echo "workflow itself would get no CI and could never merge. Opening it under"
+  echo "a human account is what makes the checks count."
+  echo
+  cat "$BODY_FILE"
+} > "$ISSUE_BODY"
+
+URL=$(gh issue create --title "$TITLE" --body-file "$ISSUE_BODY")
+echo "opened issue $URL"

--- a/formal/test-propose-pin-bump.sh
+++ b/formal/test-propose-pin-bump.sh
@@ -1,0 +1,143 @@
+#!/bin/bash
+# Drives formal/propose-pin-bump.sh against a stub `gh` and pins that it opens
+# an issue, that the issue says what a human has to do, and that it opens no
+# pull request. The defect it replaces reported success on a pull request that
+# could never merge, so "it opened something" is not the property worth
+# checking.
+#
+# The stub refuses `gh pr create` and `gh workflow run`, so a script that
+# reached for either goes red here rather than proposing a bump nothing can
+# merge.
+#
+# Hermetic: no network, no toolchain, nothing but bash.
+#
+# Usage: formal/test-propose-pin-bump.sh
+set -euo pipefail
+
+HERE=$(cd "$(dirname "$0")" && pwd)
+REPO=$(cd "$HERE/.." && pwd)
+SCRIPT="$REPO/formal/propose-pin-bump.sh"
+
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/propose-pin-bump.XXXXXX") || {
+  echo "error: could not create a temporary directory." >&2
+  exit 1
+}
+if [ -z "$tmp" ] || [ ! -d "$tmp" ]; then
+  echo "error: mktemp -d produced no usable directory." >&2
+  exit 1
+fi
+trap 'rm -rf "$tmp"' EXIT
+
+mkdir -p "$tmp/bin"
+cat > "$tmp/bin/gh" <<'STUB'
+#!/bin/bash
+# Answers `issue create`, keeps the body it was handed, and rejects everything
+# else -- `pr create` and `workflow run` included -- with exit 9.
+printf '%s\n' "$*" >> "$GH_LOG"
+body=""
+prev=""
+for a in "$@"; do
+  if [ "$prev" = "--body-file" ]; then body=$a; fi
+  prev=$a
+done
+if [ "$1 $2" != "issue create" ]; then
+  echo "stub gh: refusing '$1 $2'" >&2
+  exit 9
+fi
+if [ -n "${STUB_ISSUE_FAIL:-}" ]; then
+  echo "stub gh: issue creation refused" >&2
+  exit 1
+fi
+[ -n "$body" ] && cp "$body" "$GH_BODY"
+echo "https://github.com/o/r/issues/1"
+STUB
+chmod +x "$tmp/bin/gh"
+
+printf 'body from the caller\n' > "$tmp/body.md"
+
+cases=0
+failed=0
+
+# check <label> <expected-exit> <expected-text> <shell-snippet>
+#
+# Both the status and a fragment of the output are pinned. A status alone would
+# be satisfied by a script that died on a typo before doing anything.
+check() {
+  local label=$1 want_exit=$2 want_text=$3 snippet=$4
+  cases=$((cases + 1))
+  local out rc why=""
+  set +e
+  out=$(eval "$snippet" 2>&1)
+  rc=$?
+  set -e
+  if [ "$rc" -ne "$want_exit" ]; then
+    why="exited $rc, expected $want_exit"
+  elif ! grep -qF -- "$want_text" <<< "$out"; then
+    why="output does not contain $want_text"
+  fi
+  if [ -z "$why" ]; then
+    printf '  ok   %s\n' "$label"
+  else
+    printf '  RED  %s\n     -> %s\n' "$label" "$why" >&2
+    printf '%s\n' "$out" | sed -e 's|^|        |' >&2
+    failed=1
+  fi
+}
+
+run() {  # run <case-name> [env assignments...] -- runs the script under test
+  local name=$1; shift
+  local dir="$tmp/$name"
+  mkdir -p "$dir"
+  : > "$dir/log"
+  : > "$dir/body"
+  env PATH="$tmp/bin:$PATH" GH_LOG="$dir/log" GH_BODY="$dir/body" "$@" \
+    "$SCRIPT" pin/branch "Bump riscv-formal pin to abc123abc123" "$tmp/body.md"
+}
+
+echo "== formal/propose-pin-bump.sh"
+
+check "it opens an issue" 0 "opened issue" \
+  'run open GITHUB_REPOSITORY=o/r'
+check "it opens no pull request" 0 "no pr create in the log" \
+  '! grep -q "pr create" "$tmp/open/log" && echo "no pr create in the log"'
+check "the issue names the branch" 0 "pin/branch" \
+  'cat "$tmp/open/body"'
+check "the issue says a human opens the pull request" 0 \
+  "Open a pull request from" \
+  'cat "$tmp/open/body"'
+check "the issue links a compare page" 0 \
+  "https://github.com/o/r/compare/main...pin/branch" \
+  'cat "$tmp/open/body"'
+check "the issue carries the caller's body" 0 "body from the caller" \
+  'cat "$tmp/open/body"'
+
+check "a refused issue is not reported as opened" 1 "issue creation refused" \
+  'run issuefail STUB_ISSUE_FAIL=1'
+check "too few arguments" 2 "usage: propose-pin-bump.sh" \
+  'PATH="$tmp/bin:$PATH" "$SCRIPT" only-a-branch'
+check "an unreadable body file" 2 "cannot read body file" \
+  'PATH="$tmp/bin:$PATH" "$SCRIPT" pin/branch title "$tmp/absent.md"'
+
+# A tripwire, not a style rule. Both of these look like they work: a PR the
+# workflow opens and a run it dispatches are green in the Actions tab and
+# invisible to the merge gate.
+#
+# Comment lines are dropped first, because both scripts name these two commands
+# in prose to say why they must not be called.
+echo
+echo "== no script opens the pull request or dispatches CI"
+for f in propose-pin-bump.sh bump-riscv-formal-pin.sh; do
+  check "$f does not open a pull request" 0 "no pr create call" \
+    '! grep -v "^ *#" "$REPO/formal/'"$f"'" | grep -q "gh pr create" \
+       && echo "no pr create call"'
+  check "$f does not dispatch CI" 0 "no dispatch call" \
+    '! grep -v "^ *#" "$REPO/formal/'"$f"'" | grep -q "gh workflow run" \
+       && echo "no dispatch call"'
+done
+
+echo
+if [ "$failed" -ne 0 ]; then
+  echo "$cases checks, at least one RED." >&2
+  exit 1
+fi
+echo "$cases checks, all green."


### PR DESCRIPTION
Closes JEF-752.

## The premise holds, and the confound is ruled out

`formal/bump-riscv-formal-pin.sh` opened a PR with the Actions default `GITHUB_TOKEN` and then ran `gh workflow run ci.yml --ref "$BRANCH"`. **A dispatched run's check runs never enter the pull request's `statusCheckRollup`**, so branch protection never sees them and the PR can never merge — while the Actions tab and `gh pr checks` both read green.

The ticket noted that the three PRs it was observed on were also conflicting with `main`, which independently suppresses `pull_request` CI. **That was ruled out first**, on a scratch branch cut from `main` and `MERGEABLE` throughout.

Push the branch (`ci.yml`'s `push` is `branches: [main]`, so nothing runs):

```
$ gh api repos/thejefflarson/little-cpu/commits/f654f9e.../check-runs --jq .total_count
0
```

Dispatch, wait for the nine check runs, then open the PR and poll:

```
$ gh workflow run ci.yml --ref scratch/dispatch-rollup-probe
$ gh pr create ...   # -> PR #116
--- t+5s ---   rollup=0   mergeable=UNKNOWN    mss=UNKNOWN   runs=
--- t+10s ---  rollup=11  mergeable=MERGEABLE  mss=BLOCKED   runs=30786707981,30786707990,30786708025
--- t+15s ---  rollup=11  mergeable=MERGEABLE  mss=BLOCKED   runs=30786707981,30786707990,30786708025
```

The dispatched run is `30786655950`. It is **not** in that list. Grouping both sides by the workflow run id in each entry's `detailsUrl`:

```
$ gh api .../commits/f654f9e.../check-runs        # the COMMIT
[{"run":"30786655950","count":9,...},   <- the dispatch
 {"run":"30786707981","count":9,...},
 {"run":"30786707990","count":1,...},
 {"run":"30786708025","count":1,...}]

$ gh pr view 116 --json statusCheckRollup         # the MERGE GATE
[{"run":"30786707981","count":9,...},
 {"run":"30786707990","count":1,...},
 {"run":"30786708025","count":1,...}]
```

20 check runs on the commit, 11 in the rollup, on a `MERGEABLE` PR.

## Option 2 in the ticket does not work either — measured

The ticket offered "push an empty commit after opening the PR… it works". **It does not, under `GITHUB_TOKEN`.** A real workflow run using the default token opened a PR and then pushed an empty commit to the same branch:

```
$ gh pr view 117 --json ... -> {"mergeable":"MERGEABLE","mss":"BLOCKED","rollup":0}
$ gh api .../commits/8c58f9e.../check-runs --jq .total_count   # PR-open SHA
0
$ gh api .../commits/dd960dd.../check-runs --jq .total_count   # empty-commit SHA
0
```

The recursion guard covers `push` as well as `pull_request`.

## Option 1 is rejected: this repository is public

A PAT or App token would make a bot-opened PR fire `pull_request` and merge normally, and it is **not shipped**. The pin-bump workflow carries `workflow_dispatch`, so anyone with write access can run it at an arbitrary ref — and the script at that ref would have the secret in its environment. A token with contents + pull-requests write, reachable that way on a public repo, buys one click.

**There is no `PIN_BUMP_TOKEN` anywhere in the tree** (`grep -rn PIN_BUMP_TOKEN .` → nothing) and no branch on a secret's presence. One code path.

## The fix — option 3, with the valuable part kept

`formal/bump-riscv-formal-pin.sh` still does the work: bump `formal/pin.mk`, regenerate `test/monitor.v` at the new pin, commit, push the branch. `formal/propose-pin-bump.sh` (new) then opens an **issue** naming that branch, with a compare link that opens the PR in one click, and says that a human has to be the one to open it — which fires `pull_request` normally, so the checks count.

`gh workflow run` is gone. The "already proposed" check reads open issues as well as open PRs, so the weekly schedule does not stack duplicates while a bump waits for a human; titles are compared exactly rather than through `--search`, whose matching is fuzzy.

`docs/adr/0069-a-dispatched-run-does-not-reach-the-merge-gate.md` records it, with the PAT as a rejected alternative and the public-repo reason stated.

## What the permissions block is now, and what each entry is for

```yaml
permissions:
  contents: write     # git push, for the branch carrying the bump
  issues: write       # gh issue list, then gh issue create
  pull-requests: read # gh pr list, to notice a bump a human has already opened
```

`actions: write` is **gone** — it existed only for `gh workflow run`. `pull-requests` dropped from `write` to `read`: the only pull-request call left is the `gh pr list` that checks whether a human has already opened the PR for this SHA, and dropping the entry entirely would break it, because an explicit `permissions:` block sets every unlisted scope to `none`.

**This was verified by running the real workflow, not by reading the docs.** The `gh pr list` call happens before the issue is opened, so a permissions shortfall would have aborted the run under `set -e`:

```
run: completed success
pinned:   2bd7410cdb515d851a9d9f810ccfebd25b162709
upstream: c992aa61fdfe0846c5ed90324c596202a1c69b76
opened issue https://github.com/thejefflarson/little-cpu/issues/121
```

## Does losing the bot-opened PR cost anything real? Honestly, yes — a little

**Kept in full.** The bump itself: `formal/pin.mk` and the regenerated `test/monitor.v` are committed and pushed exactly as before. The pre-graded diff too — diffstat, and the full diff under `checks/`, `insns/`, `monitor/` when it is ≤300 lines — is in the issue body, unchanged.

**Genuinely degraded, three things:**

1. **CI does not run on the bump until a human opens the PR.** The schedule notices upstream moving; it no longer even appears to grade it. Against the *intent* of the old design that is a real reduction — but the intent never worked, so against the *behaviour* it is no change.
2. **The pre-graded diff is in the issue, not the PR description.** Partly mitigated: the commit message now carries both SHAs and the upstream compare link, so `gh pr create --fill` reproduces them in the PR body —
   ```
   Bump riscv-formal pin to c992aa61fdfe

   pinned:   2bd7410cdb515d851a9d9f810ccfebd25b162709
   upstream: c992aa61fdfe0846c5ed90324c596202a1c69b76
   compare:  https://github.com/YosysHQ/riscv-formal/compare/2bd7410...c992aa61
   ```
   The full riscv-formal diff still lives one click away in the issue rather than inline in the PR.
3. **A branch whose issue nobody acts on is left behind.** Next week upstream has moved again, the script computes a new branch name and opens a second issue; nothing deletes the first branch. That was true before this change too, and it is written down in the ADR rather than fixed here.

Everything else is one human click on the compare link.

## Tests

`formal/test-propose-pin-bump.sh` — 13 checks, hermetic (no network, no toolchain), on `make test` via a `pin-bump-test` target, so it lands in CI's required `test` job with no workflow change. The stub `gh` refuses `gh pr create` and `gh workflow run` outright, and four checks assert neither string appears outside a comment in either script.

**Red direction run twice**, because the subtler mistake matters more than the obvious one:

| mutation | result |
|---|---|
| issue → bot-opened PR **and** a dispatch | **9 of 13 red** |
| issue → bot-opened PR alone, no dispatch | **8 of 13 red** |

## Acceptance criterion 1 — demonstrated on the real workflow

`riscv-formal-pin-bump.yml` was dispatched at a branch whose pin was one commit behind upstream, running the real script:

```
run: completed success
opened issue https://github.com/thejefflarson/little-cpu/issues/121

$ gh pr list --state open --head riscv-formal-pin/bump-c992aa61fdfe
[]
```

An issue, no pull request, and the branch pushed with the regenerated `test/monitor.v`. A second dispatch printed `an issue already proposes c992aa61...; nothing to do` and opened nothing.

**And the claim the whole design rests on — that a human-opened PR from such a branch does count — was measured**, on a PR opened from a real bump branch:

```
$ gh pr view 118 --json statusCheckRollup,mergeable,mergeStateStatus
statusCheckRollup = 11   mergeable = MERGEABLE   mergeStateStatus = CLEAN
  elaborate  test  components  lint  formal  soc-timing  monitor-freshness
  nonperturbation  fit  review  auto-merge      -- all COMPLETED SUCCESS/SKIPPED
```

All seven required checks reported and `mergeStateStatus` reached `CLEAN`, against `rollup = 0` for the old path.

## `workflow_dispatch` in `ci.yml` — removed, deliberately

It existed for exactly the call this PR deletes, and its comment stated a mechanism that is measurably false. Leaving it invites the same misreading; `gh run rerun` covers a manual re-run of any past run.

**No job was renamed or removed.** All nine `ci.yml` job names are byte-identical (`elaborate`, `test`, `components`, `lint`, `fit`, `soc-timing`, `nonperturbation`, `monitor-freshness`, `formal`), so branch protection needs no change.

## No auto-merge

Nothing here enables auto-merge, and `dependabot-automerge.yml` stays scoped to `dependabot[bot]`. A pin bump is reviewed.

## Scratch artifacts created, and removed

All created to take the measurements above; all **closed and deleted**. `gh pr list --state open` shows only this PR, `gh issue list --state open` is `[]`, and `git ls-remote --heads origin | grep -E 'scratch/|riscv-formal-pin/'` matches nothing.

| | |
|---|---|
| PR #116 + branch `scratch/dispatch-rollup-probe` | closed, branch deleted |
| PR #117 + branch `scratch/token-probe-30786880612` | closed, branch deleted |
| PR #118 + branch `riscv-formal-pin/bump-c992aa61fdfe` | closed, branch deleted |
| Issues #119, #121 | closed |
| branches `scratch/pin-bump-nosecret`, `scratch/pin-bump-perms` | deleted |

## Gates run (re-run after the rewrite)

| | |
|---|---|
| `make test` | **59/59**, both baselines empty, suite shape matches `OBSERVED_FLOOR` |
| `make probe-gates` (under `make test`) | 125 graded comparisons, every failure path executed |
| `make pin-bump-test` (under `make test`) | 13 checks, all green |
| `make test-units` | 8 benches, all pass |
| `shellcheck -S warning` on all three scripts | clean |
| security pass on the diff | no Critical or High; the PAT exposure class is gone with the PAT |

The formal ladder and `soc-timing` were not run locally: no `rtl/` or `formal/` proof file is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJ77ZZJ6pDiL3vj3Qw9hKs
