### PR TITLE
Account for where the cycles actually go: per-reason stall counters (JEF-676)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -316,6 +316,20 @@ probe was re-run — delete the rs2 write-through bypass, `bad state property 1 
 k = 22 SATISFIABLE` — because a change to the regfile's forwarding is exactly the class that could
 make that check go green by stopping to ask.
 
+**Half the suite's cycles issue nothing, and the decode scoreboard is 57% of them** (ADR-0070).
+`make cycles` charges every simulated cycle of the same 59 programs to an issuing cycle or to one of
+the decoder's six stall reasons, read as the named signals `rtl/decoder.v` drives; **no `rtl/` file
+changed**, because those signals survive `write_cxxrtl` as debug items. Measured at `0314890`:
+**28632 cycles, 13853 retires, CPI 2.07**; issue 49.0%, decode scoreboard **29.3%**, operand fetch
+**16.4%**, divider 2.8%, serialization 1.5%, load turnaround 1.1%, stolen fetch window 0.03%,
+**unattributed 0**. ADR-0042's accepted +18.0% is *located* rather than inferred, and the three
+reasons that get argued about most — `fence.i`/CSR serialization, the load turnaround, the stolen
+window — are 5.4% between them. **A column is cycles CHARGED, not cycles the signal was high**:
+coincident reasons go to the first one the decoder itself would try, so `fetch_stall` is high on 26
+cycles across the three writable-text programs and is charged 8. Read ADR-0070 before quoting any of
+this; `test/decoder_tb.v` carries the identity that keeps the six-reason list from falling behind
+`stall`.
+
 **Every graded comparison in the grading layer now has a probe of its own red direction, and two of
 them had never been executed** (ADR-0053). Five of this repo's recorded defects were in that layer
 and every one was in a *script*; the class is the comparison whose failure path was never run, and
@@ -344,8 +358,9 @@ now carries `make fit`'s table-presence check and ratchet, and `soc/cell_census.
 Makefile so there is one copy of the logic. `check-unit-benches` needed no extraction: its three
 branches are probed by invoking the real target against the real `test/*_tb.v` tree with
 `UNIT_BENCHES`/`UNIT_BENCH_SRC_*` overridden on the command line, which is what its own comment
-already commits to being possible. `test/probe_gates.sh` is **125** probes now, up from 108
-(ADR-0058 added three for `soc/timing_split.py`'s LUT-versus-carry depth split).
+already commits to being possible. `test/probe_gates.sh` is **137** probes now, up from 108
+(ADR-0058 added three for `soc/timing_split.py`'s LUT-versus-carry depth split; ADR-0070 twelve for
+`test/stall_report.py` and for `run_tests.sh` driving it).
 **`make soc-timing` joins CI in the `soc-timing` job**, mirroring `fit`: non-required at the time,
 for the same reason (ADR-0036) — it publishes the census and the logic/routing split to the step
 summary whether it passes or fails. **It is required now** (ADR-0066): the floor it grades is the
@@ -912,7 +927,19 @@ make test           # assemble test/asm/*.S, run under cxxrtl, pass/fail table w
                     # both ways before a single program is assembled -- so a suite
                     # that SHRANK is red, not a smaller table that still "passes".
                     # Also runs `make probe-gates` (ADR-0053).
-make probe-gates    # forces all 125 graded comparisons in the grading scripts to
+make cycles         # THE CPI COUNTERPART OF `make fit` (ADR-0070). The same 59
+                    # programs, per-program and whole-suite, with every cycle
+                    # charged to an issuing cycle or one of the six stall
+                    # reasons. 0314890: 28632 cycles, 13853 retires, CPI 2.07,
+                    # 51.0% of cycles issuing nothing -- 29.3% decode
+                    # scoreboard, 16.4% operand fetch, 2.8% divider, 1.5%
+                    # serialization, 1.1% load turnaround, 0.03% stolen fetch.
+                    # A COLUMN IS CYCLES CHARGED, NOT CYCLES THE SIGNAL WAS
+                    # HIGH. NOT on `make test` and not on CI: no CPI ratchet
+                    # exists and this adds none. It does grade its own
+                    # arithmetic -- a stalled cycle none of the six explains
+                    # exits nonzero. THE CPI DESCRIBES THE SUITE, NOT THE CORE.
+make probe-gates    # forces all 137 graded comparisons in the grading scripts to
                     # FAIL and requires each to fail for its own reason. Hermetic
                     # (stubs, no toolchain); a prerequisite of `test` on purpose,
                     # so it is in CI's required job. All fork, no work: ~68-90s of
@@ -1370,13 +1397,13 @@ longer quietly widen.
   rejected the shifter merge at 19 cells *saved* on legibility grounds, and accepting a hygiene
   change at 37 cells *spent* would cut against that ruling. Read this before proposing the
   narrowing again — it is measured and declined, not overlooked.
-- Decisions: [`docs/adr/`](docs/adr/) — **sixty-three ADRs, sixty-two of them accepted**, plus a
-  deferred list. Re-derived by counting: `ls docs/adr/*.md | wc -l` is 64, one of which is
+- Decisions: [`docs/adr/`](docs/adr/) — **sixty-nine ADRs, sixty-eight of them accepted**, plus a
+  deferred list. Re-derived by counting: `ls docs/adr/*.md | wc -l` is 70, one of which is
   `README.md`, and the status column in that README carries exactly one non-accepted entry
-  (ADR-0016, superseded by ADR-0018). This line has now been behind three times — "forty-five
-  accepted", then "forty-seven", then "fifty-five" while seven more had landed — so **re-derive it
-  with the two commands rather than incrementing it**. The first lapse missed ADR-0049 through
-  ADR-0051 in one go, and the third missed ADR-0056 through ADR-0062.
+  (ADR-0016, superseded by ADR-0018). This line has now been behind four times — "forty-five
+  accepted", then "forty-seven", then "fifty-five" while seven more had landed, then "sixty-three"
+  while five had — so **re-derive it with the two commands rather than incrementing it**. The first
+  lapse missed ADR-0049 through ADR-0051 in one go, and the third missed ADR-0056 through ADR-0062.
 - Reference text from the old core: `git show 1709433^:rtl/riscv.v` (RVFI retire block),
   `git show e67875c^:rtl/alu.v` (arithmetic)
 - Work is tracked in Linear, project **Little CPU** (team JEF). Named here so you know where the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1397,8 +1397,8 @@ longer quietly widen.
   rejected the shifter merge at 19 cells *saved* on legibility grounds, and accepting a hygiene
   change at 37 cells *spent* would cut against that ruling. Read this before proposing the
   narrowing again — it is measured and declined, not overlooked.
-- Decisions: [`docs/adr/`](docs/adr/) — **sixty-nine ADRs, sixty-eight of them accepted**, plus a
-  deferred list. Re-derived by counting: `ls docs/adr/*.md | wc -l` is 70, one of which is
+- Decisions: [`docs/adr/`](docs/adr/) — **seventy ADRs, sixty-nine of them accepted**, plus a
+  deferred list. Re-derived by counting: `ls docs/adr/*.md | wc -l` is 71, one of which is
   `README.md`, and the status column in that README carries exactly one non-accepted entry
   (ADR-0016, superseded by ADR-0018). This line has now been behind four times — "forty-five
   accepted", then "forty-seven", then "fifty-five" while seven more had landed, then "sixty-three"

--- a/Makefile
+++ b/Makefile
@@ -386,6 +386,17 @@ pin-bump-test:
 test: sim test-units probe-gates pin-bump-test
 	@./test/run_tests.sh ./sim test/asm test/EXPECTED_FAIL test/OBSERVED_FLOOR
 
+# The same suite `make test` runs, with the runner charging every cycle to the
+# decoder's stall reasons, and test/stall_report.py turning that into a table.
+# Its own target rather than part of `make test`: the counting costs a
+# debug_eval() per cycle on every program, and a CPI figure is a measurement to
+# compare against the last one, not something to fail a merge on. What it does
+# grade is its own arithmetic -- a cycle the decoder stalled for a reason this
+# does not name is a reason nobody has written down, and it exits nonzero.
+.PHONY: cycles
+cycles: sim
+	@STALL_REPORT=1 ./test/run_tests.sh ./sim test/asm test/EXPECTED_FAIL test/OBSERVED_FLOOR
+
 # Count logic cells from nextpnr, never cell counts from yosys. A flip-flop that
 # cannot share a cell with the LUT feeding it takes a whole cell by itself, and
 # over a thousand of this design's cells are like that. Counting `SB_LUT4`

--- a/docs/adr/0070-the-suites-cycles-are-charged-to-a-named-stall-reason.md
+++ b/docs/adr/0070-the-suites-cycles-are-charged-to-a-named-stall-reason.md
@@ -1,0 +1,141 @@
+# ADR-0070: The suite's cycles are charged to a named stall reason
+
+**Status:** Accepted · 2026-08-02 · *The CPI counterpart of `make fit`. Adds `make cycles`; no
+`rtl/` file changes. Gives
+[ADR-0042](0042-the-regfile-read-is-synchronous-and-costs-a-cycle.md)'s accepted +18.0%
+an invoice, and puts a number on the six stall reasons
+[ADR-0026](0026-stalls-are-four-reasons-over-two-mechanisms.md) and
+[ADR-0060](0060-the-steal-reaches-decode-as-the-sixth-stall-reason.md) enumerate.*
+
+## Context
+
+The `.S` suite's cycle count was the only CPI number this project had, and nothing decomposed it.
+Every argument about where the cycles went was made from structure: the operand-fetch cycle "costs a
+cycle per instruction", `fence.i` "drains the pipeline", the divider "is 33 cycles". None of those
+was weighed against the others, because nothing weighed anything.
+
+Area was in that position before `make fit`, and it produced four wrong estimates inside a week,
+each corrected only by building the thing and looking. ADR-0042 then accepted a **measured +18.0%**
+cycle cost for 2735 logic cells, deliberately and correctly — but with no way to ask which part of
+the pipeline that 18% now sits in, or what it would take back.
+
+## Decision
+
+**`make cycles` runs the same 59 programs `make test` runs and charges every simulated cycle to
+either an issuing cycle or one of the decoder's six stall reasons.** Three parts:
+
+1. `test/cxxrtl.cc` gains `--stalls`. It reads `uut decoder stall` and the seven signals that make
+   it up — `divider_stall`, `accessor_stall`, `hazard_rs1`, `hazard_rs2`, `serialize`,
+   `operand_stall`, `fetch_stall` — through cxxrtl `debug_items`, once per cycle, and prints one
+   `STALLS cycles=... issue=... unattributed=...` line.
+2. `test/stall_report.py` turns those lines into a per-program and whole-suite table with CPI.
+3. `STALL_REPORT=1 test/run_tests.sh` wires the two together; the Makefile calls that `make cycles`.
+
+### The signals are read, never rebuilt
+
+Every reason is the named wire `rtl/decoder.v` drives. Nothing in the runner re-derives
+`hazard` from `uses_rs1` and the scoreboard slots, and nothing re-derives `stall` from the seven
+terms. An attribution that drifts from the RTL is worse than no attribution: it would keep printing
+a table that adds up while describing a pipeline that no longer exists. Reading `stall` itself
+rather than OR-ing the seven probes is what makes the `unattributed` column mean something — see
+below.
+
+**No `rtl/` file changed, and none needed to.** The decoder's stall signals survive
+`write_cxxrtl` as plain named debug items, so the `(* keep *)` this change was budgeted for was
+never spent.
+
+### A cycle goes to the first reason the decoder itself would try
+
+Several reasons are true at once often — `operand_stall` is high on 31 of `selfmod.S`'s cycles and
+is charged 12 of them — so the count needs an order. The order is `rtl/decoder.v`'s own: the publish
+block holds `decoder_out` for the divider and the accessor before it bubbles for anything else, and
+`stall` ORs the rest left to right.
+
+    divider · accessor · hazard (rs1, rs2) · serialize · operand · fetch
+
+`hazard_rs1` and `hazard_rs2` share a column because they are one reason, the decode scoreboard
+finding a producer still in flight, and they are adjacent in the order, so merging them cannot move
+a cycle past anything else.
+
+**A column is therefore cycles CHARGED, not cycles the signal was high**, and the difference is
+large where reasons coincide. `fetch_stall` is high on 26 cycles across the three writable-text
+programs — 6 / 4 / 16, reproducing ADR-0064's independently taken count exactly — and is charged 8.
+The report says so where the number is printed.
+
+### It is a sibling target, not part of `make test`
+
+`make test` is unchanged: same flags to the runner, same table, same set equality against
+`test/EXPECTED_FAIL`, same exit status. Two reasons.
+
+- A CPI figure is a measurement to compare against the last one, not a merge criterion. There is no
+  CPI ratchet here and this ADR does not propose one; the number moves for legitimate reasons on
+  every change to the suite.
+- The counting costs a `debug_eval()` per cycle. Measured over the suite: **1.80–1.84 s of user CPU
+  without it, 1.94–1.96 s with**, three runs each; wall time is 4.0–4.6 s either way and the two
+  distributions overlap, because the suite is fork-dominated. That is small, and it is still not
+  something to spend on the required gate for a number the gate does not read.
+
+### What it does grade
+
+`make cycles` exits nonzero on **unattributed cycles**: a cycle where `rtl/decoder.v` raised
+`stall` and none of the six named reasons was high. That is a stall reason nobody has written down,
+and it is the one wrong answer this measurement can give — the cycles would otherwise be silently
+correct in the total and attributed to nothing. It also exits nonzero when the columns stop adding
+up to the cycle count, which is a field name that has drifted between the runner and the report.
+
+## Evidence
+
+Measured at `0314890` with Homebrew yosys 0.67+post (`b8e7da6f`), riscv64-elf-gcc, `CYCLES=5000`.
+**59 programs, 28632 cycles, 13853 instructions retired, CPI 2.07.**
+
+| | cycles | share |
+|---|---|---|
+| issue | 14030 | 49.0% |
+| hazard (decode scoreboard) | **8381** | **29.3%** |
+| operand (operand-fetch cycle) | 4684 | 16.4% |
+| divider | 792 | 2.8% |
+| serialize | 419 | 1.5% |
+| accessor (load turnaround) | 318 | 1.1% |
+| fetch (stolen window) | 8 | 0.0% |
+| unattributed | 0 | 0.0% |
+
+**Half the suite's cycles issue nothing, and the RAW scoreboard is 57.4% of the ones that do not.**
+The operand-fetch cycle is 16.4% of all cycles — ADR-0042's +18.0%, now located rather than
+inferred. The three reasons that get argued about most (`fence.i` and CSR serialization, the load
+turnaround, the stolen fetch window) come to 5.4% between them.
+
+Three runs of `make cycles` are byte-identical.
+
+### Both red directions were executed
+
+- A seventh term ORed into `rtl/decoder.v`'s `stall` (`|| (rs1 == 5'd2)`, thrown away afterwards)
+  gives **259 unattributed cycles** and a nonzero `make cycles`, and trips `test/decoder_tb.v`'s new
+  identity check with 3 mismatches. The same mutation ORed with `instr_ecall` did **not** trip the
+  bench check, which is how its sampling was found to be clock-edge only and widened to both edges.
+- `test/probe_gates.sh` goes from 125 probes to **137**: eight against `test/stall_report.py`
+  directly (sum mismatch, unattributed, a missing field, a non-numeric count, a malformed line, an
+  empty input, and two controls) and four against `run_tests.sh` driving it through the sim stub.
+
+### What the number is not
+
+It is the suite's CPI, not the core's. These are small hand-written assembly programs with dense
+back-to-back dependencies and almost no loop structure; their instruction mix is not real code's.
+The report says that where the number is printed, because that is where it will be quoted from.
+
+## Consequences
+
+- There is now a per-reason cost to compare any pipeline change against, on the same suite, with the
+  same runner. The next argument about forwarding, about the divider's radix, or about narrowing
+  `operand_stall` starts from a number.
+- `test/decoder_tb.v` carries the identity `stall == the OR of the six named reasons`, checked on
+  both clock edges. A seventh stall reason is red in a required gate rather than the next time
+  somebody asks for the table.
+- **This ADR proposes no optimisation and reopens no ruling.** Forwarding still needs its own ADR
+  (invariant 4), CSR serialization still buys `minstret` exactness (ADR-0027), the load turnaround
+  is still structural (ADR-0015) and the radix-4 divider is still rejected on area (ADR-0038). The
+  measurement exists so the next conversation about any of them starts from data.
+- `make cycles` is not on CI. It grades nothing about the design, and adding a job for it would be a
+  gate on a number this ADR deliberately declines to ratchet.
+- The attribution priority is a ruling and is transcribed in three places — the runner's
+  `kStallReasons`, the report's `REASONS`, and this ADR. Reordering one without the others changes
+  which column a coincident cycle lands in, and every column would still add up.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -74,6 +74,7 @@ and what it costs. Reversing one is fine — write a new ADR that supersedes it.
 | [0067](0067-the-bus-never-refuses-and-the-eleven-are-ruled.md) | The bus never refuses a transaction, and the eleven declined checks are ruled | Accepted · pays off 0044's closing obligation; settles invariant 2 |
 | [0068](0068-a-one-hot-marking-is-spent-against-an-assertion.md) | A one-hot marking is spent against an assertion, not against inspection | Accepted · supplements 0030, which declines one of the two statements it was asked to mark |
 | [0069](0069-a-dispatched-run-does-not-reach-the-merge-gate.md) | A dispatched run does not reach the merge gate | Accepted · amends 0013; the pin bump proposes by issue, and a PAT is rejected on public-repo grounds |
+| [0070](0070-the-suites-cycles-are-charged-to-a-named-stall-reason.md) | The suite's cycles are charged to a named stall reason | Accepted · gives 0042's accepted +18.0% an invoice; measures 0026 and 0060's six reasons |
 
 0001–0007 came from the design brief
 ([`docs/ideas/finish-the-rewrite.md`](../ideas/finish-the-rewrite.md)). 0008–0011 came out of

--- a/test/cxxrtl.cc
+++ b/test/cxxrtl.cc
@@ -27,6 +27,15 @@
 // test/OBSERVED_FLOOR. Making observation a printed, graded quantity rather
 // than something inferred from a green run is the whole point of the two
 // counters; a number nobody reads is the defect this closes, not a fix for it.
+//
+// `--stalls` adds a second line, splitting the run's cycles between the
+// decoder's stall reasons and the cycles that issue an instruction:
+//
+//     STALLS cycles=<n> issue=<n> hazard=<n> ... unattributed=<n>
+//
+// It is off by default because it costs a debug_eval() per cycle; test/
+// stall_report.py turns those lines into a table. See the counter block below
+// for what each name means and why the order it tries them in is the decoder's.
 #include <cxxrtl/cxxrtl_vcd.h>
 #include "rtl.cc"
 
@@ -39,6 +48,8 @@
 #include <sstream>
 #include <stdexcept>
 #include <string>
+#include <utility>
+#include <vector>
 
 namespace {
 
@@ -135,11 +146,42 @@ bool load_rom_banks(cxxrtl::debug_items &items, const HexImage &image) {
   return true;
 }
 
+// The decoder's stall reasons, each read as the named signal rtl/decoder.v
+// drives rather than rebuilt here. Several of them are true on the same cycle
+// often enough that the count needs an order, and the order below is the
+// decoder's own: it holds `decoder_out` for the divider and the accessor before
+// it bubbles for anything else, and `stall` ORs the remaining four left to
+// right. Rebuilding the equation in C++ would let this drift from the RTL with
+// nothing to say so, which is worse than not counting at all.
+//
+// `hazard_rs1` and `hazard_rs2` share a bucket: they are one reason, the decode
+// scoreboard finding a producer still in flight, and they sit next to each
+// other in the order so merging them cannot move a cycle past anything else.
+struct StallReason {
+  const char *item;
+  int bucket;
+};
+
+constexpr const char *kStallLabels[] = {"divider", "accessor", "hazard",
+                                        "serialize", "operand", "fetch"};
+constexpr int kStallBuckets = sizeof(kStallLabels) / sizeof(kStallLabels[0]);
+
+constexpr StallReason kStallReasons[] = {
+    {"uut decoder divider_stall", 0},
+    {"uut decoder accessor_stall", 1},
+    {"uut decoder hazard_rs1", 2},
+    {"uut decoder hazard_rs2", 2},
+    {"uut decoder serialize", 3},
+    {"uut decoder operand_stall", 4},
+    {"uut decoder fetch_stall", 5},
+};
+
 struct Args {
   std::string rom_path;
   std::string ram_path;
   std::string vcd_path;
   long cycles = 0;
+  bool stalls = false;
 };
 
 bool parse_args(int argc, char **argv, Args &args) {
@@ -168,6 +210,8 @@ bool parse_args(int argc, char **argv, Args &args) {
       const char *v = next("--vcd");
       if (!v) return false;
       args.vcd_path = v;
+    } else if (arg == "--stalls") {
+      args.stalls = true;
     } else {
       std::fprintf(stderr, "error: unrecognized argument '%s'\n", arg.c_str());
       return false;
@@ -175,7 +219,8 @@ bool parse_args(int argc, char **argv, Args &args) {
   }
   if (args.rom_path.empty() || args.ram_path.empty() || args.cycles <= 0) {
     std::fprintf(stderr,
-                  "usage: sim --rom <hex> --ram <hex> --cycles N [--vcd out.vcd]\n");
+                  "usage: sim --rom <hex> --ram <hex> --cycles N [--vcd out.vcd] "
+                  "[--stalls]\n");
     return false;
   }
   return true;
@@ -268,6 +313,38 @@ int main(int argc, char **argv) {
     return 3;
   }
 
+  // `--stalls` only. Each of these is a signal rtl/decoder.v drives, looked up
+  // the same way as the items above and a setup error when missing: a stall
+  // reason that quietly stopped being counted would report the cycles it costs
+  // as issue cycles, which is the one wrong answer this measurement can give.
+  //
+  // `uut decoder stall` is the decoder's own OR of the reasons below. Reading it
+  // rather than OR-ing the seven probes is what makes `unattributed` mean
+  // something: it counts the cycles the decoder called a stall and none of the
+  // named reasons explains, i.e. a stall reason nobody has written down.
+  std::vector<std::pair<const cxxrtl::debug_item *, int>> stall_probes;
+  const cxxrtl::debug_item *stall_any = nullptr;
+  if (args.stalls) {
+    try {
+      stall_any = &all_debug_items.at("uut decoder stall").at(0);
+      for (const StallReason &reason : kStallReasons)
+        stall_probes.emplace_back(&all_debug_items.at(reason.item).at(0),
+                                  reason.bucket);
+    } catch (const std::out_of_range &) {
+      std::fprintf(stderr,
+                    "error: --stalls needs the decoder's stall signals as debug "
+                    "items, and at least one of them is not in the simulated "
+                    "design. They are plain named wires in rtl/decoder.v; a "
+                    "rename there means renaming them in kStallReasons here.\n");
+      return 3;
+    }
+  }
+
+  uint64_t counted_cycles = 0;
+  uint64_t issue_cycles = 0;
+  uint64_t unattributed_cycles = 0;
+  uint64_t stall_cycles[kStallBuckets] = {};
+
   // Printed on every path that reaches the simulation loop. Setup failures
   // above return before this point on purpose: nothing ran, so there is no
   // observation to report, and a "RETIRES 0" line for a run that never started
@@ -275,6 +352,15 @@ int main(int argc, char **argv) {
   auto report_counts = [&]() {
     std::printf("RETIRES %u SPEC-CHECKED %u\n", retires->curr[0],
                  spec_retires->curr[0]);
+    if (!args.stalls)
+      return;
+    std::printf("STALLS cycles=%llu issue=%llu",
+                 (unsigned long long)counted_cycles,
+                 (unsigned long long)issue_cycles);
+    for (int b = 0; b < kStallBuckets; ++b)
+      std::printf(" %s=%llu", kStallLabels[b],
+                   (unsigned long long)stall_cycles[b]);
+    std::printf(" unattributed=%llu\n", (unsigned long long)unattributed_cycles);
   };
 
   // Silence outranks the run's own verdict. A run whose oracle never fired has
@@ -338,6 +424,29 @@ int main(int argc, char **argv) {
       top.p_reset.set(false);
     top.p_clk.set<bool>(false);
     top.step();
+    // Sampled here, between the two edges, because these are combinational: with
+    // the clock low they hold the values that decide what the rising edge below
+    // does. Read after the rising edge instead and every count belongs to the
+    // next cycle. debug_eval() is what fills them in -- yosys leaves them
+    // outlined, so their storage is stale until it is called.
+    if (args.stalls) {
+      top.debug_eval();
+      counted_cycles++;
+      if ((stall_any->curr[0] & 1) == 0) {
+        issue_cycles++;
+      } else {
+        bool charged = false;
+        for (const auto &[item, bucket] : stall_probes) {
+          if ((item->curr[0] & 1) != 0) {
+            stall_cycles[bucket]++;
+            charged = true;
+            break;
+          }
+        }
+        if (!charged)
+          unattributed_cycles++;
+      }
+    }
     sample(cycle * 2 + 0);
     top.p_clk.set<bool>(true);
     top.step();

--- a/test/decoder_tb.v
+++ b/test/decoder_tb.v
@@ -110,6 +110,27 @@ module decoder_tb;
     prev_next_pc_valid <= 1'b1;
   end
 
+  // `stall` is exactly these seven terms ORed together. `make cycles` charges
+  // every stalled cycle to the first of them that is true, so a term added to
+  // `stall` and not there would leave the cycles it costs unexplained. This says
+  // so in a gate that runs on every change, rather than the next time somebody
+  // asks for the table.
+  //
+  // On both clock edges, not just the rising one. Every vector here presents its
+  // instruction just after a rising edge, so the falling edge is where it is
+  // settled and being decoded. Sampling only the rising edge misses that, and
+  // the probe for this check -- a seventh term ORed into `stall` -- goes green.
+  always @(clk) begin
+    if (dut.stall !== (dut.divider_stall || dut.accessor_stall || dut.hazard_rs1 ||
+                       dut.hazard_rs2 || dut.serialize || dut.operand_stall ||
+                       dut.fetch_stall)) begin
+      $display("MISMATCH stall is not the OR of the six named reasons: stall=%b divider=%b accessor=%b rs1=%b rs2=%b serialize=%b operand=%b fetch=%b",
+               dut.stall, dut.divider_stall, dut.accessor_stall, dut.hazard_rs1,
+               dut.hazard_rs2, dut.serialize, dut.operand_stall, dut.fetch_stall);
+      errors++;
+    end
+  end
+
   task automatic operand_fetch_cycle();
     begin
       @(posedge clk);

--- a/test/probe_gates.sh
+++ b/test/probe_gates.sh
@@ -27,7 +27,7 @@ REPO=$(cd "$HERE/.." && pwd)
 # Pinned as a literal: a probe that is deleted, or that stops being reached by
 # an early `return`, would otherwise cut this file's coverage while it kept
 # printing a green summary.
-PROBES_EXPECTED=125
+PROBES_EXPECTED=137
 
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/littlecpu-probe.XXXXXX") || {
   echo "error: could not create a temporary directory under ${TMPDIR:-/tmp}." >&2
@@ -141,6 +141,16 @@ make_sim_stub() {  # $1 = path
 # elaborated design.
 [ -z "${STUB_SIM_NOCOUNTS:-}" ] && \
   echo "RETIRES ${STUB_SIM_RETIRES:-10} SPEC-CHECKED ${STUB_SIM_SPEC:-10}"
+# The `--stalls` line. STUB_SIM_UNATTR stands in for a stall reason the report
+# does not name; STUB_SIM_SKEW breaks the sum without touching any column, which
+# is what a renamed field would do.
+stalls=
+for a in "$@"; do [ "$a" = "--stalls" ] && stalls=1; done
+if [ -n "$stalls" ] && [ -z "${STUB_SIM_NOSTALLS:-}" ]; then
+  unattr=${STUB_SIM_UNATTR:-0}
+  echo "STALLS cycles=$((20 + unattr + ${STUB_SIM_SKEW:-0})) issue=10 divider=0" \
+       "accessor=0 hazard=10 serialize=0 operand=0 fetch=0 unattributed=$unattr"
+fi
 case ${STUB_SIM_EXIT:-0} in
   0) echo "PASS" ;;
   1) echo "FAIL 7" ;;
@@ -223,7 +233,7 @@ rm "$tmp/bin-noobjcopy/riscv64-elf-objcopy"
 make_sim_stub "$tmp/sim"
 make_sail_stub "$tmp/sail"
 make_cosim_bin_stub "$tmp/dut"
-cp "$HERE/run_tests.sh" "$HERE/check_suite_shape.sh" "$tmp/leg-rt/"
+cp "$HERE/run_tests.sh" "$HERE/check_suite_shape.sh" "$HERE/stall_report.py" "$tmp/leg-rt/"
 cp "$HERE/run_cosim.sh" "$HERE/check_suite_shape.sh" "$tmp/leg-rc/"
 make_cosim_py_stub "$tmp/leg-rc/cosim.py"
 cp "$HERE/run_cosim.sh" "$HERE/check_suite_shape.sh" "$tmp/leg-rc-nopy/"
@@ -388,6 +398,22 @@ probe "a baselined test that starts failing a DIFFERENT way is red" 1 \
 
 probe "an unexpected PASS is red too -- the baseline is not a ceiling" 1 \
   "does NOT match" "$(rt "$d")"
+
+# STALL_REPORT=1 is `make cycles`. It leaves the pass/fail grading alone and adds
+# one of its own, so both statuses have to be able to reach the caller.
+d=$(rt_fixture)
+probe "control: STALL_REPORT prints the accounting and keeps the suite green" 0 \
+  "cycle accounting" "STALL_REPORT=1 $(rt "$d")"
+
+probe "a stall reason the accounting cannot name is red even with every test passing" 1 \
+  "stalled for a reason this report does not name" \
+  "STALL_REPORT=1 STUB_SIM_UNATTR=3 $(rt "$d")"
+
+probe "columns that no longer add up to the cycle count are red" 1 \
+  "columns sum to" "STALL_REPORT=1 STUB_SIM_SKEW=5 $(rt "$d")"
+
+probe "a runner that reports no cycles at all cannot produce a clean table" 1 \
+  "no program reported its cycles" "STALL_REPORT=1 STUB_SIM_NOSTALLS=1 $(rt "$d")"
 
 begin_group "test/run_cosim.sh"
 
@@ -971,6 +997,54 @@ probe "a declared bench with no file is named the other way" 2 \
 probe "a declared bench with no UNIT_BENCH_SRC_* would build with no design under test" 2 \
   "monitor_tb is in UNIT_BENCHES with no UNIT_BENCH_SRC_monitor_tb" \
   "$MB UNIT_BENCH_SRC_monitor_tb="
+
+begin_group "test/stall_report.py"
+
+SR="python3 $REPO/test/stall_report.py"
+
+# add.S issues 10 of its 40 cycles and spends 20 waiting on the scoreboard and
+# 10 fetching operands; lw.S is the other way round, so the two programs
+# disagree about which reason dominates and the total has to decide.
+sr_fixture() {
+  local d; d=$(new_case)
+  cat > "$d/counts" <<'COUNTS'
+add.S cycles=40 issue=10 divider=0 accessor=0 hazard=20 serialize=0 operand=10 fetch=0 unattributed=0 retires=10
+lw.S cycles=40 issue=10 divider=0 accessor=5 hazard=0 serialize=0 operand=25 fetch=0 unattributed=0 retires=10
+COUNTS
+  printf '%s' "$d"
+}
+
+d=$(sr_fixture)
+probe "control: an accounting that adds up prints the table" 0 \
+  "cycle accounting" "$SR $d/counts"
+
+probe "the dominant reason is the suite's, not the first program's" 0 \
+  "The largest single reason is operand" "$SR $d/counts"
+
+d=$(sr_fixture); sed -i.bak 's/^add.S cycles=40/add.S cycles=41/' "$d/counts"
+probe "columns that do not add up blame the report, not the core" 1 \
+  "columns sum to 40, cycles is 41" "$SR $d/counts"
+
+d=$(sr_fixture); sed -i.bak 's/^add.S \(.*\)unattributed=0/add.S \1unattributed=2/' "$d/counts"
+sed -i.bak2 's/^add.S cycles=40/add.S cycles=42/' "$d/counts"
+probe "a stall nothing in the list explains is a reason nobody wrote down" 1 \
+  "2 cycles stalled for a reason this report does not name" "$SR $d/counts"
+
+d=$(sr_fixture); sed -i.bak 's/ operand=10//' "$d/counts"
+probe "a field the runner stopped printing is named, not counted as zero" 1 \
+  "is missing operand" "$SR $d/counts"
+
+d=$(sr_fixture); sed -i.bak 's/cycles=40/cycles=lots/' "$d/counts"
+probe "a count that is not a number stops rather than summing to nonsense" 1 \
+  "cycles is 'lots', not a number" "$SR $d/counts"
+
+d=$(sr_fixture); sed -i.bak 's/ issue=10/ issue/' "$d/counts"
+probe "a field with no value is a malformed line" 1 "'issue' is not key=value" \
+  "$SR $d/counts"
+
+d=$(new_case); : > "$d/counts"
+probe "no programs at all would report a clean 0 of 0" 1 \
+  "no program reported its cycles" "$SR $d/counts"
 
 begin_group "soc/fit_report.py"
 

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -4,6 +4,12 @@
 #
 # Usage: run_tests.sh <sim-binary> <asm-dir> <expected-fail-file> <floor-file>
 #
+# STALL_REPORT=1 additionally runs the simulator with `--stalls` and prints
+# test/stall_report.py's cycle-accounting table. That is `make cycles`, not
+# `make test`: the counting costs a debug_eval() per cycle, and a CPI figure is
+# a measurement rather than a merge gate. Nothing about the pass/fail table or
+# the comparison against the baseline changes either way.
+#
 # This is the merge gate. The failure that matters is passing without having
 # tested anything, and that is what every check below is for. test/probe_gates.sh
 # breaks each one and makes sure it fails, because a check whose failing branch
@@ -24,6 +30,7 @@ EXPECTED_FAIL=$3
 OBSERVED_FLOOR=$4
 CYCLES=5000
 HERE=$(cd "$(dirname "$0")" && pwd)
+STALL_REPORT=${STALL_REPORT:-0}
 
 # A baseline that is missing or cannot be read gives an empty expected set. If
 # every test passes, that matches, and the run prints "Failure list matches"
@@ -96,6 +103,14 @@ trap 'rm -rf "$tmp"' EXIT
 declare -a failures=()
 declare -a table=()
 passed=0
+stall_counts="$tmp/stall_counts"
+: > "$stall_counts"
+# A bare word with no spaces, so it is expanded unquoted below. An empty array
+# under `set -u` is an unbound variable on the bash macOS ships.
+sim_stall_flag=""
+if [ "$STALL_REPORT" = "1" ]; then
+  sim_stall_flag="--stalls"
+fi
 
 for src in "$ASM_DIR"/*.S; do
   name=$(basename "$src")
@@ -148,7 +163,7 @@ for src in "$ASM_DIR"/*.S; do
     # means the test failed. A runner that will not start would look like a bug
     # in the CPU.
     set +e
-    "$SIM" --rom "$rom_hex" --ram "$ram_hex" --cycles "$CYCLES" \
+    "$SIM" --rom "$rom_hex" --ram "$ram_hex" --cycles "$CYCLES" $sim_stall_flag \
       > "$tmp/$base.run.log" 2>&1
     sim_status=$?
     set -e
@@ -170,6 +185,16 @@ for src in "$ASM_DIR"/*.S; do
     set -- $(awk '/^RETIRES /{print $2, $4; exit}' "$tmp/$base.run.log")
     retires=${1:-}
     spec_retires=${2:-}
+
+    # Collected for every program that ran, whatever its verdict: a program that
+    # times out is exactly the one whose cycles are worth looking at. The retire
+    # count comes from the line above rather than being counted twice.
+    if [ "$STALL_REPORT" = "1" ]; then
+      stall_line=$(awk '/^STALLS /{$1=""; print; exit}' "$tmp/$base.run.log")
+      if [ -n "$stall_line" ]; then
+        echo "$name $stall_line retires=${retires:-0}" >> "$stall_counts"
+      fi
+    fi
   fi
 
   # A PASS with no counts means the binary that ran is not the runner this
@@ -222,6 +247,18 @@ printf '%s\n' "${table[@]}"
 echo
 echo "$passed/${#table[@]} passed"
 
+# Before the baseline comparison, so the verdict stays the last thing printed.
+# The accounting is graded on its own terms -- every cycle charged to a named
+# reason -- and that is a different question from whether the programs passed,
+# so its status is kept apart and applied at the end.
+stall_report_status=0
+if [ "$STALL_REPORT" = "1" ]; then
+  set +e
+  python3 "$HERE/stall_report.py" "$stall_counts"
+  stall_report_status=$?
+  set -e
+fi
+
 # `NF` has to come before the rebuild, not after. Assigning to $1 sets NF to 1,
 # so `{$1=$1} NF` would bring every blank and comment line back as an entry.
 actual_sorted=$(printf '%s\n' "${failures[@]:-}" | awk 'NF { $1=$1; print }' | sort)
@@ -237,7 +274,7 @@ fi
 
 if [ "$actual_sorted" = "$expected_sorted" ]; then
   echo "Failure list matches $EXPECTED_FAIL exactly (name and status)."
-  exit 0
+  exit $stall_report_status
 fi
 
 echo

--- a/test/stall_report.py
+++ b/test/stall_report.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Turn the runner's per-program `STALLS` lines into a cycle-accounting table.
+
+WHAT THIS IS FOR. The `.S` suite's cycle count was the only CPI number this
+project had, and nothing decomposed it. The synchronous-read regfile cost a
+measured +18.0% on this suite and that was accepted deliberately; a decision
+like that is much easier to defend, and to revisit honestly, with an invoice
+attached. This is the invoice. It is the same move `make fit` made for area:
+one aggregate figure, argued about from structure, replaced by a measurement.
+
+EVERY CYCLE IS CHARGED EXACTLY ONCE. test/cxxrtl.cc reads the decoder's own
+`stall` signal and its six named reasons every cycle. A cycle where `stall` is
+low is an issue cycle; a cycle where it is high goes to the first reason that is
+true, in the order rtl/decoder.v tries them. So the columns add up to the cycle
+count by construction, and this script checks that they do -- a mismatch means
+the runner and the report disagree about the field names, not that the core got
+slower.
+
+`unattributed` IS THE ONE THAT MATTERS. It counts cycles the decoder called a
+stall that none of the six named reasons explains. It is zero, and if it ever is
+not, the taxonomy has fallen behind rtl/decoder.v -- a stall reason nobody has
+written down. That is a finding, so this script exits nonzero on it rather than
+printing it as a curiosity.
+
+THE CPI IT PRINTS DESCRIBES THIS SUITE, NOT THIS CORE. Said again next to the
+number itself, because that is where it will be read.
+"""
+
+import argparse
+import sys
+
+# The six the decoder has, in the order it tries them: it holds `decoder_out`
+# for the divider and the accessor, and bubbles for the other four. The runner
+# writes these names, so a rename has to happen in both places at once -- which
+# the field check below turns into an error rather than a silent zero.
+REASONS = ["divider", "accessor", "hazard", "serialize", "operand", "fetch"]
+HEADINGS = {
+    "divider": "DIVIDER",
+    "accessor": "ACCESSOR",
+    "hazard": "HAZARD",
+    "serialize": "SERIAL",
+    "operand": "OPERAND",
+    "fetch": "FETCH",
+}
+REQUIRED = ["cycles", "issue", "retires", "unattributed"] + REASONS
+
+
+def parse(path):
+    """`<program> key=value ...` per line. Returns a list of (name, counts)."""
+    rows = []
+    for lineno, line in enumerate(open(path), 1):
+        line = line.strip()
+        if not line:
+            continue
+        name, *fields = line.split()
+        counts = {}
+        for field in fields:
+            if "=" not in field:
+                sys.exit(f"{path}:{lineno}: '{field}' is not key=value")
+            key, value = field.split("=", 1)
+            try:
+                counts[key] = int(value)
+            except ValueError:
+                sys.exit(f"{path}:{lineno}: {key} is '{value}', not a number")
+        missing = [k for k in REQUIRED if k not in counts]
+        if missing:
+            sys.exit(
+                f"{path}:{lineno}: {name} is missing {', '.join(missing)}. The "
+                f"runner's STALLS line and this script's REASONS list have to "
+                f"name the same things."
+            )
+        rows.append((name, counts))
+    return rows
+
+
+def cpi(cycles, retires):
+    return f"{cycles / retires:.2f}" if retires else "-"
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "counts", help="one `<program> key=value ...` line per program"
+    )
+    args = parser.parse_args()
+
+    rows = parse(args.counts)
+    if not rows:
+        sys.exit(
+            f"{args.counts} is empty: no program reported its cycles, so there "
+            f"is nothing to account for. A table over no programs would report "
+            f"a clean 0 of 0."
+        )
+
+    total = {k: 0 for k in REQUIRED}
+    for _, counts in rows:
+        for key in REQUIRED:
+            total[key] += counts[key]
+
+    # Checked per program as well as over the suite. One program whose columns
+    # do not add up is invisible in a total that happens to.
+    broken = []
+    for name, counts in rows:
+        parts = counts["issue"] + counts["unattributed"] + sum(counts[r] for r in REASONS)
+        if parts != counts["cycles"]:
+            broken.append(f"  {name}: columns sum to {parts}, cycles is {counts['cycles']}")
+
+    width = max(len(name) for name, _ in rows)
+    header = f"{'PROGRAM':<{width}} {'CYCLES':>8} {'RETIRED':>8} {'CPI':>6} {'ISSUE':>8}"
+    header += "".join(f"{HEADINGS[r]:>9}" for r in REASONS)
+    header += f"{'UNATTR':>8}"
+
+    print()
+    print("== cycle accounting: where the suite's cycles go ==")
+    print()
+    print(header)
+    for name, counts in rows:
+        line = (
+            f"{name:<{width}} {counts['cycles']:>8} {counts['retires']:>8} "
+            f"{cpi(counts['cycles'], counts['retires']):>6} {counts['issue']:>8}"
+        )
+        line += "".join(f"{counts[r]:>9}" for r in REASONS)
+        line += f"{counts['unattributed']:>8}"
+        print(line)
+
+    suite = (
+        f"{'SUITE':<{width}} {total['cycles']:>8} {total['retires']:>8} "
+        f"{cpi(total['cycles'], total['retires']):>6} {total['issue']:>8}"
+    )
+    suite += "".join(f"{total[r]:>9}" for r in REASONS)
+    suite += f"{total['unattributed']:>8}"
+    print(suite)
+
+    def share(n):
+        return f"{100 * n / total['cycles']:.1f}%"
+
+    pct = f"{'% of cycles':<{width}} {'':>8} {'':>8} {'':>6} {share(total['issue']):>8}"
+    pct += "".join(f"{share(total[r]):>9}" for r in REASONS)
+    pct += f"{share(total['unattributed']):>8}"
+    print(pct)
+
+    stalled = sum(total[r] for r in REASONS) + total["unattributed"]
+    biggest = max(REASONS, key=lambda r: total[r])
+    print()
+    print(
+        f"{len(rows)} programs, {total['cycles']} cycles, {total['retires']} "
+        f"instructions retired, CPI {cpi(total['cycles'], total['retires'])}."
+    )
+    print(f"{stalled} of those cycles ({share(stalled)}) issued nothing.")
+    print(
+        f"The largest single reason is {biggest}: {total[biggest]} cycles, "
+        f"{share(total[biggest])} of all cycles and "
+        f"{100 * total[biggest] / stalled:.1f}% of the stalled ones."
+    )
+    print()
+    print(
+        "READ THE CPI AS A PROPERTY OF THIS SUITE. These are small hand-written\n"
+        "assembly programs with dense back-to-back dependencies and almost no\n"
+        "loop structure. Their instruction mix is not real code's, so this\n"
+        "number describes the suite and not what the core would do on a\n"
+        "program anybody wanted to run. It is useful for comparing one commit\n"
+        "against another, and for nothing else."
+    )
+    print()
+    print(
+        "A COLUMN IS CYCLES CHARGED, NOT CYCLES THE SIGNAL WAS HIGH. Several\n"
+        "reasons are true on the same cycle often, and each cycle goes to the\n"
+        "first one the decoder itself would try, so the columns add up. Measured\n"
+        "on the three writable-text programs: fetch_stall is high on 26 cycles\n"
+        "and is charged 8, because on the other 18 something else was already\n"
+        "holding the same instruction."
+    )
+
+    if broken:
+        sys.exit(
+            "\n*** the columns do not add up to the cycle count:\n"
+            + "\n".join(broken)
+            + "\n*** Every cycle is charged to exactly one column by the runner,\n"
+            "*** so this is a field name that has drifted between test/cxxrtl.cc\n"
+            "*** and this script, not a slower core."
+        )
+
+    if total["unattributed"]:
+        sys.exit(
+            f"\n*** {total['unattributed']} cycles stalled for a reason this "
+            f"report does not name.\n"
+            "*** rtl/decoder.v raised `stall` and none of the six signals this\n"
+            "*** counts was high, so there is a stall reason nobody has written\n"
+            "*** down. Add it to kStallReasons in test/cxxrtl.cc and to REASONS\n"
+            "*** here, and to the stall-reason list in CLAUDE.md."
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes JEF-676.

The `.S` suite's cycle count was the only CPI number this project had, and nothing decomposed it. `make cycles` charges every simulated cycle of the same 59 programs to an issuing cycle or to one of the decoder's six stall reasons. ADR-0070 records the decision; **no `rtl/` file changed**.

## The suite breakdown

Measured at `0314890`, Homebrew yosys 0.67+post (`b8e7da6f`), riscv64-elf-gcc, `CYCLES=5000`.
**59 programs · 28632 cycles · 13853 instructions retired · CPI 2.07.**

| | cycles | share of all cycles |
|---|---|---|
| issue | 14030 | 49.0% |
| **hazard — decode scoreboard (RAW)** | **8381** | **29.3%** |
| operand — operand-fetch cycle | 4684 | 16.4% |
| divider | 792 | 2.8% |
| serialize — CSR / `mret` / `fence.i` | 419 | 1.5% |
| accessor — load-response turnaround | 318 | 1.1% |
| fetch — stolen fetch window | 8 | 0.03% |
| **unattributed** | **0** | **0.0%** |

**The dominant reason is the decode scoreboard.** Half the suite's cycles (51.0%) issue nothing, and the RAW interlock is **57.4% of those** — more than three times the next reason. The operand-fetch cycle is 16.4% of all cycles, which locates ADR-0042's accepted +18.0% rather than inferring it. The three reasons that get argued about most — serialization, the load turnaround and the stolen fetch window — are **5.4% between them**.

Per-program table is in `make cycles`' output; `div.S` and `remu.S` are the outliers at CPI 4.57 and 5.12, both divider-bound.

### The attribution summed exactly — no remainder

`unattributed` is **0** on every one of the 59 programs. The runner reads `uut decoder stall` itself, separately from the seven signals that make it up, so that column counts cycles the decoder called a stall and none of the named reasons explains. It is not a tautology of the bucket sum, and `test/stall_report.py` exits nonzero if it is ever nonzero — a stall reason nobody has written down is a finding, not a rounding error. Three runs of `make cycles` are byte-identical.

## Six reasons, derived from `rtl/decoder.v`

The ticket says four. The RTL says six, and the list came from reading `rtl/decoder.v:484-524` and cross-checking CLAUDE.md invariant 8:

```
assign hazard = hazard_rs1 || hazard_rs2 || serialize;
assign stall  = hazard || operand_stall || divider_stall || accessor_stall || fetch_stall;
```

decode scoreboard (`hazard_rs1`/`hazard_rs2`) · divider · accessor load turnaround · serialization · `operand_stall` · `fetch_stall`. Seven probed signals, six columns: the two `hazard_rs*` share one, because they are one reason and are adjacent in the order.

## Priority rule, and why it is the RTL's

A cycle with several reasons live goes to the **first one the decoder itself would try**:

> divider · accessor · hazard · serialize · operand · fetch

That is the publish block's arm order — `divider_stall || accessor_stall` **holds** `decoder_out` and comes first, everything else **bubbles** — followed by `stall`'s own left-to-right OR. So the hold-beats-bubble ruling is reproduced by construction rather than invented here, and a `fetch_stall` coinciding with a freeze is charged to the freeze, matching the ruling that holding wins.

**A column is therefore cycles CHARGED, not cycles the signal was high.** Measured, and it is the one way to misread the table: `fetch_stall` is high on **26** cycles across the three writable-text programs — **6 / 4 / 16** for `selfmod.S` / `textload.S` / `contend.S`, reproducing ADR-0064's independently-taken count exactly — and is charged **8**. That independent agreement is also the evidence the sampling point is right. The report prints the caveat where the numbers are.

## Gates

| gate | result |
|---|---|
| `make test` | **exit 0 · 59/59 passed**, `test/EXPECTED_FAIL` matched exactly (empty), `test/OBSERVED_FLOOR` shape and floors green |
| `make test-units` | **exit 0 · 8 benches**, matching `test/*_tb.v` exactly |
| `make probe-gates` | **137 graded comparisons, every failure path executed** (was 125) |
| `make cycles` | exit 0, attribution complete |
| `make fit` / `make soc-timing` | **not run — no `rtl/` file changed**, so neither can move |

`make test`'s behaviour is unchanged: same flags to the runner, same table, same set equality, same exit status. `STALL_REPORT=1` is what `make cycles` sets, and the extra grading only exists on that path.

## Cost

`--stalls` costs a `debug_eval()` per cycle and is off by default. Over the suite, three runs each: **1.80–1.84 s user CPU without, 1.94–1.96 s with**; wall time 4.0–4.6 s either way, distributions overlapping, because the suite is fork-dominated.

## Both red directions were executed

- A seventh term ORed into `rtl/decoder.v`'s `stall` (`|| (rs1 == 5'd2)`, thrown away): **259 unattributed cycles and a red `make cycles`**, plus 3 mismatches from `test/decoder_tb.v`'s new identity check.
- The same probe written as `|| (instr_ecall && in.valid)` **went green** through the bench check first time. That is how the check was found to be rising-edge-sampled while most vectors in that bench present their instruction between edges; it samples both edges now, and the finding is recorded in the ADR.
- `test/probe_gates.sh` gains 12 probes: eight against `test/stall_report.py` directly (sum mismatch, unattributed, missing field, non-numeric count, malformed line, empty input, two controls) and four against `run_tests.sh` driving it through the sim stub.

## Scope notes

- **`test/decoder_tb.v` (+21)** is not incidental. It adds the identity `stall == the OR of the six named reasons`, checked on both clock edges. Without it the six-reason list can fall behind the RTL and nothing says so until somebody runs `make cycles`; with it, a seventh stall reason is red in a required gate. No signal was added and no RTL was touched to make it work.
- **`make cycles` is deliberately not on CI and not on `make test`.** A CPI figure is a measurement to compare against the last one, not a merge criterion — there is no CPI ratchet here and this adds none. The ticket's criterion 5 also forbids adding a gate to `make test`, and the accounting's own consistency check *is* graded, so it needed its own target.
- **Measurement only.** No CPI lever was touched, proposed or reopened: forwarding still needs its own ADR, CSR serialization still buys `minstret` exactness, the load turnaround is still structural, and radix-4 division is still rejected on area.
- ADR-0070 is the number reserved for this change; `docs/adr/README.md` gains one row, which will conflict trivially with the concurrent 0069/0071.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
