### PR TITLE
Prove the trap commit path by k-induction (JEF-650)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,9 @@ jobs:
       - name: Fetcher/decoder PC-loop proof
         run: make -C formal components_pcloop
 
+      - name: Trap commit proof
+        run: make -C formal components_traps
+
       - name: Report job wall time
         if: always()
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1410,8 +1410,8 @@ longer quietly widen.
   rejected the shifter merge at 19 cells *saved* on legibility grounds, and accepting a hygiene
   change at 37 cells *spent* would cut against that ruling. Read this before proposing the
   narrowing again — it is measured and declined, not overlooked.
-- Decisions: [`docs/adr/`](docs/adr/) — **seventy ADRs, sixty-nine of them accepted**, plus a
-  deferred list. Re-derived by counting: `ls docs/adr/*.md | wc -l` is 71, one of which is
+- Decisions: [`docs/adr/`](docs/adr/) — **seventy-one ADRs, seventy of them accepted**, plus a
+  deferred list. Re-derived by counting: `ls docs/adr/*.md | wc -l` is 72, one of which is
   `README.md`, and the status column in that README carries exactly one non-accepted entry
   (ADR-0016, superseded by ADR-0018). This line has now been behind four times — "forty-five
   accepted", then "forty-seven", then "fifty-five" while seven more had landed, then "sixty-three"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -528,10 +528,12 @@ the failure this section exists to prevent, so they stay as markers rather than 
   assertion reports `UNKNOWN rc=4`, not `FAIL`, because the guard is basecase-unreachable at depth
   20 against a 33-cycle divider (ADR-0049 F3). The task went 6.5s → 50.3s.
 - ~~**Three of the five component-proof tasks are vacuous**~~ — **they were deleted; there are
-  three tasks now and all three assert something.** `formal/components.sby` carries `decoder`,
-  `executor` and `pcloop`; `fetcher`, `accessor` and `writeback` are gone, and `formal/Makefile`
-  says so where the targets used to be. ADR-0006's slate is discharged. The rule the bullet was
-  protecting stands and is worth keeping: a green run of a task with no assertions is not a result.
+  four tasks now and all four assert something.** `formal/components.sby` carries `decoder`,
+  `executor`, `pcloop` and `traps`; `fetcher`, `accessor` and `writeback` are gone, and
+  `formal/Makefile` says so where the targets used to be. ADR-0006's slate is discharged. The rule
+  the bullet was protecting stands and is worth keeping: a green run of a task with no assertions is
+  not a result. `traps` landed with its `$assert` cell count read off the prepared netlist (25),
+  because "PASS" says nothing about how many questions were asked.
 - **`components_pcloop` was failing on `main`, and nothing ran it** (ADR-0046). It has failed since
   `e4f5250` — `failed assertion ... at pcloop.sv:273 step 3`, the sequential-advance assertion —
   because its `f_may_stall` over-approximation predates ADR-0042's fifth stall reason and therefore
@@ -696,10 +698,12 @@ port, `imem_tb`, which walks rtl/imemory.v's bank select at every word index and
 against a flat reference plus its range decode (ADR-0054), `accessor_tb`, which exists for the one
 signal nothing else can see stuck low — `mem_ren`, the read enable the memory's arbiter keys on
 (ADR-0060) — and `monitor_tb`, which checks the oracle
-itself rather than the core), and **all three**
-component proofs — decoder, executor and `pcloop` — pass by k-induction (`mode prove`; re-run and
+itself rather than the core), and **all four**
+component proofs — decoder, executor, `pcloop` and `traps` — pass by k-induction (`mode prove`;
+re-run and
 read off each `sby` summary, not inferred from a green job. See ADR-0017 for what the decoder proof
-does and does not establish, and ADR-0046 for what `pcloop` discharges). `make waves`
+does and does not establish, ADR-0046 for what `pcloop` discharges, and ADR-0071 for what `traps`
+does — including the two mutations it does NOT catch and why both are the RTL being right). `make waves`
 now runs the iverilog leg (`testbench.vvp`) instead of the cxxrtl runner, matching the verification
 table below, and produces a real `waves.vcd` — and, as of ADR-0055, grades the run it produces one
 too: `ci.yml`'s `elaborate` job runs and checks this same `testbench.vvp` directly, on one fixed
@@ -1004,12 +1008,21 @@ make soc-timing     # THE SoC PLACE-AND-TIME FLOW (ADR-0054), and NOT `make fit`
                     # Probe: `make soc-timing SOC_MIN_MHZ=99` exits 2 (the
                     # script exits 1 and make reports its own status).
 
-make -C formal components_decoder   # component proofs. THREE tasks, all with real assertions:
-make -C formal components_executor  # decoder, executor, pcloop -- the assertion-free fetcher /
-make -C formal components_pcloop    # accessor / writeback tasks were deleted, not left unrun.
+make -C formal components_decoder   # component proofs. FOUR tasks, all with real assertions:
+make -C formal components_executor  # decoder, executor, pcloop, traps -- the assertion-free
+make -C formal components_pcloop    # fetcher / accessor / writeback tasks were deleted, not left
+make -C formal components_traps     # unrun.
                                     # pcloop is the composed fetcher+decoder proof that discharges
                                     # ADR-0017's assume(in.pc == pc); it needs `smtbmc boolector`
-                                    # (see formal/components.sby) and is on CI as of ADR-0046
+                                    # (see formal/components.sby) and is on CI as of ADR-0046.
+                                    # traps composes fetcher+decoder+csrs so that mtvec, mepc,
+                                    # mcause and mstatus are REAL REGISTERS under a proof -- the
+                                    # ladder drops every value comparison once an instruction
+                                    # traps and its pc checks accept any target, so nothing else
+                                    # says a trap lands on mtvec (ADR-0071). PASS 0 2, 25 assert
+                                    # cells, 2-3s, default yices. mcause/mstatus are read through
+                                    # the architectural read port with the instruction word free,
+                                    # not through a reference model
 make -C formal check                # the riscv-formal ladder (85 checks; see ADR-0023). ALWAYS a
                                     # fresh run -- it deletes checks/ first (ADR-0040)
 make -C formal check-baseline       # re-grade a finished ladder: EXPECTED_CHECKS + EXPECTED_FAIL

--- a/docs/adr/0071-the-trap-commit-path-is-proved-and-its-priority-encoder-is-still-vacuous.md
+++ b/docs/adr/0071-the-trap-commit-path-is-proved-and-its-priority-encoder-is-still-vacuous.md
@@ -1,0 +1,177 @@
+# ADR-0071: The trap commit path is proved by k-induction, and its priority encoder is still vacuous
+
+**Status:** Accepted · 2026-08-02 · *Supplements [ADR-0011](0011-misalignment-detection-stays-in-accessor-until-m3.md),
+[ADR-0028](0028-the-rvfi-convention-for-a-trapping-retire.md) and
+[ADR-0030](0030-trap-cause-priority-and-why-the-causes-are-disjoint.md). Adds a fourth task to
+`formal/components.sby`.*
+
+## Context
+
+riscv-formal's `checks/rvfi_insn_check.sv` wraps every value comparison it makes — `rd_addr`,
+`rd_wdata`, `pc_wdata`, all five `mem_*` fields — in `if (!spec_trap)`. Under `spec_trap` the only
+surviving assertion is `assert(spec_trap == trap)`: the core has to *say* it trapped, and nothing
+more is checked. ADR-0028 recorded which existing checks cover the consequences indirectly —
+`dmemcheck` for a store that was suppressed but executed anyway, `reg` for a corrupted `rd`,
+`pc_fwd`/`pc_bwd` for the redirect itself.
+
+**Nothing anywhere checked that the trap target is `mtvec`, or that `mepc`, `mcause` and `mstatus`
+are right.** `pc_fwd` and `pc_bwd` compare the core's reported `pc_wdata` against the core's own
+next `pc_rdata`, so they are satisfied by *any* target the core commits to consistently, `mtvec` of
+0 included. And riscv-formal ships no spec model at all for `ecall`, `ebreak`, `mret` or `csrr*` at
+the pin, so `complete` excludes the whole SYSTEM class by declaration
+(`formal/COMPLETE_EXCLUSIONS`).
+
+`rtl/decoder.v`'s own `ifdef FORMAL` block does assert `pc == mtvec` after a trap. It asserts it
+against a **free input**: in `components_decoder` the decoder is alone, and `mtvec`/`mepc` are
+whatever the solver picks. That is the right proof for that task and it is not a proof about the
+CSR file.
+
+The ladder is also `mode bmc` throughout. A trap either redirects correctly or it does not, forever;
+that deserves an unbounded answer.
+
+## Decision
+
+**A fourth task, `traps`, in `formal/components.sby`**, `mode prove` like the other three, over
+`formal/traps.sv` — the fetcher, the decoder and the CSR file wired together the way
+`rtl/littlecpu.v` wires them. `make -C formal components_traps`, and a step in CI's required
+`components` job.
+
+**No RTL changed.** The proof found no defect in the trap path.
+
+### What it asserts, and how it observes state it cannot reach
+
+`mtvec_value` and `mepc_value` are output ports of `rtl/csrs.v`, so they are read directly.
+`mcause`, `mstatus` and the two counters are not: they are internal registers.
+
+They are read **the way software reads them**. `csr_addr` is `instr[31:20]` on every cycle, whatever
+the instruction is, and `csr_rdata` answers it combinationally in the same cycle. The instruction
+word is a free input to the harness, so the solver can point that address at any register on any
+cycle — including the cycle after a trap, and including the trapping cycle itself, because a
+reserved-opcode word carries twelve bits the decoder hands straight to the CSR address port. No
+reference model of `rtl/csrs.v` was needed and none was written.
+
+The assertions, in groups:
+
+- **Interlock.** The three stall reasons that arrive as inputs (`divider_stall`, `accessor_stall`,
+  `fetch_stall`) each stop the decoder issuing. Nothing raises a CSR enable, a retire, a trap or an
+  `mret` on a cycle that did not issue. A cycle that did not issue leaves `mtvec`, `mepc` and every
+  register the read mux answers for exactly as it found them.
+- **One general no-side-effects assertion**, over every address the read mux serves: a CSR reads
+  back what it read last cycle unless `csr_wen`, `trap_entry` or `mret_entry` named it. The two
+  counters are excluded on the cycles they advance, and only then — `mcycle` on every cycle,
+  `minstret` only when `instret` is high.
+- **Trap commit.** `pc` takes the `mtvec` the CSR file held when the trapping instruction issued.
+  `mepc` takes the faulting instruction's own address with bit 0 cleared and bit 1 preserved.
+  `mcause` takes the cause an independent oracle in the harness says it should. MIE moves into MPIE
+  and MIE goes to zero. `decoder_out.rd` is zero and no load or store flag survives.
+- **`mret`.** `pc` takes `mepc`, MPIE comes back as MIE, MPIE is set. The MIE half reaches one cycle
+  further back than the other assertions, because an `mret`'s own instruction word puts `0x302` on
+  the CSR address port and so cannot read `mstatus`; the harness reads `mstatus` the cycle before
+  and holds it still across the edge in between.
+- **`minstret` does not count a trapping issue.** Asserted twice — on the count enable, and on the
+  register through a held address — because a counter that ticked from somewhere else would satisfy
+  the first alone.
+- **WARL.** `mtvec[1:0]` is zero, `mepc[0]` is zero, `mstatus.MPP` reads `2'b11`. All three are
+  inductive and none needs a guard.
+
+### The cause oracle is written from the ISA, not transcribed from the decoder
+
+Working out whether an arbitrary 32-bit word is legal is most of decode, and a copy of decode makes
+a poor oracle for decode. So the harness names a **small set of encodings the ISA fixes** and states
+what each must do: `ecall` (11), `ebreak` and `c.ebreak` (3), a misaligned uncompressed `lw`/`lh`/
+`lhu` (4), a misaligned `sw`/`sh` (6), and two encodings illegal in every conforming RV32
+implementation — opcode `7'b1111111`, which is reserved for instructions longer than 32 bits, and
+the all-zero halfword (2). It also names three encodings that **must not** trap, because a core that
+trapped on everything would otherwise satisfy most of the file.
+
+The effective address is computed in the harness from the I- and S-format immediates and `reg_rs1`,
+each sum its own statement with both operands marked `$signed`. A signed sum written as an arm of a
+conditional takes its signedness from the other arms, and that has produced silently unsigned
+arithmetic in this repo twice.
+
+### `fetch_stall` is deliberately left free
+
+`formal/arbiter.v` exists so that `fetch_stall` is a free input in none of the whole-core harnesses:
+an environment free to choose it can hold the core still forever, which starves `hang` and
+`liveness_ch0`. **This task has no liveness assertion**, and for a safety proof a free stall input
+is an over-approximation — strictly more cycles to check, never fewer. `formal/pcloop.sv` leaves it
+free for the same reason. Instantiating the arbiter here would constrain the input and weaken the
+result.
+
+### Assumptions
+
+Three, all of them the same one: reset is high before the first clock edge and low forever after.
+It stands for the harness convention every task in this tree uses and for `rtl/littlesoc.v`'s
+power-on counter. It carries more weight here than in `pcloop`: `mtvec`, `mepc`, `mcause` and
+`mstatus` have no initial value in the RTL, so without it the base case starts them anywhere and the
+two WARL assertions fail on registers nothing had written yet.
+
+**No other assume.** In particular the RTL is read **without** `-formal`, so `rtl/decoder.v`'s own
+`assume(in.pc == pc)` is not compiled into the instance — the `fetcher` instance answers that
+question here instead. Confirmed structurally: the prepared model carries three `$assume` cells and
+all three are `traps.sv:140-142`.
+
+## Evidence
+
+`PASS 0 2` — `successful proof by k-induction`, 2-3 seconds of wall time on an idle machine under
+the default `smtbmc` (yices) engine, against `components_executor`'s 28 and `components_decoder`'s
+6. **25 `$assert` cells** in the prepared netlist, read off the yosys log rather than inferred from
+the word PASS, so this is not a fourth green task with nothing in it.
+
+Eleven mutations. Ten produce a counterexample; one does not, and that one is a finding. A second
+finding came out of a mutation that passed against the first version of the harness.
+
+| mutation | result |
+|---|---|
+| `next_pc = mtvec` → `32'b0` on trap | FAIL, `traps.sv:334` step 4 |
+| `trap_entry = issuing && trap_pending` → `!reset && trap_pending` | FAIL, `traps.sv:312` step 1 |
+| swap the illegal and load-misaligned **arms** of the cause encoder | **PASS — see below** |
+| swap the two cause **values** | FAIL, `traps.sv:343` step 3 |
+| `instret = committing` → `issuing` | FAIL, `traps.sv:377` step 2 |
+| trap does not push MIE into MPIE | FAIL, `traps.sv:351` step 4 |
+| `mret` does not set MPIE | FAIL, `traps.sv:359` step 3 |
+| drop `mtvec`'s WARL alignment mask | FAIL, `traps.sv:400` step 3 |
+| trap entry clears `mepc[1]` as well as `mepc[0]` | FAIL, `traps.sv:340` step 4 |
+| `csr_wen = committing && ...` → `issuing && ...` | FAIL, `traps.sv:389` step 2 — **see below** |
+| make `load_misaligned` also raise illegal, so two causes overlap | FAIL, `traps.sv:343` step 3 |
+
+### Finding 1: the arm swap is unfalsifiable, and that is ADR-0030 being right
+
+Swapping two arms of a `case (1'b1)` whose guards are provably disjoint is a no-op. ADR-0030 already
+says so in prose: an illegal instruction has no memory operand, so it cannot also be misaligned, and
+the priority encoder is vacuous today. The task passes the swap, and it should.
+
+What makes the order observable is an **overlap**, so that is the mutation to reach for. Widening
+`instr_illegal` to include `load_misaligned` makes a misaligned `lw` commit cause 2 where the ISA
+oracle says 4, and the task fails in under a second. The disjointness itself stays asserted where it
+already was — `rtl/decoder.v`'s `$onehot0` over the five cause terms, checked by
+`components_decoder`.
+
+### Finding 2: the trap gate on `csr_wen` is redundant with the address decode
+
+`csr_wen = committing && csr_write_op` waits for a non-trapping commit. Remove that wait and
+**nothing about the architectural state changes**, which is why the first version of this task
+passed the mutation. The reason is worth writing down: a CSR access can only trap by being illegal,
+and it is illegal only when its address is unimplemented or read-only (`addr[11:10] == 2'b11`).
+`rtl/csrs.v` writes neither — `warl` falls back to `rdata` and the write `case` takes its empty
+`default` — so a spuriously enabled write on a trapping cycle lands nowhere.
+
+The gate is still the rule the design states, so the task now asserts it structurally: a trapping
+instruction commits no CSR access. That assertion is the only thing in the tree that would notice
+the gate going away, and it makes the mutation red at `traps.sv:389` step 2.
+
+## Consequences
+
+- `make -C formal components_traps` is a step in CI's required `components` job. It adds about three
+  seconds to a job whose 5-minute timeout is currently spent mostly on `components_executor`.
+- **The task must be re-read whenever a trap cause is added.** The harness's cause oracle is a list
+  of encodings and their causes; a new cause that overlaps an existing one changes what the oracle
+  should say, and ADR-0030's priority order is what decides it.
+- The observation technique — read internal CSR state through the architectural read port, with the
+  instruction word free — is available to any future task over `rtl/csrs.v` and does not need a
+  reference model.
+- What this does **not** cover: `mtval` (read-only zero here, so there is nothing to commit), the
+  counters' arithmetic beyond "they do not move when nothing asked" (`csrc_upcnt_*` on the ladder
+  and `test/csr_tb.v` carry that), and anything downstream of decode — a trapping instruction's
+  passage through the executor, accessor and writeback is `dmemcheck` and `reg`'s business, as
+  ADR-0028 recorded.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -75,6 +75,7 @@ and what it costs. Reversing one is fine — write a new ADR that supersedes it.
 | [0068](0068-a-one-hot-marking-is-spent-against-an-assertion.md) | A one-hot marking is spent against an assertion, not against inspection | Accepted · supplements 0030, which declines one of the two statements it was asked to mark |
 | [0069](0069-a-dispatched-run-does-not-reach-the-merge-gate.md) | A dispatched run does not reach the merge gate | Accepted · amends 0013; the pin bump proposes by issue, and a PAT is rejected on public-repo grounds |
 | [0070](0070-the-suites-cycles-are-charged-to-a-named-stall-reason.md) | The suite's cycles are charged to a named stall reason | Accepted · gives 0042's accepted +18.0% an invoice; measures 0026 and 0060's six reasons |
+| [0071](0071-the-trap-commit-path-is-proved-and-its-priority-encoder-is-still-vacuous.md) | The trap commit path is proved by k-induction, and its priority encoder is still vacuous | Accepted · supplements 0011, 0028 and 0030; adds a fourth `components.sby` task |
 
 0001–0007 came from the design brief
 ([`docs/ideas/finish-the-rewrite.md`](../ideas/finish-the-rewrite.md)). 0008–0011 came out of

--- a/formal/Makefile
+++ b/formal/Makefile
@@ -12,7 +12,7 @@ override JOBS := 4
 endif
 
 all: complete complete_cover complete-exclusions check dmemcheck imemcheck \
-     components_decoder components_executor components_pcloop
+     components_decoder components_executor components_pcloop components_traps
 
 # THE RULE FOR EVERY sby TARGET IN THIS FILE, INCLUDING ONES ADDED LATER:
 # it re-runs unconditionally, and it throws its workdir away first.
@@ -220,7 +220,7 @@ nonperturbation: check-nonperturbation.py
 # rule: always run, delete the workdir first. Before this they named the
 # directory sby creates and listed one rtl/ file each, so a warm tree made
 # `make components_decoder` after a structs.v edit answer "up to date".
-.PHONY: components_decoder components_executor components_pcloop
+.PHONY: components_decoder components_executor components_pcloop components_traps
 components_decoder: components.sby ../rtl/decoder.v ../rtl/structs.v
 	rm -rf $@
 	sby -f $< decoder
@@ -239,6 +239,15 @@ components_pcloop: components.sby ../rtl/fetcher.v ../rtl/decoder.v \
                    ../rtl/structs.v pcloop.sv
 	rm -rf $@
 	sby -f $< pcloop
+# The composed decoder+csrs task. It is the only place mtvec, mepc, mcause and
+# mstatus are real registers under a proof: the generated ladder drops every
+# value comparison once an instruction traps, keeping only the trap flag, and
+# its pc checks accept whatever target the core reports. So nothing else says a
+# trap lands on mtvec or that the saved state is right.
+components_traps: components.sby ../rtl/fetcher.v ../rtl/decoder.v ../rtl/csrs.v \
+                  ../rtl/structs.v traps.sv
+	rm -rf $@
+	sby -f $< traps
 
 # The riscv-formal clone rule and its pin guard live in pin.mk, included above,
 # so this and the root Makefile cannot drift apart on it.

--- a/formal/components.sby
+++ b/formal/components.sby
@@ -2,6 +2,7 @@
 executor all
 decoder all
 pcloop all
+traps all
 
 [options]
 all: mode prove
@@ -49,6 +50,14 @@ pcloop:
 read -sv structs.v fetcher.v decoder.v
 read -sv -formal structs.v pcloop.sv
 prep -top pcloop
+
+traps:
+# Same split as pcloop, for the same reason: -formal on the RTL would compile
+# rtl/decoder.v's own assume(in.pc == pc) into the instance, and the fetcher
+# below is what answers that here. Only the harness carries proof content.
+read -sv structs.v fetcher.v decoder.v csrs.v
+read -sv -formal structs.v traps.sv
+prep -top traps
 --
 [files]
 decoder:
@@ -64,5 +73,12 @@ pcloop:
 ../rtl/decoder.v
 ../rtl/structs.v
 pcloop.sv
+
+traps:
+../rtl/fetcher.v
+../rtl/decoder.v
+../rtl/csrs.v
+../rtl/structs.v
+traps.sv
 
 --

--- a/formal/traps.sv
+++ b/formal/traps.sv
@@ -1,0 +1,406 @@
+// The fetcher, the decoder and the CSR file, wired together the way
+// rtl/littlecpu.v wires them, so that mtvec, mepc, mcause and mstatus are real
+// registers rather than free inputs. That is the whole reason this file exists.
+// The riscv-formal ladder stops comparing values the moment an instruction
+// traps -- its instruction check keeps only the trap flag itself -- and its two
+// pc checks accept any target the core reports, mtvec of 0 included. So nothing
+// else in the tree says where a trap goes or what it writes.
+//
+// Keep reading the RTL without -formal for this task; formal/components.sby
+// does. With -formal the decoder brings its own assume(in.pc == pc) along, and
+// the fetcher instance below is what answers that question here.
+//
+// mcause, mstatus and the two counters are internal to rtl/csrs.v. They are read
+// here the way software reads them: `csr_addr` is instr[31:20] every cycle,
+// whatever the instruction, and `csr_rdata` answers it combinationally. The
+// instruction word is a free input, so the solver can point that address
+// anywhere it likes on any cycle -- including the cycle after a trap.
+`default_nettype none
+
+module traps (
+    input logic clk,
+    input logic reset,
+    input logic [31:0] imem_data,
+    input logic [31:0] imem_data2,
+    input logic [31:0] reg_rs1,
+    input logic [31:0] reg_rs2,
+    input executor_output executor_out,
+    input logic divider_stall,
+    input logic accessor_stall,
+    input logic fetch_stall,
+    input logic accessor_pending_valid,
+    input logic [4:0] accessor_pending_rd,
+    input logic accessor_out_valid
+);
+  logic [31:0] pc, next_pc;
+  logic [31:0] imem_addr, imem_addr2, imem_addr_next;
+  fetcher_output fetcher_out;
+  decoder_output decoder_out;
+  logic [4:0] rs1, rs2;
+  logic [11:0] csr_addr;
+  logic        csr_ren, csr_wen, instret;
+  logic [31:0] csr_wdata, csr_rdata;
+  logic        csr_implemented;
+  logic        trap_entry, mret_entry;
+  logic [31:0] trap_cause, trap_epc;
+  logic [31:0] mtvec_value, mepc_value;
+
+  fetcher fetcher (
+    .clk(clk),
+    .reset(reset),
+    .pc(pc),
+    .next_pc(next_pc),
+    .imem_addr(imem_addr),
+    .imem_data(imem_data),
+    .imem_addr2(imem_addr2),
+    .imem_data2(imem_data2),
+    .imem_addr_next(imem_addr_next),
+    .out(fetcher_out)
+  );
+
+  decoder decoder (
+    .clk(clk),
+    .reset(reset),
+    .in(fetcher_out),
+    .reg_rs1(reg_rs1),
+    .reg_rs2(reg_rs2),
+    .executor_out(executor_out),
+    .divider_stall(divider_stall),
+    .accessor_stall(accessor_stall),
+    .fetch_stall(fetch_stall),
+    .accessor_pending_valid(accessor_pending_valid),
+    .accessor_pending_rd(accessor_pending_rd),
+    .accessor_out_valid(accessor_out_valid),
+    .csr_rdata(csr_rdata),
+    .csr_implemented(csr_implemented),
+    .mtvec(mtvec_value),
+    .mepc(mepc_value),
+    .pc(pc),
+    .next_pc(next_pc),
+    .rs1(rs1),
+    .rs2(rs2),
+    .csr_addr(csr_addr),
+    .csr_ren(csr_ren),
+    .csr_wen(csr_wen),
+    .csr_wdata(csr_wdata),
+    .instret(instret),
+    .trap_entry(trap_entry),
+    .trap_cause(trap_cause),
+    .trap_epc(trap_epc),
+    .mret_entry(mret_entry),
+    .out(decoder_out)
+  );
+
+  csrs csrs (
+    .clk(clk),
+    .reset(reset),
+    .addr(csr_addr),
+    .ren(csr_ren),
+    .wen(csr_wen),
+    .wdata(csr_wdata),
+    .rdata(csr_rdata),
+    .implemented(csr_implemented),
+    .instret(instret),
+    .trap_entry(trap_entry),
+    .trap_cause(trap_cause),
+    .trap_epc(trap_epc),
+    .mret_entry(mret_entry),
+    .mtvec_value(mtvec_value),
+    .mepc_value(mepc_value)
+  );
+
+ `ifdef FORMAL
+  localparam logic [11:0] MSTATUS   = 12'h300;
+  localparam logic [11:0] MEPC      = 12'h341;
+  localparam logic [11:0] MCAUSE    = 12'h342;
+  localparam logic [11:0] MCYCLE    = 12'hB00;
+  localparam logic [11:0] MINSTRET  = 12'hB02;
+  localparam logic [11:0] MCYCLEH   = 12'hB80;
+  localparam logic [11:0] MINSTRETH = 12'hB82;
+
+  localparam logic [31:0] CAUSE_ILLEGAL    = 32'd2;
+  localparam logic [31:0] CAUSE_BREAKPOINT = 32'd3;
+  localparam logic [31:0] CAUSE_LOAD_MIS   = 32'd4;
+  localparam logic [31:0] CAUSE_STORE_MIS  = 32'd6;
+  localparam logic [31:0] CAUSE_ECALL_M    = 32'd11;
+
+  logic clocked;
+  initial clocked = 0;
+  always_ff @(posedge clk) clocked <= 1;
+
+  // Assumed: reset is high before the first clock edge and low forever after.
+  // Every harness in this tree drives it that way, and rtl/littlesoc.v holds it
+  // over a power-on counter. Nothing proves it, so this is a convention.
+  //
+  // It carries more weight here than it does in formal/pcloop.sv. mtvec, mepc,
+  // mcause and mstatus have no initial value in the RTL, so without a reset the
+  // first step of the base case starts them anywhere, and the two WARL
+  // assertions below would fail on a register nothing had written yet.
+  initial assume(reset);
+  always_comb if (!clocked) assume(reset);
+  always_comb if (clocked) assume(!reset);
+
+  // Build every guard from this module's own signals. Do not write
+  // `decoder.trap_pending` or anything like it: yosys does not reach into the
+  // instance, it declares a new undriven wire with that name and the solver
+  // picks its value, so the proof passes having asked nothing.
+  //
+  // Mask the upper half exactly as the decoder does. A compressed instruction
+  // sits in the low 16 bits and the high 16 are the next instruction in memory.
+  logic [31:0] instr;
+  assign instr = (fetcher_out.instr[1:0] == 2'b11) ? fetcher_out.instr
+                                                   : {16'b0, fetcher_out.instr[15:0]};
+  logic       uncompressed;
+  logic [4:0] opcode;
+  logic [2:0] funct3;
+  assign uncompressed = instr[1:0] == 2'b11;
+  assign opcode = instr[6:2];
+  assign funct3 = instr[14:12];
+
+  // `issuing` is not a port, but it is exactly this: the decoder counts a
+  // retired instruction on every cycle it issues one that does not trap, and
+  // raises trap_entry on every cycle it issues one that does. Nothing else
+  // raises either.
+  logic issuing;
+  assign issuing = instret || trap_entry;
+
+  // The three stall reasons that arrive as inputs. Each one on its own forces
+  // the decoder to hold, so this is a sufficient condition for a stall and
+  // never a necessary one -- the hazard, serialization and operand-fetch
+  // reasons are decided inside the decoder and are not visible here.
+  logic hard_stall;
+  assign hard_stall = divider_stall || accessor_stall || fetch_stall;
+
+  // Which instructions must trap, and with which cause. Written from the ISA,
+  // not transcribed from rtl/decoder.v: each encoding below is one this core
+  // must either execute or fault on, and the cause is the one the privileged
+  // spec names. A decoder that changed its mind about any of them disagrees
+  // with this, which is the point of writing it out a second way.
+  //
+  // The list is deliberately small. Working out whether an arbitrary word is
+  // legal is most of decode, and a copy of decode makes a poor oracle for
+  // decode.
+  logic [31:0] i_immediate, s_immediate;
+  assign i_immediate = {{20{instr[31]}}, instr[31:20]};
+  assign s_immediate = {{20{instr[31]}}, instr[31:25], instr[11:7]};
+
+  // Each address is its own statement with both operands marked signed. A
+  // signed sum written as an arm of a conditional takes its signedness from the
+  // other arms, and that has silently produced unsigned arithmetic in this repo
+  // twice.
+  logic [31:0] load_addr, store_addr;
+  assign load_addr  = $signed(i_immediate) + $signed(reg_rs1);
+  assign store_addr = $signed(s_immediate) + $signed(reg_rs1);
+
+  logic is_load_op, is_store_op;
+  assign is_load_op  = uncompressed && opcode == 5'b00000;
+  assign is_store_op = uncompressed && opcode == 5'b01000;
+
+  logic lw_misaligned, lh_misaligned, sw_misaligned, sh_misaligned;
+  assign lw_misaligned = is_load_op && funct3 == 3'b010 && load_addr[1:0] != 2'b00;
+  assign lh_misaligned = is_load_op && (funct3 == 3'b001 || funct3 == 3'b101) && load_addr[0];
+  assign sw_misaligned = is_store_op && funct3 == 3'b010 && store_addr[1:0] != 2'b00;
+  assign sh_misaligned = is_store_op && funct3 == 3'b001 && store_addr[0];
+
+  // Opcode 7'b1111111 is reserved for instructions longer than 32 bits, and an
+  // all-zero halfword is the encoding the C extension defines as illegal. Both
+  // are illegal in every conforming RV32 implementation, so neither depends on
+  // what this core chose to decode.
+  logic reserved_opcode, zero_halfword, is_illegal;
+  assign reserved_opcode = uncompressed && opcode == 5'b11111;
+  assign zero_halfword = instr == 32'h0000_0000;
+  assign is_illegal = reserved_opcode || zero_halfword;
+
+  logic is_ecall, is_ebreak;
+  assign is_ecall  = instr == 32'h0000_0073;
+  assign is_ebreak = instr == 32'h0010_0073 || instr == 32'h0000_9002;
+
+  // The order is illegal, breakpoint, environment call, load misaligned, store
+  // misaligned. No two of the terms above can hold at once -- a reserved opcode
+  // is not a load -- so the chain states the order rather than resolving
+  // anything. Make two causes overlap and this is what decides which one the
+  // core is allowed to report.
+  logic expected_trap;
+  logic [31:0] expected_cause;
+  assign expected_trap = is_illegal || is_ebreak || is_ecall ||
+                         lw_misaligned || lh_misaligned || sw_misaligned || sh_misaligned;
+  always_comb begin
+    if (is_illegal) expected_cause = CAUSE_ILLEGAL;
+    else if (is_ebreak) expected_cause = CAUSE_BREAKPOINT;
+    else if (is_ecall) expected_cause = CAUSE_ECALL_M;
+    else if (lw_misaligned || lh_misaligned) expected_cause = CAUSE_LOAD_MIS;
+    else expected_cause = CAUSE_STORE_MIS;
+  end
+
+  // The other direction. Without these a core that trapped on everything would
+  // satisfy most of this file.
+  logic must_not_trap;
+  assign must_not_trap =
+      (uncompressed && opcode == 5'b01100 && instr[31:25] == 7'b0 && funct3 == 3'b000) ||
+      (is_load_op && funct3 == 3'b010 && load_addr[1:0] == 2'b00) ||
+      (is_store_op && funct3 == 3'b010 && store_addr[1:0] == 2'b00);
+
+  // mstatus changes on three edges and no others: a write to it, a trap and an
+  // mret. The write term is any write, not just one to this address -- coarser
+  // than it needs to be, which only narrows the cycles the mret assertion below
+  // fires on.
+  logic mstatus_addressed, mstatus_static;
+  assign mstatus_addressed = csr_addr == MSTATUS;
+  assign mstatus_static = !csr_wen && !trap_entry && !mret_entry;
+
+  // The two counters advance without any instruction asking, so a held address
+  // reading one of them says nothing about side effects. mcycle counts every
+  // cycle; minstret counts only the cycles an instruction retires, so it is
+  // excluded only on those.
+  logic counter_ticking;
+  assign counter_ticking = csr_addr == MCYCLE || csr_addr == MCYCLEH ||
+      (instret && (csr_addr == MINSTRET || csr_addr == MINSTRETH));
+
+  // Trap entry writes mepc, mcause and mstatus. mret writes mstatus. Every
+  // other address must read back the same value it read last cycle.
+  logic csr_written_by_trap;
+  assign csr_written_by_trap =
+      (trap_entry && (csr_addr == MEPC || csr_addr == MCAUSE || mstatus_addressed)) ||
+      (mret_entry && mstatus_addressed);
+
+  logic [31:0] past_pc, prev_mtvec, prev_mepc, prev_rdata, prev_cause;
+  logic [11:0] prev_csr_addr;
+  logic prev_reset, prev_trap_entry, prev_mret_entry, prev_csr_wen;
+  logic prev_expected_trap, prev_counter_ticking, prev_written_by_trap;
+  logic prev_mstatus_addressed, prev_mstatus_static;
+  logic [31:0] prev2_rdata;
+  logic prev2_reset, prev2_mstatus_addressed, prev2_mstatus_static;
+  always_ff @(posedge clk) begin
+    past_pc                <= pc;
+    prev_reset             <= reset;
+    prev_mtvec             <= mtvec_value;
+    prev_mepc              <= mepc_value;
+    prev_rdata             <= csr_rdata;
+    prev_csr_addr          <= csr_addr;
+    prev_csr_wen           <= csr_wen;
+    prev_trap_entry        <= trap_entry;
+    prev_mret_entry        <= mret_entry;
+    prev_cause             <= expected_cause;
+    prev_expected_trap     <= expected_trap;
+    prev_counter_ticking   <= counter_ticking;
+    prev_written_by_trap   <= csr_written_by_trap;
+    prev_mstatus_addressed <= mstatus_addressed;
+    prev_mstatus_static    <= mstatus_static;
+
+    prev2_rdata             <= prev_rdata;
+    prev2_reset             <= prev_reset;
+    prev2_mstatus_addressed <= prev_mstatus_addressed;
+    prev2_mstatus_static    <= prev_mstatus_static;
+  end
+
+  // The address held across an edge, so that two reads of csr_rdata are two
+  // reads of the same register.
+  logic addr_held;
+  assign addr_held = csr_addr == prev_csr_addr;
+
+  // Reset holds only before the first edge, so the CSR registers carry no
+  // defined value until then and neither does any history register above.
+  // Every assertion that compares two cycles waits for this.
+  logic settled, settled2;
+  assign settled = clocked && !prev_reset;
+  assign settled2 = settled && !prev2_reset;
+
+  // Nothing raises a CSR enable, a retire or a redirect on a cycle the decoder
+  // did not issue an instruction. This is the interlock, and it is what a change
+  // to the stall protocol would break without anything else noticing: a trap
+  // committed on a stalled cycle is a trap taken twice.
+  always_comb if (clocked && hard_stall) assert(!issuing);
+  always_comb if (clocked && !issuing) assert(!csr_wen && !csr_ren && !mret_entry);
+
+  // The other half of the same property, and stated on the write enables rather
+  // than on the stall, so it covers the three stall reasons the decoder keeps to
+  // itself as well. mtvec moves only through a write to it; mepc through a write
+  // or a trap.
+  always_comb if (settled && !prev_csr_wen && !prev_trap_entry) begin
+    assert(mtvec_value == prev_mtvec);
+    assert(mepc_value == prev_mepc);
+  end
+
+  // A CSR reads back what it read last cycle unless one of the three write
+  // paths named it. This is one assertion over every register the read mux
+  // answers for, so a fourth way to change CSR state has to come through a port
+  // this file already watches.
+  always_comb if (settled && addr_held && !prev_counter_ticking && !prev_csr_wen &&
+                  !prev_written_by_trap)
+    assert(csr_rdata == prev_rdata);
+
+  // Where the trap goes. mtvec is the register the CSR file held when the
+  // trapping instruction issued, not a free input.
+  always_comb if (settled && prev_trap_entry) assert(pc == prev_mtvec);
+  always_comb if (settled && prev_mret_entry) assert(pc == prev_mepc);
+
+  // mepc is the faulting instruction's own address with bit 0 cleared, which is
+  // what lets a handler read the instruction and resume past it. Bit 1 survives
+  // because a compressed instruction can sit at a two-byte address.
+  always_comb if (settled && prev_trap_entry) assert(mepc_value == {past_pc[31:1], 1'b0});
+
+  always_comb if (settled && prev_trap_entry && prev_expected_trap && csr_addr == MCAUSE)
+    assert(csr_rdata == prev_cause);
+
+  // MIE moves into MPIE and interrupts go off. Both halves need the value
+  // mstatus held before the trap, so this fires only when the trapping
+  // instruction happened to address mstatus -- the instruction word is free, so
+  // the solver can always arrange that.
+  always_comb if (settled && prev_trap_entry && prev_mstatus_addressed && mstatus_addressed) begin
+    assert(csr_rdata[3] == 1'b0);
+    assert(csr_rdata[7] == prev_rdata[3]);
+  end
+
+  // mret pops the pair back. MPIE is observable on the cycle after, but MIE
+  // needs the value from before the mret, and an mret's own instruction word
+  // addresses 0x302 rather than mstatus. So this reaches one cycle further
+  // back, and holds mstatus still across the cycle in between.
+  always_comb if (settled && prev_mret_entry && mstatus_addressed) begin
+    assert(csr_rdata[7] == 1'b1);
+    if (settled2 && prev2_mstatus_addressed && prev2_mstatus_static)
+      assert(csr_rdata[3] == prev2_rdata[7]);
+  end
+
+  // A trapping instruction issues and reaches the end of the pipeline having
+  // done nothing. No register write, and no memory access for the accessor to
+  // start.
+  always_comb if (settled && prev_trap_entry) begin
+    assert(decoder_out.rd == 5'b0);
+    assert(!decoder_out.is_lb && !decoder_out.is_lbu && !decoder_out.is_lh &&
+           !decoder_out.is_lhu && !decoder_out.is_lw);
+    assert(!decoder_out.is_sb && !decoder_out.is_sh && !decoder_out.is_sw);
+  end
+
+  // minstret counts instructions that retired, and a trapping one did not.
+  // Asserted twice: once on the count enable, and once on the register, because
+  // a counter that ticked from somewhere else would satisfy the first.
+  always_comb if (clocked) assert(!(trap_entry && instret));
+  always_comb if (settled && prev_trap_entry && addr_held &&
+                  (csr_addr == MINSTRET || csr_addr == MINSTRETH))
+    assert(csr_rdata == prev_rdata);
+
+  always_comb if (clocked) assert(!(trap_entry && mret_entry));
+
+  // A trapping instruction commits no CSR access, whatever else it was. Today
+  // this is belt to the address decode's braces: an access can only trap by
+  // naming an address that is read-only or not implemented, and rtl/csrs.v
+  // writes neither. Drop the gate and nothing about the architectural state
+  // changes, so this assertion is the only thing that would say so.
+  always_comb if (clocked) assert(!(trap_entry && (csr_wen || csr_ren)));
+
+  // The encodings the ISA fixes: these fault, those do not, whatever else the
+  // decoder decides about them.
+  always_comb if (clocked && issuing && expected_trap) assert(trap_entry);
+  always_comb if (clocked && issuing && must_not_trap) assert(!trap_entry);
+
+  // WARL. mtvec is direct mode only, so its low two bits are a mode field that
+  // must stay zero; mepc's bit 0 must stay zero because instructions are at
+  // least two bytes apart; MPP is hardwired to machine mode because there is no
+  // other mode.
+  always_comb if (clocked) assert(mtvec_value[1:0] == 2'b00);
+  always_comb if (clocked) assert(mepc_value[0] == 1'b0);
+  always_comb if (clocked && mstatus_addressed) assert(csr_rdata[12:11] == 2'b11);
+ `endif
+endmodule
+
+`default_nettype wire


### PR DESCRIPTION
Closes JEF-650.

`rvfi_insn_check.sv` wraps every value comparison it makes in `if (!spec_trap)`. Under `spec_trap` the only surviving assertion is `assert(spec_trap == trap)` — the core has to *say* it trapped, and nothing more. `pc_fwd`/`pc_bwd` compare the core's reported `pc_wdata` against its own next `pc_rdata`, so they are satisfied by **any** target it commits to consistently, `mtvec == 0` included. And riscv-formal ships no spec model for `ecall`/`ebreak`/`mret`/`csrr*` at the pin, so `complete` excludes the whole SYSTEM class by declaration.

So nothing in the tree said a trap lands on `mtvec`, or that `mepc`/`mcause`/`mstatus` are right. `rtl/decoder.v`'s own `FORMAL` block does assert `pc == mtvec` — against a **free input**, because in `components_decoder` the decoder is alone.

**No RTL changed.** The proof found no defect in the trap path. It did find two things about the RTL worth writing down; both are below.

## What landed

`formal/traps.sv` — a fourth `mode prove` task in `formal/components.sby`, composing the fetcher, the decoder and the CSR file the way `rtl/littlecpu.v` wires them, so `mtvec`, `mepc`, `mcause` and `mstatus` are real registers. `make -C formal components_traps`, plus a step in CI's required `components` job. `docs/adr/0071` records the decision.

**Observing state the harness cannot reach.** `mtvec_value`/`mepc_value` are output ports. `mcause`, `mstatus` and the counters are internal, and are read **the way software reads them**: `csr_addr` is `instr[31:20]` on every cycle whatever the instruction is, `csr_rdata` answers it combinationally, and the instruction word is a free input — so the solver can point that address at any register on any cycle, including the trapping cycle itself (a reserved-opcode word carries twelve bits straight to the CSR address port). No reference model of `rtl/csrs.v` was needed and none was written.

**The cause oracle is written from the ISA, not transcribed from the decoder.** Deciding whether an arbitrary word is legal is most of decode, and a copy of decode makes a poor oracle for decode. The harness names a small set of encodings the ISA fixes — `ecall` (11), `ebreak`/`c.ebreak` (3), misaligned `lw`/`lh`/`lhu` (4), misaligned `sw`/`sh` (6), opcode `7'b1111111` and the all-zero halfword (2) — plus three that **must not** trap, because a core that trapped on everything would otherwise satisfy most of the file.

## sby summary

```
SBY [components_traps] summary: engine_0 (smtbmc) returned pass for basecase
SBY [components_traps] summary: engine_0 (smtbmc) returned pass for induction
SBY [components_traps] summary: successful proof by k-induction.
SBY [components_traps] DONE (PASS, rc=0)
status file: PASS 0 2
```

**25 `$assert` cells** in the prepared netlist (`components_traps/model/design_smt2.log`), read off the log rather than inferred from the word PASS — this is not a fourth green task with nothing in it.

**2-3 s** on an idle machine, default `smtbmc` (yices), against `components_executor`'s 28 s and `components_decoder`'s 6 s. The `components` job's 5-minute timeout does not move.

## Mutations: ten of eleven red

Each run against the shipping harness, RTL reverted between runs.

| mutation | result |
|---|---|
| `next_pc = mtvec` → `32'b0` on trap | FAIL `traps.sv:334` step 4 |
| `trap_entry = issuing && trap_pending` → `!reset && trap_pending` | FAIL `traps.sv:312` step 1 |
| swap the illegal / load-misaligned **arms** of the cause encoder | **PASS — finding 1** |
| swap the two cause **values** | FAIL `traps.sv:343` step 3 |
| `instret = committing` → `issuing` | FAIL `traps.sv:377` step 2 |
| trap does not push MIE into MPIE | FAIL `traps.sv:351` step 4 |
| `mret` does not set MPIE | FAIL `traps.sv:359` step 3 |
| drop `mtvec`'s WARL alignment mask | FAIL `traps.sv:400` step 3 |
| trap entry clears `mepc[1]` as well as `mepc[0]` | FAIL `traps.sv:340` step 4 |
| `csr_wen = committing && ...` → `issuing && ...` | FAIL `traps.sv:389` step 2 — **finding 2** |
| make `load_misaligned` also raise illegal, so two causes overlap | FAIL `traps.sv:343` step 3 |

Representative output:

```
===== MUTATION pc-to-zero (rtl/decoder.v) =====
engine_0.basecase: Assert failed in traps: traps.sv:334.47-334.71
summary: engine_0 (smtbmc) returned FAIL for basecase
summary:   failed assertion ... at traps.sv:334.47-334.71 step 4
DONE (FAIL, rc=2)          status: FAIL 2 0

===== MUTATION trap-entry-unstalled (rtl/decoder.v) =====
engine_0.basecase: Assert failed in traps: traps.sv:312.42-312.58
summary:   failed assertion ... at traps.sv:312.42-312.58 step 1
DONE (FAIL, rc=2)          status: FAIL 2 0

===== MUTATION instret-on-trap (rtl/decoder.v) =====
engine_0.basecase: Assert failed in traps: traps.sv:377.28-377.60
summary:   failed assertion ... at traps.sv:377.28-377.60 step 2
DONE (FAIL, rc=2)          status: FAIL 2 0

===== MUTATION cause-value-swap (rtl/decoder.v) =====
engine_0.basecase: Assert failed in traps: traps.sv:343.5-343.36
summary:   failed assertion ... at traps.sv:343.5-343.36 step 3
DONE (FAIL, rc=2)          status: FAIL 2 0
```

### Finding 1 — the arm swap the ticket asks for is unfalsifiable, and that is ADR-0030 being right

```
===== MUTATION cause-arm-swap (rtl/decoder.v) =====
summary: engine_0 (smtbmc) returned pass for basecase
summary: engine_0 (smtbmc) returned pass for induction
summary: successful proof by k-induction.
DONE (PASS, rc=0)          status: PASS 0 5
```

Swapping two arms of a `case (1'b1)` whose guards are provably disjoint is a **no-op**. ADR-0030 already says so in prose: an illegal instruction clears every execution flag, so it has no memory operand and cannot also be misaligned; the priority encoder is vacuous today. The task passes the swap, and it should — reporting it as "caught" would have been the dishonest option.

What makes the order observable is an **overlap**, so that is the mutation to reach for. Widening `instr_illegal` to include `load_misaligned` makes a misaligned `lw` commit cause 2 where the ISA oracle says 4 — red in under a second, last row of the table. The disjointness itself stays asserted where it already lives, `rtl/decoder.v`'s `$onehot0` over the five cause terms, checked by `components_decoder`.

### Finding 2 — the trap gate on `csr_wen` is redundant with the address decode

`csr_wen = committing && csr_write_op` waits for a non-trapping commit. Remove that wait and **nothing about the architectural state changes**, which is why the first version of this harness passed the mutation at `PASS 0 3`. A CSR access can only trap by being illegal, and it is illegal only when its address is unimplemented or read-only (`addr[11:10] == 2'b11`) — and `rtl/csrs.v` writes neither: `warl` falls back to `rdata` and the write `case` takes its empty `default`. A spuriously enabled write on a trapping cycle lands nowhere.

The gate is still the rule the design states, so the harness now asserts it structurally — a trapping instruction commits no CSR access — and the mutation is red at `traps.sv:389`. That assertion is the only thing in the tree that would notice the gate going away.

## Every assume, and the model it stands for

Three statements, one model:

```systemverilog
initial assume(reset);
always_comb if (!clocked) assume(reset);
always_comb if (clocked) assume(!reset);
```

**Reset is high before the first clock edge and low forever after.** It stands for the harness convention every task in this tree uses and for `rtl/littlesoc.v`'s power-on counter. Nothing proves it. It carries more weight here than in `pcloop`: `mtvec`/`mepc`/`mcause`/`mstatus` have no initial value in the RTL, so without it the base case starts them anywhere and the two WARL assertions fail on registers nothing had written yet.

**There is no other assume**, and that is measured rather than asserted. The RTL is read **without** `-formal` (same split `pcloop` uses), so `rtl/decoder.v`'s own `assume(in.pc == pc)` is not compiled into the instance — the `fetcher` instance discharges it by composition instead, which is criterion 3's preferred form. Confirmed structurally: the prepared model carries exactly three `$assume` cells and all three are `traps.sv:140-142`.

```
$ grep -B6 'cell $assume' components_traps/model/design_prep.il | grep src
attribute \src "traps.sv:142.28-142.42"
attribute \src "traps.sv:141.29-141.42"
attribute \src "traps.sv:140.11-140.24"
```

## `fetch_stall` is deliberately left free — a decision worth flagging

`formal/arbiter.v` exists so `fetch_stall` is free in none of the whole-core harnesses: an environment free to choose it can hold the core still forever, which starves `hang` and `liveness_ch0`. **This task has no liveness assertion.** For a safety proof a free stall input is an over-approximation — strictly more cycles to check, never fewer — so instantiating the arbiter here would *constrain* the input and *weaken* the result. `formal/pcloop.sv`, the other component-level harness, leaves it free for the same reason; the arbiter's five consumers are `wrapper.v` plus the four whole-core `.sv` harnesses.

## Gates

| gate | result |
|---|---|
| `make -C formal components_traps` | `PASS 0 2`, successful proof by k-induction, 25 asserts |
| `make -C formal components_decoder` | `PASS 0 6`, successful proof by k-induction |
| `make -C formal components_executor` | `PASS 0 31`, successful proof by k-induction |
| `make -C formal components_pcloop` | `PASS 0 1`, successful proof by k-induction |
| `make -C formal check` | `85 checks: 85 pass, 0 fail` · `Failure list matches EXPECTED_FAIL exactly` · `Generated check set matches EXPECTED_CHECKS exactly (85 checks)` |
| `make test` | `59/59 passed`, `Failure list matches test/EXPECTED_FAIL exactly`, exit 0 |

Each `sby` summary was read off directly, not inferred from an exit code.

## Scope

`formal/traps.sv` (new), `formal/components.sby`, `formal/Makefile`, one step in `ci.yml`'s `components` job, `docs/adr/0071` + its README row, and the three places `CLAUDE.md` said "three component proofs". `rtl/`, `formal/EXPECTED_FAIL` and `checks.cfg` are untouched.

## What this does not cover

`mtval` (read-only zero, nothing to commit); the counters' arithmetic beyond "they do not move when nothing asked" — `csrc_upcnt_*` and `test/csr_tb.v` carry that; and anything downstream of decode — a trapping instruction's passage through the executor, accessor and writeback is `dmemcheck` and `reg`'s business, as ADR-0028 recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
