### PR TITLE
Replace the CLAUDE.md citations with the mechanism they stood in for

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,8 +68,7 @@ jobs:
         #
         # iverilog emits 20 "sorry: constant selects in always_* processes"
         # notes here, all against rtl/writeback.v's accessor_output, and still
-        # exits 0. They are notes rather than warnings and CLAUDE.md tracks the
-        # count separately; do not grep for them.
+        # exits 0. They are notes rather than warnings; do not grep for them.
         run: make rvfi_macros.vh testbench.vvp
 
       - name: iverilog full-pipeline simulation (one fixed program, graded)
@@ -393,8 +392,8 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
   # Regenerates test/monitor.v from a from-scratch riscv-formal clone at the pin
-  # and diffs it against the tracked copy (CLAUDE.md invariant 7: generated but
-  # tracked, never hand-edited). A fresh runner gives the from-scratch clone for
+  # and diffs it against the tracked copy, which is generated but tracked and
+  # must never be hand-edited. A fresh runner gives the from-scratch clone for
   # free, and this needs only python3 and git.
   monitor-freshness:
     name: monitor-freshness

--- a/.svlint.toml
+++ b/.svlint.toml
@@ -1,9 +1,9 @@
 # svlint configuration -- the structural lint gate (`make lint`).
 #
 # WHY THIS EXISTS. svlint is a THIRD independent SystemVerilog frontend
-# (sv-parser), alongside yosys and iverilog. By the same reasoning CLAUDE.md's
-# verification table applies to the three simulation legs, a third parser earns
-# its place by seeing what the other two structurally cannot. It has already
+# (sv-parser), alongside yosys and iverilog. By the same reasoning that gives
+# each simulation leg its place, a third parser earns its own by seeing what the
+# other two structurally cannot. It has already
 # demonstrated that: svlint cannot resolve rtl/structs.v without an explicit
 # include path (`-i rtl`), a parse-configuration fact neither yosys nor
 # iverilog surfaces.
@@ -64,9 +64,8 @@
 # Text rules -- all off.
 #
 # header_copyright, style_directives, style_semicolon, style_textwidth encode a
-# house style this repo has not adopted, and CLAUDE.md is explicit that this
-# project optimises for readability over conformance. Whitespace findings would
-# bury the structural rules that are the entire reason svlint is here.
+# house style this repo has not adopted. Whitespace findings would bury the
+# structural rules that are the entire reason svlint is here.
 # ---------------------------------------------------------------------------
 [textrules]
 header_copyright = false   # no per-file copyright header convention in this repo
@@ -93,9 +92,9 @@ eventlist_comma_always_ff = true
 # ENABLED -- process kind must be stated, not inferred.
 #
 # A bare `always` whose sensitivity list the tool infers is how a combinational
-# block silently becomes a latch. CLAUDE.md invariant 1 (fetch is
-# combinational, no flush logic) depends on the comb/ff split being exactly
-# what it reads as.
+# block silently becomes a latch. Fetch is combinational and no later cycle
+# un-commits state; both depend on the comb/ff split being exactly what it
+# reads as.
 # ---------------------------------------------------------------------------
 general_always_no_edge = true
 general_always_level_sensitive = true
@@ -171,9 +170,8 @@ action_block_with_side_effect = true  # assertion action blocks must not drive s
 # elaborate job and the test/rtl.cc recipe already gate that class. The only
 # thing case_default catches that yosys does not is a `case` that is ALREADY
 # SAFE, because it has its defaults assigned first. That is a style
-# requirement, not a defect class, and it is not worth an rtl/ edit to the
-# stage whose legibility CLAUDE.md singles out. Reopening it needs a defect
-# class yosys does not already error on.
+# requirement, not a defect class, and it is not worth an rtl/ edit for style
+# alone. Reopening it needs a defect class yosys does not already error on.
 case_default = false               # style, not safety: yosys already errors on the latch -- see above
 explicit_case_default = false      # 10 findings; 4 provably exhaustive, and it fires inside always_ff too
 implicit_case_default = false      # 8 findings; measured NOT to honour a preceding default assignment
@@ -238,9 +236,9 @@ tab_character = false                    # style: whitespace
 # DISABLED -- house-style families, off wholesale.
 #
 # These forbid language keywords, impose identifier casing, or enforce name
-# prefixes/regexes. They encode a house style this repo has not adopted, and
-# CLAUDE.md is explicit that readability is the design goal. Enabling any of
-# them would produce hundreds of findings and bury the rules above, which is
+# prefixes/regexes. They encode a house style this repo has not adopted.
+# Enabling any of them would produce hundreds of findings and bury the rules
+# above, which is
 # the specific outcome this gate is meant to avoid. Listed by family rather
 # than one line each -- the reason is identical for every member.
 # ---------------------------------------------------------------------------

--- a/formal/Makefile
+++ b/formal/Makefile
@@ -140,8 +140,8 @@ genchecks-check: $(RISCV_FORMAL_DIR)/checks/genchecks.py genchecks-local.py | $(
 
 # The whole core, in the order every whole-core .sby reads it. These four
 # targets each ran against an `.sby` and an `.sv` and NOTHING ELSE before this
-# list existed, which is how `make imemcheck` -- the check CLAUDE.md names for
-# ADR-0003's dual-word fetch window, and so the one most likely to be re-run by
+# list existed, which is how `make imemcheck` -- the check that covers the
+# dual-word fetch window, and so the one most likely to be re-run by
 # hand after touching rtl/fetcher.v -- could report a verdict about RTL it had
 # never read.
 #

--- a/formal/check-nonperturbation.py
+++ b/formal/check-nonperturbation.py
@@ -173,7 +173,7 @@ def run_yosys(out_dir):
         raise SystemExit("yosys failed (exit %d) -- see output above" % proc.returncode)
     # yosys -q still prints warnings; surface them rather than swallowing them.
     # NOT promoted to errors here, deliberately: CI's `elaborate` job already
-    # owns that policy for this RTL, with a curated allowlist (CLAUDE.md's "Deep
+    # owns that policy for this RTL, with a curated allowlist (the "Deep
     # recursion in AST simplifier" note), and a second promotion on a different
     # yosys pipeline would go red for reasons that have nothing to do with the
     # property this gate decides. Zero appear today; if that changes, read them.

--- a/formal/components.sby
+++ b/formal/components.sby
@@ -20,8 +20,8 @@ all: smtbmc
 # Deliberately NOT the `btor` engine, which is what the generated ladder uses:
 # btormc does bmc and cover only, and this task is `mode prove`.
 #
-# boolector ships in the pinned OSS CAD Suite, which CLAUDE.md already names as
-# a requirement for anything under formal/. It is NOT in a bare `brew install
+# boolector ships in the pinned OSS CAD Suite, which anything under formal/
+# needs anyway. It is NOT in a bare `brew install
 # yosys` (ADR-0024 says so about the ladder's own engine choice); if that ever
 # has to hold, `smtbmc z3` is the next thing to measure rather than reverting to
 # the default and calling a fourteen-minute non-answer a slow proof.

--- a/rtl/csrs.v
+++ b/rtl/csrs.v
@@ -6,9 +6,9 @@
 // This is a sibling of the decoder, not a pipeline stage. Every access is read
 // and committed in decode on the same edge the accessing instruction issues, so
 // no CSR state exists downstream: nothing to forward, nothing to replay, and no
-// "what does mcycle read with three instructions in flight" corner. CLAUDE.md
-// invariant 5 (CSR instructions serialize) is enforced in rtl/decoder.v; this
-// module has no idea a stall exists.
+// "what does mcycle read with three instructions in flight" corner. CSR
+// instructions serialize, and rtl/decoder.v is what holds them; this module has
+// no idea a stall exists.
 //
 // The set below is a floor, not a closed list: every register the privileged
 // spec lists unconditionally for RV32 machine mode is here, because trapping on
@@ -17,7 +17,7 @@
 // Trap entry and `mret` are the second write port, and the only architectural
 // CSR update no CSR instruction performs. They arrive from the decoder on the
 // edge the trapping instruction issues, because that is where every trap is
-// detected and committed (invariant 2). `mtvec_value`/`mepc_value` go back out
+// detected and committed. `mtvec_value`/`mepc_value` go back out
 // to the decoder, which owns the PC and therefore has to redirect it.
 //
 // This module never decides that an access is illegal. `implemented` feeds the
@@ -97,7 +97,7 @@ module csrs(
   localparam logic [11:0] MIMPID    = 12'hF13;
   localparam logic [11:0] MHARTID   = 12'hF14;
 
-  // RV32 I M C, MXL = 1 -- CLAUDE.md's ISA target.
+  // RV32 I M C, MXL = 1.
   localparam logic [31:0] MISA_VALUE = 32'h4000_1104;
 
   logic [63:0] mcycle, minstret;

--- a/rtl/fetcher.v
+++ b/rtl/fetcher.v
@@ -15,8 +15,8 @@ module fetcher(
   // construction the value `imem_addr` takes on the next edge. A synchronous
   // memory that latches it therefore answers `imem_addr` for the whole of the
   // cycle in which `imem_addr` names that word -- which is what lets fetch stay
-  // combinational from decode's point of view (CLAUDE.md invariant 1) on a part
-  // whose every memory primitive is synchronous (ADR-0044).
+  // combinational from decode's point of view on a part whose every memory
+  // primitive is synchronous (ADR-0044).
   //
   // Only the first word address is published. The second is `+ 4`, which the
   // memory system already has to compute for its own bank indexing, and adding
@@ -33,13 +33,15 @@ module fetcher(
   // follows a compressed instruction), so fetch always reads the
   // word-aligned pair straddling pc and windows the 32 bits starting at pc
   // out of the two -- stateless, so a straddle costs nothing: no aligner
-  // FSM, no buffer, no stall (CLAUDE.md invariant 1).
+  // FSM, no buffer, no stall.
   assign imem_addr  = {pc[31:2], 2'b00};
   assign imem_addr2 = imem_addr + 4;
   assign imem_addr_next = {next_pc[31:2], 2'b00};
 
-  // Named continuous assigns, not part-selects inside the always_comb below
-  // (CLAUDE.md's documented `sorry:` exception is rtl/executor.v only).
+  // Named continuous assigns, not part-selects inside the always_comb below:
+  // iverilog cannot build a precise sensitivity entry for a constant select
+  // there and emits `sorry:`. rtl/writeback.v is the one file that carries
+  // those; do not add more anywhere else.
   logic [63:0] fetch_pair;
   assign fetch_pair = {imem_data2, imem_data} >> (pc[1] ? 16 : 0);
   logic [31:0] windowed_instr;
@@ -51,8 +53,8 @@ module fetcher(
       out.pc = 32'b0;
       out.instr = 32'b0;
     end else begin
-      // Fetch never presents a wrong-path instruction (CLAUDE.md invariant 1),
-      // so it is valid on every non-reset cycle.
+      // Fetch never presents a wrong-path instruction, so it is valid on
+      // every non-reset cycle.
       out.valid = 1'b1;
       out.instr = windowed_instr;
       out.pc = pc;

--- a/rtl/memory.v
+++ b/rtl/memory.v
@@ -66,9 +66,9 @@ module memory #(
   // **11 logic cells and 3.6% of the SoC's critical path** (88.51 -> 91.67 ns,
   // 41 -> 53 logic levels), measured by building both, twice each. This module
   // is not on that path at all: 11 cells of difference anywhere in the netlist
-  // is enough to redistribute placement. ADR-0038 rejected the shifter merge at
-  // 19 cells SAVED on legibility grounds and CLAUDE.md declines a hygiene
-  // change costing 37; spending 11 cells and 3.6% of the only timing number
+  // is enough to redistribute placement. The same trade was declined twice
+  // before: a shifter merge worth 19 cells SAVED, and a counter narrowing
+  // costing 37. Spending 11 cells and 3.6% of the only timing number
   // this project has, on a design already 6% short of its declared 12 MHz,
   // cuts the same way. Read ADR-0054 before rewriting it back.
   always_ff @(posedge clk) begin

--- a/rtl/structs.v
+++ b/rtl/structs.v
@@ -52,10 +52,10 @@ typedef struct packed {
   logic [31:0] rs1_rdata;
   logic [31:0] rs2_rdata;
   // ADR-0028: `rvfi_trap` for this instruction. Decode is the one stage that
-  // knows it -- every trap is detected and committed there (CLAUDE.md
-  // invariant 2) -- so it rides down with the rest of the shadow rather than
-  // being recomputed at retire. A trapping instruction still retires
-  // (`valid` reaching writeback, invariant 3); it just retires having
+  // knows it -- every trap is detected and committed there -- so it rides down
+  // with the rest of the shadow rather than being recomputed at retire. A
+  // trapping instruction still retires (`valid` reaching writeback); it just
+  // retires having
   // architecturally done nothing except redirect the PC.
   logic        trap;
   // Exactly the CSRs formal/checks.cfg's `[csrs]` list names, captured in

--- a/rtl/writeback.v
+++ b/rtl/writeback.v
@@ -52,8 +52,8 @@ module writeback(
       waddr = 0;
       wdata = 32'b0;
     end else begin
-      // Retire is `valid` reaching writeback (CLAUDE.md invariant 3): a bubble
-      // must never commit a register write.
+      // Retire is `valid` reaching writeback: a bubble must never commit a
+      // register write.
       wen = in.valid && (in.rd != 0);
       waddr = in.rd;
       wdata = in.rd_data;
@@ -79,8 +79,8 @@ module writeback(
   // struct-field read inside an `always_comb` is a constant part-select
   // iverilog cannot build a precise sensitivity entry for, so it emits
   // `sorry: constant selects in always_* processes are not fully supported`.
-  // The fallback is safe but is a diagnostic, and CLAUDE.md caps the count at
-  // 20 (ADR-0034). This one line inside there made it 21.
+  // The fallback is safe, but it is still a diagnostic. Keeping this read out
+  // of the always_comb is what stops one more being emitted.
   assign rvfi_trap = in.rvfi.trap;
 
   always_comb begin

--- a/soc/rom_banks.py
+++ b/soc/rom_banks.py
@@ -16,7 +16,7 @@ built from one image and cannot come to disagree about the program.
 
 Both banks are written at full depth, zero-padded. A short file is not a
 correctness problem for yosys (it initialises what it is given) but it IS one
-for iverilog, which warns at run time -- and CLAUDE.md makes warnings errors.
+for iverilog, which warns at run time, and a warning fails the build here.
 """
 
 import argparse

--- a/test/OBSERVED_FLOOR
+++ b/test/OBSERVED_FLOOR
@@ -75,8 +75,7 @@
 # against an oracle. csr.S, minstret.S and trap.S therefore show the widest gap
 # between the two columns, and that gap is the pin's coverage boundary, not a
 # bug in this core. Whoever first sees a low number here should not have to
-# rediscover that — CLAUDE.md says the same thing next to the EXPECTED_FAIL
-# contract.
+# rediscover that.
 #
 # HOW TO RE-MEASURE. Run `make test` and copy the table's third column. Record
 # the commit SHA it was measured at in the PR that changes a number, the way

--- a/test/asm/straddle.S
+++ b/test/asm/straddle.S
@@ -4,8 +4,8 @@
 #
 # ADR-0003 regression: a 32-bit instruction can straddle a 4-byte boundary
 # when pc % 4 == 2 (immediately after a compressed instruction). Fetch reads
-# the window combinationally every cycle (CLAUDE.md invariant 1 -- no
-# aligner FSM, no stall, no flush), so this costs nothing structurally; the
+# the window combinationally every cycle (no aligner FSM, no stall, no
+# flush), so this costs nothing structurally; the
 # point of this test is to prove it costs nothing *in practice* too, in both
 # sim legs, for both a straight-line straddle and a branch redirect landing
 # on one.

--- a/test/regfile_tb.v
+++ b/test/regfile_tb.v
@@ -1,7 +1,7 @@
 `timescale 1 ns / 1 ps
 `default_nettype none
 
-// rtl/regfile.v's contract (CLAUDE.md invariants 6 and 9, ADR-0042). The read
+// rtl/regfile.v's contract. The read
 // is registered, so an operand takes two cycles to obtain and the two are not
 // interchangeable:
 //
@@ -148,8 +148,8 @@ module regfile_tb;
     check_hex("the bypassed write reached the array (rs1)", reg_rs1, 32'h55555555);
     check_mirrors("arrays agree after the forwarded writes");
 
-    // Invariant 9: the read register is keyed to the address presented in the
-    // FETCH cycle, not to whatever rs1 holds during the use cycle. This is not a
+    // The read register is keyed to the address presented in the FETCH cycle,
+    // not to whatever rs1 holds during the use cycle. This is not a
     // behaviour to rely on -- it is why rtl/decoder.v must hold the PC across
     // the pair, and it is what breaks loudly if the read is made combinational
     // again without removing `operand_stall`.


### PR DESCRIPTION
Comment and string edits only. No RTL logic, no workflow logic, no script behaviour.

The governing rule is already in the repo and these sites predate it: **no ADR numbers and no
invariant numbers in comments — say the mechanism instead.** A citation reads as the explanation
while carrying none. The renumbering in the CLAUDE.md rewrite (9 folded into 6, 7 demoted to
Verification) also leaves several of them pointing at nothing.

**Twenty-four removed across thirteen files.** Each citation was replaced with the mechanism in the
comment's own words, or dropped where the surrounding sentence already said it. None was swapped for
a paraphrase of the new section titles — that would reproduce the defect with new words.

**Two kept**, both strings a developer reads at the moment something fails, not comments:

- `.github/workflows/ci.yml:59` — the `::error::` line printed when a promoted yosys warning fails
  the `elaborate` job. It names the policy and where it lives, to someone who is looking at a red
  job and asking why.
- `test/stall_report.py:190` — the message printed when a stalled cycle matches none of the six
  named reasons. It tells the reader where to record the seventh.

### One was factually wrong

`rtl/fetcher.v:42` said the documented `sorry:` exception is `rtl/executor.v` only. It is
**`rtl/writeback.v`**. `executor.v` emits **zero** of those diagnostics — its body is in
`always_ff`, whose sensitivity list is written out rather than inferred, and the diagnostic is
specific to `always_comb`. The comment asserted the opposite of the measured fact in the
authoritative voice of a citation, which is the failure mode the rule exists to prevent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
