### PR TITLE
Redo the first-round comment cleanup in the seven worst files (JEF-748)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,7 @@ on:
 permissions:
   contents: read
 
-# The tag and the filename must name the same oss-cad-suite release
-# (https://github.com/YosysHQ/oss-cad-suite-build/releases); bump them together.
 jobs:
-  # Both elaboration frontends: yosys write_cxxrtl, then iverilog over
-  # test/testbench.v + rtl/ + test/monitor.v.
   elaborate:
     name: elaborate
     runs-on: little-cpu-runners
@@ -27,28 +23,21 @@ jobs:
         uses: ./.github/actions/setup-oss-cad-suite
 
       - name: yosys write_cxxrtl, warnings promoted
-        # `make elaborate-strict` runs `proc; opt_clean; check` ahead of
+        # `make elaborate-strict` runs `proc; opt_clean; check` before
         # write_cxxrtl, which is what reports "is used but has no driver"; the
         # bare recipe elaborates an undriven wire silently and exits 0.
         #
-        # Do not spell the source list out here. This step used to, under a
-        # comment claiming it could not diverge from the Makefile's, and it
-        # diverged -- the gate spent a run elaborating a testbench whose memory
-        # instances resolved to nothing. The list lives once, in the Makefile
-        # variable both sim legs build from.
+        # Do not spell the source list out here. This step once did, it diverged
+        # from the Makefile's, and the gate spent a run elaborating a testbench
+        # whose memory instances resolved to nothing.
         #
-        # The grep is an allowlist rather than `yosys -e '.*'` because this
-        # design legitimately emits "Warning: Deep recursion in AST simplifier",
-        # a recursion-depth notice with no correctness content. Everything else
-        # yosys prefixes "Warning:" fails the build. Implicit declarations and
-        # conflicting drivers already abort with a hard ERROR before
-        # write_cxxrtl, so what this actually promotes is undriven wires and
-        # width mismatches.
+        # An allowlist rather than `yosys -e '.*'`: this design legitimately
+        # emits "Deep recursion in AST simplifier", which carries no correctness
+        # content. Implicit declarations and conflicting drivers already abort
+        # hard before write_cxxrtl, so what is promoted here is undriven wires
+        # and width mismatches.
         run: |
           set -euo pipefail
-          # Redirect rather than pipe: this repo has shipped a graded command
-          # whose status was `tee`'s once already (ADR-0037), and pipefail being
-          # set here is one edit away from not being.
           if ! make elaborate-strict > /tmp/yosys-elaborate.log 2>&1; then
             echo "::error::elaboration failed before warnings were even graded"
             cat /tmp/yosys-elaborate.log
@@ -63,8 +52,8 @@ jobs:
           echo "yosys write_cxxrtl: zero promoted warnings"
 
       - name: iverilog full-pipeline elaboration (second frontend)
-        # rvfi_macros.vh clones the pinned riscv-formal (formal/pin.mk), so this
-        # step also exercises the from-scratch-clone pin guard.
+        # rvfi_macros.vh clones the pinned riscv-formal, so this step also
+        # exercises the from-scratch-clone pin guard.
         #
         # iverilog emits 20 "sorry: constant selects in always_* processes"
         # notes here, all against rtl/writeback.v's accessor_output, and still
@@ -72,9 +61,8 @@ jobs:
         run: make rvfi_macros.vh testbench.vvp
 
       - name: iverilog full-pipeline simulation (one fixed program, graded)
-        # testbench.vvp's baked-in 200-cycle program. test/testbench.v fatals on
-        # a nonzero monitor errcode or a write/retire floor (ADR-0055). Not the
-        # `.S` suite -- this file has no image loader.
+        # test/testbench.v fatals on a nonzero monitor errcode or a write/retire
+        # floor. Not the `.S` suite -- it has no image loader.
         run: vvp testbench.vvp
 
       - name: Report job wall time
@@ -86,17 +74,6 @@ jobs:
             echo "wall time: ${elapsed}s"
           } >> "$GITHUB_STEP_SUMMARY"
 
-  # The cxxrtl regression gate. `make test` pulls in three things besides the
-  # `.S` suite: `test-units` (the seven iverilog benches, each of which
-  # $fatal(1)s on a mismatch), `probe-gates` (ADR-0053, which forces every
-  # graded comparison in the grading scripts to fail for its own reason), and
-  # the suite-shape check that grades test/OBSERVED_FLOOR's name set both ways
-  # before a program is assembled.
-  #
-  # The pass/fail table is graded against test/EXPECTED_FAIL by set equality in
-  # both directions, so a baselined test that starts passing fails this gate as
-  # loudly as a passing test that starts failing, until its line moves in the
-  # same commit (ADR-0014).
   test:
     name: test
     runs-on: little-cpu-runners
@@ -110,7 +87,7 @@ jobs:
       # An assertion, not an install: these runners are runAsNonRoot with
       # allowPrivilegeEscalation:false, so `sudo apt-get install` fails with
       # "the 'no new privileges' flag is set" and the cross compiler has to be
-      # baked into the runner image.
+      # baked into the runner image instead.
       - name: Verify the toolchain is present in the runner image
         uses: ./.github/actions/verify-toolchain
         with:
@@ -131,15 +108,10 @@ jobs:
             echo "wall time: ${elapsed}s"
           } >> "$GITHUB_STEP_SUMMARY"
 
-  # formal/components.sby carries three tasks -- decoder, executor, pcloop --
-  # and this job runs all three, so a task added there needs a step here or it
-  # runs nowhere. They pass by k-induction (`mode prove`), and unlike the
-  # ladder they are not bounded checks.
-  #
-  # The executor proof caps the divide family's operand magnitudes with the sign
-  # left free (ADR-0051). The standalone decoder proof assumes its pc input is
-  # what it last produced, and components_pcloop is what discharges that
-  # assumption -- so the decoder task's result is worth only what pcloop's is.
+  # Every task in formal/components.sby needs a step here or it runs nowhere.
+  # The standalone decoder proof assumes its pc input is what it last produced,
+  # and components_pcloop is what discharges that, so the decoder task's result
+  # is worth only what pcloop's is.
   components:
     name: components
     runs-on: little-cpu-runners
@@ -174,15 +146,6 @@ jobs:
             echo "wall time: ${elapsed}s"
           } >> "$GITHUB_STEP_SUMMARY"
 
-  # svlint over rtl/ with the tracked .svlint.toml. It parses with sv-parser, a
-  # third SystemVerilog frontend after yosys's and iverilog's. `make lint` runs
-  # it twice, with and without the RVFI macros, because roughly a fifth of rtl/
-  # sits behind `ifdef RISCV_FORMAL` and svlint's preprocessor drops it
-  # otherwise.
-  #
-  # Needs no oss-cad-suite and no cross compiler -- `make lint-setup` fetches
-  # and verifies the pinned svlint archive, and the Makefile owns that pin so
-  # the workflow cannot run a different svlint than a local build does.
   lint:
     name: lint
     runs-on: little-cpu-runners
@@ -211,16 +174,10 @@ jobs:
             echo "wall time: ${elapsed}s"
           } >> "$GITHUB_STEP_SUMMARY"
 
-  # `make fit` -- the repo's area ratchet against FIT_MAX_LC (ADR-0038). Quote
-  # this job's number and name the toolchain with it: the same commit
-  # synthesises ~21 cells apart under the pinned OSS CAD Suite and a local
-  # Homebrew yosys. The ratchet's own failure directions are probed
-  # hermetically in test/probe_gates.sh.
-  #
-  # Not in main's required set, deliberately: area is a design constraint, not
-  # a correctness one, so growing past the budget should be visible and
-  # discussed rather than blocking. Branch protection is a repository setting no
-  # pull request may touch (ADR-0036).
+  # Quote this job's number and name the toolchain with it: the same commit
+  # synthesises about 21 cells apart under the pinned OSS CAD Suite and a local
+  # Homebrew yosys. Not in main's required set, deliberately -- area is a design
+  # constraint, not a correctness one.
   fit:
     name: fit
     runs-on: little-cpu-runners
@@ -238,16 +195,13 @@ jobs:
         # Never pipe a graded command in a `run:` block. Without an explicit
         # `shell:` key the step is `bash -e {0}` -- errexit but not pipefail --
         # so `cmd | tee` takes its status from `tee` and always succeeds. This
-        # repo shipped exactly that once (ADR-0037). Redirect, take the status
-        # off the unpiped command, then publish. The same pattern below in
-        # `soc-timing`, `nonperturbation` and the `formal` gate is this rule.
+        # repo shipped exactly that once. The same shape in `soc-timing`,
+        # `nonperturbation` and the `formal` gate is this rule.
         #
         # `make fit` expects placement to FAIL: the fit top presents 231 SB_IO
-        # against sg48's 39, so nextpnr always errors on a pad -- after printing
-        # the utilisation table, which is the measurement (ADR-0038 decision
-        # 1a). The Makefile checks for that table, so "nextpnr died before
-        # measuring anything" is red and "measured, then failed to place" is
-        # green.
+        # against sg48's 39, so nextpnr always errors on a pad, after printing
+        # the utilisation table that is the measurement. The Makefile checks for
+        # that table, so "died before measuring anything" is red.
         run: |
           set +e
           make fit > "$RUNNER_TEMP/fit.txt" 2>&1
@@ -273,18 +227,11 @@ jobs:
             echo "wall time: ${elapsed}s"
           } >> "$GITHUB_STEP_SUMMARY"
 
-  # `make soc-timing` -- the SoC place-and-route and the only timing figure this
-  # project has (ADR-0054). It is in main's required set, unlike `fit`: the
-  # floor it grades is the clock the board runs at, so missing it means the
-  # design does not run on the target part.
-  #
-  # Unlike `fit` it needs the cross compiler as well as the OSS CAD Suite,
-  # because it assembles a real ROM image before synthesising, and it expects
-  # placement to SUCCEED: the SoC's memories are internal, so it presents 4
-  # SB_IO against sg48's 39. There is no `.asc` for icetime to read without a
-  # completed placement. What is graded is soc/cell_census.py's SPRAM/EBR census
-  # and soc/timing_split.py's SOC_MIN_MHZ ratchet, both probed hermetically in
-  # test/probe_gates.sh.
+  # In main's required set, unlike `fit`: the floor it grades is the clock the
+  # board runs at, so missing it means the design does not run on the target
+  # part. It needs the cross compiler because it assembles a real ROM image
+  # before synthesising, and unlike `fit` it expects placement to SUCCEED --
+  # icetime has no `.asc` to read otherwise.
   soc-timing:
     name: soc-timing
     runs-on: little-cpu-runners
@@ -304,9 +251,9 @@ jobs:
         uses: ./.github/actions/setup-oss-cad-suite
 
       - name: make soc-timing
-        # Redirected rather than piped -- see the `fit` job's step for why. The
-        # summary is written before the exit, so the census and the
-        # logic/routing split land whether this passes or fails.
+        # Redirected rather than piped -- see the `fit` job for why. The summary
+        # is written before the exit, so the census and the logic/routing split
+        # land whether this passes or fails.
         run: |
           set +e
           make soc-timing > "$RUNNER_TEMP/soc-timing.txt" 2>&1
@@ -334,17 +281,11 @@ jobs:
             echo "wall time: ${elapsed}s"
           } >> "$GITHUB_STEP_SUMMARY"
 
-  # ADR-0047: the `-D RISCV_FORMAL` build, with its rvfi_* ports deleted and
-  # every gate that only fed them swept away, must be structurally identical to
-  # the plain build -- same cell histogram, same name-independent connectivity
-  # fingerprint. That is the mechanical form of the obligation that the RVFI
-  # shadow payload not change what the core does.
-  #
-  # It is strictly weaker than sequential equivalence and must not be quoted as
-  # if it were: it proves the instrumentation is unread, not that two designs
-  # behave alike. Both failure directions were demonstrated on real mutations,
-  # the smaller being an `ifdef`'d value gating rtl/accessor.v's `out.valid` at
-  # +11 cells.
+  # The `-D RISCV_FORMAL` build, with its rvfi_* ports deleted and every gate
+  # that only fed them swept away, must be structurally identical to the plain
+  # build. Strictly weaker than sequential equivalence and must not be quoted as
+  # if it were: it shows the instrumentation is unread, not that two designs
+  # behave alike.
   #
   # Not in main's required set. Which jobs are is a repository setting, so read
   # it live rather than from any comment here:
@@ -365,7 +306,7 @@ jobs:
         uses: ./.github/actions/setup-oss-cad-suite
 
       - name: make -C formal nonperturbation
-        # Redirected rather than piped -- see the `fit` job's step for why.
+        # Redirected rather than piped -- see the `fit` job for why.
         run: |
           set +e
           make -C formal nonperturbation > "$RUNNER_TEMP/nonperturbation.txt" 2>&1
@@ -391,10 +332,8 @@ jobs:
             echo "wall time: ${elapsed}s"
           } >> "$GITHUB_STEP_SUMMARY"
 
-  # Regenerates test/monitor.v from a from-scratch riscv-formal clone at the pin
-  # and diffs it against the tracked copy, which is generated but tracked and
-  # must never be hand-edited. A fresh runner gives the from-scratch clone for
-  # free, and this needs only python3 and git.
+  # Both steps need a from-scratch riscv-formal clone at the pin, which a fresh
+  # runner gives for free, and nothing but python3 and git.
   monitor-freshness:
     name: monitor-freshness
     runs-on: little-cpu-runners
@@ -410,8 +349,7 @@ jobs:
 
       # The same control for the repo's other vendored generated file:
       # formal/genchecks-local.py may differ from the pin's checks/genchecks.py
-      # only by this repo's header and `basedir` (ADR-0031). It shares this job
-      # because the step above has already paid for the clone.
+      # only by this repo's header and `basedir`.
       - name: make -C formal genchecks-check
         run: make -C formal genchecks-check
 
@@ -424,39 +362,25 @@ jobs:
             echo "wall time: ${elapsed}s"
           } >> "$GITHUB_STEP_SUMMARY"
 
-  # The riscv-formal ladder, plus every hand-authored formal task the repo owns.
+  # What is gated here is formal/check-baseline.sh's exit status, not sby's:
+  # every generated .sby carries `expect pass,fail`, so sby exits 0 whether a
+  # check passed or failed and its exit code never carried a verdict. The
+  # verdict is the two set equalities check-baseline.sh performs.
   #
-  # What is gated is formal/check-baseline.sh's exit status, not sby's: every
-  # generated .sby carries `expect pass,fail`, so sby exits 0 whether a check
-  # passed or failed and its exit code has never carried a verdict. The verdict
-  # is the two set equalities check-baseline.sh performs, each in both
-  # directions (ADR-0014) -- formal/EXPECTED_CHECKS for which checks genchecks
-  # generated, formal/EXPECTED_FAIL for which of them are red. Deleting a
-  # baseline line without fixing the check fails here, and so does fixing a
-  # check without deleting its line.
-  #
-  # A green run means the ladder still matches its baseline and nothing more.
-  # Every check is `mode bmc` -- no counterexample within a configured depth,
-  # not a proof -- and the whole ladder runs under RISCV_FORMAL_ALTOPS, so a
+  # A green run means the checks still match their baseline and nothing more.
+  # Every one is `mode bmc`, and they all run under RISCV_FORMAL_ALTOPS, so a
   # passing insn_mul or insn_div says nothing about the real multiplier or
-  # divider (ADR-0010).
-  #
-  # The Sail co-sim stays off this job deliberately: ADR-0032 forbids putting it
-  # on the required set, and its fetch has not had formal/pin.mk's treatment.
+  # divider.
   formal:
     name: formal
-    # GitHub-hosted for memory, not packaging. One ladder check peaks around
-    # 876 MiB resident (insn_add_ch0, measured), and the in-cluster pod has a
-    # 1.5 GiB limit with ~836 MiB already held at job start -- so a single check
-    # does not fit there at any parallelism, and two runs died with the runner
-    # losing contact before they could upload a log. Moving back in-cluster
-    # needs that pod's memory limit raised to at least JOBS x 1 GiB plus the
-    # ~1 GiB the runner and toolchain hold.
+    # GitHub-hosted for memory, not packaging. One check peaks around 876 MiB
+    # resident (insn_add_ch0, measured) and the in-cluster pod has a 1.5 GiB
+    # limit with ~836 MiB already held at job start, so a single check does not
+    # fit there at any parallelism.
     runs-on: ubuntu-latest
     # Loose because there is no per-check wall bound: one non-converging check
     # starves everything scheduled after it, and `-k` does not help because the
-    # job dies rather than the check. Raising a depth in checks.cfg re-opens
-    # this number.
+    # job dies rather than the check.
     timeout-minutes: 20
     steps:
       - name: Record job start
@@ -468,12 +392,10 @@ jobs:
         uses: ./.github/actions/setup-oss-cad-suite
 
       # sby's btor engine replays a counterexample with btorsim, so btorsim is
-      # reached only by a check that found one -- on a box without it, every red
-      # check reports ERROR instead of FAIL. On an all-green ladder, which is
-      # the state this repo is in, its absence is therefore invisible until the
-      # first check goes red, and the diagnostic then reads "status changed"
-      # rather than "install btorsim". Asserting up front is what makes the
-      # failure name its own cause.
+      # reached only by a check that found one -- without it, every red check
+      # reports ERROR instead of FAIL. With everything green its absence is
+      # therefore invisible until the first check goes red, and the diagnostic
+      # then reads "status changed" rather than "install btorsim".
       - name: Confirm the BMC toolchain is complete
         run: |
           set -euo pipefail
@@ -493,16 +415,12 @@ jobs:
             exit 1
           fi
 
-      # Generation runs formal/genchecks-audit.py, which asserts the ladder's
-      # shape against EXPECTED_CHECKS in about a second before any check runs.
-      #
       # JOBS is a memory budget, not a speed knob: one check peaks around
-      # 876 MiB resident, so the ladder's footprint is roughly JOBS GiB and 4
-      # fits a 16 GiB hosted runner. formal/Makefile defaults it to `nproc`,
-      # which is right on a workstation and wrong in a container, where the
-      # affinity mask is not narrowed by a CPU quota. The diagnostics below
-      # print what the host actually has; re-tune against those, not by
-      # guessing.
+      # 876 MiB resident, so the footprint is roughly JOBS GiB and 4 fits a
+      # 16 GiB hosted runner. formal/Makefile defaults it to `nproc`, which is
+      # right on a workstation and wrong in a container, where a CPU quota does
+      # not narrow the affinity mask. The diagnostics below print what the host
+      # actually has; re-tune against those rather than guessing.
       - name: Generate and run the ladder (make -C formal check)
         run: |
           set -uo pipefail
@@ -512,23 +430,19 @@ jobs:
           free -h 2>/dev/null || true
           make -C formal check JOBS=4
 
-      # The step above already ends in this same comparison (formal/Makefile's
-      # `check` puts a leading `-` on the sby sub-make and then runs
-      # check-baseline), so the two agree by construction. Re-grading a finished
-      # ladder re-runs no check and costs a second, and it publishes the verdict
-      # instead of leaving it inferred.
-      #
-      # `!cancelled()` rather than the default, because if the ladder step goes
-      # red this step is what says why. A ladder that failed to generate at all
-      # exits 2 here ("no *.sby files"), so a red step above cannot be followed
-      # by a green one here.
+      # The step above already ends in this same comparison, so the two agree by
+      # construction; re-grading re-runs no check and publishes the verdict
+      # instead of leaving it inferred. `!cancelled()` because if the step above
+      # goes red this one is what says why -- and a run that failed to generate
+      # at all exits 2 here ("no *.sby files"), so a red step above cannot be
+      # followed by a green one here.
       - name: Gate on formal/EXPECTED_FAIL + formal/EXPECTED_CHECKS
         if: ${{ !cancelled() }}
         run: |
-          # Redirected rather than piped -- see the `fit` job's step for why.
-          # Demonstrated here specifically: with `| tee` in place, a
-          # deliberately wrong formal/EXPECTED_FAIL printed "Failure list does
-          # NOT match" and the job still reported success.
+          # Redirected rather than piped -- see the `fit` job for why.
+          # Demonstrated here: with `| tee` in place, a deliberately wrong
+          # formal/EXPECTED_FAIL printed "Failure list does NOT match" and the
+          # job still reported success.
           set +e
           formal/check-baseline.sh formal/checks formal/EXPECTED_FAIL > "$RUNNER_TEMP/baseline-report.txt" 2>&1
           status=$?
@@ -547,14 +461,10 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
           exit "$status"
 
-      # The hand-authored tasks. These are not on the generated ladder --
-      # formal/EXPECTED_FAIL covers the genchecks sweep only -- so each one's
-      # verdict is its own exit status and nothing else.
-      #
-      # One step each rather than one step running three `make`s, because make
-      # stops at the first failure: a red imemcheck would leave dmemcheck and
-      # cover unrun while the log read as a single failure. Split, the step list
-      # is the per-check record.
+      # The hand-authored tasks. formal/EXPECTED_FAIL covers the genchecks sweep
+      # only, so each one's verdict is its own exit status. One step each rather
+      # than one step running three `make`s, because make stops at the first
+      # failure and the log would read as a single one.
       - name: imemcheck (ADR-0003's dual-word fetch window)
         run: make -C formal imemcheck
 
@@ -564,36 +474,27 @@ jobs:
       - name: cover (five goals, incl. >=2 compressed retires)
         run: make -C formal cover
 
-      # complete.sby carries no `expect` line, unlike every generated ladder
-      # check, so this step's status is sby's own.
+      # complete.sby carries no `expect` line, unlike every generated check, so
+      # this step's status is sby's own.
       #
-      # What a green `complete` means: on every trace of at most 50 cycles from
-      # reset, every non-trapping retire the core reports carries an encoding
-      # riscv-formal's whole-ISA model recognises and agrees is non-trapping.
-      # Each of the 70 insn_* ladder checks constrains rvfi_insn to its own
-      # encoding, so an encoding none of them names is invisible to all of them,
-      # and this is what sees it.
+      # A green run means every non-trapping retire the core reports, on any
+      # trace of at most 50 cycles, carries an encoding riscv-formal's whole-ISA
+      # model recognises. Each of the 70 insn_* checks constrains rvfi_insn to
+      # its own encoding, so an encoding none of them names is invisible to all
+      # of them, and this is what sees it. It says nothing about spec values and
+      # is silent on the classes in formal/COMPLETE_EXCLUSIONS.
       #
-      # What it does not mean: it is `mode bmc` at depth 50, it says nothing
-      # about spec values, and it is silent on the opcode classes declared in
-      # formal/COMPLETE_EXCLUSIONS -- which `make -C formal complete` refuses to
-      # run until they match complete.sv in both directions. Whole-ISA coverage
-      # minus a declared, baselined hole is not whole-ISA coverage.
-      #
-      # complete.sby runs `abc bmc3`, a third engine after the ladder's
-      # `btor btormc` and components.sby's `smtbmc boolector`, so the btorsim
-      # assertion above does not cover it.
+      # complete.sby runs `abc bmc3`, a third engine after `btor btormc` and
+      # components.sby's `smtbmc boolector`, so the btorsim check above does not
+      # cover it.
       - name: complete (whole-ISA BMC walk, depth 50)
         run: make -C formal complete
 
-      # The anti-vacuity control for the step above, and a gate for the same
-      # reason it is. `complete`'s assertion is guarded by `rvfi_valid`,
-      # `!rvfi_trap` and `!insn_excluded`, so a core that never retired, or
-      # claimed a trap on everything, or an exclusion set that had grown to
-      # swallow the ISA would each pass it having been asked nothing. This runs
-      # the same complete.sv under `mode cover` and requires a real
-      # non-trapping, non-excluded retire of every opcode class the exclusion
-      # set does not name. Green above without green here is not a result.
+      # `complete`'s assertion is guarded by `rvfi_valid`, `!rvfi_trap` and
+      # `!insn_excluded`, so a core that never retired, or claimed a trap on
+      # everything, or an exclusion set grown to swallow the ISA would each pass
+      # it having been asked nothing. Green above without green here is not a
+      # result.
       - name: complete_cover (anti-vacuity — every non-excluded class retires)
         run: make -C formal complete_cover
 

--- a/formal/Makefile
+++ b/formal/Makefile
@@ -2,10 +2,9 @@ include pin.mk
 
 .DELETE_ON_ERROR:
 
-# GNU nproc / macOS sysctl; neither is on every box, so fall back to 4. The
-# result is spliced into a shell command line, so anything that is not a plain
-# decimal (an error message on stderr-to-stdout, an empty string) falls back
-# rather than being passed through.
+# JOBS is spliced into a shell command line, so anything that is not a plain
+# decimal -- an error message, an empty string -- falls back rather than being
+# passed through.
 JOBS := $(shell nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)
 ifeq ($(shell printf '%s' '$(JOBS)' | grep -cE '^[1-9][0-9]{0,3}$$'),0)
 override JOBS := 4
@@ -14,34 +13,16 @@ endif
 all: complete complete_cover complete-exclusions check dmemcheck imemcheck \
      components_decoder components_executor components_pcloop components_traps
 
-# THE RULE FOR EVERY sby TARGET IN THIS FILE, INCLUDING ONES ADDED LATER:
-# it re-runs unconditionally, and it throws its workdir away first.
+# Every sby target here names a directory sby creates, and a directory's mtime
+# bumps whenever an entry is written inside it -- so after one run the workdir
+# is newer than every prerequisite and make calls the target up to date
+# forever. FORCE and the `rm -rf` are what stop that, and the same applies to
+# any sby target added later.
 #
-# Every one of them names a DIRECTORY that sby creates, and make's up-to-date
-# decision on a directory is worthless: a directory's mtime bumps whenever an
-# entry is created inside it, so a workdir is newer than every prerequisite in
-# the list the moment the previous run wrote its first file into it. That is
-# ADR-0040's finding about `checks`, and the identical shape sat unfixed on its
-# siblings for as long again -- with `imemcheck` and `dmemcheck` reachable
-# through this rule and listing NO rtl/ file at all, so `make imemcheck` after
-# a fetcher change printed "`imemcheck' is up to date" and exited 0. Both CI
-# workflows are fresh checkouts and never saw it; the path a developer uses to
-# convince themselves before pushing is the path that lied.
-#
-# `rm -rf $@` is belt to `sby -f`'s braces. `-f` already force-overwrites, so
-# unlike `checks` -- whose generated makefile hardcodes an `sby` with no `-f`
-# (ADR-0040) -- this recipe does not depend on the delete to re-run. It is here
-# so that "the workdir is gone" is a property of THIS file rather than of a
-# flag someone may later move, and so a run interrupted mid-write cannot leave
-# half a workdir that the next run reads as its own output.
-#
-# FORCE, not `.PHONY`. A .PHONY target is EXCLUDED from implicit rule search,
-# so `.PHONY: imemcheck` deletes the only rule that builds it and `make
-# imemcheck` answers "Nothing to be done for `imemcheck'" and exits 0 --
-# measured on GNU Make 3.81 and 4.x alike. That is the same failure this rule
-# exists to remove, restated as a fix, so it must not be reached for here.
-# Explicit targets (components_* below) are not pattern-matched and CAN use
-# .PHONY; the split is deliberate and is why two mechanisms appear in one file.
+# FORCE rather than .PHONY: a .PHONY target is excluded from implicit rule
+# search, so `.PHONY: imemcheck` would delete the only rule that builds it and
+# `make imemcheck` would answer "Nothing to be done" and exit 0. The explicit
+# targets further down are not pattern-matched and can use .PHONY.
 FORCE:
 .PHONY: FORCE
 
@@ -49,106 +30,46 @@ FORCE:
 	rm -rf $@
 	sby -f $<
 
-# `-k`: without it, GNU make stops scheduling new jobs at the first failing
-# check, so a ladder with known failures (formal/EXPECTED_FAIL) never runs
-# past its first parallel wave and the rest report as "no status" rather
-# than PASS or FAIL (ADR-0022). `-k` is what makes "all 82 checks ran" true.
-#
-# The leading `-` on the sub-make is what lets check-baseline below be the
-# target's verdict, and it is not laundering an error. Every generated .sby
-# carries `expect pass,fail`, so `sby` exits 0 whether a check passed or
-# failed and the sub-make's exit status never carried a verdict in the first
-# place -- what it CAN do is abort before the compare step runs, which would
-# leave the target exiting 0 with nothing having been checked. Anything the
-# sub-make really failed to run shows up as a missing status file, which
-# check-baseline counts as non-PASS.
+# `-k` so one failing check does not stop the rest from being scheduled. The
+# leading `-` lets check-baseline below be the verdict: every generated .sby
+# carries `expect pass,fail`, so sby exits 0 whether a check passed or failed,
+# and anything that really failed to run reaches check-baseline as a missing
+# status file.
 check: checks $(RISCV_FORMAL_DIR)
 	-$(MAKE) -C $< -j$(JOBS) -k
 	$(MAKE) check-baseline
 
-# Set equality against BOTH baselines, in both directions: EXPECTED_CHECKS
-# (which checks exist) and EXPECTED_FAIL (which of them are red). Split out
-# as its own target so a ladder that has already run can be re-graded in a
-# second without re-running it, and so a local `make check` is gated by the
-# same script CI grades with rather than by sby's suppressed exit code
-# (ADR-0022, ADR-0033). That script is reached from `.github/workflows/ci.yml`'s
-# `formal` job, which is required; there is no nightly (ADR-0050).
+# Split out so a finished run can be re-graded in a second without re-running
+# it, and so a local `make check` is gated by the same script CI grades with.
 .PHONY: check-baseline
 check-baseline: check-baseline.sh EXPECTED_FAIL EXPECTED_CHECKS
 	./check-baseline.sh checks EXPECTED_FAIL EXPECTED_CHECKS
 
-# genchecks-audit.py runs genchecks-local.py and additionally asserts the
-# ladder's SHAPE before anything runs it: the generated set against
-# EXPECTED_CHECKS, and the set genchecks DECLINED (no [depth] line, silently
-# skipped) against checks.cfg's `#omit` declarations. Both are set
-# equalities in both directions. It fails in about a second, which is the
-# point -- check-baseline catches the same shrunken ladder, but only after
-# the full run (ADR-0033).
+# genchecks-audit.py runs genchecks-local.py and also compares the generated
+# set against EXPECTED_CHECKS, and the set genchecks silently declined against
+# checks.cfg's `#omit` lines, both ways round, in about a second.
 #
-# `checks` is PHONY and starts by deleting the directory, and both halves of
-# that are load-bearing (ADR-0040). It used to be a plain file target whose
-# recipe was just `python3 $<`, and in that form `make check` could not
-# re-run the ladder at all -- it silently re-graded the PREVIOUS run's
-# verdict:
-#
-#   1. `checks` is a DIRECTORY, and a directory's mtime bumps whenever an
-#      entry is created inside it. `sby` creates checks/<name>/ for every
-#      check it runs, so after one ladder run checks/ is newer than
-#      checks.cfg, genchecks-local.py and EXPECTED_CHECKS all at once, and
-#      make reports it up to date forever. Editing checks.cfg between two
-#      runs therefore did NOT regenerate the ladder.
-#   2. genchecks-local.py:72 is `sbycmd = "sby"` with no `-f`, and the
-#      makefile it emits hardcodes that string. sby refuses to overwrite an
-#      existing workdir, so every re-invocation aborted with "Directory
-#      '<name>' already exists" and left the prior `status` file untouched.
-#      `make -BC checks` -- which this target used to pass -- forces the
-#      RULE, not sby, so it made the aborts louder without making anything
-#      re-run.
-#
-# Measured on this repo at 317b86c, both runs from the same tree: run 1 took
-# 310s and wrote 82 status files; run 2 took 22s, printed "Directory already
-# exists" for all 82, and check-baseline still reported "82 checks: 82 pass".
-# Every status file's mtime was byte-identical between the two. A ladder that
-# reports a verdict it did not compute is docs/THREAT_MODEL.md's category 1,
-# and it is a verdict about RTL that may since have changed underneath it.
-#
-# genchecks-local.py must not be patched to add `-f` (ADR-0031 constrains that
-# vendored copy to differ from the pin by `basedir` only, and
-# `make genchecks-check` enforces it), so the fix is here: throw the run
-# directories away, regenerate, and let every status file be built by a real
-# sby invocation. Regeneration costs about a second. `-B` is correspondingly
-# gone from `check` above -- with no status file on disk every rule fires on
-# its own, and keeping a flag that forces rules rather than reruns is what
-# made this look handled for as long as it did.
-#
-# Re-grading a finished ladder without re-running it is still available, and
-# is what `make check-baseline` is for.
+# PHONY and the `rm -rf` are both load-bearing; reverting either brings back a
+# verdict nobody computed. `checks` is a directory, and a directory's mtime
+# bumps on every entry sby writes into it, so a plain file target reads as up
+# to date forever. genchecks-local.py also emits a makefile hardcoding `sby`
+# with no `-f`, which then refuses to overwrite the old workdir. Measured: a
+# second run printed "Directory already exists" for every check, wrote no
+# status file, and check-baseline still reported them all passing.
 .PHONY: checks
 checks: genchecks-audit.py genchecks-local.py checks.cfg EXPECTED_CHECKS | $(RISCV_FORMAL_DIR)
 	rm -rf $@
 	python3 $<
 
 # genchecks-local.py is vendored from the pin and may differ from it only by
-# this repo's header and `basedir` (ADR-0031). That rule used to be enforced by
-# a `cp` + `diff -u` recipe in the script's own header, run by hand or not at
-# all -- the same gap `make monitor-check` already closes for test/monitor.v,
-# the repo's other vendored generated artifact. Drift here is what produced the
-# five-year-stale fork ADR-0031 exists to end.
+# this repo's header and `basedir`. Nothing enforced that before this target.
 .PHONY: genchecks-check
 genchecks-check: $(RISCV_FORMAL_DIR)/checks/genchecks.py genchecks-local.py | $(RISCV_FORMAL_DIR)
 	python3 check-genchecks.py $^
 
-# The whole core, in the order every whole-core .sby reads it. These four
-# targets each ran against an `.sby` and an `.sv` and NOTHING ELSE before this
-# list existed, which is how `make imemcheck` -- the check that covers the
-# dual-word fetch window, and so the one most likely to be re-run by
-# hand after touching rtl/fetcher.v -- could report a verdict about RTL it had
-# never read.
-#
-# Read these lists as DOCUMENTATION of what each task compiles, not as a gate.
-# The gate is the FORCE rule above: the target re-runs whatever this says. What
-# they still buy is a loud `No rule to make target` if an rtl/ file is renamed
-# out from under a check, instead of a confusing failure inside sby.
+# Documentation of what each whole-core task compiles, not a gate -- the FORCE
+# rule re-runs the target whatever this list says. What it buys is a loud "No
+# rule to make target" if an rtl/ file is renamed out from under a check.
 RTL_SOURCES := ../rtl/structs.v ../rtl/fetcher.v ../rtl/regfile.v \
                ../rtl/csrs.v ../rtl/decoder.v ../rtl/executor.v \
                ../rtl/accessor.v ../rtl/writeback.v ../rtl/littlecpu.v
@@ -157,69 +78,38 @@ dmemcheck: dmemcheck.sby dmemcheck.sv arbiter.v $(RTL_SOURCES) | $(RISCV_FORMAL_
 imemcheck: imemcheck.sby imemcheck.sv arbiter.v $(RTL_SOURCES) | $(RISCV_FORMAL_DIR)
 cover:     cover.sby     cover.sv     arbiter.v $(RTL_SOURCES) | $(RISCV_FORMAL_DIR)
 
-# `complete` is the depth-50 walk and by far the most expensive thing here, so
-# unconditional re-running is the least welcome on it. It gets it anyway: a
-# target asked for BY NAME must run, and the alternative -- a prerequisite list
-# deciding -- is what this whole change removes, because the thing that list is
-# compared against is a directory whose mtime is meaningless. Nothing pulls
-# `complete` in implicitly except `all`.
-#
-# `complete-exclusions` is a real prerequisite rather than a companion gate:
-# the exclusion set is what makes this check passable at all, and a run whose
-# exclusions have drifted from their baseline is a verdict about a check nobody
-# declared. It costs milliseconds and it fails before sby starts.
+# complete-exclusions is a prerequisite rather than a companion target: the
+# exclusion set is what makes this check passable at all, and checking it costs
+# milliseconds and fails before sby starts.
 complete:  complete.sby  complete.sv  arbiter.v complete-exclusions $(RTL_SOURCES) | $(RISCV_FORMAL_DIR)
 
-# The anti-vacuity control for the line above, over the same complete.sv: the
-# twelve opcode classes the exclusion set does NOT name must each be reachable
-# as a real non-trapping retire. See complete_cover.sby's header for why it is
-# a separate file and not a task.
+# The anti-vacuity control for the line above, over the same complete.sv: every
+# opcode class the exclusion set does not name must be reachable as a real
+# non-trapping retire.
 complete_cover: complete_cover.sby complete.sv arbiter.v complete-exclusions $(RTL_SOURCES) | $(RISCV_FORMAL_DIR)
 
-# Set equality in both directions between complete.sv's declared exclusion set
-# and formal/COMPLETE_EXCLUSIONS, plus a re-derivation from the pinned clone
-# that each excluded mnemonic really has no spec model. ADR-0014's contract,
-# applied to a restriction rather than to a result: excluding an opcode from an
-# assertion is weakening a check (ADR-0010 one level up), and a restriction
-# nothing compares against is not recorded.
+# Set equality both ways between complete.sv's declared exclusions and
+# COMPLETE_EXCLUSIONS, plus a re-derivation from the pinned clone that each
+# excluded mnemonic really has no spec model.
 .PHONY: complete-exclusions
 complete-exclusions: check-complete-exclusions.py complete.sv COMPLETE_EXCLUSIONS | $(RISCV_FORMAL_DIR)
 	python3 $< complete.sv COMPLETE_EXCLUSIONS $(RISCV_FORMAL_DIR)
 
-# ADR-0006 / ADR-0020 / ADR-0047: proves RVFI instrumentation doesn't change
-# core behaviour. Not a .sby task -- it is a structural comparison of two yosys
-# builds, not a solver query -- so it isn't covered by the generic `%: %.sby`
-# rule above. Needs nothing but yosys and python3, and runs in about nine
-# seconds, which is why it is a PR gate rather than a nightly.
-#
-# This REPLACES formal/equiv.sh, deleted in ADR-0047 along with its nightly
-# step. That script asked equiv_make/equiv_simple/equiv_induct to prove
-# sequential equivalence of the two builds and never converged at any budget:
-# equiv_make's name-based matching left 459 of 495 $equiv cells unproven
-# (essentially the whole datapath), because the two builds optimise to
-# differently-named netlists. It sat in the nightly behind `continue-on-error`
-# and `timeout 3600`, so "it's on the nightly" read as coverage for a check
-# that had never once produced a verdict. A suppressed red is worse than no
-# check.
-#
-# What replaced it is STRICTLY WEAKER than sequential equivalence and the
-# script says so at length: it proves the instrumentation is UNREAD, not that
-# two designs behave alike. That is the property ADR-0006 actually asked for.
+# A structural comparison of two yosys builds rather than a solver query, so it
+# is not covered by the `%: %.sby` rule above. It shows the RVFI instrumentation
+# is unread by the core, which is strictly weaker than sequential equivalence
+# and must not be quoted as if it were.
 .PHONY: nonperturbation
 nonperturbation: check-nonperturbation.py
 	python3 $<
 
-# pipeline stages. fetcher/accessor/writeback are deliberately not here: their
-# formal/components.sby tasks were deleted for carrying zero assertions
-# (ADR-0006, ADR-0017) -- a "passing" proof with nothing asserted is not a
-# result.
+# fetcher, accessor and writeback are deliberately absent: their tasks carried
+# zero assertions and were deleted rather than left to pass having asked
+# nothing.
 #
-# These three carry their own recipes rather than reaching the `%: %.sby` rule
-# (they pass a task name), so they are the half of the file that CAN say
-# .PHONY -- implicit rule search is not involved. Same two properties as that
-# rule: always run, delete the workdir first. Before this they named the
-# directory sby creates and listed one rtl/ file each, so a warm tree made
-# `make components_decoder` after a structs.v edit answer "up to date".
+# These four pass a task name, so they need their own recipes and cannot reach
+# the `%: %.sby` rule -- which is why they can say .PHONY where that rule
+# cannot. Same two properties as it: always run, delete the workdir first.
 .PHONY: components_decoder components_executor components_pcloop components_traps
 components_decoder: components.sby ../rtl/decoder.v ../rtl/structs.v
 	rm -rf $@
@@ -227,34 +117,24 @@ components_decoder: components.sby ../rtl/decoder.v ../rtl/structs.v
 components_executor: components.sby ../rtl/executor.v ../rtl/structs.v
 	rm -rf $@
 	sby -f $< executor
-# The composed fetcher+decoder task. It exists to DISCHARGE the standalone
-# decoder task's `assume(in.pc == pc)` (ADR-0017), which is the one place that
-# proof's content went, and ADR-0017 puts the pc loop in M2's scope. It had no
-# target here and no CI step, and it had been FAILING since `e4f5250` -- its
-# f_may_stall over-approximation predates ADR-0042's fifth stall reason, so the
-# sequential-advance assertion covered a cycle on which the decoder legitimately
-# holds the pc. Nothing noticed for the obvious reason (ADR-0046). It runs on CI
-# now; a proof nobody runs is a prose-only guard.
+# Discharges the standalone decoder task's `assume(in.pc == pc)`, which is
+# where that proof's content went.
 components_pcloop: components.sby ../rtl/fetcher.v ../rtl/decoder.v \
                    ../rtl/structs.v pcloop.sv
 	rm -rf $@
 	sby -f $< pcloop
-# The composed decoder+csrs task. It is the only place mtvec, mepc, mcause and
-# mstatus are real registers under a proof: the generated ladder drops every
-# value comparison once an instruction traps, keeping only the trap flag, and
-# its pc checks accept whatever target the core reports. So nothing else says a
-# trap lands on mtvec or that the saved state is right.
+# The only place mtvec, mepc, mcause and mstatus are real registers under a
+# proof. The generated checks drop every value comparison once an instruction
+# traps, keeping only the trap flag, and their pc checks accept whatever target
+# the core reports -- so nothing else says a trap lands on mtvec, or that the
+# state it saved is right.
 components_traps: components.sby ../rtl/fetcher.v ../rtl/decoder.v ../rtl/csrs.v \
                   ../rtl/structs.v traps.sv
 	rm -rf $@
 	sby -f $< traps
 
-# The riscv-formal clone rule and its pin guard live in pin.mk, included above,
-# so this and the root Makefile cannot drift apart on it.
-
 # Written out rather than brace-expanded: `rm -rf {a,b,c}` is a bashism that
-# /bin/sh (make's default shell) passes through literally, silently deleting
-# nothing.
+# /bin/sh, make's default shell, passes through literally and deletes nothing.
 clean:
 	rm -rf checks complete complete_cover cover dmemcheck imemcheck components components_*
 	rm -rf $(RISCV_FORMAL_DIR) $(RISCV_FORMAL_DIR).tmp

--- a/formal/checks.cfg
+++ b/formal/checks.cfg
@@ -1,12 +1,12 @@
 [options]
 # The insn_c_* checks this generates exercise rtl/decoder.v's compressed decode
-# on its own: imem_data is a free value every cycle here (formal/wrapper.v), so
-# no fetch window is involved. The .S suite is what covers the two together.
+# on its own: imem_data is a free value every cycle here, so no fetch window is
+# involved. The .S suite is what covers the two together.
 isa rv32imc
 # `solver` selects genchecks' engine, not just an SMT solver name: `bmc3` means
 # `abc bmc3`, `btormc` means `btor btormc`, anything else means `smtbmc <that>`.
-# Keep btormc -- reg_ch0 is one depth-21 query that did not converge under
-# `smtbmc yices` in over 20 minutes and returns in 8-12s here (ADR-0024).
+# Keep btormc -- reg_ch0 is one query that did not converge under `smtbmc yices`
+# in over 20 minutes and returns in 8-12s here.
 solver btormc
 
 [csrs]
@@ -16,14 +16,11 @@ solver btormc
 # reachable at all.
 #
 # This is not the set of CSRs the core implements. It is the subset
-# rvfi_csrw_check.sv can say something true about, and adding a WARL CSR
-# (mtvec, mepc, mcause, mstatus) or a read-only-zero one (mie, mip, mtval) puts
-# a FAIL on a correct core: that check has no WARL model, it asserts that every
-# bit the instruction offered appears set in what landed, and masked bits do not
-# land. Those are checked field by field in test/csr_tb.v instead. The csrc_*
-# models do read a RISCV_FORMAL_CSRC_MASK and so can state a WARL CSR, but a
-# name here generates its csrw_* check whether or not it also carries a test
-# list.
+# rvfi_csrw_check.sv can say something true about. Adding a WARL CSR (mtvec,
+# mepc, mcause, mstatus) or a read-only-zero one (mie, mip, mtval) puts a FAIL on
+# a correct core: that check has no WARL model, it asserts that every bit the
+# instruction offered appears set in what landed, and masked bits do not land.
+# Those are checked field by field in test/csr_tb.v instead.
 #
 # A name here also makes the generated rvfi_macros.vh declare
 # rvfi_csr_<name>_{rmask,wmask,rdata,wdata}, which formal/wrapper.v connects to
@@ -32,57 +29,43 @@ solver btormc
 # re-run of `make -C formal nonperturbation`.
 #
 # `inc` is spelled here with no `csrc_inc` line in [depth] on purpose: that is
-# what makes genchecks consider and drop those two checks, which is what
-# requires their `#omit` lines below. Delete the word and the decline becomes
-# prose only. rvfi_csrc_inc_check.sv is red on a correct core here -- it clears
-# `csr_written` every non-check cycle, so its post-write fallback lives one
-# cycle, and CSR serialization (invariant 5) means two CSR retires are never
-# adjacent. Measured PASS at 6..12, red at 13..16; no depth escapes it.
+# what makes genchecks consider and drop those two checks, which is what their
+# `#omit` lines below then have to declare. Delete the word and the decline
+# becomes prose only. rvfi_csrc_inc_check.sv is red on a correct core here: it
+# clears `csr_written` every non-check cycle, so its post-write fallback lives
+# one cycle, and CSR serialization means two CSR retires are never adjacent.
+# Measured PASS at 6..12, red at 13..16; no depth escapes it.
 #
 # `upcnt` says the counter strictly increases between two reads, with writes
 # assumed away. It does not say minstret advances by exactly the non-trapping
-# issues, so ADR-0027's rule is narrowed here rather than closed:
-# test/asm/minstret.S and test/csr_tb.v still carry that half.
-#
-# `mscratch any` is the only check here that asserts a CSR write sticks. Delete
-# `MSCRATCH: mscratch <= warl;` from rtl/csrs.v and csrc_any_mscratch_ch0 goes
-# red while csrw_mscratch_ch0 stays PASS, because every value csrw reasons about
-# comes from the reported write rather than from the register.
+# issues, so test/asm/minstret.S and test/csr_tb.v still carry that half.
 mcycle   inc upcnt
 minstret inc upcnt
 mscratch any
 
-# ------------------------------------------------------------------------
 # [depth] below is the list of checks that EXIST, not a tuning table. Both of
 # genchecks' call sites return early on a check with no depth line, so such a
 # check is not generated at all -- no .sby, no directory, no status, no warning,
-# exit 0. A never-generated check is then missing from the results and from
-# formal/EXPECTED_FAIL at once, so set equality reports a clean match on the
-# smaller ladder (ADR-0033).
+# exit 0. It is then missing from the results and from formal/EXPECTED_FAIL at
+# once, and set equality reports a clean match on the smaller set.
 #
-# The declined set is therefore declared, not described. Each `#omit` line names
+# So the declined set is declared rather than described. Each `#omit` line names
 # one check genchecks considered and skipped, with its reason.
 # formal/genchecks-audit.py traces the generator's own get_depth_cfg calls and
-# set-equalities everything it dropped against these lines in both directions,
-# so a check upstream adds at the next pin bump fails generation until someone
-# rules on it. genchecks' cfg parser drops `#` lines, so none of this can
-# perturb generation.
+# compares everything it dropped against these lines in both directions, so a
+# check upstream adds at the next pin bump fails generation until someone rules
+# on it. genchecks' cfg parser drops `#` lines, so none of this perturbs
+# generation. The tag is free-form to that script, which reads only the name.
 #
 #   [BLOCKED]  the property is wanted and there is no hardware here to state it
 #              about.
 #   [DESIGN]   declined on the merits; no hardware change reopens it.
-#
-# The tag is free-form to the audit script, which captures only the check name.
 #
 # The bus never refuses a transaction, and that is decided rather than pending.
 # An in-range access is answered, an out-of-range load reads zero, an
 # out-of-range store is dropped, and a fetch past the end of text reads zero,
 # which decode raises as an illegal instruction. There is no access fault for
 # the five fault checks to be about.
-#
-# bus_imem_ch0 and bus_dmem_ch0 would restate what formal/imemcheck.sv and
-# formal/dmemcheck.sv already hold against the real fetch and data ports, and
-# taking them means driving nine more RVFI outputs that nothing else needs.
 #omit fault_ch0                   [DESIGN] the bus never refuses a transaction, so no access fault can be raised
 #omit bus_imem_ch0                [DESIGN] formal/imemcheck.sv holds this against the real fetch ports
 #omit bus_imem_fault_ch0          [DESIGN] no fault line on the fetch bus, and none is coming
@@ -97,11 +80,10 @@ mscratch any
 #omit csrc_inc_mcycle_ch0         [DESIGN] rvfi_csrc_inc_check.sv is red on a CORRECT core here; measured, see [csrs]
 #omit csrc_inc_minstret_ch0       [DESIGN] rvfi_csrc_inc_check.sv is red on a CORRECT core here; measured, see [csrs]
 #omit cover                       [DESIGN] run standalone by formal/cover.sby with this repo's own five goals
-# ------------------------------------------------------------------------
 
 [depth]
-# Depths are derived, not inherited (ADR-0025), from two figures the ladder
-# measures about itself in seconds each:
+# Depths are derived, not inherited, from two figures the checks measure about
+# themselves in seconds each:
 #
 #   F = 6   worst-case first retire. Sweep `hang`'s check cycle: red at 6, PASS
 #           at 7 -- rvfi_hang_check.sv asserts on a registered flag, so the flip
@@ -112,30 +94,25 @@ mscratch any
 #           since rvfi_liveness_check.sv opens with `assume(rvfi_valid)` at its
 #           trig cycle.
 #
-# G was 4 until the sixth stall reason landed (ADR-0060), and the two cycles are
-# not what the reason itself costs: one is the steal bubble and the other is the
-# refetch the weakened imem-stability assumption in formal/wrapper.v allows.
-# ADR-0057 measured them apart, one configuration at a time.
-#
 # To re-measure: copy this file with only the `hang` (or `liveness`) line in
 # [depth], run `python3 genchecks-local.py <copy>`, and sweep the last column.
 # Any change that adds a stall reason, lengthens a stage or widens the
 # scoreboard past its three fixed slots has to do that before it lands. The
-# figures the table is checked against are the single hop F + G = 12 and the two
-# hops F + 2G = 18, and `insn 19` and `reg 15 22` clear 18 by one cycle -- the
+# table is checked against the single hop F + G = 12 and the two hops
+# F + 2G = 18, and `insn 19` and `reg 15 22` clear 18 by one cycle -- the
 # thinnest margin here.
 #
-# The first column of a [depth] line is RISCV_FORMAL_RESET_CYCLES, which
-# checks/rvfi_testbench.sv wires to the CHECKER's shadow state only; the DUT is
-# held in reset for cycle 0 regardless. So a two-column check has to clear G
-# over its depth-minus-start window, not F + G, and `reg 15 22` is a window of 7
-# against G = 6 rather than something vacuous.
+# The first column is RISCV_FORMAL_RESET_CYCLES, which checks/rvfi_testbench.sv
+# wires to the CHECKER's shadow state only; the DUT is held in reset for cycle 0
+# regardless. So a two-column check has to clear G over its depth-minus-start
+# window, not F + G, and `reg 15 22` is a window of 7 against G = 6 rather than
+# something vacuous.
 #
-# csrc_upcnt and csrc_any are the only two-retire checks here, and F and G do
-# not bound them: they shadow a value from one retire of a CSR instruction
-# naming the CSR under test and assert against a second, and CSR instructions
-# serialize. Their floor is measured at 9 -- three one-line mutations of
-# rtl/csrs.v each PASS at 6..8 and go red at 9..16 -- and 15 clears it.
+# csrc_upcnt and csrc_any are the only two-retire checks here, and F and G do not
+# bound them: they shadow a value from one retire of a CSR instruction naming the
+# CSR under test and assert against a second, and CSR instructions serialize.
+# Their floor is measured at 9 -- three one-line mutations of rtl/csrs.v each
+# PASS at 6..8 and go red at 9..16 -- and 15 clears it.
 #
 # A depth below its floor does not fail; it goes green having stopped asking.
 # The probe for the 70 insn_* checks: delete rtl/executor.v's `rs2[4:0]` shift
@@ -143,15 +120,14 @@ mscratch any
 # counterexample at the depth below. Sweep `insn` down on that same mutation and
 # the counterexample survives to 5 and disappears at 4, where no instruction can
 # retire and `assume(rvfi_valid && spec_valid)` is unsatisfiable. Reach for it
-# before believing any insn_* result taken under a changed configuration.
-# The three csrc_* checks have one-line probes of their own:
+# before believing any insn_* result taken under a changed configuration. The
+# three csrc_* checks have one-line probes of their own:
 # `assign mcycle_plus = mcycle;`, `assign minstret_plus = minstret;`, and
 # deleting `MSCRATCH: mscratch <= warl;` from rtl/csrs.v.
 #
-# Depths move only on evidence, in either direction (ADR-0025). There is no
-# per-check wall bound, and the ladder's only budget is the `formal` job's
-# `timeout-minutes: 20` against a 4m22s whole-job measurement, so a raised depth
-# that stops converging takes the four hand-authored tasks down with it.
+# Depths move only on evidence, in either direction, and there is no per-check
+# wall bound -- the only budget is the `formal` job's `timeout-minutes: 20`, so a
+# raised depth that stops converging takes the hand-authored tasks down with it.
 #
 # All of the above assumes RISCV_FORMAL_ALTOPS (see [defines]). Without it the
 # real divider holds executor_out.valid for 32 cycles, F becomes ~37 and G ~36,

--- a/formal/complete.sv
+++ b/formal/complete.sv
@@ -2,8 +2,8 @@ module rvfi_testbench (
   input var clk,
   output logic [31:0] imem_addr,
   input  logic [31:0] imem_data,
-  // The dual-word fetch window's second word (ADR-0003), left fully free per
-  // cycle for the same reason imem_data is.
+  // The fetch window's second word, left free every cycle for the same reason
+  // imem_data is.
   output logic [31:0] imem_addr2,
   input  logic [31:0] imem_data2,
   output logic [31:0] mem_addr,
@@ -19,28 +19,17 @@ module rvfi_testbench (
   logic trap;
 
   // A one-address write-through shadow of the data bus: the most recent store
-  // only, not a memory array. Without it mem_rdata is free every cycle (see
-  // wrapper.v), and a load that did not see back what an earlier store in the
-  // same trace wrote would fail rvfi_isa_rv32imc's spec check for reasons that
-  // have nothing to do with the core. A read of an address some earlier,
-  // since-overwritten store touched is still left free. dmemcheck.sv carries
-  // the fuller version of this argument.
+  // only, not a memory array. Without it mem_rdata is free every cycle, and a
+  // load that did not see back what an earlier store in the same trace wrote
+  // would fail the spec check for reasons that have nothing to do with the core.
+  // A read of an address some earlier, since-overwritten store touched is still
+  // left free. dmemcheck.sv carries the fuller version of this argument, and
+  // imem needs none of it because rtl/fetcher.v answers combinationally.
   //
-  // imem is deliberately NOT made stable this way: rtl/fetcher.v drives
-  // imem_addr = pc and out.instr = imem_data combinationally, with no
-  // cross-cycle latency, so nothing here depends on two cycles' fetches of the
-  // same address agreeing.
-  //
-  // Nothing discharges this assumption, and there is no structural argument
-  // behind it either (ADR-0049 F4). The only writable memory in the tree is
-  // rtl/memory.v, which answers any address at or past 4*RAM with
-  // `mem_rdata <= mem_wdata` rather than with stored data, while mem_addr here
-  // is a free 32-bit value -- so the modelled memory and the real module
-  // disagree over most of the address space, and test/mem_tb.v never says what
-  // an out-of-range read returns. Do not invent a discharge for it. What limits
-  // the damage is that it constrains a DUT input rather than the core, so it
-  // can only shrink the trace set, never make the core's job easier on a trace
-  // that survives.
+  // Nothing discharges this assumption and there is no structural argument
+  // behind it either, so do not invent a discharge. What limits the damage is
+  // that it constrains a DUT input rather than the core, so it can only shrink
+  // the trace set, never make the core's job easier on a trace that survives.
   logic [31:0] dmem_shadow;
   logic [31:0] dmem_shadow_addr;
   logic        dmem_shadow_valid = 0;
@@ -60,9 +49,8 @@ module rvfi_testbench (
       assume(mem_rdata == dmem_shadow);
   end
 
-  // The fetch address one cycle early. Unread here, since this environment
-  // answers imem_data in the same cycle, but connected rather than left
-  // dangling.
+  // Unread here, since this environment answers imem_data in the same cycle,
+  // but connected rather than left dangling.
   logic [31:0] imem_addr_next;
   logic        mem_ren;
   logic        fetch_stall;
@@ -127,28 +115,20 @@ module rvfi_testbench (
     .spec_mem_wdata(spec_mem_wdata)
   );
 
-  // The declared exclusion set.
-  //
   // riscv-formal ships no spec model at all for two opcode classes at the pin,
   // so spec_valid is 0 on every such retire and the assertion below fails on
-  // correct hardware. Measured with `insn_excluded` forced to 0: FAIL at step
-  // 5, on a non-trapping FENCE retire the model has never heard of. To
-  // reproduce, copy this file and complete.sby under another name and edit the
-  // copy -- check-complete-exclusions.py rejects an insn_excluded that is not
-  // the disjunction of the declared wires, so editing in place will not run.
+  // correct hardware. Measured with `insn_excluded` forced to 0: FAIL at step 5,
+  // on a non-trapping FENCE retire the model has never heard of.
   //
-  // Excluding an opcode from an assertion is weakening a check, admissible only
-  // if recorded (ADR-0010, one level up). Each entry names its encoding and its
-  // reason, formal/COMPLETE_EXCLUSIONS carries the same set as a baseline, and
-  // check-complete-exclusions.py compares the two in both directions before
-  // this check may run. It also re-derives "no spec model at the pin" from the
-  // clone, so an entry that stops being true at a future pin fails rather than
-  // quietly over-excluding.
+  // Excluding an opcode weakens a check, which is admissible only if recorded.
+  // formal/COMPLETE_EXCLUSIONS carries the same set as a baseline and
+  // check-complete-exclusions.py compares the two both ways before this check
+  // may run, re-deriving "no spec model at the pin" from the clone so an entry
+  // that stops being true fails rather than quietly over-excluding.
   //
-  // Each predicate keys on the encoding out of rvfi_insn and on nothing the
-  // core decodes, so a core that wrongly decodes an ADD as a FENCE cannot
-  // excuse itself from its own check -- it still retires an OP encoding and is
-  // still asserted on. check-complete-exclusions.py enforces that shape
+  // Each predicate keys on the encoding out of rvfi_insn and on nothing the core
+  // decodes, so a core that wrongly decodes an ADD as a FENCE cannot excuse
+  // itself from its own check. check-complete-exclusions.py enforces that shape
   // textually, because a one-line edit to use a decoder flag instead would not
   // look like it had broken anything.
   //
@@ -159,38 +139,34 @@ module rvfi_testbench (
   wire [6:0]  insn_opcode       = rvfi_insn[6:0];
 
   // EXCLUDE MISC-MEM 0001111 fence fence.i
-  //   No spec model at the pin. rtl/decoder.v makes both the NOPs ADR-0005
-  //   specifies, and they retire non-trapping, so unlike ecall/ebreak they are
-  //   not already excused by the !rvfi_trap guard below. This is the class the
-  //   measured failure above came from.
+  //   No spec model at the pin. rtl/decoder.v makes both NOPs and they retire
+  //   non-trapping, so unlike ecall/ebreak they are not already excused by the
+  //   !rvfi_trap guard below. This is the class the failure above came from.
   wire exclude_misc_mem = insn_uncompressed && insn_opcode == 7'b0001111;
 
   // EXCLUDE SYSTEM 1110011 ecall ebreak mret wfi csrrw csrrs csrrc csrrwi csrrsi csrrci
-  //   No spec model at the pin for any of the ten -- the whole of M3's
-  //   behaviour. `mret`, `wfi` and the six csrr* forms retire non-trapping and
-  //   would otherwise fail here; `ecall`/`ebreak` are already excused by the
-  //   !rvfi_trap guard and are named anyway, because this entry states which
-  //   encodings have no oracle rather than which reach the assertion today.
-  //   What checks them instead: test/asm/trap.S, test/asm/csr.S,
-  //   test/csr_tb.v, test/decoder_tb.v and rtl/decoder.v's component proof --
-  //   this repo's own assertions, not an oracle.
+  //   No spec model at the pin for any of the ten. `ecall`/`ebreak` are already
+  //   excused by the !rvfi_trap guard and are named anyway, because this entry
+  //   states which encodings have no oracle rather than which reach the
+  //   assertion today. What checks them instead is this repo's own assertions:
+  //   test/asm/trap.S, test/asm/csr.S, test/csr_tb.v, test/decoder_tb.v and the
+  //   decoder and traps proofs.
   wire exclude_system = insn_uncompressed && insn_opcode == 7'b1110011;
 
   wire insn_excluded = exclude_misc_mem || exclude_system;
 
   // There is no compressed entry, and that is a result. The one compressed
-  // encoding this core implements that isa_rv32imc.txt does not name is
-  // C.EBREAK (16'h9002, ADR-0048), and it raises breakpoint -- so it reaches
-  // the assertion only if the core reports it as a non-trapping retire, at
-  // which point spec_valid is 0 and this check fires. Excluding it would throw
-  // that away.
+  // encoding this core implements that isa_rv32imc.txt does not name is C.EBREAK
+  // (16'h9002), and it raises breakpoint -- so it reaches the assertion only if
+  // the core reports it as a non-trapping retire, at which point spec_valid is 0
+  // and this check fires. Excluding it would throw that away.
 
   // The !rvfi_trap term is core-supplied, unlike the exclusion predicate, and
-  // has to be: a trapping retire has no spec-value obligation (ADR-0028), and
-  // an illegal encoding retires with rvfi_trap and has no spec model by
-  // definition, so `assert(spec_valid)` cannot be hoisted out of the guard. The
-  // cost is that a core claiming rvfi_trap on everything would pass this
-  // vacuously, which is what the cover goals below exist to rule out.
+  // has to be: a trapping retire has no spec-value obligation, and an illegal
+  // encoding retires with rvfi_trap and has no spec model by definition, so
+  // `assert(spec_valid)` cannot be hoisted out of the guard. The cost is that a
+  // core claiming rvfi_trap on everything would pass this vacuously, which is
+  // what the cover goals below rule out.
   always_comb begin
     if (!reset && rvfi_valid && !rvfi_trap && !insn_excluded) begin
       assert(spec_valid && !spec_trap);
@@ -200,19 +176,17 @@ module rvfi_testbench (
   // Anti-vacuity: every non-excluded opcode class really does retire. sby's
   // `mode bmc` strips cover cells and `mode cover` strips assertions, so these
   // are inert in complete.sby's run and are the whole of complete_cover.sby's.
-  // Each goal is a non-trapping, non-excluded retire of one class -- a cycle on
-  // which the assertion above was live and had something to say.
   //
-  // `complete_live` repeats the assertion's guard as a wire rather than a
-  // macro: a macro leaks into every file read after it in the same yosys
-  // invocation, and sby reports a macro-expanded cover statement against the
-  // macro's source range, so all twelve goals would resolve to overlapping
-  // spans and could not be told apart in the summary.
+  // `complete_live` repeats the assertion's guard as a wire rather than a macro.
+  // A macro leaks into every file read after it in the same yosys invocation,
+  // and sby reports a macro-expanded cover statement against the macro's source
+  // range, so all twelve goals would resolve to overlapping spans and could not
+  // be told apart in the summary.
   //
   // `insn_excluded` is redundant on the nine uncompressed goals and kept for
-  // that reason: a future exclusion that shadowed one of these classes makes
-  // the goal unreachable and fails this task, instead of leaving the assertion
-  // quiet with nothing to say.
+  // that reason: a future exclusion that shadowed one of these classes makes the
+  // goal unreachable and fails this task, instead of leaving the assertion quiet
+  // with nothing to say.
   wire complete_live = !reset && rvfi_valid && !rvfi_trap && !insn_excluded;
   cover property (complete_live && insn_uncompressed && insn_opcode == 7'b0000011); // LOAD
   cover property (complete_live && insn_uncompressed && insn_opcode == 7'b0010011); // OP-IMM

--- a/rtl/csrs.v
+++ b/rtl/csrs.v
@@ -1,42 +1,28 @@
 `timescale 1 ns / 1 ps
 `default_nettype none
 `include "structs.v"
-// The machine-mode CSR file (ADR-0005).
-//
-// This is a sibling of the decoder, not a pipeline stage. Every access is read
-// and committed in decode on the same edge the accessing instruction issues, so
-// no CSR state exists downstream: nothing to forward, nothing to replay, and no
-// "what does mcycle read with three instructions in flight" corner. CSR
+// A sibling of the decoder, not a pipeline stage. Every access is read and
+// committed in decode on the same edge the accessing instruction issues, so no
+// CSR state exists downstream: nothing to forward and nothing to replay. CSR
 // instructions serialize, and rtl/decoder.v is what holds them; this module has
 // no idea a stall exists.
 //
-// The set below is a floor, not a closed list: every register the privileged
+// The set below is a floor, not a closed list. Every register the privileged
 // spec lists unconditionally for RV32 machine mode is here, because trapping on
 // a mandatory register is non-conformant however minimal the set is.
 //
-// Trap entry and `mret` are the second write port, and the only architectural
-// CSR update no CSR instruction performs. They arrive from the decoder on the
-// edge the trapping instruction issues, because that is where every trap is
-// detected and committed. `mtvec_value`/`mepc_value` go back out
-// to the decoder, which owns the PC and therefore has to redirect it.
-//
 // This module never decides that an access is illegal. `implemented` feeds the
-// decoder's `instr_valid` term and the read-only test is on the address
-// (addr[11:10] == 2'b11), so both illegal-CSR rules are decided in
-// rtl/decoder.v alongside every other trap cause (ADR-0030).
+// decoder's `instr_valid` term and the read-only test is on the address, so both
+// illegal-CSR rules are decided in rtl/decoder.v with every other trap cause.
 module csrs(
   input  logic clk,
   input  logic reset,
 
-  // The decode-stage access port. `addr` is instr[31:20], presented
-  // combinationally every cycle; `rdata` and `implemented` answer it the same
-  // cycle, because the decoder needs the read value in time to register it into
-  // decoder_out at this edge.
-  //
-  // `ren`/`wen` describe the instruction the decoder is issuing this edge.
-  // Zicsr's suppression rules (CSRRS/CSRRC with a zero source suppress the
-  // write; CSRRW with rd == x0 suppresses the read) are resolved in the decoder,
-  // where the operand fields live, so `wen` here means "commit this".
+  // `addr` is instr[31:20], presented every cycle; `rdata` and `implemented`
+  // answer it the same cycle, because the decoder needs the read value in time
+  // to register it into decoder_out at this edge. Zicsr's suppression rules are
+  // resolved in the decoder, where the operand fields live, so `wen` here means
+  // "commit this".
   input  logic [11:0] addr,
   input  logic        ren,
   input  logic        wen,
@@ -45,16 +31,14 @@ module csrs(
   output logic        implemented,
 
   // minstret counts non-trapping issues, so this is high for exactly the cycles
-  // the decoder issues one (ADR-0027).
+  // the decoder issues one.
   input  logic        instret,
 
-  // `trap_entry` is high for exactly the cycle the decoder commits a trap;
-  // `mret_entry` for exactly the cycle it commits an `mret`. They cannot
-  // coincide with each other (a trapping instruction does not also execute) nor
-  // with `wen` (the decoder gates `csr_wen` on a non-trapping commit, and `mret`
-  // is not a CSR access), so the three write paths below need no priority
-  // between them -- the code states the exclusion rather than relying on
-  // last-assignment-wins (ADR-0028).
+  // `trap_entry` is high for exactly the cycle the decoder commits a trap and
+  // `mret_entry` for the cycle it commits an `mret`. They cannot coincide with
+  // each other (a trapping instruction does not also execute) nor with `wen`
+  // (the decoder gates `csr_wen` on a non-trapping commit, and `mret` is not a
+  // CSR access), so the three write paths below need no priority between them.
   input  logic        trap_entry,
   input  logic [31:0] trap_cause,
   input  logic [31:0] trap_epc,
@@ -65,9 +49,8 @@ module csrs(
  `ifdef RISCV_FORMAL
   ,
   // Shadow payloads for exactly the CSRs formal/checks.cfg's `[csrs]` list
-  // names. Combinational off this cycle's access; the decoder latches them into
-  // the issuing instruction's shadow so they ride to writeback on the ordinary
-  // valid-bit protocol.
+  // names. The decoder latches them into the issuing instruction's shadow, so
+  // they ride to writeback on the ordinary valid-bit protocol.
   output rvfi_csr64 rvfi_mcycle,
   output rvfi_csr64 rvfi_minstret,
   output rvfi_csr32 rvfi_mscratch
@@ -75,9 +58,9 @@ module csrs(
 );
   localparam logic [11:0] MSTATUS   = 12'h300;
   localparam logic [11:0] MISA      = 12'h301;
-  // Both read-only zero, and zero is a legal value for each rather than a stub:
+  // Both read-only zero, and zero is legal for each rather than a stub:
   // mstatush's only fields are SBE and MBE, where 0 means the little-endian
-  // M-mode data accesses this core does, and mconfigptr = 0 is the spec's own
+  // M-mode accesses this core does, and mconfigptr = 0 is the spec's own
   // encoding for "no configuration data structure exists".
   localparam logic [11:0] MSTATUSH  = 12'h310;
   localparam logic [11:0] MCONFIGPTR = 12'hF15;
@@ -106,10 +89,9 @@ module csrs(
   // (WARL, and this core has no other mode) and every other bit is 0.
   logic        mstatus_mie, mstatus_mpie;
 
-  // Halves of the two counters, selected out here rather than inside the
-  // always_* blocks below. A constant part-select taken inside an always_* block
-  // defeats iverilog's sensitivity analysis and draws a `sorry:` note, so this
-  // file uses named continuous assigns throughout (ADR-0034).
+  // Selected out here rather than inside the always_* blocks below: a constant
+  // part-select taken inside one defeats iverilog's sensitivity analysis and
+  // draws a `sorry:` note. Use a named continuous assign for any added later.
   logic [31:0] mcycle_lo, mcycle_hi, minstret_lo, minstret_hi;
   assign mcycle_lo   = mcycle[31:0];
   assign mcycle_hi   = mcycle[63:32];
@@ -120,11 +102,10 @@ module csrs(
   // MPP = 2'b11 at [12:11]; MPIE at [7]; MIE at [3]; everything else 0.
   assign mstatus_value = {19'b0, 2'b11, 3'b0, mstatus_mpie, 3'b0, mstatus_mie, 3'b0};
 
-  // The two registers the decoder redirects the PC through, as of the start of
-  // the issuing cycle. That phase is the right one: decode issues at most one
-  // instruction per cycle, so a trapping instruction and a `csrw mtvec` are
-  // never the same edge, and the trap must vector through the mtvec that was
-  // architecturally in place when it issued.
+  // As of the start of the issuing cycle, which is the right phase: decode
+  // issues at most one instruction per cycle, so a trapping instruction and a
+  // `csrw mtvec` are never the same edge, and the trap must vector through the
+  // mtvec that was in place when it issued.
   assign mtvec_value = mtvec;
   assign mepc_value  = mepc;
 
@@ -155,15 +136,13 @@ module csrs(
   end
 
   // `warl` is the value the addressed CSR holds after this write, with the
-  // legal-value mask already applied. It is defined for every address, including
-  // the read-only ones (where it falls back to `rdata`), and that uniformity is
-  // what lets the RVFI report below tell the truth about what landed rather than
-  // echo back an operand the mask threw away.
+  // legal-value mask applied. It is defined for every address, including the
+  // read-only ones, and that is what lets the RVFI report below say what landed
+  // rather than echo back an operand the mask threw away.
   logic [31:0] wdata_mtvec, wdata_mepc, wdata_mstatus;
-  // Direct mode only: mtvec[1:0] is the mode field, and a 4-byte-aligned
-  // base leaves it zero either way.
+  // Direct mode only: mtvec[1:0] is the mode field.
   assign wdata_mtvec   = {wdata[31:2], 2'b00};
-  // Only bit 0 is forced: C makes 2-byte branch targets legal, so bit 1 is a
+  // Only bit 0 is forced. C makes 2-byte branch targets legal, so bit 1 is a
   // legal value here and must survive.
   assign wdata_mepc    = {wdata[31:1], 1'b0};
   assign wdata_mstatus = {19'b0, 2'b11, 3'b0, wdata[7], 3'b0, wdata[3], 3'b0};
@@ -187,12 +166,11 @@ module csrs(
   assign warl_mie  = warl[3];
   assign warl_mpie = warl[7];
 
-  // Trap entry writes mepc through the same WARL mask an explicit `csrw mepc`
-  // goes through. `trap_epc` is an instruction address, so bit 0 is already
-  // clear and the mask changes nothing today; what it states is that bit 1 is
-  // preserved, because a mask that cleared it too would resume two bytes early
-  // after a fault at `pc % 4 == 2`. test/asm/trap.S faults a compressed
-  // instruction at exactly that alignment.
+  // Trap entry writes mepc through the same mask an explicit `csrw mepc` goes
+  // through. `trap_epc` is an instruction address, so bit 0 is already clear and
+  // the mask changes nothing today; what it states is that bit 1 survives,
+  // because clearing it too would resume two bytes early after a fault at
+  // `pc % 4 == 2`. test/asm/trap.S faults at exactly that alignment.
   logic [31:0] trap_epc_warl;
   assign trap_epc_warl = {trap_epc[31:1], 1'b0};
 
@@ -203,17 +181,14 @@ module csrs(
   assign wr_minstreth = wen && addr == MINSTRETH;
   assign wr_mscratch  = wen && addr == MSCRATCH;
 
-  // "Any CSR write takes precedence over the automatic increment" (priv spec
-  // 20211203 §3.1.11) is a statement about the 64-bit COUNTER, not about the
-  // half whose address the instruction names: mcycle and mcycleh are two views
-  // of one register, so a write to either half suppresses that cycle's increment
-  // of the whole thing. Hence a `_tick` term per counter rather than the two
-  // per-half overrides below doing the job alone.
-  //
-  // Suppressing per half instead differs only at the carry boundary, where the
-  // increment's carry lands in the high half while the write replaces the low
-  // one -- so `csrw mcycle` advances mcycleh. test/csr_tb.v is the only thing
-  // that can see it (ADR-0048).
+  // "Any CSR write takes precedence over the automatic increment" is about the
+  // 64-bit counter, not the half whose address the instruction names: mcycle and
+  // mcycleh are two views of one register, so a write to either half suppresses
+  // that cycle's increment of the whole thing. Hence a `_tick` term per counter
+  // rather than the per-half overrides below doing it alone. Suppressing per
+  // half differs only at the carry boundary, where the carry lands in the high
+  // half while the write replaces the low one, so `csrw mcycle` would advance
+  // mcycleh. test/csr_tb.v is the only thing that sees it.
   logic mcycle_tick, minstret_tick;
   assign mcycle_tick   = !wr_mcycle   && !wr_mcycleh;
   assign minstret_tick = !wr_minstret && !wr_minstreth && instret;
@@ -239,10 +214,9 @@ module csrs(
       mcycle       <= 64'b0;
       minstret     <= 64'b0;
       mscratch     <= 32'b0;
-      // The spec leaves mtvec's reset value implementation-defined. 0 puts it
-      // at test/asm/sections.lds's .text, so both sim legs catch a trap taken
-      // before a handler is installed rather than let it look like a silent
-      // program restart (ADR-0029).
+      // The spec leaves mtvec's reset value implementation-defined. 0 puts it at
+      // the base of .text, so both sim legs catch a trap taken before a handler
+      // is installed rather than let it look like a silent program restart.
       mtvec        <= 32'b0;
       mepc         <= 32'b0;
       mcause       <= 32'b0;
@@ -263,21 +237,18 @@ module csrs(
           MEPC:     mepc     <= warl;
           MCAUSE:   mcause   <= warl;
           // The counters are driven unconditionally above, with an explicit
-          // write folded into *_next so it beats the increment. Every other
-          // address is read-only or unimplemented.
+          // write folded into *_next so it beats the increment.
           default: ;
         endcase
       end
       // The privileged-spec sequence: a trap saves the faulting PC and the
       // cause, pushes MIE into MPIE and disables interrupts; `mret` pops it back
-      // and leaves MPIE set. This core has no interrupts (mie/mip are read-only
-      // zero), so MIE/MPIE gate nothing and are only observable through mstatus
-      // -- nothing but test/csr_tb.v would notice them being wrong.
-      //
-      // `else if` rather than two independent `if`s: the two are mutually
-      // exclusive by construction (see the port comments), and stating that here
-      // means a future cause that broke it fails at rtl/decoder.v's priority
-      // encoder rather than silently double-writing mstatus.
+      // and leaves MPIE set. This core has no interrupts, so MIE/MPIE gate
+      // nothing and only test/csr_tb.v would notice them being wrong. `else if`
+      // rather than two independent `if`s because the two are mutually exclusive
+      // by construction (see the port comments), so a future cause that broke
+      // that fails at rtl/decoder.v's priority encoder rather than silently
+      // double-writing mstatus.
       if (trap_entry) begin
         mepc         <= trap_epc_warl;
         mcause       <= trap_cause;
@@ -292,14 +263,14 @@ module csrs(
 
  `ifdef RISCV_FORMAL
   // Write-only with respect to the core: nothing below drives a signal any
-  // non-`ifdef` logic reads. That is the structural argument the
-  // non-perturbation guarantee rests on (ADR-0047), so do not break it.
+  // non-`ifdef` logic reads. That is what `make -C formal nonperturbation` rests
+  // on, so do not break it.
   //
   // The two counters are one 64-bit RVFI CSR each, with mcycleh/minstreth
   // addressing the upper half of the same report, which is why the masks are
   // built per half. rvfi_csrw_check asserts that a write through the low address
-  // leaves the high half unchanged, computed from these reported values, so a
-  // mask claiming both halves fails on a correct core.
+  // leaves the high half unchanged, so a mask claiming both fails on a correct
+  // core.
   logic rd_mcycle, rd_mcycleh, rd_minstret, rd_minstreth, rd_mscratch;
   assign rd_mcycle    = ren && addr == MCYCLE;
   assign rd_mcycleh   = ren && addr == MCYCLEH;
@@ -309,9 +280,7 @@ module csrs(
 
   // What the instruction wrote, which is not what the register will hold: the
   // free-running increment is not this instruction's doing, and RVFI's wdata is
-  // the instruction's write. Reporting the incremented value with a zero wmask
-  // would be harmless (rvfi_csrw_check masks it away) but would read as though
-  // the CSR instruction had bumped the counter.
+  // the instruction's write.
   logic [31:0] mcycle_next_lo_reported, mcycle_next_hi_reported;
   logic [31:0] minstret_next_lo_reported, minstret_next_hi_reported;
   assign mcycle_next_lo_reported   = wr_mcycle    ? warl : mcycle_lo;

--- a/rtl/executor.v
+++ b/rtl/executor.v
@@ -5,26 +5,22 @@ module executor(
   input  logic clk,
   input  logic reset,
 
-  // inputs
   input  decoder_output in,
-  // High for the one cycle a load's response is still in flight in the accessor
-  // (ADR-0015). The executor is upstream of it and must freeze rather than
-  // advance, or a fresh instruction collides with the completing load over the
-  // accessor's single output register and the single-port memory bus.
+  // High for the one cycle a load's response is still in flight in the
+  // accessor. Freeze rather than advance, or a fresh instruction collides with
+  // the completing load over the accessor's single output register.
   input  logic accessor_stall,
-  // outputs
   output executor_output out,
-  // Broadcast to littlecpu.v, and from there back to the decoder, whenever a
-  // multi-cycle divide is in flight.
+  // High while a multi-cycle divide runs. littlecpu.v routes it back to decode.
   output logic stalled
 );
   logic [31:0] rs1, rs2;
   assign rs1 = in.rs1;
   assign rs2 = in.rs2;
 
-  // Signed div/rem operate on the two's-complement magnitude of the operands; the
-  // restoring divider below only performs unsigned division. Quotient/remainder signs
-  // are restored from the original operand signs once the loop completes.
+  // The restoring divider below only divides unsigned, so signed div/rem hand it
+  // the magnitudes. The result signs are restored from the original operand
+  // signs once the loop finishes.
   logic [31:0] div_x, div_y;
   assign div_x = (in.is_div || in.is_rem) && rs1[31] ? -rs1 : rs1;
   assign div_y = (in.is_div || in.is_rem) && rs2[31] ? -rs2 : rs2;
@@ -38,26 +34,21 @@ module executor(
   always_comb
     stalled = state != init;
 
-  // Once decode is stalled for a divide it bubbles, rather than holding `in`
-  // unchanged, so that the executor cannot misread a stale in-flight instruction
-  // the moment it returns to `init` (ADR-0009). `in` is therefore not to be
-  // trusted at completion time, and the op-select and operand signs the last
+  // Decode bubbles rather than holding `in` while a divide runs, so `in` cannot
+  // be read when the divide completes. The op-select and operand signs the last
   // iteration needs are latched here at issue instead.
   logic op_is_div, op_is_divu, op_is_rem, op_is_remu, op_sign_x, op_sign_y;
 
  `ifdef RISCV_FORMAL_ALTOPS
-  // The operands as latched by the ALTOPS issue arm below, named so the
-  // completion arm reads them as operands rather than as slices of the divider's
-  // working registers. Raw rs1/rs2: ALTOPS does no magnitude conversion, so the
-  // sign wrapper above does not apply.
+  // Named so the completion arm reads these as operands rather than as slices of
+  // the divider's working registers. ALTOPS does no magnitude conversion.
   logic [31:0] div_alt_rs1, div_alt_rs2;
   assign div_alt_rs1 = mul_div_x[31:0];
   assign div_alt_rs2 = mul_div_y[62:31];
  `endif
 
-  // Continuous assignments, so the product tracks the operands every cycle
-  // instead of being latched once at time 0. sign_x covers is_mulh (signed rs1)
-  // and is_mulhsu (rs1 signed, rs2 unsigned); sign_y covers only is_mulh.
+  // sign_x covers is_mulh (rs1 signed) and is_mulhsu (rs1 signed, rs2
+  // unsigned); sign_y covers only is_mulh.
   logic mul_sign_x, mul_sign_y;
   assign mul_sign_x = in.rs1[31] & (in.is_mulh | in.is_mulhsu);
   assign mul_sign_y = in.rs2[31] & in.is_mulh;
@@ -79,22 +70,17 @@ module executor(
       op_sign_x <= 0;
       op_sign_y <= 0;
     end else if (accessor_stall) begin
-      // Freeze: emit a bubble and hold every other register unchanged. This
-      // never overlaps a divide in progress, because decode freezes everything
-      // upstream while dividing, so no load can reach the accessor until the
-      // divide has drained.
+      // This never overlaps a divide: decode freezes everything upstream while
+      // dividing, so no load can reach the accessor until the divide finishes.
       out <= 0;
     end else begin
       (* parallel_case, full_case *)
       case (state)
         init: begin
-          // A bubble propagates straight through, except on the cycle a divide
-          // issues, where out.valid is held low below until it completes.
           out.valid <= in.valid;
          `ifdef RISCV_FORMAL
-          // Latched at issue for the same reason as op_is_div/op_sign_x below,
-          // as are out.rd and out.rd_data: this is the only cycle `in` is
-          // trustworthy for a divide.
+          // Latched at issue for the same reason op_is_div is: this is the only
+          // cycle `in` can be read for a divide.
           out.rvfi <= in.rvfi;
          `endif
           out.rd <= in.rd;
@@ -114,8 +100,7 @@ module executor(
             in.is_add: out.rd_data <= rs1 + rs2;
             in.is_lui: out.rd_data <= rs1;
             in.is_sub: out.rd_data <= rs1 - rs2;
-            // The RV32I shift amount is rs2[4:0] only (spec Vol I §2.4.2): the
-            // upper 27 bits are ignored, not folded in as a wider count.
+            // The RV32I shift amount is rs2[4:0]; the upper 27 bits are ignored.
             in.is_sll: out.rd_data <= rs1 << rs2[4:0];
             in.is_slt: out.rd_data <= {31'b0, $signed(rs1) < $signed(rs2)};
             in.is_sltu: out.rd_data <= {31'b0, rs1 < rs2};
@@ -143,9 +128,8 @@ module executor(
             end
 
             in.is_div || in.is_divu || in.is_rem || in.is_remu: begin
-              // Latched regardless of which sub-path fires below: harmless for
-              // the short-circuits, which never leave `init` and so never read
-              // them back, and required for the real divide.
+              // Latched whichever sub-path fires below. The short-circuits never
+              // leave `init` and never read them back; the real divide does.
               op_is_div <= in.is_div;
               op_is_divu <= in.is_divu;
               op_is_rem <= in.is_rem;
@@ -153,8 +137,8 @@ module executor(
               op_sign_x <= in.rs1[31];
               op_sign_y <= in.rs2[31];
              `ifndef RISCV_FORMAL_ALTOPS
-              // The two specified results (spec Vol I §7.2). Both stay in
-              // `init`, so neither enters the divider.
+              // The two architecturally specified results. Both stay in `init`,
+              // so neither enters the divider.
               if (rs2 == 0) begin
                 if (in.is_rem || in.is_remu) out.rd_data <= rs1; // remainder = dividend
                 else out.rd_data <= 32'hffffffff; // quotient = -1 (div) or MAX_UINT (divu)
@@ -169,9 +153,8 @@ module executor(
                 mul_div_store <= 0;
                 mul_div_x <= {32'b0, div_x};
                 mul_div_y <= {1'b0, div_y, 31'b0};
-                // The result is not ready this cycle, so downstream drains a
-                // bubble rather than a repeat of whatever the executor last held
-                // (ADR-0009).
+                // The result is not ready this cycle, so send a bubble rather
+                // than a repeat of whatever the executor last held.
                 out.valid <= 1'b0;
               end
              `else
@@ -183,9 +166,9 @@ module executor(
               out.valid <= 1'b0;
              `endif
             end
-            // A Zicsr access never appears here: rtl/csrs.v reads and commits it
-            // in decode (ADR-0005), and the read result arrives as `is_add` with
-            // rs2 zeroed, so by this stage it is an add.
+            // A Zicsr access never appears here. rtl/csrs.v reads and commits it
+            // in decode, and the read result arrives as `is_add` with rs2
+            // zeroed, so by this stage it is an add.
             in.is_ecall || in.is_ebreak: ;
             in.is_valid_instr: ;
           endcase // case (1'b1)
@@ -203,8 +186,6 @@ module executor(
             mul_div_y <= mul_div_y >> 1;
             mul_div_counter <= mul_div_counter - 1;
           end else begin
-            // The op-select and sign bits latched at issue, not `in`, which
-            // decode has long since bubbled.
             (* parallel_case, full_case *)
             case (1'b1)
               op_is_div: out.rd_data <= op_sign_x != op_sign_y ? -mul_div_store[31:0] : mul_div_store[31:0];
@@ -216,12 +197,8 @@ module executor(
             state <= init;
           end
          `else
-          // The operands latched at issue, not `in`. ALTOPS collapses the divide
-          // to a single cycle, so by the time this arm runs `in` already holds
-          // the next decoded instruction and the placeholder would be computed
-          // from its operands. The ALTOPS issue arm latches raw rs1/rs2 rather
-          // than ADR-0012's magnitudes, which is what riscv-formal's placeholder
-          // model expects.
+          // ALTOPS collapses the divide to one cycle, so by the time this arm
+          // runs `in` already holds the next instruction.
           (* parallel_case, full_case *)
           case (1'b1)
             op_is_div: out.rd_data <= (div_alt_rs1 - div_alt_rs2) ^ 32'h7f8529ec;
@@ -239,57 +216,36 @@ module executor(
   end
 
  `ifdef FORMAL
-  // The executor component proof. The multiplication operator itself is checked
-  // differentially rather than exhaustively -- there is no miter here between
-  // two 32x32 products, because such a miter returns no verdict in two minutes
-  // even standing alone (no divider, no pipeline state, no cap, `mode bmc depth
-  // 1`): the obstacle is two structurally distinct `bvmul` terms, and neither
-  // bit width nor engine moves it. What is proved instead is everything around
-  // the product -- the 33-bit operands the multiplier is handed, the slice of it
-  // each variant retires, and three lemmas over the term itself that multiply by
-  // a CONSTANT, which a solver sees as shifts and adds. The residual, a `*`
-  // wrong for some operand pair no lemma names, is covered by test/exec_tb.v's
-  // >= 10,000 randomized vectors per op, which ADR-0010 makes the primary
-  // guarantee for this arithmetic (ADR-0051; ADR-0012 made the same move for
-  // the divider).
+  // There is no miter between two 32x32 products: one returns no verdict in two
+  // minutes even standing alone, because the obstacle is two structurally
+  // distinct `bvmul` terms and neither bit width nor engine moves it. What is
+  // proved instead is everything around the product, plus three lemmas that
+  // multiply by a constant. A `*` wrong for some operand pair no lemma names is
+  // covered by test/exec_tb.v's randomized vectors.
   logic clocked;
   initial clocked = 0;
   always_ff @(posedge clk) clocked <= 1;
-  // Assumed: reset is asserted before the first clock edge. Every harness that
-  // instantiates this core drives it high initially, but no check asserts that,
-  // so this is discharged nowhere. It is unguarded and therefore in force over
-  // every assertion here, which is what it was written for -- `state` and the
-  // mul_div registers have no defined value before the first edge (ADR-0049).
+  // Assumed: reset is asserted before the first clock edge. True of every
+  // harness in the tree and asserted by none, so nothing discharges it, and
+  // `state` and the mul_div registers have no defined value before that edge.
   initial assume(reset);
   always_comb if(!clocked) assume(reset);
   // Otherwise the solver may start mid-divide, for free, at step 0.
   initial state = init;
-  // Assumed: reset never returns after the first cycle. True of every harness in
-  // the tree and asserted by none, so again discharged nowhere. It was written
-  // for the divide-family assertions, which span many cycles and where a
-  // re-asserted reset would jump from `divide` to `init` with out.rd_data zeroed
-  // by the reset branch rather than computed by the divider. Being unguarded its
-  // scope is larger than that: it equally excuses the multiply section and the
-  // freeze block from ever seeing a mid-trace reset, which is harmless because a
-  // re-asserted reset is not a real environment.
+  // Assumed: reset never returns after the first cycle. Discharged nowhere
+  // either. Without it a re-asserted reset jumps to `init` mid-divide with
+  // out.rd_data zeroed by the reset branch rather than computed.
   always_comb if (clocked) assume(!reset);
 
-  // This proof stands alone with no accessor, so accessor_stall is left a free
-  // input -- not even ADR-0015's at-most-one-consecutive-cycle bound is assumed,
-  // which makes it stronger than the real environment. The price is the
-  // `!$past(accessor_stall)` guard on each of the four multiply slice assertions
-  // below: a frozen edge computes nothing, so an ungated assertion there would
-  // be asserting arithmetic about a bubble. Nothing else here needs it. The
-  // operand and lemma assertions are combinational over `in` and mention `out`
-  // nowhere, a freeze holds every register the divide invariants read, and the
-  // completion guard ($past(state) == divide && state == init) already implies
-  // an unfrozen edge, since a frozen one cannot change state.
+  // No accessor here, so accessor_stall is a free input -- not even the
+  // at-most-one-consecutive-cycle bound is assumed. The price is the
+  // `!$past(accessor_stall)` guard on the four multiply slice assertions below:
+  // a frozen edge computes nothing, so an ungated one would be asserting
+  // arithmetic about a bubble.
 
-  // The freeze branch itself: the cycle after accessor_stall, the executor
-  // emitted a bubble and held state, the divider datapath and the op/sign
-  // latches unchanged. Guarded on !$past(reset) because reset wins over the
-  // freeze in the RTL, and the pre-reset values of the mul_div registers are
-  // free.
+  // The cycle after accessor_stall, the executor emitted a bubble and held
+  // state, the divider datapath and the op/sign latches. Guarded on
+  // !$past(reset) because reset wins over the freeze in the RTL.
   always_ff @(posedge clk)
     if (clocked && !reset && !$past(reset) && $past(accessor_stall)) begin
       assert(out == '0);
@@ -306,17 +262,13 @@ module executor(
       assert(op_sign_y == $past(op_sign_y));
     end
 
-  // Assumed: the decoder emits at most one op-select flag per instruction. This
-  // proof stands alone, so without it the solver picks combinations no real
-  // instruction produces. It is discharged by rtl/decoder.v's own `$onehot`
-  // assertion under `instr_valid`, in components_decoder, which CI runs -- the
-  // one assume in this repo with a running discharge rather than a structural
-  // argument (ADR-0049). Unguarded, so it is in force over the freeze block and
-  // the divide invariants too, and correctly so.
+  // Assumed: the decoder emits at most one op-select flag per instruction.
+  // Without it the solver picks combinations no real instruction produces.
+  // Discharged by rtl/decoder.v's own `$onehot` assertion under `instr_valid`.
   //
   // All 29 `is_*` fields of `decoder_output` are listed here and
-  // `is_valid_instr` is deliberately not among them. Adding a flag to the struct
-  // without adding it here silently widens the environment for everything below.
+  // `is_valid_instr` deliberately is not. Adding a flag to the struct without
+  // adding it here silently widens the environment for everything below.
   always_comb assume($onehot0({in.is_add, in.is_sub, in.is_xor, in.is_or, in.is_and,
     in.is_sll, in.is_slt, in.is_sltu, in.is_srl, in.is_sra, in.is_lui,
     in.is_mul, in.is_mulh, in.is_mulhu, in.is_mulhsu,
@@ -324,30 +276,17 @@ module executor(
     in.is_lb, in.is_lbu, in.is_lh, in.is_lhu, in.is_lw, in.is_sb, in.is_sh, in.is_sw,
     in.is_ecall, in.is_ebreak}));
 
-  // Multiply, against free 32-bit operands: the divide invariant's cap below is
-  // guarded to the divide family, so nothing here is bounded. It was unguarded
-  // until ADR-0051, and an unguarded assume is proof-global, so these assertions
-  // ran against operands in 0..15 where every high half and every sign bit is
-  // zero -- MULH/MULHU/MULHSU asserted `out.rd_data == 0` and three of the four
-  // multiplier defects ADR-0010 names passed the proof written to catch them.
-  //
-  // Three obligations replace the miter, each returning in seconds:
-  //
-  //   (a) the 33-bit operands handed to `multiply` are the correct extensions
-  //       of rs1/rs2 for the variant being issued;
-  //   (b) the correct SLICE of that same `multiply` term reaches out.rd_data;
-  //   (c) three constant-multiplication lemmas over `multiply` itself.
-  //
-  // (a) and (b) read the same product term the RTL does, so neither can see a
-  // product that is simply wrong. That is why (c) is not optional: it is the
-  // only part of this section that constrains the term's own value.
+  // Multiply, against free 32-bit operands: the divide cap below is guarded to
+  // the divide family. It was unguarded once, and an unguarded assume is
+  // proof-global, so these assertions ran against operands in 0..15 where every
+  // high half and sign bit is zero -- MULH/MULHU/MULHSU asserted
+  // `out.rd_data == 0` and three known multiplier defects passed the proof
+  // written to catch them.
 
-  // (a) MUL and MULHU take both operands unsigned, MULH takes both signed, and
-  // MULHSU takes rs1 signed and rs2 unsigned -- an asymmetry ADR-0010 names
-  // getting backwards as a defect. The extensions are derived by width-extending
-  // assignment from a self-determined right-hand side rather than by restating
-  // the RTL's `in.rs1[31] & (...)`, so a sign taken from the wrong bit disagrees
-  // here.
+  // MUL and MULHU take both operands unsigned, MULH both signed, MULHSU rs1
+  // signed and rs2 unsigned. The extensions are derived by width-extending
+  // assignment rather than by restating the RTL's own sign expression, so a sign
+  // taken from the wrong bit disagrees here.
   logic [32:0] rs1_sext33, rs2_sext33, rs1_zext33, rs2_zext33;
   assign rs1_sext33 = $signed(in.rs1);
   assign rs2_sext33 = $signed(in.rs2);
@@ -356,15 +295,15 @@ module executor(
   logic [32:0] mul_op_x_ref, mul_op_y_ref;
   // The `?:` selects between two already-computed 33-bit nets, with no
   // arithmetic in an arm of it: signed arithmetic in a reference model must be a
-  // self-determined statement of its own, or IEEE 1800's sign-context rules
-  // silently evaluate it unsigned (ADR-0019).
+  // self-determined statement of its own, or the sign-context rules silently
+  // evaluate it unsigned.
   assign mul_op_x_ref = (in.is_mulh || in.is_mulhsu) ? rs1_sext33 : rs1_zext33;
   assign mul_op_y_ref = in.is_mulh ? rs2_sext33 : rs2_zext33;
   always_comb assert({mul_sign_x, in.rs1} == mul_op_x_ref);
   always_comb assert({mul_sign_y, in.rs2} == mul_op_y_ref);
 
-  // (b) Sliced into plain 32-bit signals so the $past() below applies to a
-  // simple signal rather than to a part-select of a $past() result.
+  // Sliced into plain 32-bit signals so the $past() below applies to a simple
+  // signal rather than to a part-select of a $past() result.
   logic [31:0] mul_lo, mul_hi;
   assign mul_lo = multiply[31:0];
   assign mul_hi = multiply[63:32];
@@ -382,74 +321,54 @@ module executor(
     if (clocked && !reset && !$past(reset) && !$past(accessor_stall) && $past(state) == init && $past(in.is_mulhsu))
       assert(out.rd_data == $past(mul_hi));
 
-  // (c) Each of these multiplies by a constant -- zero, zero and one -- so the
-  // solver sees shifts and adds rather than a second `bvmul` term. They catch
-  // what (a) and (b) structurally cannot: a masked high half, a product forced
-  // to a constant, a product that has stopped tracking its operands. The third
-  // is the load-bearing one, pinning all 64 bits of the product for a family of
-  // operand pairs, which is why deleting the high half fails here while (a) and
-  // (b) stay green.
+  // Each multiplies by a constant -- zero, zero and one -- so the solver sees
+  // shifts and adds rather than a second `bvmul` term. These are the only
+  // assertions here that constrain the product's own value; the two above read
+  // the same term the RTL does. The third pins all 64 bits for a family of
+  // operand pairs, which is why deleting the high half fails here.
   //
-  // An `in.rs2 == 32'hffffffff` lemma (multiply by -1) is the obvious fourth and
-  // is measured not to work -- no verdict in two minutes. Do not add it back
-  // without re-measuring (ADR-0051).
+  // An `in.rs2 == 32'hffffffff` lemma is the obvious fourth and is measured not
+  // to work: no verdict in two minutes. Do not add it back without re-measuring.
   always_comb if (in.rs1 == 32'b0) assert(multiply == 64'b0);
   always_comb if (in.rs2 == 32'b0) assert(multiply == 64'b0);
   always_comb if (in.rs2 == 32'h1 && !mul_sign_y)
     assert(multiply == {{32{mul_sign_x}}, in.rs1});
 
   // The divider is proved through a loop invariant rather than by unrolling its
-  // 33-cycle latency, which sby's 20-step default depth cannot reach anyway. At
-  // every point while state == divide,
-  //   dividend == remainder-so-far + quotient-so-far * (divisor << iterations-remaining)
-  // and remainder-so-far < (divisor << iterations-remaining). Each iteration of
-  // the shift/subtract loop preserves both regardless of how many have run,
-  // which is what makes them provable in one induction step; at 0 iterations
-  // remaining they collapse to the division identity, tying the invariant to
-  // real division and, with the completion assertions below, to out.rd_data.
+  // 33-cycle latency, which sby's 20-step default depth cannot reach. At every
+  // point while state == divide,
+  //   dividend == remainder-so-far + quotient-so-far * (divisor << iterations-left)
+  // and remainder-so-far < (divisor << iterations-left). Each iteration
+  // preserves both however many have run, and at zero iterations left they
+  // collapse to the division identity.
   //
-  // Assumed: the values the divider loads (`div_x`/`div_y`, the ADR-0012
-  // magnitudes) are at most 15, which keeps the invariant's intermediate
-  // arithmetic inside 64 bits without wraparound. This is ADR-0010's recorded
-  // restriction on the proof rather than a claim about the design, so nothing
-  // discharges it and nothing should; the divider at full width is covered by
-  // test/exec_tb.v. It is scoped to the divide family and `state == divide`, so
-  // every multiply assertion above runs against free 32-bit operands.
+  // Assumed: the values the divider loads are at most 15, which keeps the
+  // invariant's arithmetic inside 64 bits. That is a recorded restriction on the
+  // proof rather than a claim about the design; full width is covered by
+  // test/exec_tb.v.
   //
-  // Two things about the shape of this cap are non-obvious and both were
-  // measured (ADR-0051):
-  //
-  // 1. The `|| state == divide` term is required and is not redundant with the
-  //    op flags. k-induction may start in `divide` with every `is_div*` low, and
-  //    without that term the cap lapses in exactly those states, whereupon the
-  //    `mul_div_store <= div_x` invariant fails induction.
-  // 2. It caps `div_x`/`div_y` rather than `in.rs1`/`in.rs2`, which is what
-  //    makes it a MAGNITUDE cap and leaves the sign free: `div_x <= 15` admits
-  //    `in.rs1` anywhere in -15..15, so `in.rs1[31]` is a free bit and the
-  //    completion assertions below mean something. The `in.rs1 <= 32'h0f` form
-  //    it replaces held bit 31 at constant zero, so ADR-0012's magnitude wrapper
-  //    had no coverage here at all and deleting either sign restore passed.
-  //    Capping `$signed(in.rs1)` to -15..15 instead was built and does not work:
-  //    it leaves `div_y` free up to ~2^32 for DIVU/REMU, where no magnitude
-  //    conversion happens, so the product wraps mod 2^64 and induction fails on
-  //    the very bound that exists to rule wraparound out. Do not simplify this
-  //    cap back onto in.rs1/in.rs2.
+  // Two things about the cap's shape were measured and must not be simplified
+  // away. The `|| state == divide` term is not redundant with the op flags:
+  // k-induction may start in `divide` with every `is_div*` low, and without it
+  // the `mul_div_store <= div_x` invariant fails induction. And it caps
+  // `div_x`/`div_y` rather than `in.rs1`/`in.rs2`, which leaves the sign free --
+  // `div_x <= 15` admits `in.rs1` anywhere in -15..15, so the completion
+  // assertions below mean something. Capping `$signed(in.rs1)` instead leaves
+  // `div_y` free up to ~2^32 for DIVU/REMU, where the product wraps mod 2^64 and
+  // induction fails on the very bound that rules wraparound out.
   logic div_family;
   assign div_family = in.is_div || in.is_divu || in.is_rem || in.is_remu ||
                       state == divide;
   always_comb if (div_family) assume(div_x <= 32'h0000000f);
   always_comb if (div_family) assume(div_y <= 32'h0000000f);
 
-  // Assumed: ADR-0009's stall protocol holds `in` steady for the duration of a
-  // multi-cycle divide, so a free-running formal input cannot corrupt the opcode
-  // selection at capture time. Discharged nowhere -- rtl/decoder.v's own task
-  // asserts that the pc holds on a stalled cycle, not that `decoder_out` does.
-  // The guard scopes it to the divide assertions and nothing else.
+  // Assumed: the stall protocol holds `in` steady for the whole of a multi-cycle
+  // divide. Discharged nowhere -- rtl/decoder.v's own task asserts that the pc
+  // holds on a stalled cycle, not that `decoder_out` does. Without it `in` is
+  // free to disagree with what was latched into mul_div_x/mul_div_y, and the
+  // `in.is_divu`/`is_remu` read below free to disagree with the operands the
+  // divider actually ran on.
   always_ff @(posedge clk)
-    // It covers the first divide-state cycle, where `in` would otherwise be free
-    // to disagree with what was just latched into mul_div_x/mul_div_y, and the
-    // capture cycle, where `in.is_divu`/`is_remu` read below would otherwise be
-    // free to disagree with the operands the divider actually ran on.
     if (clocked && (state == divide || $past(state) == divide)) begin
       assume(in.rs1 == $past(in.rs1));
       assume(in.rs2 == $past(in.rs2));
@@ -459,10 +378,9 @@ module executor(
       assume(in.is_remu == $past(in.is_remu));
     end
 
-  // Ties the op_is_*/op_sign_* latches back to `in` while dividing. Without this
-  // as a stated one-step-inductive invariant, k-induction has no intermediate
-  // fact linking a latch taken once at issue to the `in.is_divu` read many
-  // cycles later at the completion assertions, and induction fails to close.
+  // Ties the op_is_*/op_sign_* latches back to `in` while dividing. Without it
+  // k-induction has no fact linking a latch taken once at issue to the
+  // `in.is_divu` read many cycles later, and induction fails to close.
   always_comb if (state == divide) assert(op_is_div == in.is_div);
   always_comb if (state == divide) assert(op_is_divu == in.is_divu);
   always_comb if (state == divide) assert(op_is_rem == in.is_rem);
@@ -470,24 +388,21 @@ module executor(
   always_comb if (state == divide) assert(op_sign_x == in.rs1[31]);
   always_comb if (state == divide) assert(op_sign_y == in.rs2[31]);
 
-  // k-induction otherwise has no reason to rule out an unreachable starting
-  // state with a wild counter, and the invariant below reads it as an exact
-  // count of the divisor halvings remaining.
+  // k-induction otherwise has no reason to rule out a starting state with a wild
+  // counter, and the invariant below reads it as an exact count of the divisor
+  // halvings remaining.
   always_comb if (state == divide) assert(mul_div_counter <= 32);
 
-  // Ties mul_div_y to the same "divisor scaled by iterations remaining" quantity
-  // the invariant below reasons about. Without it mul_div_y is a free register
-  // to the solver, and the comparison the RTL branches on (mul_div_x >=
-  // mul_div_y) has no connection to what the invariant expects. Scoped to
-  // counter > 0, since at 0 mul_div_y has taken its last, possibly
-  // LSB-dropping, right-shift and nothing reads it again.
+  // Ties mul_div_y to the same "divisor scaled by iterations left" quantity the
+  // invariant below reasons about. Without it the comparison the RTL branches on
+  // has no connection to what the invariant expects. Scoped to counter > 0,
+  // since at 0 mul_div_y has taken its last right-shift and nothing reads it.
   always_comb
     if (state == divide && mul_div_counter > 0)
       assert(mul_div_y == ({32'b0, div_y} << (mul_div_counter - 1)));
 
   // div_x/div_y, what the divider actually loaded, rather than in.rs1/in.rs2 --
-  // so this covers is_div/is_rem's magnitude conversion and not just the
-  // unsigned ops.
+  // so this covers is_div/is_rem's magnitude conversion too.
   logic [63:0] div_scaled_divisor;
   assign div_scaled_divisor = ({32'b0, div_y}) << mul_div_counter;
   always_comb
@@ -496,26 +411,21 @@ module executor(
   always_comb
     if (state == divide)
       assert(mul_div_x < div_scaled_divisor);
-  // Without this the equality invariant above is only an equation over 64-bit
-  // modular arithmetic, and the solver can satisfy it from an induction start
-  // whose mul_div_store is a wraparound solution mod 2^64. True quotients never
-  // exceed the dividend for a divisor >= 1, so this is a real fact about the
-  // algorithm rather than only a proof crutch.
+  // Without this the equality above is only an equation over 64-bit modular
+  // arithmetic, and the solver can satisfy it from an induction start whose
+  // mul_div_store is a wraparound solution mod 2^64. True quotients never exceed
+  // the dividend for a divisor >= 1, so it is a real fact about the algorithm.
   always_comb
     if (state == divide)
       assert(mul_div_store <= {32'b0, div_x});
 
-  // Completion: the four divide-family results. The signed pair
-  // (`div_ref`/`rem_ref`) is the only thing in this proof that exercises
-  // ADR-0012's magnitude wrapper -- the divider loop is unsigned, `div_x`/`div_y`
-  // are absolute values, and the sign is restored at capture. Under the old
-  // value cap those two capture arms could be deleted outright and the task
-  // still passed.
-  //
-  // `div_q` and `div_r` are computed first and only the already-computed 32-bit
-  // results are selected by the divide-by-zero mux, so no sign context is taken
-  // away from the division itself the way ADR-0019's monitor models had it taken
-  // away from theirs.
+  // Completion: the four divide-family results. `div_ref`/`rem_ref` are the only
+  // things here that exercise the magnitude wrapper, since the divider loop is
+  // unsigned and the sign is restored at capture -- under the old operand cap
+  // those two capture arms could be deleted outright and the task still passed.
+  // `div_q` and `div_r` are computed first, so the divide-by-zero mux selects
+  // between already-computed results and takes no sign context away from the
+  // division itself.
   logic signed [31:0] div_srs1, div_srs2;
   assign div_srs1 = $signed(in.rs1);
   assign div_srs2 = $signed(in.rs2);
@@ -529,13 +439,10 @@ module executor(
   assign div_ref  = (in.rs2 == 0) ? 32'hffffffff : div_q;
   assign rem_ref  = (in.rs2 == 0) ? in.rs1 : div_r;
 
-  // The guard `$past(state) == divide && state == init` is unreachable in the
-  // basecase: components.sby sets no depth, so `mode prove`'s basecase runs 20
-  // steps and the real divider needs 33 cycles from issue. A mutation that
-  // breaks one of these therefore reports `UNKNOWN (rc=4)` -- basecase pass,
-  // induction FAIL -- rather than `FAIL`, which is this assertion class's normal
-  // detection signal. Raising the basecase past 33 is a depth change needing its
-  // own evidence (ADR-0025, ADR-0049 F3).
+  // The guard below is unreachable in the basecase: components.sby sets no
+  // depth, so `mode prove` runs 20 basecase steps and the real divider needs 33
+  // cycles from issue. A mutation that breaks one of these reports
+  // `UNKNOWN (rc=4)` -- basecase pass, induction FAIL -- rather than `FAIL`.
   always_ff @(posedge clk)
     if (clocked && !reset && $past(state) == divide && state == init && $past(in.is_divu))
       assert(out.rd_data == divu_ref);

--- a/test/exec_tb.v
+++ b/test/exec_tb.v
@@ -2,43 +2,25 @@
 `default_nettype none
 `include "structs.v"
 
-// Standalone randomized differential bench for the executor's arithmetic. It
-// drives `executor` directly, with no decoder or pipeline involved, and compares
-// against SystemVerilog `*`, `/`, `%` and the three shift operators with RISC-V
-// divide-by-zero and INT_MIN / -1 semantics.
+// Randomized differential bench for the executor's arithmetic, driving
+// `executor` directly with no decoder or pipeline.
 //
-// For mul and div it is the *primary* guarantee (ADR-0010), because riscv-formal
-// runs under RISCV_FORMAL_ALTOPS and never checks that arithmetic at all. The
-// shifts and ADD/SUB do have ladder checks, but those are `mode bmc`, and an ADD
+// For mul and div it is the primary guarantee, because riscv-formal runs under
+// RISCV_FORMAL_ALTOPS and never checks that arithmetic at all. The shifts and
+// ADD/SUB do have generated checks, but those are `mode bmc`, and an ADD
 // off-by-one was measured reaching `tohost` through the `.S` suite and the Sail
 // co-simulation while every unit bench stayed silent.
 //
-// ADR-0045 names this bench as M2's mul/div oracle, so it asserts its own shape
-// before it asserts anything about the core. Three mechanisms do that, each
-// because the bench could once stop checking and still print PASSED:
-//
-//   * `ref_selftest` pins every reference -- mul, div and shift -- against
-//     literals computed by hand. A literal captured from a run of this bench is
-//     derived from the function it is supposed to check, so it proves nothing;
-//     a degraded reference says ORACLE BROKEN and stops rather than blaming the
-//     core.
-//   * `check_vector_counts` pins the per-operation vector count against
-//     ADR-0010's contract, written as its own literal, so a loop bound that
-//     drifted to zero fails here. It used to print PASSED and exit 0.
-//   * `check_directed_manifest` pins that each required directed corner vector
-//     actually ran, from a manifest kept apart from the call sites, so deleting
-//     a call site is red rather than a shorter run.
+// So it asserts its own shape before it asserts anything about the core: the
+// three check_* tasks below each exist because this bench could once stop
+// checking and still print PASSED.
 module exec_tb;
   localparam int RANDOM_VECTORS = 10000;
   localparam logic [1:0] DIVIDE_STATE = 2'b10; // must match executor.v's `divide` state
 
-  // ADR-0010's contract (">= 10,000 randomized operand pairs per operation")
-  // written as literals of its own, deliberately not a second copy of the loop
-  // bounds: they must not move when a loop bound does.
-  // `MIN_DIRECTED_SHIFT_PER_OP` is 6 patterns x 32 amounts x {clean, dirty rs2}.
-  //
-  // If a count check below goes red, restore the loop; never edit the number
-  // down to match it.
+  // The required coverage, deliberately not a second copy of the loop bounds:
+  // these must not move when a loop bound does. If a count check below goes red,
+  // restore the loop; never edit the number down to match it.
   localparam int MIN_RANDOM_PER_OP        = 10000;
   localparam int MIN_DIRECTED_SHIFT_PER_OP = 384;
 
@@ -60,9 +42,8 @@ module exec_tb;
 
   int errors = 0;
 
-  // One source of truth for the op names: `run_op` resolves its `op_name`
-  // argument through this table, which is what makes a typo fatal rather than a
-  // silent comparison against whatever the executor left on rd_data.
+  // `run_op` resolves its `op_name` argument through this table, which is what
+  // makes a typo fatal rather than silent.
   localparam int OP_MUL    = 0;
   localparam int OP_MULH   = 1;
   localparam int OP_MULHU  = 2;
@@ -81,19 +62,16 @@ module exec_tb;
   string op_names  [0:NUM_OPS-1];
   int    vec_count [0:NUM_OPS-1];
 
-  // The corner vectors this bench is required to run: ADR-0010's three
-  // sign-enable cases, then the six architecturally specified divide-by-zero and
-  // INT_MIN / -1 results. None is meaningfully reachable by the randomized
-  // sweep, since each names both operands exactly -- ten thousand `$random`
-  // pairs hit one with probability around 10^4 / 2^64 -- so deleting one is a
-  // real loss of coverage rather than a rounding error on a big number.
+  // The corner vectors this bench is required to run. None is meaningfully
+  // reachable by the randomized sweep, since each names both operands exactly --
+  // ten thousand `$random` pairs hit one with probability around 10^4 / 2^64 --
+  // so deleting one is a real loss of coverage rather than a rounding error on a
+  // big number.
   //
   // The manifest deliberately does not issue them. `run_op` witnesses each
-  // (op, rs1, rs2) it actually drove into the DUT against this list and
-  // `check_directed_manifest` fails on any entry never witnessed, so a deleted
-  // call site is red. Each entry also carries its expected value and is checked
-  // against the call site, which catches a directed vector kept but weakened in
-  // place.
+  // (op, rs1, rs2) it drove into the DUT against this list, so a deleted call
+  // site is red, and each entry's expected value is checked against the call
+  // site, which catches one kept but weakened in place.
   localparam int DIRECTED_N = 9;
   int          dir_op  [0:DIRECTED_N-1];
   logic [31:0] dir_rs1 [0:DIRECTED_N-1];
@@ -102,9 +80,8 @@ module exec_tb;
   logic        dir_ran [0:DIRECTED_N-1];
   string       dir_why [0:DIRECTED_N-1];
   // Witnessing is a linear scan per vector driven, and there are ~111,000 of
-  // them; this counts down to zero on the ninth directed call site, after which
-  // `run_op` skips the scan. Purely a cost thing -- `check_directed_manifest`
-  // reads `dir_ran` itself, so a deleted call site is caught either way.
+  // them; this counts down so `run_op` can skip the scan once the last directed
+  // call site has run. Purely a cost thing.
   int          dir_pending;
 
   task automatic add_directed(input int slot, input int op, input logic [31:0] rs1_v,
@@ -139,11 +116,10 @@ module exec_tb;
       for (k = 0; k < NUM_OPS; k++) vec_count[k] = 0;
       dir_pending = DIRECTED_N;
 
-      // ADR-0010's three required sign-enable vectors.
       add_directed(0, OP_MULH,   32'hffffffff, 32'hffffffff, 32'h00000000, "ADR-0010 MULH(-1,-1)=0");
       add_directed(1, OP_MULHSU, 32'hffffffff, 32'h00000001, 32'hffffffff, "ADR-0010 MULHSU(-1,1)=-1");
       add_directed(2, OP_MULHU,  32'hffffffff, 32'hffffffff, 32'hfffffffe, "ADR-0010 MULHU(-1,-1)=0xFFFFFFFE");
-      // Divide-by-zero and INT_MIN / -1: specified values, not computed ones.
+      // Specified values, not computed ones.
       add_directed(3, OP_DIV,    32'h00000064, 32'h00000000, 32'hffffffff, "div by zero");
       add_directed(4, OP_DIVU,   32'h00000064, 32'h00000000, 32'hffffffff, "divu by zero");
       add_directed(5, OP_REM,    32'h00000064, 32'h00000000, 32'h00000064, "rem by zero");
@@ -162,14 +138,12 @@ module exec_tb;
     end
   endfunction
 
-  // The reference model. The signed-arithmetic rule written out further down,
-  // above the shift references, governs these too, and `ref_div`/`ref_rem` are
-  // where it bites:
-  // their RISC-V special cases are an if / else-if / else over separate
-  // statements rather than one `?:` chain, because a chain whose other arms are
-  // unsigned literals evaluates `$signed(a) / $signed(b)` unsigned. That is
-  // ADR-0019's defect, at exactly these two functions, where -7 / 2 scored
-  // 0x7ffffffc.
+  // The sign-context rule further down, above the shift references, governs
+  // these too, and `ref_div`/`ref_rem` are where it bites: their cases are an
+  // if / else-if / else over separate statements rather than one `?:` chain,
+  // because a chain whose other arms are unsigned literals evaluates
+  // `$signed(a) / $signed(b)` unsigned. That has happened at exactly these two
+  // functions, where -7 / 2 scored 0x7ffffffc.
   function automatic logic [31:0] ref_mul(input logic [31:0] a, input logic [31:0] b);
     logic [63:0] p;
     begin
@@ -232,9 +206,8 @@ module exec_tb;
     end
   endfunction
 
-  // Two's-complement add and sub are signedness-independent bit for bit, so
-  // neither of these needs `$signed` and the sign-context hazard below does not
-  // apply to them.
+  // Two's-complement add and sub are signedness-independent bit for bit, so the
+  // sign-context hazard below does not apply to these two.
   function automatic logic [31:0] ref_add(input logic [31:0] a, input logic [31:0] b);
     ref_add = a + b;
   endfunction
@@ -244,21 +217,17 @@ module exec_tb;
   endfunction
 
   // Each shift below is computed in a statement of its own, into a local whose
-  // signedness is declared, and is never an arm of a `?:`. Keep them that way.
+  // signedness is declared, and is never an arm of a `?:`. Keep them that way. A
+  // conditional expression is unsigned if any operand is unsigned, and that
+  // pushes down into the context-determined operands, so a `$signed(a) >>> sh`
+  // in one arm evaluates as a logical shift -- with no warning, and only for
+  // negative operands, so every non-negative vector still agrees. The assignment
+  // target cannot rescue it. This repo has been bitten twice, the second time
+  // here, where the natural one-line `ref_sra` written as a `?:` arm reported
+  // six mismatches against correct hardware.
   //
-  // IEEE 1800 makes a conditional expression unsigned if any of its operands is
-  // unsigned, and pushes that unsignedness down into the context-determined
-  // operands, so a `$signed(a) >>> sh` in one arm of such a conditional
-  // evaluates as a LOGICAL shift -- with no warning, and only for negative
-  // operands, so every non-negative vector still agrees. The assignment target
-  // cannot rescue it: an expression's type does not depend on its left-hand
-  // side. This repo has been bitten twice, at ADR-0019's two monitor spec models
-  // and then here, where the natural one-line `ref_sra` written as a `?:` arm
-  // reported six mismatches against correct hardware.
-  //
-  // The `b[4:0]` masks are this reference's own model of the RV32I rule that the
-  // shift amount is rs2[4:0] (spec Vol I 2.4.2). The vectors drive rs2 values
-  // far above 31 so the RTL has to agree rather than coincide.
+  // The `b[4:0]` masks are this reference's own model of the rs2[4:0] rule. The
+  // vectors drive rs2 far above 31 so the RTL has to agree rather than coincide.
   function automatic logic [31:0] ref_sll(input logic [31:0] a, input logic [31:0] b);
     logic [31:0] v;
     begin
@@ -293,14 +262,13 @@ module exec_tb;
   endtask
 
   // Checks the oracle, not the core -- no RTL is involved in any call to this. A
-  // reference that degraded to a logical shift (or an unsigned divide) agrees
+  // reference that degraded to a logical shift, or an unsigned divide, agrees
   // with a correct one on every non-negative operand, so it would pass thousands
   // of randomized vectors and then report mismatches against correct hardware.
   //
-  // Every expected value passed here is computed by hand and written as a
-  // literal. A literal captured from a run of this bench is derived from the
-  // function it is supposed to check, which is the same defect one level down;
-  // if you add a case, do the arithmetic on paper.
+  // Every expected value here is computed by hand. A literal captured from a run
+  // of this bench is derived from the function it is supposed to check, which is
+  // the same defect one level down; do the arithmetic on paper.
   task automatic ref_selftest(input string what, input logic [31:0] got,
                                input logic [31:0] want);
     begin
@@ -312,8 +280,7 @@ module exec_tb;
   endtask
 
   // Checks that the bench ran what it says it runs. A loop bound edited to zero
-  // during a debugging session and never put back used to print PASSED and exit
-  // 0.
+  // during a debugging session and never put back used to print PASSED.
   task automatic check_vector_counts;
     int k, want;
     begin
@@ -330,9 +297,8 @@ module exec_tb;
     end
   endtask
 
-  // Checks that every required directed corner vector reached the DUT. A
-  // randomized vector cannot cover for a deleted one: these are the cases random
-  // operands do not reach, or reach only by accident.
+  // A randomized vector cannot cover for a deleted directed one: these are the
+  // cases random operands do not reach, or reach only by accident.
   task automatic check_directed_manifest;
     int d;
     begin
@@ -357,11 +323,11 @@ module exec_tb;
     end
   endtask
 
-  // The executor is done exactly when it has returned to `init` after the issue
-  // edge -- immediately for the multiply family and the divide short-circuits,
-  // 33 cycles later for a real division. Polling for that rather than hardcoding
-  // a count keeps this task correct however long the divider takes; the cycle
-  // count itself is the timing monitor's job, at the bottom of this file.
+  // The executor is done when it has returned to `init` after the issue edge --
+  // immediately for the multiply family and the divide short-circuits, 33 cycles
+  // later for a real division. Polling rather than hardcoding a count keeps this
+  // correct however long the divider takes; the count is checked at the bottom
+  // of this file.
   task automatic run_op(input string op_name, input logic [31:0] rs1_v, input logic [31:0] rs2_v,
                          input logic [31:0] expected);
     int guard;
@@ -394,8 +360,6 @@ module exec_tb;
         OP_SUB:    in.is_sub    = 1'b1;
       endcase
 
-      // Coverage is measured here, on the vectors actually driven into the DUT,
-      // rather than inferred from a loop bound.
       vec_count[id]++;
       if (dir_pending > 0) begin
         for (d = 0; d < DIRECTED_N; d++) begin
@@ -431,10 +395,9 @@ module exec_tb;
   logic [31:0] a, b;
   int i;
 
-  // Shift patterns chosen so that a lost sign bit, a dropped mask or an
-  // off-by-one fill is visible: INT_MIN, all-ones, INT_MAX, a negative
-  // non-trivial value, a positive alternating one, and 1 (which walks a single
-  // bit off each end).
+  // Chosen so a lost sign bit, a dropped mask or an off-by-one fill is visible:
+  // INT_MIN, all-ones, INT_MAX, a negative non-trivial value, a positive
+  // alternating one, and 1, which walks a single bit off each end.
   localparam int SHIFT_PATTERNS = 6;
   logic [31:0] pattern [0:SHIFT_PATTERNS-1];
   int p, sh;
@@ -448,20 +411,17 @@ module exec_tb;
     #1;
     reset = 0;
 
-    // The oracle is checked before it is trusted to judge anything. Every
-    // literal below is hand-computed, and the arithmetic behind it is written
-    // out so a reader can verify it without running anything.
+    // The arithmetic behind each literal is written out so a reader can verify
+    // it without running anything.
     //
     // MUL: low 32 bits, signedness-independent. (-1)*(-1) = 1; 2^31 * 2 = 2^32,
     // whose low half is zero; 65535^2 = 0xfffe0001.
     ref_selftest("mul(ffffffff,ffffffff)",  ref_mul(32'hffffffff, 32'hffffffff), 32'h00000001);
     ref_selftest("mul(80000000,00000002)",  ref_mul(32'h80000000, 32'h00000002), 32'h00000000);
     ref_selftest("mul(0000ffff,0000ffff)",  ref_mul(32'h0000ffff, 32'h0000ffff), 32'hfffe0001);
-    // MULH: signed x signed, high 32. (-1)*(-1) = +1 -> high half 0.
-    // (-2^31)*(-2^31) = 2^62 = 0x4000_0000_0000_0000 -> high half 0x40000000.
-    // (-2^31)*2 = -2^32 = 0xffff_ffff_0000_0000 -> high half 0xffffffff.
-    // 2*(-2^31) = -2^32 as well: this one is the pair for the MULHSU/MULHU
-    // cases just below, which take the same operands and differ.
+    // MULH: signed x signed, high 32. (-1)*(-1) = +1 -> 0.
+    // (-2^31)*(-2^31) = 2^62 -> 0x40000000. (-2^31)*2 = 2*(-2^31) = -2^32 ->
+    // 0xffffffff, and that last pair recurs in the MULHU/MULHSU cases below.
     ref_selftest("mulh(ffffffff,ffffffff)", ref_mulh(32'hffffffff, 32'hffffffff), 32'h00000000);
     ref_selftest("mulh(80000000,80000000)", ref_mulh(32'h80000000, 32'h80000000), 32'h40000000);
     ref_selftest("mulh(80000000,00000002)", ref_mulh(32'h80000000, 32'h00000002), 32'hffffffff);
@@ -471,19 +431,17 @@ module exec_tb;
     ref_selftest("mulhu(ffffffff,ffffffff)", ref_mulhu(32'hffffffff, 32'hffffffff), 32'hfffffffe);
     ref_selftest("mulhu(00000002,80000000)", ref_mulhu(32'h00000002, 32'h80000000), 32'h00000001);
     ref_selftest("mulhu(ffffffff,80000000)", ref_mulhu(32'hffffffff, 32'h80000000), 32'h7fffffff);
-    // MULHSU: rs1 SIGNED, rs2 UNSIGNED, high 32. Each of these three differs
+    // MULHSU: rs1 signed, rs2 unsigned, high 32. Each of these three differs
     // from at least one of the two above on the same operands, which is what
     // makes them a check of the signedness rather than of the multiply:
-    //   (-1)*1        = -1                     -> 0xffff_ffff_ffff_ffff, high 0xffffffff
-    //   2 * 2^31      = 2^32                   -> 0x0000_0001_0000_0000, high 0x00000001
-    //                                             (mulh of the same pair is 0xffffffff)
-    //   (-1) * 2^31   = -2^31                  -> 0xffff_ffff_8000_0000, high 0xffffffff
-    //                                             (mulhu of the same pair is 0x7fffffff)
+    //   (-1)*1      = -1    -> 0xffffffff
+    //   2 * 2^31    = 2^32  -> 0x00000001 (mulh of the same pair is 0xffffffff)
+    //   (-1) * 2^31 = -2^31 -> 0xffffffff (mulhu of the same pair is 0x7fffffff)
     ref_selftest("mulhsu(ffffffff,00000001)", ref_mulhsu(32'hffffffff, 32'h00000001), 32'hffffffff);
     ref_selftest("mulhsu(00000002,80000000)", ref_mulhsu(32'h00000002, 32'h80000000), 32'h00000001);
     ref_selftest("mulhsu(ffffffff,80000000)", ref_mulhsu(32'hffffffff, 32'h80000000), 32'hffffffff);
-    // ADR-0019's own case. -7 / 2 truncates toward zero to -3 (0xfffffffd); a
-    // reference degraded to an unsigned divide scores 0x7ffffffc, which is what
+    // -7 / 2 truncates toward zero to -3 (0xfffffffd). A reference degraded to
+    // an unsigned divide scores 0x7ffffffc, which is what
     // `divu(fffffff9,00000002)` legitimately is -- written out just below so the
     // two are visibly different numbers.
     ref_selftest("div(fffffff9,00000002)",  ref_div(32'hfffffff9, 32'h00000002), 32'hfffffffd);
@@ -493,7 +451,7 @@ module exec_tb;
     ref_selftest("div(80000000,ffffffff)",  ref_div(32'h80000000, 32'hffffffff), 32'h80000000);
     ref_selftest("divu(fffffff9,00000002)", ref_divu(32'hfffffff9, 32'h00000002), 32'h7ffffffc);
     ref_selftest("divu(00000064,00000000)", ref_divu(32'h00000064, 32'h00000000), 32'hffffffff);
-    // REM takes the sign of the DIVIDEND: -7 % 2 = -1, 7 % -2 = +1. An unsigned
+    // REM takes the sign of the dividend: -7 % 2 = -1, 7 % -2 = +1. An unsigned
     // degradation scores 0x00000001 for the first, which is the second's answer.
     ref_selftest("rem(fffffff9,00000002)",  ref_rem(32'hfffffff9, 32'h00000002), 32'hffffffff);
     ref_selftest("rem(00000007,fffffffe)",  ref_rem(32'h00000007, 32'hfffffffe), 32'h00000001);
@@ -523,13 +481,11 @@ module exec_tb;
       $fatal(1);
     end
 
-    // ADR-0010's required directed vectors: the cases a swapped sign enable gets
-    // wrong.
+    // The required directed vectors: the cases a swapped sign enable gets wrong.
     run_op("mulh",   32'hffffffff, 32'hffffffff, 32'h00000000);
     run_op("mulhsu", 32'hffffffff, 32'h00000001, 32'hffffffff);
     run_op("mulhu",  32'hffffffff, 32'hffffffff, 32'hfffffffe);
 
-    // Directed divide-by-zero / INT_MIN-over-negative-one vectors.
     run_op("div",  32'h00000064, 32'h00000000, 32'hffffffff);
     run_op("divu", 32'h00000064, 32'h00000000, 32'hffffffff);
     run_op("rem",  32'h00000064, 32'h00000000, 32'h00000064);
@@ -540,8 +496,7 @@ module exec_tb;
     // Every shift amount 0..31 against each pattern, driven twice: once with a
     // clean rs2 and once with all 27 upper bits set. `$random` reaches every
     // amount with overwhelming probability but does not guarantee it, and the
-    // pair is what states the rs2[4:0] rule -- the same amount with and without
-    // garbage above bit 4 must give the same answer.
+    // pair is what states the rs2[4:0] rule.
     pattern[0] = 32'h80000000;
     pattern[1] = 32'hffffffff;
     pattern[2] = 32'h7fffffff;
@@ -600,8 +555,7 @@ module exec_tb;
     end
   end
 
-  // The divider produces its result exactly 33 cycles after issue -- 32
-  // restoring-division iterations plus one capture cycle -- checked against
+  // 32 restoring-division iterations plus one capture cycle, checked against
   // every real division performed in the run above.
   int cycle_count;
   logic prev_divide;


### PR DESCRIPTION
Closes JEF-748

Comment-only cleanup of the seven files with the worst comment-to-code ratios.
Six were cleaned in the first round, before three rules existed; `formal/Makefile`
was never in that round and was the worst in the tree.

## Both proofs from criterion 1

**Proof 1 — `-U0` diff shows no non-comment line.**

```
$ git diff -U0 origin/main -- .github/workflows/ci.yml formal/checks.cfg formal/Makefile \
    | grep '^[+-]' | grep -v '^[+-][+-]' | grep -vE '^[+-][[:space:]]*(#|$)'
(empty)
$ git diff -U0 origin/main -- rtl/executor.v rtl/csrs.v test/exec_tb.v formal/complete.sv \
    | grep '^[+-]' | grep -v '^[+-][+-]' | grep -vE '^[+-][[:space:]]*(//|$)'
(empty)
```

**Proof 2 — each file hashes identically to base once comments and blanks are stripped.**

| file | sha256 base | sha256 head |
|---|---|---|
| `.github/workflows/ci.yml` | `dd3fcaacb1fa10c2` | `dd3fcaacb1fa10c2` |
| `rtl/executor.v` | `3037adb40ca58d2d` | `3037adb40ca58d2d` |
| `test/exec_tb.v` | `515d0cb4bb86171a` | `515d0cb4bb86171a` |
| `formal/checks.cfg` | `30be2582a47a13bd` | `30be2582a47a13bd` |
| `rtl/csrs.v` | `a78d19fed3f63166` | `a78d19fed3f63166` |
| `formal/complete.sv` | `035fb2561cb1e54a` | `035fb2561cb1e54a` |
| `formal/Makefile` | `9f9af2318f36d6a2` | `9f9af2318f36d6a2` |

Two extra proofs, because those two files have failure modes the first two cannot see:

- **`formal/Makefile`**: a stray tab or a broken line continuation is invisible to a
  comment-stripped hash. `make -n` output is byte-identical across all 17 targets
  (`all check check-baseline checks genchecks-check complete complete_cover
  complete-exclusions nonperturbation components_{decoder,executor,pcloop,traps}
  dmemcheck imemcheck cover clean`).
- **`.github/workflows/ci.yml`**: parsed with `yaml.safe_load` and compared to base
  structurally. It differs in exactly two places — `.jobs.elaborate.steps[3].run` and
  `.jobs.formal.steps[5].run` — and in both, only in **shell comment lines inside the
  block scalar**. All nine job names, every key, and every command are identical.

## Per-file before / after

| file | before | after | removed | ratio before → after |
|---|---|---|---|---|
| `.github/workflows/ci.yml` | 229 | 130 | 99 | 0.72 → 0.41 |
| `rtl/executor.v` | 231 | 138 | 93 | 0.79 → 0.47 |
| `test/exec_tb.v` | 158 | 112 | 46 | 0.37 → 0.26 |
| `formal/checks.cfg` | 147 | 123 | 24 | 3.87 → 3.24 |
| `rtl/csrs.v` | 122 | 91 | 31 | 0.63 → 0.47 |
| `formal/complete.sv` | 98 | 72 | 26 | 0.84 → 0.62 |
| `formal/Makefile` | 184 | 65 | 119 | 3.12 → 1.10 |
| **total** | **1169** | **731** | **438** | **37%** |

(Counts are whole-line comments; a trailing comment on a code line counts as code,
which is why these differ by a line or two from the ticket's table.)

## False and stale claims found — the highest-value output

Three, all in `ci.yml`, each found by reading the source the comment described.

1. **The oss-cad-suite pinning rule describes a scheme that no longer exists.** The
   header above `jobs:` read *"The tag and the filename must name the same
   oss-cad-suite release; bump them together."* There is no tag and no filename in
   `ci.yml`. `.github/actions/setup-oss-cad-suite` resolves the **latest** release
   from the GitHub API and derives the asset name from the tag programmatically
   (`asset="oss-cad-suite-linux-x64-${tag//-/}.tgz"`). Nothing to bump, and nothing
   to keep in sync. It sat above `jobs:` where it read as a rule for the whole file.
   Deleted.

2. **The components job's task list was stale, in exactly the way its own warning
   predicted.** It said `formal/components.sby` *"carries three tasks — decoder,
   executor, pcloop — and this job runs all three, so a task added there needs a step
   here or it runs nowhere."* It carries **four**: `traps` was added, a step was added,
   and the comment was not. Rewritten to state the rule without a count.

3. **`make test-units` was called "the seven iverilog benches"; there are eight.**
   Deleted rather than corrected: `check-unit-benches` already compares `UNIT_BENCHES`
   against `test/*_tb.v` in both directions, so a count here is a second copy that can
   only rot.

Two numbers were re-derived and **are correct**, so they stay: the **70** `insn_*`
checks (counted in `formal/EXPECTED_CHECKS`) and `complete.sv`'s **twelve** cover goals
over **nine** uncompressed opcode classes. `rtl/executor.v`'s claim that all **29**
`is_*` fields of `decoder_output` are listed in its `$onehot0` also holds exactly.

One thing that went quietly out of date rather than being wrong: `formal/EXPECTED_FAIL`
now has **zero** entries, so `formal/Makefile`'s `-k` comment no longer described a set
"with known failures". It states the mechanism instead — without `-k`, make stops
scheduling at the first failing check and the rest report no status.

## Criterion 2 — references

**Zero** ADR or invariant references in comments across the seven files. Nine remain in
**code**, left alone as the criterion requires:

- `ci.yml`: five `echo` strings written to `$GITHUB_STEP_SUMMARY` (lines 212, 264, 271,
  317, 460) and one step name (line 468, `imemcheck (ADR-0003's dual-word fetch window)`).
- `test/exec_tb.v`: three `dir_why` manifest strings that `$display` prints on failure
  (lines 119–121, `"ADR-0010 MULH(-1,-1)=0"` and siblings).

The word **"invariant"** survives six times in `rtl/executor.v` in its mathematical
sense — *loop* invariant, the divider's induction hypothesis. That is the subject of the
proof, not a cross-reference to a numbered design commitment.

**"ladder"** and **"drains"** are gone from every comment. "ladder" survives in five
`ci.yml` `echo` strings and one step name, which are code; happy to change those in a
follow-up, but they would break the byte-identical proof above.

## Criterion 5 — `formal/checks.cfg`

The fourteen `#omit` lines are **byte-identical** (`git diff | grep -c '^[+-]#omit'` is
0), confirmed end-to-end by `make -C formal check`'s `EXPECTED_CHECKS` set equality
passing in both directions. That file's 3.24 ratio is mostly those config lines; judged
on its surrounding prose it went 147 → 123.

## Gates — all run on this tree

| gate | result |
|---|---|
| `make test` | **59/59**, `EXPECTED_FAIL` matches exactly |
| `make test-units` | **8 benches**, matching `test/*_tb.v` in both directions |
| `make probe-gates` | **137** graded comparisons, every failure path executed |
| `make lint` | svlint clean in both passes |
| `make -C formal check` | **85 checks, 85 pass**; both set equalities match both ways |
| `components_decoder` / `_executor` / `_pcloop` / `_traps` | all four **pass by k-induction** |
| `complete` / `complete_cover` | PASS / PASS |
| `imemcheck` / `dmemcheck` / `cover` | PASS / PASS / PASS |
| `nonperturbation` / `genchecks-check` | PASS / PASS |

**Criterion 4 — neither measurement moved:**

- `make fit` → **3880 of 5280 cells (73%)**, ratchet OK against 4100. Identical to main.
- `make soc-timing` → **13.01 MHz** against the **12.00 MHz** floor, OK. Inside main's
  12.69–13.45 spread. `SOC_MIN_MHZ` untouched at 12.0.

Expected, and the reason the hash proof matters: comments are stripped in the lexer, so a
genuinely comment-only diff cannot reach the netlist. Both were run anyway.

## Notes

- **`rtl/executor.v` and `formal/checks.cfg` are near their floor and I did not force
  them lower.** What remains in `executor.v`'s `FORMAL` block is almost entirely
  *undischarged assumptions* and *measured negative results* (the miter that returns no
  verdict in two minutes; the fourth lemma that does not work; the two cap spellings that
  fail induction). Those are the two things this repo's rules say to keep. Same for
  `checks.cfg`'s `[depth]` prose: the F/G derivation and the re-measurement procedure are
  what a change adding a stall reason has to follow before it lands.
- **Two `// inputs` / `// outputs` banners deleted from `rtl/executor.v`.** The same
  banners survive in `rtl/fetcher.v` and `rtl/writeback.v`, which are out of scope here —
  worth a follow-up so the convention is not half-converted.
- `/soundcheck:pr-review`: no Critical or High findings. Nothing executable changed;
  `permissions`, the `actions/checkout` SHA pin and the file's single `${{ }}` expression
  (`!cancelled()`, a built-in with no untrusted input) are all untouched.
- `/simplify` ran as a **single inline pass, not the 4-agent fan-out** (Agent tool
  unavailable). It caught three things I had introduced, all fixed: a cross-reference in
  `exec_tb.v` that pointed the reader the wrong way after being shortened, and two places
  (`executor.v`'s merged reset assumptions, `csrs.v`'s "respectively") where compressing
  two comments into one left a statement with no adjacent explanation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
