### PR TITLE
State why the cheaper operand-fetch spelling was declined

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,8 +17,9 @@ Three habits carry the goals:
   a tidier spelling that costs measured speed or area without recording the trade. Three standing
   precedents: `rtl/memory.v` ships the flat spelling of its write/read arms (the nested one costs
   3.6% of Fmax), `rtl/executor.v`'s `mul_div_counter` stays `[6:0]` (narrowing it costs 37 cells),
-  and `rtl/decoder.v`'s operand-fetch cycle stays (removing it buys 13% of CPI and misses the
-  12 MHz requirement) — all measured and declined, not overlooked.
+  and `rtl/decoder.v`'s operand-fetch cycle stays (removing it buys 13% of CPI and misses 12 MHz;
+  a cheaper spelling holds 12 MHz on 0.83% margin against today's 4.5%, and was declined on that)
+  — all measured and declined, not overlooked.
 - **Prove the property, then spend it.** Find a place the design pays for a property it already
   proves — a priority chain over proven-disjoint flags, a comparator that cannot differ — simplify
   it, and let the riscv-formal checks, the component proofs and the `.S` suite say whether the


### PR DESCRIPTION
The precedent line landed as "removing it buys 13% of CPI and misses the 12 MHz requirement."

That is accurate for the headline variant. It is not the whole story: the variant without RVC field extraction **met** the gate at 12.10–12.68 MHz and was declined because it spent margin 4.5% → 0.83% to buy 10% of CPI. A reader of the one-liner alone would conclude the idea is gate-blocked outright and never revisit a decision that was a judgement call.

That matters because of what the list is for. Its whole job is to stop someone re-running an experiment that has already been run — so it has to be accurate about *why* each was declined, not just that it was. CLAUDE.md's own framing is that commitments change when measurement supports it; a precedent that overstates the blocker argues against that.

ADR-0074 carries the full numbers. This makes the pointer honest about what kind of decision it was.

Found by the architect reviewing #127 — the flawed line was mine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)