### PR TITLE
Unpack the downloaded tools outside the checkout (JEF-763)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,17 +42,15 @@ obj_dir/
 rtl/rom.mem
 sim
 sim.dSYM/
-# The Sail co-simulation spike (docs/adr/0032): a second cxxrtl binary and
-# the prebuilt sail-riscv release `make sail-setup` unpacks. Both are build
-# artifacts; neither is on `make test`'s path.
+# The Sail co-simulation runner: a second cxxrtl binary, and not on `make
+# test`'s path.
 cosim
 cosim.dSYM/
-tools/sail
-tools/sail.tmp
-# The pinned svlint release archive `make lint-setup` unpacks (the structural
-# lint gate, .svlint.toml). A downloaded binary; never commit it.
-tools/svlint
-tools/svlint.tmp
+# `make sail-setup` and `make lint-setup` unpack into a cache outside the
+# checkout, so a git worktree sees the same install the main checkout does.
+# tools/ stays ignored so an install an older checkout left behind here can
+# never be committed.
+tools/
 test/a.out.dSYM/
 # Swarm agent worktrees (.claude/tracker.json stays tracked).
 .claude/worktrees/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,6 +225,11 @@ make cosim-run      # co-sim one program (PROG=add.S)
 make cosim-suite    # the whole suite, graded against COSIM_EXPECTED_FAIL
 ```
 
+`make sail-setup` and `make lint-setup` unpack into `~/.cache/little-cpu`
+(`XDG_CACHE_HOME` moves it), **outside the checkout**. A git worktree is given tracked files only
+and a downloaded tool is gitignored, so an install inside the checkout is invisible from every
+worktree — which is why it does not live there. `make test` enforces it.
+
 Toolchain: macOS `brew install riscv64-elf-gcc`; Linux `apt install gcc-riscv64-unknown-elf`.
 Tests are freestanding assembly, so no multilib or newlib. Formal needs the pinned YosysHQ OSS CAD
 Suite. CI runs on every PR (`.github/workflows/ci.yml`); read the required set live from

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,14 @@ sim: test/cxxrtl.cc test/rtl.cc
 	clang++ -O2 -DNDEBUG -std=c++17 -Wall -Wextra -Werror \
 	  -isystem $$(yosys-config --datdir)/include/backends/cxxrtl/runtime $< -o $@
 
+# Downloaded tools are unpacked here, outside the checkout. An install inside
+# it would be gitignored, and a git worktree gets tracked files only, so it
+# would be invisible from every worktree -- which is how `make cosim-suite`
+# came to report Sail as not installed on a machine that had it.
+# XDG_CACHE_HOME moves this; test/cosim.py resolves the same path from the same
+# rule, and test/tool_cache_test.sh is what says the two still agree.
+TOOL_CACHE := $(if $(XDG_CACHE_HOME),$(XDG_CACHE_HOME),$(HOME)/.cache)/little-cpu
+
 # Sail co-simulation is opt-in. Nothing from here down to `cosim-suite` is
 # reachable from `make test` or `make test-units`. Keep it that way: the runner
 # stops with an error when Sail is not installed, so making any of this a
@@ -56,7 +64,7 @@ SAIL_ASSET_Darwin_arm64   := sail-riscv-Mac-arm64
 SAIL_ASSET_Linux_x86_64   := sail-riscv-Linux-x86_64
 SAIL_ASSET_Linux_aarch64  := sail-riscv-Linux-aarch64
 
-SAIL_RISCV_DIR := tools/sail
+SAIL_RISCV_DIR := $(TOOL_CACHE)/sail
 SAIL_SIM_BIN   := $(SAIL_RISCV_DIR)/bin/sail_riscv_sim
 SAIL_ASSET     := $(SAIL_ASSET_$(shell uname -s)_$(shell uname -m))
 SAIL_SHA256    := $(SAIL_SHA256_$(SAIL_ASSET))
@@ -98,10 +106,10 @@ sail-setup:
 	  echo "tarball this machine cannot check." >&2; \
 	  exit 1; \
 	fi; \
-	if [ -x $(SAIL_SIM_BIN) ] && \
-	   [ "$$(sed -n 1p $(SAIL_STAMP) 2>/dev/null)" = '$(SAIL_PIN)' ]; then \
-	  want=$$(sed -n 2p $(SAIL_STAMP)); \
-	  got=$$($$sha $(SAIL_SIM_BIN) | cut -d ' ' -f 1); \
+	if [ -x '$(SAIL_SIM_BIN)' ] && \
+	   [ "$$(sed -n 1p '$(SAIL_STAMP)' 2>/dev/null)" = '$(SAIL_PIN)' ]; then \
+	  want=$$(sed -n 2p '$(SAIL_STAMP)'); \
+	  got=$$($$sha '$(SAIL_SIM_BIN)' | cut -d ' ' -f 1); \
 	  if [ "$$want" != "$$got" ]; then \
 	    echo "$(SAIL_SIM_BIN) is not the binary its stamp was written for:" >&2; \
 	    echo "  recorded : $$want" >&2; \
@@ -114,8 +122,8 @@ sail-setup:
 	  exit 0; \
 	fi; \
 	url=https://github.com/riscv/sail-riscv/releases/download/$(SAIL_RISCV_VERSION)/$(SAIL_ASSET).tar.gz; \
-	tmp=$(SAIL_RISCV_DIR).tmp; tgz=$$tmp/$(SAIL_ASSET).tar.gz; \
-	rm -rf $$tmp; mkdir -p $$tmp; \
+	mkdir -p '$(TOOL_CACHE)'; \
+	tmp=$$(mktemp -d '$(SAIL_RISCV_DIR)'.XXXXXX); tgz=$$tmp/$(SAIL_ASSET).tar.gz; \
 	echo "fetching $$url"; \
 	curl -fsSL -o $$tgz "$$url"; \
 	got=$$($$sha $$tgz | cut -d ' ' -f 1); \
@@ -143,9 +151,9 @@ sail-setup:
 	test -x $$tmp/bin/sail_riscv_sim; \
 	printf '%s\n' '$(SAIL_PIN)' > $$tmp/.sail-pin; \
 	$$sha $$tmp/bin/sail_riscv_sim | cut -d ' ' -f 1 >> $$tmp/.sail-pin; \
-	rm -rf $(SAIL_RISCV_DIR); \
-	mv $$tmp $(SAIL_RISCV_DIR)
-	@$(SAIL_SIM_BIN) --version
+	rm -rf '$(SAIL_RISCV_DIR)'; \
+	mv $$tmp '$(SAIL_RISCV_DIR)'
+	@'$(SAIL_SIM_BIN)' --version
 
 cosim: test/cosim.cc test/rtl.cc
 	clang++ -O2 -DNDEBUG -std=c++17 -Wall -Wextra -Werror \
@@ -238,11 +246,11 @@ SVLINT_ASSET_Linux_x86_64  := svlint-v$(SVLINT_VERSION)-x86_64-lnx
 SVLINT_ASSET_Darwin_x86_64 := svlint-v$(SVLINT_VERSION)-x86_64-mac
 SVLINT_ASSET_Darwin_arm64  := svlint-v$(SVLINT_VERSION)-aarch64-mac
 
-SVLINT_DIR   := tools/svlint
+SVLINT_DIR   := $(TOOL_CACHE)/svlint
 SVLINT_ASSET := $(SVLINT_ASSET_$(shell uname -s)_$(shell uname -m))
 SVLINT_SHA256 := $(SVLINT_SHA256_$(SVLINT_ASSET))
 
-SVLINT ?= $(shell command -v svlint 2>/dev/null || echo ./$(SVLINT_DIR)/bin/svlint)
+SVLINT ?= $(shell command -v svlint 2>/dev/null || echo $(SVLINT_DIR)/bin/svlint)
 
 # `-i rtl` is required. svlint looks up `include "structs.v"` on the include path
 # and nowhere else, so without it nothing parses. The two passes below both
@@ -278,9 +286,9 @@ lint-setup:
 	  echo "archive this machine cannot check." >&2; \
 	  exit 1; \
 	fi; \
-	tmp=$(SVLINT_DIR).tmp; zip=$$tmp/$(SVLINT_ASSET).zip; \
 	url=https://github.com/dalance/svlint/releases/download/v$(SVLINT_VERSION)/$(SVLINT_ASSET).zip; \
-	rm -rf $$tmp; mkdir -p $$tmp; \
+	mkdir -p '$(TOOL_CACHE)'; \
+	tmp=$$(mktemp -d '$(SVLINT_DIR)'.XXXXXX); zip=$$tmp/$(SVLINT_ASSET).zip; \
 	echo "fetching $$url"; \
 	curl -fsSL -o $$zip "$$url"; \
 	got=$$($$sha $$zip | cut -d ' ' -f 1); \
@@ -302,9 +310,9 @@ lint-setup:
 	rm -f $$zip; \
 	chmod +x $$tmp/bin/svlint; \
 	test -x $$tmp/bin/svlint; \
-	rm -rf $(SVLINT_DIR); \
-	mv $$tmp $(SVLINT_DIR)
-	@./$(SVLINT_DIR)/bin/svlint --version
+	rm -rf '$(SVLINT_DIR)'; \
+	mv $$tmp '$(SVLINT_DIR)'
+	@'$(SVLINT_DIR)'/bin/svlint --version
 
 UNIT_BENCHES := exec_tb mem_tb imem_tb decoder_tb regfile_tb csr_tb accessor_tb monitor_tb
 
@@ -382,8 +390,15 @@ probe-gates:
 pin-bump-test:
 	@./formal/test-propose-pin-bump.sh
 
+# Reads the two directories this file resolves and checks them against
+# test/cosim.py's. Hangs off `test` like the other bash checks: python3 and a
+# shell, no cross compiler, no Sail, no yosys.
+.PHONY: tool-cache-test
+tool-cache-test:
+	@./test/tool_cache_test.sh '$(SAIL_RISCV_DIR)' '$(SVLINT_DIR)'
+
 .PHONY: test
-test: sim test-units probe-gates pin-bump-test
+test: sim test-units probe-gates pin-bump-test tool-cache-test
 	@./test/run_tests.sh ./sim test/asm test/EXPECTED_FAIL test/OBSERVED_FLOOR
 
 # The same suite `make test` runs, with the runner charging every cycle to the

--- a/docs/adr/0075-downloaded-tools-live-outside-the-checkout.md
+++ b/docs/adr/0075-downloaded-tools-live-outside-the-checkout.md
@@ -1,0 +1,104 @@
+# ADR-0075: Downloaded tools live outside the checkout
+
+**Status:** Accepted · 2026-08-06 · *Moves the install location named by
+[ADR-0032](0032-sail-co-simulation-is-worth-building-and-stays-opt-in.md),
+[ADR-0033](0033-what-the-green-ladder-does-not-cover.md) and
+[ADR-0043](0043-the-reference-model-is-configured-as-this-core.md), all of which say `tools/sail`.
+No `rtl/` change ships from this ADR, and co-simulation stays off `make test` and off CI's required
+set.*
+
+## Context
+
+`make sail-setup` unpacked the pinned sail-riscv release into `tools/sail`, and `make lint-setup`
+unpacked svlint into `tools/svlint`. Both directories are gitignored, which is correct — they hold
+downloaded binaries.
+
+A git worktree is given the repository's **tracked** files. Nothing else crosses. So an install made
+in the main checkout exists there and in no worktree, and the only thing a worktree gets is
+`sail_riscv_sim not found. Run 'make sail-setup'` — a message that is true about that directory and
+says nothing about the copy sitting one directory up.
+
+This matters more than a missing binary because of what co-simulation is. It is the only oracle here
+that reads the core's real `regs_a` array instead of the core's own report of what it retired; the
+worked case is an extra `regs[31] <=` write enabled only past the BMC bound, invisible to every
+riscv-formal check and to all 59 `.S` programs, and reported by co-simulation in 0.6s. Every
+engineer working in a worktree was working without that instrument and had nothing telling them so.
+
+## What was measured
+
+- Six of six live worktrees lacked `tools/sail/bin/sail_riscv_sim`. The main checkout had it, and
+  `make cosim-suite` there was 59/59 agreed against an empty `test/COSIM_EXPECTED_FAIL`.
+- It has already cost a verdict.
+  [ADR-0074](0074-the-operand-fetch-cycle-is-removable-and-costs-more-than-it-saves.md) records that
+  `make cosim-suite` was run on neither operand-fetch variant, because the worktree those
+  measurements were taken in had no Sail binary — while the checkout it branched from did. That ADR
+  named the cause correctly, which is the better outcome and not the one to plan for: the message
+  the worktree gives says only that the binary is absent from that directory, so reading it as
+  "Sail is not installed on this machine" is the expected reading, not a careless one.
+- `make lint` has the same shape and does not bite the same way. `SVLINT` resolves from `PATH`
+  first and only falls back to `tools/svlint`, so a `brew install svlint` or a
+  `cargo install svlint` satisfies every checkout at once; CI's lint job runs `make lint-setup`
+  into a fresh full checkout, never a worktree. The hole is real but latent — it appears only for
+  someone whose only svlint is the one `lint-setup` unpacked, working in a worktree — so it is
+  fixed here for the same reason and by the same mechanism rather than left as an asymmetry
+  somebody has to rediscover.
+
+## Decision
+
+**Both setups unpack into `${XDG_CACHE_HOME:-$HOME/.cache}/little-cpu`.** One install serves every
+checkout, every worktree and every clone on the machine. `tools/` is no longer written by anything
+and stays gitignored so an install an older checkout left there can never be committed.
+
+The pinned-release integrity check is untouched and still gates the unpack: `sail-setup` refuses to
+extract a tarball whose SHA-256 is not the digest in the Makefile, refuses to run at all when no
+digest is pinned for the host asset, rejects archive members outside the top directory or containing
+`..`, records the unpacked binary's own digest in `.sail-pin`, and `test/cosim.py` re-checks that
+digest before executing it. `lint-setup` verifies its archive the same way. Moving a directory
+changes none of that; the verification was never a property of the path.
+
+### Rejected: symlink `tools/sail` into each worktree at creation
+
+Cheapest, and it reopens silently. It needs a hook or a documented step wherever worktrees are
+made, and a worktree created without that step is back to the state this ADR is about — with the
+same message, which is what made the original defect invisible.
+
+### Rejected: have `sail-setup` detect a worktree and link to the main checkout's copy
+
+Fixes the symptom for `sail-setup` only, and buys a dependency on `git worktree` layout — the main
+checkout's path, resolved out of `.git`, in a Makefile. A plain clone with no worktree still gets
+nothing shared, and the "which checkout is primary" question has no good answer for a machine with
+two clones.
+
+## Evidence
+
+Both installs verified from a **fresh worktree**, not inferred from the main checkout, because
+inferring is the mistake that hid this:
+
+- `make sail-setup` in a worktree: `sha256 ok: 53d0c6f…0737`, then `0.13.1`.
+- `make cosim-suite` in a *second*, freshly created worktree that ran no setup at all:
+  `59/59 agreed`, matching the empty `test/COSIM_EXPECTED_FAIL`.
+- With `~/.cache/little-cpu` moved aside, `make test` is unaffected — 59/59 passed, both baselines
+  empty — and `make cosim-suite` stops before running anything with `co-simulation setup is
+  incomplete`. Co-simulation degrading to a loud refusal on a machine that never ran the setup is
+  the property that keeps it off the merge gate, and it is unchanged.
+
+## Consequences
+
+- **Two files now compute one path**, and a drift between them would make `make cosim-suite` report
+  a binary `make sail-setup` had just written as missing — the same failure, from the other end.
+  `test/tool_cache_test.sh` compares the Makefile's `SAIL_RISCV_DIR` against `test/cosim.py`'s
+  `SAIL_DIR`, and rejects an install directory inside the checkout or named relatively. It hangs off
+  `make test`, and its four red directions are forced by `make probe-gates`.
+- **An install left in `tools/` by a checkout from before this is now dead weight.** Nothing reads
+  it. Delete it; `rm -rf tools`.
+- **The staging directory is `mktemp -d`, not a fixed `.tmp` name.** Two checkouts each had their
+  own; one cache means two concurrent setups would have shared one staging path. The final
+  `rm -rf` / `mv` swap is still not atomic, so two `*-setup` runs racing on one `$HOME` can leave a
+  mangled install — a case with no caller today (co-simulation is not in CI, and the lint job runs
+  `lint-setup` once), and one the digest re-check in `test/cosim.py` turns into a loud refusal
+  rather than a wrong answer. CI cannot reach it either: `little-cpu-runners` is a scale set that
+  gives every job its own ephemeral runner, so no two jobs share a `$HOME` — three jobs of one run
+  were checked and landed on three distinct runners. The exposure is a workstation running two
+  setups at once, by hand.
+- `XDG_CACHE_HOME` is honoured by the Makefile and by `test/cosim.py` under the same rule, which is
+  also what lets the probes decide the cache location without installing anything.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -77,6 +77,7 @@ and what it costs. Reversing one is fine — write a new ADR that supersedes it.
 | [0070](0070-the-suites-cycles-are-charged-to-a-named-stall-reason.md) | The suite's cycles are charged to a named stall reason | Accepted · gives 0042's accepted +18.0% an invoice; measures 0026 and 0060's six reasons |
 | [0071](0071-the-trap-commit-path-is-proved-and-its-priority-encoder-is-still-vacuous.md) | The trap commit path is proved by k-induction, and its priority encoder is still vacuous | Accepted · supplements 0011, 0028 and 0030; adds a fourth `components.sby` task |
 | [0074](0074-the-operand-fetch-cycle-is-removable-and-costs-more-than-it-saves.md) | The operand-fetch cycle is removable, and it costs more clock than it saves | Accepted · declines a change to 0042; measured with 0070, graded by 0066; sharpens 0064's coupling |
+| [0075](0075-downloaded-tools-live-outside-the-checkout.md) | Downloaded tools live outside the checkout, so a worktree can run co-simulation | Accepted · moves the install location named by 0032, 0033 and 0043 |
 
 0001–0007 came from the design brief
 ([`docs/ideas/finish-the-rewrite.md`](../ideas/finish-the-rewrite.md)). 0008–0011 came out of

--- a/test/cosim.py
+++ b/test/cosim.py
@@ -89,7 +89,16 @@ import tempfile
 REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 ASM_DIR = os.path.join(REPO, "test", "asm")
 SAIL_CONFIG = os.path.join(REPO, "test", "sail", "rv32imc_zicsr.json")
-SAIL_DIR = os.path.join(REPO, "tools", "sail")
+# `make sail-setup` unpacks the release here, outside any checkout. The install
+# used to live in the gitignored tools/, and a git worktree gets tracked files
+# only, so co-simulation was unavailable from every worktree while the main
+# checkout ran it fine. The Makefile computes this same path from TOOL_CACHE;
+# test/tool_cache_test.sh is what says the two still agree.
+TOOL_CACHE = os.path.join(
+    os.environ.get("XDG_CACHE_HOME")
+    or os.path.join(os.path.expanduser("~"), ".cache"),
+    "little-cpu")
+SAIL_DIR = os.path.join(TOOL_CACHE, "sail")
 SAIL_BIN = os.path.join(SAIL_DIR, "bin", "sail_riscv_sim")
 # Written by `make sail-setup` after it verifies the release tarball's SHA-256:
 # line 1 is the pin (version, asset, tarball digest), line 2 is the digest of
@@ -187,7 +196,7 @@ def sha256(path):
 
 
 def read_pin():
-    """(pin_line, binary_sha256) from tools/sail/.sail-pin, or (None, None)."""
+    """(pin_line, binary_sha256) from the install's .sail-pin, or (None, None)."""
     try:
         with open(SAIL_STAMP) as fh:
             lines = [ln.strip() for ln in fh.read().splitlines() if ln.strip()]
@@ -208,11 +217,11 @@ def find_sail(explicit):
        asset (the Makefile's sail-setup names it), so it is honoured even when
        it does not match the pin -- but never silently: an unmatched binary is
        announced on stderr with its digest.
-    2. `tools/sail/bin/sail_riscv_sim` -- must match the SHA-256 that
-       `make sail-setup` recorded in tools/sail/.sail-pin after verifying the
-       release tarball. A mismatch is fatal, not a warning: nobody named this
-       path, so an unexpected binary here is a substituted one, and tools/sail
-       is gitignored so it never shows up in `git status` or in review.
+    2. SAIL_BIN in the shared tool cache -- must match the SHA-256 that
+       `make sail-setup` recorded in SAIL_STAMP after verifying the release
+       tarball. A mismatch is fatal, not a warning: nobody named this path, so
+       an unexpected binary here is a substituted one, and it sits outside
+       every checkout so it never shows up in `git status` or in review.
 
     There is deliberately no bare PATH fallback. It executed whatever
     `sail_riscv_sim` happened to be first on PATH, with no version or digest
@@ -220,8 +229,8 @@ def find_sail(explicit):
     SAIL_RISCV_SIM is one environment variable away and is then a choice.
 
     What this does NOT establish: the stamp is checked against the binary, not
-    against the Makefile. A whole tools/sail tree substituted along with its
-    stamp passes here. `make cosim-run` catches that -- the Makefile compares
+    against the Makefile. A whole install tree substituted along with its stamp
+    passes here. `make cosim-run` catches that -- the Makefile compares
     line 1 of the stamp to its own `override` pin before running anything --
     so the two checks are complementary and a direct ./test/cosim.py
     invocation only gets this one.
@@ -264,7 +273,7 @@ def find_sail(explicit):
 
     raise Fatal(
         "sail_riscv_sim not found. Run 'make sail-setup' to install the pinned "
-        "release into tools/sail/, or set SAIL_RISCV_SIM to an existing build."
+        f"release into {SAIL_DIR}/, or set SAIL_RISCV_SIM to an existing build."
     )
 
 

--- a/test/probe_gates.sh
+++ b/test/probe_gates.sh
@@ -27,7 +27,7 @@ REPO=$(cd "$HERE/.." && pwd)
 # Pinned as a literal: a probe that is deleted, or that stops being reached by
 # an early `return`, would otherwise cut this file's coverage while it kept
 # printing a green summary.
-PROBES_EXPECTED=137
+PROBES_EXPECTED=142
 
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/littlecpu-probe.XXXXXX") || {
   echo "error: could not create a temporary directory under ${TMPDIR:-/tmp}." >&2
@@ -1045,6 +1045,35 @@ probe "a field with no value is a malformed line" 1 "'issue' is not key=value" \
 d=$(new_case); : > "$d/counts"
 probe "no programs at all would report a clean 0 of 0" 1 \
   "no program reported its cycles" "$SR $d/counts"
+
+begin_group "test/tool_cache_test.sh"
+
+# XDG_CACHE_HOME is what both the Makefile and test/cosim.py resolve the tool
+# cache from, so setting it here decides the python side of the comparison
+# without installing anything. Nothing below is created on disk: the check
+# compares path strings and never stats them.
+TCT="$HERE/tool_cache_test.sh"
+tc_cache="$tmp/cache/little-cpu"
+
+probe "control: two agreeing paths outside the checkout are green" 0 \
+  "outside the checkout and agreed on" \
+  "XDG_CACHE_HOME=$tmp/cache $TCT $tc_cache/sail $tc_cache/svlint"
+
+probe "the Makefile and test/cosim.py drifting apart is red" 1 \
+  "do not agree on where the Sail" \
+  "XDG_CACHE_HOME=$tmp/cache $TCT $tc_cache/elsewhere $tc_cache/svlint"
+
+probe "a Sail install back inside the checkout is red" 1 \
+  "test/cosim.py installs tools inside the checkout" \
+  "XDG_CACHE_HOME=$REPO/cache $TCT $REPO/cache/little-cpu/sail $tc_cache/svlint"
+
+probe "an svlint install inside the checkout is red on its own" 1 \
+  "$REPO/tools/svlint" \
+  "XDG_CACHE_HOME=$tmp/cache $TCT $tc_cache/sail $REPO/tools/svlint"
+
+probe "a relative install directory is red before it is compared" 1 \
+  "names a relative tool install directory" \
+  "XDG_CACHE_HOME=$tmp/cache $TCT tools/sail tools/svlint"
 
 begin_group "soc/fit_report.py"
 

--- a/test/tool_cache_test.sh
+++ b/test/tool_cache_test.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+# Asserts that the downloaded tools land somewhere every checkout can reach,
+# and that the two files which independently compute that location still agree.
+#
+# Usage: tool_cache_test.sh <sail-dir> <svlint-dir>   # the Makefile's values
+#
+# WHY THIS EXISTS. `make sail-setup` used to unpack into the gitignored
+# `tools/sail`. A git worktree is given tracked files only, so the install was
+# present in the main checkout and in no worktree -- and the message a worktree
+# got, "run 'make sail-setup'", never said the binary already existed one
+# directory up. Six of six live worktrees lacked it, and a recorded measurement
+# shipped with co-simulation unrun for that reason alone. Co-simulation
+# is the only oracle here that reads the core's real register array, so that is
+# the instrument every engineer working in a worktree could not run.
+#
+# The fix moves the installs out of the checkout, which creates the one thing
+# that can silently regress: the Makefile computes the path for `sail-setup` to
+# write, test/cosim.py computes it again for the runner to read, and nothing
+# makes them the same string. If they drift, `make cosim-suite` looks for a
+# binary `make sail-setup` did not write and reports it as missing -- the exact
+# failure this replaced. The comparison below is that check.
+#
+# Hermetic: python3 and a shell, no toolchain, no Sail, no yosys, so it runs
+# inside `make test` anywhere that already ran.
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+  echo "usage: tool_cache_test.sh <sail-dir> <svlint-dir>" >&2
+  exit 1
+fi
+
+MAKE_SAIL_DIR=$1
+MAKE_SVLINT_DIR=$2
+HERE=$(cd "$(dirname "$0")" && pwd)
+REPO=$(cd "$HERE/.." && pwd)
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "error: python3 is not on PATH, so test/cosim.py's idea of where the" >&2
+  echo "Sail install lives cannot be read. Without it there is no comparison." >&2
+  exit 1
+fi
+
+# Imported rather than re-derived here. A second copy of the rule would agree
+# with the Makefile while cosim.py disagreed with both, which is the failure
+# this is written to catch. `-B` keeps the import from leaving a __pycache__
+# behind in a tracked directory.
+py_sail_dir=$(cd "$HERE" && python3 -B -c 'import cosim; print(cosim.SAIL_DIR)')
+
+if [ -z "$py_sail_dir" ]; then
+  echo "error: test/cosim.py named no Sail install directory." >&2
+  exit 1
+fi
+
+rc=0
+
+if [ "$MAKE_SAIL_DIR" != "$py_sail_dir" ]; then
+  echo "error: the Makefile and test/cosim.py do not agree on where the Sail" >&2
+  echo "install lives:" >&2
+  echo "  Makefile     : $MAKE_SAIL_DIR" >&2
+  echo "  test/cosim.py: $py_sail_dir" >&2
+  echo "\`make sail-setup\` writes the first and \`make cosim-suite\` reads the" >&2
+  echo "second, so co-simulation would report a binary it just installed as" >&2
+  echo "missing. Both derive from XDG_CACHE_HOME; change them together." >&2
+  rc=1
+fi
+
+# outside_checkout <who> <dir>
+outside_checkout() {
+  local who=$1 dir=$2
+  # An absolute path is what makes the prefix test mean anything: a relative
+  # one is read against whatever directory make happened to be run from.
+  case "$dir" in
+    /*) ;;
+    *)
+      echo "error: $who names a relative tool install directory '$dir'." >&2
+      echo "It has to be absolute; a relative one moves with the caller's" >&2
+      echo "working directory and cannot be checked against the checkout." >&2
+      rc=1
+      return
+      ;;
+  esac
+  case "$dir/" in
+    "$REPO"/*)
+      echo "error: $who installs tools inside the checkout:" >&2
+      echo "  $dir" >&2
+      echo "  checkout: $REPO" >&2
+      echo "Downloaded tools are gitignored, and a git worktree is given" >&2
+      echo "tracked files only, so an install here is invisible from every" >&2
+      echo "worktree. Put it under the shared cache instead." >&2
+      rc=1
+      ;;
+  esac
+}
+
+outside_checkout Makefile "$MAKE_SAIL_DIR"
+outside_checkout test/cosim.py "$py_sail_dir"
+outside_checkout Makefile "$MAKE_SVLINT_DIR"
+
+if [ "$rc" -ne 0 ]; then
+  exit 1
+fi
+
+echo "Tool installs are outside the checkout and agreed on: $py_sail_dir"


### PR DESCRIPTION
Closes JEF-763.

## The defect

`make sail-setup` unpacked the pinned sail-riscv release into the gitignored `tools/sail`, and `make lint-setup` unpacked svlint into `tools/svlint`. **A git worktree is given the repository's tracked files and nothing else**, so an install made in the main checkout existed there and in no worktree. Six of six live worktrees lacked `tools/sail/bin/sail_riscv_sim`. The message a worktree got — `run 'make sail-setup'` — was true about that directory and said nothing about the copy sitting one directory up.

Co-simulation is the only oracle here that reads the core's real `regs_a` array instead of its self-report, so that is the instrument every engineer dispatched into a worktree could not run. It has already cost a verdict: the operand-fetch measurement ADR records "Sail is not installed on this machine." It was.

## Option chosen: move the install out of the repo

`${XDG_CACHE_HOME:-$HOME/.cache}/little-cpu`. One install serves every checkout, worktree and clone on the machine, and there is **no per-worktree step that can be skipped**.

The other two lose:

- **Symlink `tools/sail` into each worktree at creation** — needs a hook or a documented step wherever worktrees are made, and a worktree created without it is back to exactly this state, with the same message that made the defect invisible the first time. It reopens silently, which is the one property that matters here.
- **Have `sail-setup` detect a worktree and link to the main checkout's copy** — fixes `sail-setup` only, and buys a dependency on `git worktree` layout (the primary checkout's path, resolved out of `.git`, in a Makefile). A plain second clone still shares nothing, and "which checkout is primary" has no good answer on a machine with two.

## The digest verification still holds — nothing about it was weakened

Moving a directory is not a property the verification depended on. Unchanged and still gating the unpack:

- `SAIL_RISCV_VERSION` / `SVLINT_VERSION` are still `override` and still refuse to be set from the command line or the environment.
- The archive's SHA-256 is still compared against the Makefile's literal **before anything is extracted**; a mismatch prints expected/actual and refuses.
- A host with no pinned digest is still refused rather than fetched unverified; a host with neither `shasum` nor `sha256sum` is still refused.
- Archive members are still checked for escaping the top directory, for `..`, and for being anything other than a file or directory.
- `sail-setup` still records the unpacked binary's own digest in `.sail-pin`, and `test/cosim.py` still re-checks that digest before executing it — fatal, not a warning.

Observed on this branch: `sha256 ok: 53d0c6fd84edd898728e7ba01c1575e66e5f17efd098847c5273690abbbd0737` and `sha256 ok: d032be600f0ee04130e0663daa05da3cc562d3d34bbc4305d6b70cb99310c6df`.

Two hardening changes came with the relocation, both because the path now derives from `$HOME`: the staging directory is `mktemp -d` rather than a fixed `.tmp` (two checkouts each had their own; one cache would have had two concurrent setups sharing one), and the shell expansions around `rm -rf` are quoted.

## What happened to `tools/svlint`

**Same shape, and it was fixed the same way.** `make lint` resolves `SVLINT` from `PATH` first and only falls back to `tools/svlint`, so a `brew install svlint` or `cargo install svlint` satisfies every checkout at once — that is why `make lint` passes in worktrees on this machine and why the hole had never bitten. CI's lint job runs `make lint-setup` into a fresh full checkout, never a worktree. The hole is real but latent: it appears only for someone whose only svlint is the one `lint-setup` unpacked, working in a worktree. Left alone it would be an asymmetry somebody has to rediscover, so `SVLINT_DIR` moved to the same cache and `make lint` is checked against the cached binary as well as the `PATH` one.

## The regression this creates, and its guard

Two files now compute one path — the Makefile for `sail-setup` to write, `test/cosim.py` for the runner to read — and a drift between them would make `make cosim-suite` report a binary `make sail-setup` had just written as missing. That is the same failure, from the other end.

`test/tool_cache_test.sh` compares the Makefile's `SAIL_RISCV_DIR` against `test/cosim.py`'s `SAIL_DIR` (imported, not re-derived) and rejects an install directory inside the checkout or named relatively. It hangs off `make test` alongside `probe-gates` and `pin-bump-test`; it needs python3 and a shell, no cross compiler, no Sail, no yosys. Its four red directions are forced by `make probe-gates`, which goes 137 → 142.

## Acceptance

**1. From a FRESH worktree, created for this and running no setup step at all** (`ls tools` → *No such file or directory*):

```
$ make cosim-suite
Suite shape matches test/OBSERVED_FLOOR: 59 programs.

cross compiler     : riscv64-elf-gcc
sail               : /Users/jeff/.cache/little-cpu/sail/bin/sail_riscv_sim
sail provenance    : pinned: 0.13.1 sail-riscv-Mac-arm64 53d0c6fd84edd898728e7ba01c1575e66e5f17efd098847c5273690abbbd0737
cosim runner       : ./cosim

add.S            AGREE
...
zicsr.S          AGREE

59/59 agreed
Divergence list matches test/COSIM_EXPECTED_FAIL exactly (name and status).
```

**2. A checkout that still has the old install lying around** — which is what the main checkout looks like the moment this merges. Decoy `tools/sail/bin/sail_riscv_sim` planted in the fresh worktree:

```
sail               : /Users/jeff/.cache/little-cpu/sail/bin/sail_riscv_sim
sail provenance    : pinned: 0.13.1 sail-riscv-Mac-arm64 53d0c6f...
$ git status --short
(empty -- tools/ stays ignored, so a 100 MB leftover can never be committed)
```

The stale copy is not read, and it is not committable. `rm -rf tools` when convenient.

**3. Degrades gracefully with Sail absent.** `~/.cache/little-cpu` moved aside:

```
$ make test
59/59 passed
Failure list matches test/EXPECTED_FAIL exactly (name and status).

$ make cosim-suite
Suite shape matches test/OBSERVED_FLOOR: 59 programs.
error: sail_riscv_sim not found. Run 'make sail-setup' to install the pinned
release into /Users/jeff/.cache/little-cpu/sail/, or set SAIL_RISCV_SIM to an
existing build.
error: co-simulation setup is incomplete; nothing was run.
```

Note that the message now names the absolute shared path, so it no longer describes a directory that is empty by construction. Co-simulation stays off `make test`'s path and off CI's required set — unchanged, and deliberately so.

**4. Discoverable.** CLAUDE.md's Commands section states the location and the reason next to the `sail-setup` line; the `.gitignore` entry for `tools/` says why it is still ignored; `make setup` on Linux prints the cache path; `make test` fails if anyone moves an install back inside the checkout.

## Checks

| | |
|---|---|
| `make test` | 59/59 passed, `EXPECTED_FAIL` matched exactly (empty) |
| `make test-units` | all benches pass, positive controls fire |
| `make probe-gates` | 142 graded comparisons, every failure path executed |
| `make lint` | clean in both passes, via `PATH` svlint and via the cached one |
| `make cosim-suite` | 59/59 agreed, `COSIM_EXPECTED_FAIL` matched exactly (empty) — in this worktree and in a fresh one |
| `make sail-setup` / `make lint-setup` | both digests verified; the "already verified" fast path re-checks the installed binary |

Not run, and not expected to move: the riscv-formal checks and `make soc-timing`. No `rtl/` or `formal/` file is touched — the diff is the Makefile, `test/cosim.py`, `test/probe_gates.sh`, `.gitignore`, CLAUDE.md, ADR-0075 and a new `test/tool_cache_test.sh`.

## Decision recorded

ADR-0075, including the two rejected options, the residual it leaves (two concurrent `*-setup` runs sharing one `$HOME` can still race on the final rename — no caller does that today, and the digest re-check turns it into a loud refusal rather than a wrong answer), and the note that a leftover `tools/` install is now dead weight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)