### PR TITLE
Replace the ADR citations in test/, soc/ and .github/ with the mechanism

### DIFF
--- a/.github/actions/setup-oss-cad-suite/action.yml
+++ b/.github/actions/setup-oss-cad-suite/action.yml
@@ -24,8 +24,8 @@ runs:
         fi
 
     # Latest, not a pin. A toolchain bump that changes the hardware shows up in
-    # `make fit` and `make soc-timing`, both of which ratchet: ADR-0052 measured
-    # 21 cells between two yosys builds on identical RTL. formal/pin.mk is a
+    # `make fit` and `make soc-timing`, both of which ratchet: 21 cells were
+    # measured between two yosys builds on identical RTL. formal/pin.mk is a
     # different question and stays pinned -- test/monitor.v is generated from it
     # and tracked, so bumping that one means regenerating the monitor.
     - name: Resolve the latest OSS CAD Suite release

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,10 +5,9 @@
 # .github/workflows/.
 #
 # These PRs auto-merge once CI is green -- see .github/workflows/
-# dependabot-automerge.yml and ADR-0018. That is safe because `main` carries
-# required status checks (elaborate, test, components, monitor-freshness), so
-# `gh pr merge --auto` has a real gate to wait for. ADR-0016 records why the
-# same setup was unsafe before those checks existed.
+# dependabot-automerge.yml. That is safe only because `main` carries required
+# status checks, which is what gives `gh pr merge --auto` a real gate to wait
+# for. The set is not listed here; read it from the API, as that file says.
 #
 # The posture is deliberately "stay current" rather than "merge late by hand":
 # unpatched bugs in the code that runs our CI are a certain, cumulative cost,

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,17 +1,14 @@
 name: Dependabot Auto-merge
 
-# Re-armed 2026-07-29 (supersedes ADR-0016's deletion; see ADR-0018).
-#
-# This workflow is only safe because `main` now has required status checks
-# with strict: true. That is
-# what `gh pr merge --auto` waits for. Without them `--auto` merges instantly
-# and this workflow is a rubber stamp — which is exactly why ADR-0016 deleted
-# it while criterion 8 was still outstanding.
+# This workflow is only safe because `main` has required status checks with
+# strict: true. That is what `gh pr merge --auto` waits for. Without them
+# `--auto` merges instantly and this workflow is a rubber stamp — which is why
+# it was deleted once, back when `main` had no required checks to wait on.
 #
 # The set is deliberately NOT enumerated here. It was, and it said four while
 # the API returned six -- this file is not the register of what is required,
 # branch protection is, and a hand-copied list of it drifts silently while
-# looking authoritative (ADR-0050). What this workflow actually depends on is
+# looking authoritative. What this workflow actually depends on is
 # that SOME required set exists with strict: true, which is what the command
 # below reads.
 #
@@ -33,9 +30,9 @@ jobs:
     steps:
       - name: Enable auto-merge
         # --squash, not --merge: main requires linear history, so a merge
-        # commit is rejected outright. The pre-ADR-0016 version of this file
-        # used --merge and would have failed on every run once linear history
-        # was enforced.
+        # commit is rejected outright. An earlier version of this file used
+        # --merge and would have failed on every run once linear history was
+        # enforced.
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/riscv-formal-pin-bump.yml
+++ b/.github/workflows/riscv-formal-pin-bump.yml
@@ -2,7 +2,7 @@ name: riscv-formal pin bump
 
 # Notices when upstream YosysHQ/riscv-formal's `main` has moved past
 # formal/pin.mk's SHA, pushes a branch bumping it with test/monitor.v
-# regenerated against the new pin (ADR-0013), and opens an issue asking a human
+# regenerated against the new pin, and opens an issue asking a human
 # to open the pull request from that branch. The existing gates --
 # monitor-freshness, formal/check-genchecks.py,
 # formal/check-complete-exclusions.py, the ladder itself -- grade the bump;
@@ -10,8 +10,8 @@ name: riscv-formal pin bump
 #
 # It opens an issue rather than a pull request because a PR opened by this
 # workflow would get no CI and could never merge; formal/propose-pin-bump.sh has
-# the mechanism. No auto-merge either: ADR-0018's dependabot-automerge.yml is
-# scoped to `dependabot[bot]` and does not apply here.
+# the mechanism. No auto-merge either: dependabot-automerge.yml is scoped to
+# `dependabot[bot]` and does not apply here.
 on:
   schedule:
     - cron: "17 6 * * 1" # weekly, Monday

--- a/soc/cell_census.py
+++ b/soc/cell_census.py
@@ -3,14 +3,13 @@
 
 Replaces the Makefile's `soc_expect_cells` define so `test/probe_gates.sh`
 can drive `make soc-timing`'s SPRAM/EBR census against a fixture log without a
-real yosys run (ADR-0053) -- the same reason `soc/timing_split.py` carries
+real yosys run -- the same reason `soc/timing_split.py` carries
 `make soc-timing`'s frequency ratchet instead of a second parser in the
 recipe.
 
 Matched by cell NAME, not by presence: yosys logs a cell's library definition
 in the same "Number of cells" table whether or not it actually instantiates
-one, so `grep -q SB_SPRAM256KA` passed on a build that inferred zero of them
-(ADR-0054).
+one, so `grep -q SB_SPRAM256KA` passed on a build that inferred zero of them.
 """
 
 import argparse

--- a/soc/fit_report.py
+++ b/soc/fit_report.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """Read nextpnr's fit.log, print the utilisation table, and apply the
-FIT_MAX_LC ratchet (ADR-0042).
+FIT_MAX_LC ratchet.
 
 Replaces the Makefile's inline grep/sed/awk chain so `test/probe_gates.sh`
 can drive both checks against a fixture log without running nextpnr --
@@ -9,9 +9,9 @@ instead of a second parser in the recipe.
 
 `make fit` EXPECTS placement to fail: `littlecpu` with its memories external
 presents 231 SB_IO against sg48's 39, so nextpnr always errors out on a pad,
-after printing the utilisation table -- which is the measurement (ADR-0038
-decision 1a). nextpnr's exit status carries no signal either way; the
-presence of the table is what says a measurement was taken at all.
+after printing the utilisation table -- which is the measurement. nextpnr's
+exit status carries no signal either way; the presence of the table is what
+says a measurement was taken at all.
 """
 
 import argparse
@@ -25,7 +25,7 @@ LC_LINE = re.compile(r"ICESTORM_LC:\s+(\d+)/\s*(\d+)\s+(\S+)")
 # phase gives up: "Unable to place cell ... no BELs remaining" when a BEL
 # class is exhausted, "Unable to find a placement location for cell" when it
 # cannot site a constrained IO. Matching only the first made a normal 80%-full
-# run print the "read fit.log before quoting this" warning (ADR-0042).
+# run print the "read fit.log before quoting this" warning.
 PLACEMENT_ERROR = re.compile(r"^ERROR: Unable to (place cell|find a placement location for cell)")
 
 

--- a/soc/littlesoc.pcf
+++ b/soc/littlesoc.pcf
@@ -1,14 +1,14 @@
 # Pin constraints for rtl/littlesoc.v on an ice40 up5k in an sg48 package.
 #
-# FOUR PINS, and that is the honest answer rather than a shortcut (ADR-0054).
+# FOUR PINS, and that is the honest answer rather than a shortcut.
 # Both memories are internal -- ROM in block RAM, RAM in SPRAM -- so the design
 # has no external bus at all. That is precisely why it places when `make fit`'s
 # top does not: `littlecpu` with its memories external presents 231 `SB_IO`
-# against sg48's 39 and always fails on a pad (ADR-0038 decision 1a).
+# against sg48's 39 and always fails on a pad.
 #
 # The pin numbers are the iCEBreaker 1.0e assignments for its 12 MHz oscillator,
 # its user button and its two on-board LEDs, which is the up5k/sg48 board this
-# project has been written against since ADR-0038 quoted its oscillator. Nothing
+# project has been written against from the first area measurement on. Nothing
 # here is load-bearing for the timing measurement -- `icetime` reports the
 # critical path through the fabric, and four IO pads cannot move it -- but a
 # made-up pinout would place differently from a real one, and a number taken

--- a/soc/rom_banks.py
+++ b/soc/rom_banks.py
@@ -2,9 +2,9 @@
 """Split a flat ROM image into rtl/imemory.v's two interleaved banks.
 
 rtl/imemory.v stores word W in `rom_even` at index W/2 when W is even and in
-`rom_odd` at the same index when it is odd (ADR-0054). That is what removes the
-duplicated ROM the SoC used to need for ADR-0003's dual-word fetch window, and
-it means the bitstream's ROM image is two `$readmemh` files rather than one.
+`rom_odd` at the same index when it is odd. That is what removes the duplicated
+ROM the SoC used to need to serve the dual-word fetch window, and it means the
+bitstream's ROM image is two `$readmemh` files rather than one.
 
 Two files rather than one plus a de-interleaving loop in RTL, because yosys does
 not turn an `initial` block that copies between arrays into memory init: such a
@@ -64,7 +64,7 @@ def main():
 
     # A program that does not fit is a FINDING, not something to truncate. The
     # ROM ceiling is the part's block RAM and it is the whole reason this SoC
-    # can be initialised from its bitstream at all (ADR-0054).
+    # can be initialised from its bitstream at all.
     top = max(image)
     if top >= args.rom_words:
         sys.exit(

--- a/soc/timing_split.py
+++ b/soc/timing_split.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Summarise an `icetime -r` report: the critical path's LOGIC/ROUTING split.
 
-THE SPLIT IS THE FINDING, not the frequency (ADR-0054). The only real timing
+THE SPLIT IS THE FINDING, not the frequency. The only real timing
 number this project had before the SoC placed was `rtl/regfile.v` on its own --
 2.04 ns logic + 12.78 ns routing, 86% routing -- and what made it useful was the
 breakdown, because it said the cost was a distributed mux's wires rather than
@@ -23,7 +23,7 @@ interconnect at all; every other LogicCell40 hop is entered through a LocalMux
 and an InMux. On the SoC's own critical path that is 0.34 ns against 3.31 --
 roughly tenfold -- so a design that trades a carry hop for a LUT level gets
 shorter by icetime's count and slower in nanoseconds. Read the two apart before
-deciding a path is deep (ADR-0058).
+deciding a path is deep.
 
 `--min-mhz` grades the result. The check lives HERE rather than in the Makefile
 because this is the thing that already parses the report: a second parser --

--- a/soc/timing_sweep.sh
+++ b/soc/timing_sweep.sh
@@ -3,10 +3,9 @@
 # spread.
 #
 # One placement is a sample, not a measurement. Unmodified `main` spans about
-# 1.2% across four seeds (ADR-0058) and an edit that changes no hardware moves
-# the number by up to 3.6% (ADR-0054), so a comparison between two designs needs
-# distributions on both sides. Three ADRs have needed exactly this and each ran
-# it by hand.
+# 1.2% across four seeds and an edit that changes no hardware moves the number
+# by up to 3.6%, so a comparison between two designs needs distributions on
+# both sides.
 #
 #   soc/timing_sweep.sh                     # the default placement plus seeds 1-3
 #   SOC_SEEDS='default 1 2 3 4 5' soc/timing_sweep.sh
@@ -21,7 +20,7 @@
 # `make soc-timing | grep 'critical path'`, whose status is grep's -- so a
 # placement under SOC_MIN_MHZ printed its row and the sweep exited 0. Same shape
 # as the graded comparison piped into `tee` that hid a red formal gate for
-# months (ADR-0037).
+# months.
 #
 # It also calls the whole target per seed rather than re-running nextpnr with a
 # new seed against one `soc.json`. That would skip four resyntheses and cost a

--- a/test/COSIM_EXPECTED_FAIL
+++ b/test/COSIM_EXPECTED_FAIL
@@ -1,7 +1,6 @@
-# The co-simulation baseline (ADR-0039), in ADR-0035's format and under
-# ADR-0014's contract. `make cosim-suite` exits 0 only when the set of programs
-# that do NOT agree with the Sail RISC-V model matches this file exactly, in
-# both directions — so an unexpected *agreement* is caught too.
+# The co-simulation baseline. `make cosim-suite` exits 0 only when the set of
+# programs that do NOT agree with the Sail RISC-V model matches this file
+# exactly, in both directions — so an unexpected *agreement* is caught too.
 #
 # THIS FILE IS EMPTY, AND EMPTY IS NOT THE SAME AS ABSENT. Both directions
 # still run: every program in test/asm must AGREE, and any one that does not is
@@ -35,9 +34,9 @@
 # kind of claim as removing the line and needs the same justification in the PR
 # that does it. This file is never regenerated wholesale from a run.
 #
-# HOW THE TWO ENTRIES THAT USED TO BE HERE WERE CLOSED (ADR-0043). Neither was
-# closed by changing the core, and neither was closed the same way, which is
-# the part worth reading before the next divergence arrives:
+# HOW THE TWO ENTRIES THAT USED TO BE HERE WERE CLOSED. Neither was closed by
+# changing the core, and neither was closed the same way, which is the part
+# worth reading before the next divergence arrives:
 #
 #   csr.S       was `DISAGREE AT 17` on `csrr a0, misa` — Sail 0x4034112f
 #               against this core's 0x40001104. The reference model was a
@@ -66,11 +65,3 @@
 # different paths, no value exemption can help, and the assertion belongs in a
 # bench with no reference model in it? Only when none of the three fit is it a
 # baseline entry, and then it needs a paragraph here, not a line.
-
-# ADR-0048 finding 3. The other half of test/EXPECTED_FAIL's `csrset.S FAIL 2`:
-# this core raises illegal instruction on mstatush (0x310) where the reference
-# model reads it and continues, so the handler runs here and does not there and
-# the register traces part company at architectural change 2. Read this file's
-# three questions above before concluding anything from it -- this entry passes
-# them because the divergence is in THIS CORE and is deliberately left open,
-# not because the comparison or the model configuration is at fault.

--- a/test/EXPECTED_FAIL
+++ b/test/EXPECTED_FAIL
@@ -1,14 +1,13 @@
-# The `.S` suite's regression baseline (ADR-0014). `make test` exits 0 only when
-# the set of tests that do NOT pass matches this file exactly — in both
-# directions, so an unexpected *pass* is caught too, not just an unexpected
-# failure.
+# The `.S` suite's regression baseline. `make test` exits 0 only when the set
+# of tests that do NOT pass matches this file exactly — in both directions, so
+# an unexpected *pass* is caught too, not just an unexpected failure.
 #
 # Lines come out one at a time, in the same commit as the fix that makes that
 # test pass: the deletion is the evidence the fix worked. Never regenerate this
 # file wholesale from a run — that launders a regression into the baseline. Edit
 # it by hand, and justify any line added back in the PR that adds it.
 #
-# FORMAT — two fields, not one (ADR-0035):
+# FORMAT — two fields, not one:
 #
 #     <test>.S  <STATUS>
 #
@@ -30,24 +29,9 @@
 # a review flag.
 #
 # THIS IS NOT THE PLACE TO PARK A DEFECT IN THE ORACLE. When the generated
-# monitor itself is wrong, the repair belongs in test/sanitize_monitor.py —
-# read ADR-0019 before adding a line back for a monitor-side problem.
+# monitor itself is wrong, the repair belongs in test/sanitize_monitor.py, which
+# is re-applied every time the monitor is regenerated at the pin. Baselining the
+# one program that tripped it leaves the oracle wrong for every other program.
 #
-# The history of what was baselined here and when lives in git and in the ADRs
-# above; it is not repeated in this file, which describes the contract in force.
-
-# ADR-0048 finding 3, landed red on purpose. Two CSRs the RV32 privileged
-# specification lists unconditionally -- mstatush (0x310, priv 20211203
-# §3.1.6.4) and mconfigptr (0xF15, §3.1.4) -- are absent from rtl/csrs.v's
-# `implemented` set, so an access to either raises illegal instruction where the
-# spec says it should read zero. The Sail reference model reads both and
-# continues; this core traps on both, so the divergence is measured rather than
-# argued, and test/COSIM_EXPECTED_FAIL carries the other half of it.
-#
-# NOT fixed in the change that found it: ADR-0005 states its CSR set as *exact*,
-# so widening it is an ISA-scope decision belonging to an amendment of
-# ADR-0002/ADR-0005, not to the audit that noticed. The status pins the first
-# failing case; when mstatush alone lands, this becomes `FAIL 3` and the second
-# field goes red, which is ADR-0035's mechanism working rather than a
-# regression. When both land, this line and the co-simulation one come out
-# together.
+# The history of what was baselined here and when lives in git; it is not
+# repeated in this file, which describes the contract in force.

--- a/test/OBSERVED_FLOOR
+++ b/test/OBSERVED_FLOOR
@@ -16,9 +16,9 @@
 # both empty, so nothing in them would disappear if the suite itself did. A bad
 # rebase, a directory rename, a .gitignore change or a glob that stopped
 # matching would leave `make test` reporting `12/12 passed`, matching an empty
-# baseline exactly, and exiting 0. ADR-0033 named that shape on the formal side
-# — a verdict baseline "cannot report whether a check stopped existing", which
-# is why formal/EXPECTED_CHECKS exists. The name set below is the same
+# baseline exactly, and exiting 0. The formal side has the same shape: a verdict
+# baseline cannot report whether a check stopped existing, which is why
+# formal/EXPECTED_CHECKS exists. The name set below is the same
 # assertion for simulation. It is checked in BOTH directions: a program in
 # test/asm with no line here is red, so a `.S` that lands without being wired in
 # fails immediately rather than joining the suite unmeasured.
@@ -27,11 +27,11 @@
 # its per-retire oracle, but nothing in the gate measured whether the oracle
 # ever fired. test/cxxrtl.cc sampled the monitor's errcode and counted nothing,
 # so a monitor whose `rvfi_valid` never asserted — an under-sensitivity defect
-# of exactly the kind ADR-0037 found in the iverilog leg, an `ifdef` that
+# of exactly the kind already found in the iverilog leg, an `ifdef` that
 # dropped the shadow payload, a `write_cxxrtl` that optimised the instance
-# away — left every program here reporting PASS off `tohost` alone. ADR-0032
-# had already measured that end-state checking on its own is blind to real
-# architectural corruption, and test/EXPECTED_FAIL is empty, so there was no
+# away — left every program here reporting PASS off `tohost` alone. Checking
+# the end state alone was already measured to be blind to real architectural
+# corruption, and test/EXPECTED_FAIL is empty, so there was no
 # red entry whose disappearance would have said otherwise either. This file
 # turns observation into a graded quantity instead of an inference.
 #
@@ -49,12 +49,12 @@
 # and test/EXPECTED_FAIL or formal/EXPECTED_CHECKS, and it is deliberate. The
 # numbers move for legitimate reasons: the assembler is free to compress
 # differently, a test gains an instruction, a macro in test/asm/riscv_test.h
-# grows one. An exact ratchet over 52 numbers is one nobody would keep, and a
-# ratchet nobody keeps gets raised until it means nothing. What must not happen
-# is a program going QUIET, and `>=` catches exactly that.
+# grows one. An exact ratchet over every number in this file is one nobody
+# would keep, and a ratchet nobody keeps gets raised until it means nothing.
+# What must not happen is a program going QUIET, and `>=` catches exactly that.
 #
 # The NAME set, on the other hand, IS a set equality in both directions, the
-# same contract ADR-0014 puts on the two files above — that is the manifest
+# same contract the two files above carry — that is the manifest
 # half, described at the top. It is checked by test/check_suite_shape.sh BEFORE
 # either leg assembles anything, so a mismatch in either direction names the
 # programs involved and stops, rather than being discovered after a full run

--- a/test/accessor_tb.v
+++ b/test/accessor_tb.v
@@ -2,7 +2,7 @@
 `default_nettype none
 `include "structs.v"
 
-// The read enable rtl/imemory.v arbitrates on (ADR-0059/ADR-0060).
+// The read enable rtl/imemory.v arbitrates on.
 //
 // The idle bus presents address 0, which is inside the text range, so the
 // memory cannot tell a real load from an idle cycle by address alone. This

--- a/test/asm/cebreak.S
+++ b/test/asm/cebreak.S
@@ -24,13 +24,13 @@
 # drives the 32-bit form.
 #
 # Both alignments are exercised. `c.ebreak` at pc % 4 == 2 is where mepc's WARL
-# mask has to preserve bit 1 (ADR-0005) — the same property test/asm/trap.S
+# mask has to preserve bit 1 — the same property test/asm/trap.S
 # checks with a `c.lw`, restated here against a trap cause that comes from the
 # instruction itself rather than from its operand address.
 #
 # Layout: each faulting `c.ebreak` is followed by exactly one `c.nop`, because
 # the recording handler resumes at mepc+4 unconditionally and cannot read the
-# faulting instruction to learn it was 2 bytes (Harvard buses, ADR-0008). The
+# faulting instruction to learn it was 2 bytes (Harvard buses). The
 # `.align 2` before each block is what makes the alignment claim true rather
 # than incidental, and tests 4 and 8 assert it, so this file cannot quietly
 # degrade into two copies of the same case.
@@ -42,7 +42,7 @@
 RVTEST_RV64U
 RVTEST_CODE_BEGIN
 
-  # mtvec resets to 0, which is _start (ADR-0029) — install before faulting.
+  # mtvec resets to 0, which is _start — install before faulting.
   RVTEST_INSTALL_TRAP_HANDLER
 
   #-------------------------------------------------------------
@@ -100,7 +100,7 @@ test_9:
   bne   a4, x29, fail
 
   #-------------------------------------------------------------
-  # A trapping `c.ebreak` writes no register (ADR-0028), the same commitment
+  # A trapping `c.ebreak` writes no register, the same commitment
   # every other trapping instruction here makes. c.ebreak's encoding has rd
   # == x0 anyway, so this is really a check that decode's trap suppression did
   # not route something into the rd field on the way past.
@@ -115,7 +115,7 @@ test_9:
   TEST_CASE( 11, a4, 3, la a3, trap_count; lw a4, 0(a3); )
 
   #-------------------------------------------------------------
-  # ADR-0027: a trapping instruction does not increment `minstret`, and that
+  # A trapping instruction does not increment `minstret`, and that
   # has to hold for the compressed breakpoint too. Same shape as trap.S's
   # test 19: the difference across the pair is the first `csrr` plus one
   # handler entry, and the `c.ebreak` itself contributes nothing.

--- a/test/asm/csr.S
+++ b/test/asm/csr.S
@@ -4,14 +4,14 @@
 # csr.S
 #-----------------------------------------------------------------------------
 #
-# The Zicsr access semantics and the CSR set of ADR-0005, checked in band.
+# The Zicsr access semantics and this core's CSR set, checked in band.
 # riscv-formal has no spec model for csrr*/mret at the pinned SHA, so the
 # per-retire monitor reports nothing about any instruction in this file (see
 # riscv_test.h) — every claim here is asserted by the test itself.
 #
 # No trap is expected anywhere in this file, so it installs the *fatal* handler:
 # an unexpected fault reports the live test number instead of restarting the
-# program from mtvec = 0 (ADR-0029).
+# program from mtvec = 0.
 #
 
 #include "riscv_test.h"
@@ -42,7 +42,7 @@ RVTEST_CODE_BEGIN
   TEST_CASE( 4, a1, 0x5678, csrr a1, mscratch; )
 
   #-------------------------------------------------------------
-  # CSRRS with rs1 == x0 suppresses the write entirely (ADR-0005), so it is
+  # CSRRS with rs1 == x0 suppresses the write entirely, so it is
   # legal against a read-only CSR — if it raised illegal-instruction instead,
   # the fatal handler below would report this test number.
   #-------------------------------------------------------------
@@ -62,7 +62,7 @@ RVTEST_CODE_BEGIN
   TEST_CASE( 9, a0, 0x5670, csrrsi a0, mscratch, 0x03; )
 
   #-------------------------------------------------------------
-  # The read-only identification CSRs (ADR-0005).
+  # The read-only identification CSRs.
   #-------------------------------------------------------------
 
   TEST_CASE( 10, a0, 0x40001104, csrr a0, misa; )
@@ -71,7 +71,7 @@ RVTEST_CODE_BEGIN
   TEST_CASE( 13, a0, 0, csrr a0, mimpid; )
   TEST_CASE( 14, a0, 0, csrr a0, mhartid; )
 
-  # mtval is hardwired zero (ADR-0002), so it reads zero out of reset and
+  # mtval is hardwired zero, so it reads zero out of reset and
   # after any trap. That much is true of the reference model too.
   TEST_CASE( 15, a0, 0, csrr a0, mtval; )
 
@@ -79,15 +79,15 @@ RVTEST_CODE_BEGIN
   # that `mie` reads zero, that `mip` reads zero, and that a write to either
   # (or to `mtval`) does not stick. All three are true of this core and all
   # three are implementation choices rather than ISA rules: with no interrupt
-  # sources, mie and mip are read-only zero and mtval may be hardwired
-  # (ADR-0002), while a machine with a timer reports mip.MTIP set, mie's
-  # MSIE/MTIE/MEIE writable and mtval writable — and is equally spec-legal.
+  # sources, mie and mip are read-only zero and mtval may be hardwired, while a
+  # machine with a timer reports mip.MTIP set, mie's MSIE/MTIE/MEIE writable
+  # and mtval writable — and is equally spec-legal.
   #
   # The Sail RISC-V model IS that other machine and cannot be configured out of
   # it. Measured against sail-riscv 0.13.1: `platform.clint.supported: false`
   # unmaps the CLINT's MMIO window but leaves mtime advancing, so mip.MTIP
   # comes up on the first tick; and the config schema names no knob for mie's
-  # writable bits or for a read-only mtval (ADR-0043).
+  # writable bits or for a read-only mtval.
   #
   # So an assertion here would not merely read a different value under
   # co-simulation — it would take a DIFFERENT BRANCH: the reference model runs
@@ -114,9 +114,9 @@ test_17:
   bne   a0, x29, fail
 
   #-------------------------------------------------------------
-  # WARL fields. MPP is hardwired to M-mode, so it survives a zero write
-  # (ADR-0005), and mepc's bit 0 is always clear — only bit 0, because C makes
-  # 2-byte targets legal.
+  # WARL fields. MPP is hardwired to M-mode, so it survives a zero write, and
+  # mepc's bit 0 is always clear — only bit 0, because C makes 2-byte targets
+  # legal.
   #-------------------------------------------------------------
 
   TEST_CASE( 18, a1, 0x1800, \
@@ -131,7 +131,7 @@ test_17:
     csrr a1, mepc; )
 
   #-------------------------------------------------------------
-  # fence and wfi are NOPs here (ADR-0005): they retire and change nothing.
+  # fence and wfi are NOPs here: they retire and change nothing.
   #-------------------------------------------------------------
 
   TEST_CASE( 20, a1, 7, \

--- a/test/asm/csrset.S
+++ b/test/asm/csrset.S
@@ -4,14 +4,10 @@
 # csrset.S
 #-----------------------------------------------------------------------------
 #
-# ***THIS TEST IS BASELINED RED.*** It is in test/EXPECTED_FAIL as
-# `csrset.S FAIL 2` and in test/COSIM_EXPECTED_FAIL, on purpose, and it is the
-# executable form of ADR-0048's finding 3.
-#
 # Two CSRs the RV32 privileged specification lists unconditionally in the
-# machine-mode register tables are absent from rtl/csrs.v's `implemented` set,
-# so an access to either raises illegal instruction where the spec says it
-# should read zero:
+# machine-mode register tables. Both were once missing from rtl/csrs.v's
+# `implemented` set, so an access to either raised illegal instruction where
+# the spec says it should read zero. This file is what says they stay:
 #
 #   mstatush   (0x310)  priv 20211203 §3.1.6.4, "For RV32 only, mstatush is a
 #                       32-bit read/write register". SBE and MBE are its only
@@ -26,17 +22,11 @@
 #                       address is read-only (addr[11:10] == 2'b11), so a
 #                       write to it correctly faults already.
 #
-# THE DIVERGENCE IS MEASURED, NOT ARGUED. The Sail reference model reads both
-# and continues; this core traps on both. That is what makes this a finding
-# rather than one reading of a specification sentence.
-#
-# It is deliberately NOT fixed in the change that found it. ADR-0005 states its
-# CSR set as *exact*, so widening it is an ISA-scope decision that belongs to an
-# amendment of ADR-0002/ADR-0005 with its own reasoning about what
-# "RV32IMC_Zicsr, machine mode only" commits to. Landing the divergence red is
-# ADR-0033's rule applied to the `.S` suite: a known-red test in the suite is
-# the system working, and a known-red property with no test at all is the
-# system lying.
+# THE CSR SET IS A FLOOR, NOT A CLOSED LIST, and that is why this file exists.
+# Trapping on a register the spec mandates is non-conformance, not minimality:
+# the spec lets almost every mandatory register read zero, so the two barely
+# trade off. A scope statement calling the set "exact" is what once made this
+# gap read as a design choice; do not remove either arm to shrink rtl/csrs.v.
 #
 # TWO THINGS THAT ARE *NOT* FINDINGS, checked the same way and recorded here so
 # nobody re-opens them:
@@ -49,11 +39,6 @@
 #     to zero"), so trapping is a legal way to not implement it. Sail happens
 #     to implement it; that is Sail's choice, not a requirement.
 #
-# BURN-DOWN. When mstatush lands, this file starts failing at test 3 instead of
-# test 2, and the baseline's second field goes red (ADR-0035) -- which is the
-# mechanism working, not a regression. When both land, both baseline lines come
-# out in the same commit and this header loses its first paragraph.
-#
 
 #include "riscv_test.h"
 #include "test_macros.h"
@@ -61,7 +46,7 @@
 RVTEST_RV64U
 RVTEST_CODE_BEGIN
 
-  # mtvec resets to 0, which is _start (ADR-0029) — install before faulting.
+  # mtvec resets to 0, which is _start — install before faulting.
   # The RECORDING handler, not the fatal one: the failure this file reports has
   # to be an assertion about a trap count, so the trap must be survivable.
   RVTEST_INSTALL_TRAP_HANDLER

--- a/test/asm/fencenop.S
+++ b/test/asm/fencenop.S
@@ -8,10 +8,10 @@
 // insns/isa_rv32imc.txt, so every other instruction in the ISA has an `insn_*`
 // ladder check. The pin models none of `c_nop`, `c_ebreak`, `fence`, `ecall`,
 // `ebreak` -- and that five-instruction blind spot is where the c.ebreak trap
-// cause defect lived (ADR-0048). `ecall` and `ebreak` are covered by trap.S,
+// cause defect lived. `ecall` and `ebreak` are covered by trap.S,
 // `c.ebreak` by cebreak.S; these four had nothing.
 //
-// ADR-0005 makes all four NOPs: one hart, no caches, no interrupt sources, so
+// All four are NOPs here: one hart, no caches, no interrupt sources, so
 // there is nothing for a fence to order, nothing for fence.i to invalidate,
 // and nothing for wfi to wait on. What is checked is that they retire without
 // trapping and without disturbing architectural state -- the two ways a NOP

--- a/test/asm/hazard.S
+++ b/test/asm/hazard.S
@@ -1,4 +1,4 @@
-# Direct regression coverage for ADR-0004's stall-only hazard
+# Direct regression coverage for the stall-only hazard
 # scoreboard. Every case below has zero cycles of separation between the
 # producer and the consumer, so a core with no interlock (or an incomplete
 # one) reads stale operands and gets the wrong answer.

--- a/test/asm/minstret.S
+++ b/test/asm/minstret.S
@@ -6,18 +6,16 @@
 #
 # The counter rules that nothing else can check.
 #
-# `minstret` is exact as read. CSR instructions serialize (ADR-0005), and
-# ADR-0027 records that exactness — not hazard safety — is the whole reason
-# that stall exists. Without it, `csrr minstret` reads a count inflated by
-# whatever happens to be in flight behind it, and the difference between two
-# reads separated by three nops is a function of pipeline occupancy rather
-# than of architectural state. Here it must be exactly 4.
+# `minstret` is exact as read. CSR instructions serialize, and exactness — not
+# hazard safety — is the whole reason that stall exists. Without it, `csrr
+# minstret` reads a count inflated by whatever happens to be in flight behind
+# it, and the difference between two reads separated by three nops is a
+# function of pipeline occupancy rather than of architectural state. Here it
+# must be exactly 4.
 #
-# ADR-0027's *other* rule — a trapping instruction issues but does not
+# The *other* counter rule — a trapping instruction issues but does not
 # increment `minstret`, because it did not retire architecturally — is checked
-# in test/asm/trap.S, next to the trap that provokes it. It cannot be checked
-# here: no trap can be taken until trap entry lands, which is deliberately the
-# next M3 step and not this one (ADR-0011).
+# in test/asm/trap.S, next to the trap that provokes it. No trap is taken here.
 #
 # The riscv-formal ladder cannot see either rule — rvfi_csrw_check checks that
 # a CSR *write* lands, not that a counter's increment semantics are right, and
@@ -25,8 +23,8 @@
 # So simulation is the only mechanised check of them today.
 #
 # No trap is expected anywhere in this file, so it installs the *fatal*
-# handler: once trap entry exists, an unexpected fault reports the live test
-# number instead of restarting the program from mtvec = 0 (ADR-0029).
+# handler: an unexpected fault reports the live test number instead of
+# restarting the program from mtvec = 0.
 #
 
 #include "riscv_test.h"
@@ -41,7 +39,8 @@ RVTEST_CODE_BEGIN
   # Exactness: csrr, nop, nop, nop — four instructions retire between the two
   # reads, counting the first csrr and not the second. Exactly 4, not "about
   # 4": that is the deliverable the serialization stall buys, and an off-by-N
-  # here is the drain predicate being wrong (ADR-0026).
+  # here means the check that holds a CSR instruction until execute, access and
+  # writeback are empty is looking at the wrong thing.
   #-------------------------------------------------------------
 
   TEST_CASE( 2, a2, 4, \
@@ -69,7 +68,7 @@ RVTEST_CODE_BEGIN
     csrr a1, minstreth; \
     or   a2, a0, a1; )
 
-  # An explicit write takes precedence over that cycle's increment (ADR-0005).
+  # An explicit write takes precedence over that cycle's increment.
   # For minstret that is exact, because nothing issues between the write and
   # the read back — the read serializes behind the write.
   TEST_CASE( 5, a1, 0x100, \

--- a/test/asm/rvc.S
+++ b/test/asm/rvc.S
@@ -6,22 +6,21 @@
 #
 # Test RVC corner cases.
 #
-# Adapted from riscv-software-src/riscv-tests isa/rv64uc/rvc.S (the file
-# isa/rv32uc/rvc.S there just #includes, per ADR-0002's RV32-only target).
-# `#if __riscv_xlen == 64` blocks are dead code here (this core is RV32,
-# ADR-0002) but stay, unmodified, so this file can be diffed against
-# upstream directly. One deliberate deviation, called out where it happens
-# below: upstream's `data:` blob lives in .text and its load/store tests
-# (6, 40) read and write it there, which only works on riscv-tests' unified
-# memory model. ADR-0008 makes this core strictly Harvard -- mem_addr (the
-# data bus) and imem_addr (the instruction bus) are physically disjoint
+# Adapted from riscv-software-src/riscv-tests isa/rv64uc/rvc.S (upstream's
+# isa/rv32uc/rvc.S is just an #include of it). `#if __riscv_xlen == 64` blocks
+# are dead code on this RV32 core but stay, unmodified, so this file can be
+# diffed against upstream directly. One deliberate deviation, called out where
+# it happens below: upstream's `data:` blob lives in .text and its load/store
+# tests (6, 40) read and write it there, which only works on riscv-tests'
+# unified memory model. This core is strictly Harvard -- mem_addr (the data
+# bus) and imem_addr (the instruction bus) are physically disjoint
 # buses over disjoint address ranges (see sections.lds) -- so a store
 # through `data:`'s ROM address is a silent no-op here, not upstream's
 # round-trip. Tests 6 and 40 are repointed at a second, RAM-resident copy
 # (`ram_data`, added below) instead; `data:` itself stays exactly as
 # upstream for test 2, which never loads or stores through it -- it only
 # needs *something* to skip over while proving a 32-bit instruction fetch
-# across a straddle works (ADR-0003), and ROM is where fetches happen.
+# across a straddle works, and ROM is where fetches happen.
 
 #include "riscv_test.h"
 #include "test_macros.h"
@@ -54,7 +53,7 @@ RVTEST_CODE_BEGIN
   RVC_TEST_CASE (4, sp, 0x1234 + 496, c.addi16sp sp, 496)
   RVC_TEST_CASE (5, sp, 0x1234 + 496 - 512, c.addi16sp sp, -512)
 
-  // ADR-0008: RAM-resident twin of `data:`, for the load/store tests below
+  // RAM-resident twin of `data:`, for the load/store tests below
   // (upstream reads and writes `data:` itself, which is in ROM here -- see
   // the file header).
   .pushsection .data

--- a/test/asm/sections.lds
+++ b/test/asm/sections.lds
@@ -1,5 +1,5 @@
 /*
- * Two regions, per ADR-0008. This core is Harvard: imem_addr indexes ROM,
+ * Two regions. This core is Harvard: imem_addr indexes ROM,
  * mem_addr indexes RAM, and the two buses are physically disjoint — they
  * are not two windows onto one address space. A single `*(*)` catch-all
  * (the old version of this file) put .text and .data in the same output
@@ -12,7 +12,7 @@
  * purely to keep the linker happy. `rom` and `ram` are sized generously
  * above the largest measured `.text`/`.data` in this suite so headroom, not
  * link-map tightness, is the constraint. `rom` grew from 8K to 16K when
- * test/asm/rvc.S (riscv-tests' rv32uc/rvc.S, ADR-0003/ADR-0021) landed --
+ * test/asm/rvc.S (riscv-tests' rv32uc/rvc.S) landed --
  * its page-boundary-straddle case alone pads past 8K (`.align 12` then
  * `.skip 4094`) before the rest of the suite's ~1.5K text even starts.
  * test/testbench.v's simulation ROM/RAM arrays are sized to match (see the

--- a/test/asm/straddle.S
+++ b/test/asm/straddle.S
@@ -2,7 +2,7 @@
 # straddle.S
 #-----------------------------------------------------------------------------
 #
-# ADR-0003 regression: a 32-bit instruction can straddle a 4-byte boundary
+# A 32-bit instruction can straddle a 4-byte boundary
 # when pc % 4 == 2 (immediately after a compressed instruction). Fetch reads
 # the window combinationally every cycle (no aligner FSM, no stall, no
 # flush), so this costs nothing structurally; the

--- a/test/asm/trap.S
+++ b/test/asm/trap.S
@@ -4,7 +4,7 @@
 # trap.S
 #-----------------------------------------------------------------------------
 #
-# Every trap cause this core implements (ADR-0005 / ADR-0030), taken
+# Every trap cause this core implements, taken
 # deliberately, recorded by the opt-in handler in riscv_test.h, and asserted
 # on from the test body.
 #
@@ -16,7 +16,7 @@
 #
 # Every trapping instruction is wrapped in `.option norvc` because the handler
 # resumes at mepc+4 unconditionally — it cannot read the faulting instruction
-# to find out how long it was (Harvard buses, ADR-0008).
+# to find out how long it was (Harvard buses).
 #
 # The handler clobbers t0/t1, so nothing here holds a live value in either
 # across a fault.
@@ -28,7 +28,7 @@
 RVTEST_RV64U
 RVTEST_CODE_BEGIN
 
-  # mtvec resets to 0, which is _start (ADR-0029) — install before faulting.
+  # mtvec resets to 0, which is _start — install before faulting.
   RVTEST_INSTALL_TRAP_HANDLER
 
   #-------------------------------------------------------------
@@ -58,7 +58,7 @@ test_4:
   li    TESTNUM, 4
   bne   a4, x29, fail
 
-  # A trapping load writes no register (ADR-0028): a1 still holds its sentinel.
+  # A trapping load writes no register: a1 still holds its sentinel.
   TEST_CASE( 5, a1, 0x5a5, nop; )
 
   #-------------------------------------------------------------
@@ -104,7 +104,7 @@ test_4:
   #-------------------------------------------------------------
   # Illegal instruction: cause 2. Two flavours — an encoding that decodes to
   # nothing (the all-zero word is illegal by definition), and a read of an
-  # unimplemented CSR (ADR-0005).
+  # unimplemented CSR.
   #-------------------------------------------------------------
 
   .option push
@@ -147,15 +147,15 @@ test_4:
   #-------------------------------------------------------------
   # A COMPRESSED faulting instruction, so `mepc` is exercised at pc % 4 == 2 --
   # the one case the WARL mask on mepc must not break. That mask clears bit 0
-  # only, because C makes 2-byte targets legal (ADR-0005); a mask that cleared
+  # only, because C makes 2-byte targets legal; a mask that cleared
   # bit 1 as well would resume two bytes early here and nowhere else in this
   # file, since every other trapping instruction above is `.option norvc` and
   # therefore 4-byte aligned.
   #
   # Two pieces of layout are load-bearing, both consequences of the handler
   # resuming at mepc+4 unconditionally (it cannot read the faulting instruction
-  # to learn its length: Harvard buses, ADR-0008, and riscv_test.h constraint
-  # 1). The `.align 2` plus a 2-byte `c.nop` puts the faulting instruction at
+  # to learn its length: Harvard buses, and riscv_test.h constraint 1). The
+  # `.align 2` plus a 2-byte `c.nop` puts the faulting instruction at
   # pc % 4 == 2; the `c.nop` behind it is 2 bytes of padding so mepc+4 lands on
   # an instruction boundary rather than inside one. Test 16 asserts the
   # alignment actually came out that way, so this cannot quietly degrade into a
@@ -186,15 +186,15 @@ test_15:
 
   TEST_CASE( 16, a4, 2, la a3, mis_clw; andi a4, a3, 3; )
 
-  # A trapping compressed load writes no register either (ADR-0028).
+  # A trapping compressed load writes no register either.
   TEST_CASE( 17, a1, 0x5a5, nop; )
 
   # Eight traps taken, eight handler entries.
   TEST_CASE( 18, a4, 8, la a3, trap_count; lw a4, 0(a3); )
 
   #-------------------------------------------------------------
-  # ADR-0027's second counter rule: a trapping instruction issues, and retires
-  # in RVFI with rvfi_trap = 1, but it did NOT retire architecturally — so it
+  # A trapping instruction issues, and retires in RVFI with
+  # rvfi_trap = 1, but it did NOT retire architecturally — so it
   # must not increment `minstret`. This lives here rather than in
   # test/asm/minstret.S because it needs a trap to be takeable at all; that
   # file carries the exactness rule, which does not.

--- a/test/asm/zicsr.S
+++ b/test/asm/zicsr.S
@@ -39,8 +39,7 @@
 # consequence rather than an implementation choice. Where it is a choice --
 # what mtval/mie/mip actually read -- only the absence of a trap is asserted,
 # because the Sail reference model is a machine with interrupt sources and
-# would legally disagree about the values (ADR-0043, and the long note in
-# csr.S).
+# would legally disagree about the values (see the long note in csr.S).
 #
 # Every trapping instruction is `.option norvc`: the handler resumes at mepc+4
 # unconditionally (riscv_test.h constraint 1). CSR instructions have no
@@ -58,7 +57,7 @@
 RVTEST_RV64U
 RVTEST_CODE_BEGIN
 
-  # mtvec resets to 0, which is _start (ADR-0029) — install before faulting.
+  # mtvec resets to 0, which is _start — install before faulting.
   RVTEST_INSTALL_TRAP_HANDLER
 
   #-------------------------------------------------------------
@@ -172,7 +171,7 @@ RVTEST_CODE_BEGIN
   # legal no-op, not a fault. This is the case that is opposite in law to
   # test 2 and identical in appearance. Only the absence of a trap is
   # asserted: what these three read is an implementation choice this core and
-  # the Sail reference model legally differ on (ADR-0043).
+  # the Sail reference model legally differ on.
   #-------------------------------------------------------------
 
   li    a5, 0xffffffff
@@ -187,7 +186,7 @@ RVTEST_CODE_BEGIN
   # value handed to rd is the one from BEFORE the write even when the two name
   # the same register -- `csrrw a0, mscratch, a0` is a swap. On this core the
   # read result rides the `is_add` pass-through to writeback while the write
-  # commits in decode off `reg_rs1` (ADR-0005), so the two really do come from
+  # commits in decode off `reg_rs1`, so the two really do come from
   # different places and the ordering is a property rather than a tautology.
   #-------------------------------------------------------------
 

--- a/test/check_suite_shape.sh
+++ b/test/check_suite_shape.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # Asserts that the .S suite CONTAINS what it is supposed to contain, before
-# either sim leg runs a single program. ADR-0033's argument, applied to the
-# simulation side.
+# either sim leg runs a single program.
 #
 # Usage: check_suite_shape.sh <asm-dir> <manifest>
 #
@@ -30,7 +29,7 @@
 #   * test/run_cosim.sh did not read the manifest at all. Its own comment says
 #     its program-count guard exists so an empty glob cannot match an empty
 #     baseline — which is a guard against a suite of size ZERO, not against a
-#     suite that shrank from 52 to 12;
+#     suite that lost most of its programs;
 #   * neither leg rejected a manifest line that named a program twice, which
 #     would make the set comparison below quietly non-symmetric.
 #

--- a/test/cosim.cc
+++ b/test/cosim.cc
@@ -57,8 +57,7 @@
 
 namespace {
 
-// Kept in sync with test/cxxrtl.cc, test/testbench.v and test/asm/sections.lds
-// (ADR-0008).
+// Kept in sync with test/cxxrtl.cc, test/testbench.v and test/asm/sections.lds.
 constexpr uint32_t kRamBase = 0x00010000;
 
 using HexImage = std::map<uint32_t, uint32_t>;
@@ -109,7 +108,7 @@ bool load_image(cxxrtl::debug_items &items, const std::string &name,
   return true;
 }
 
-// The instruction ROM is two INTERLEAVED BANKS since ADR-0054: word W lives in
+// The instruction ROM is two INTERLEAVED BANKS: word W lives in
 // `imem rom_even` at index W/2 when W is even, and in `imem rom_odd` at the
 // same index when it is odd. Banking is what removed the duplicated ROM the SoC
 // needed for the dual-word fetch window, so the de-interleaving has to happen
@@ -212,19 +211,18 @@ int main(int argc, char **argv) {
   // flattens the instance path to a space-separated debug-item name, the same
   // convention test/cxxrtl.cc uses for "monitor errcode".
   //
-  // `regs_a`, not `regs`: ADR-0042 split the array in two because an ice40 EBR
-  // has one read port, so rtl/regfile.v now holds two identical copies, one per
-  // read port. This probe reads ONE of them, which is the whole point of the
-  // cross-check below.
+  // `regs_a`, not `regs`: an ice40 EBR has one read port, so rtl/regfile.v
+  // holds two identical copies of the array, one per read port. This probe
+  // reads ONE of them, which is the whole point of the cross-check below.
   //
   // WHY THIS BEING RIGHT MATTERS MORE THAN IT LOOKS. This is the only oracle in
   // the repo that reads the core's architectural state directly rather than its
-  // RVFI self-report (ADR-0032), so a probe that silently pointed at the wrong
+  // RVFI self-report, so a probe that silently pointed at the wrong
   // item -- or at a stale copy, or at nothing -- would turn the whole
   // co-simulation leg into a comparison of nothing against nothing, which is
   // docs/THREAT_MODEL.md's category 1. The name lookup and the shape check
   // below fail closed; that they read the array the core actually commits to
-  // is established by mutation, recorded in ADR-0042.
+  // is established by mutation.
   const cxxrtl::debug_item *regs_item = nullptr;
   const cxxrtl::debug_item *regs_b_item = nullptr;
   const cxxrtl::debug_item *pc_item = nullptr;
@@ -272,13 +270,13 @@ int main(int argc, char **argv) {
     top.p_clk.set<bool>(true);
     top.step();
 
-    // ADR-0042: the two arrays are one architectural register file, written
+    // The two arrays are one architectural register file, written
     // from one address and one data word. Nothing else in this program would
     // notice them diverging -- every comparison below reads regs_a alone -- so
     // a rs2-side write defect would produce a co-simulation that agrees
     // perfectly while the core computes wrong answers on its rs2 port.
     // test/regfile_tb.v asserts this over a handful of directed vectors; this
-    // asserts it on every cycle of all 52 programs.
+    // asserts it on every cycle of every program in the suite.
     if (std::memcmp(regs, regs_b, sizeof(shadow)) != 0) {
       std::fprintf(stderr,
                    "error: rtl/regfile.v's two arrays diverged at cycle %ld -- "

--- a/test/cosim.py
+++ b/test/cosim.py
@@ -31,15 +31,15 @@ HTIF IS SPOKEN, NOT WORKED AROUND
 Sail auto-detects HTIF from the ELF's `tohost` symbol and claims the whole
 DOUBLEWORD at that address as an IO window.  `tohost` used to be a 32-bit
 `.word` at the base of RAM, so `.data` -- every load/store test's TEST_DATA,
-which ADR-0008 places immediately after -- began four bytes INSIDE that
+which sections.lds places immediately after -- began four bytes INSIDE that
 window: Sail answered every `lw` from 0x10004 with zero and eight programs
 "diverged" for a reason that was entirely this repo's fault.  The spike
-(ADR-0032) worked around it by stripping the symbol from a throwaway ELF copy
+worked around it by stripping the symbol from a throwaway ELF copy
 and then bounding the reference run with `--inst-limit`, checking it had
 reached the pass/fail spin loop by looking for a self-loop at one PC.
 
 Both workarounds are gone.  test/asm/riscv_test.h now emits `tohost` as an
-8-byte-aligned `.dword` (ADR-0039), which is what the HTIF protocol always
+8-byte-aligned `.dword`, which is what the HTIF protocol always
 specified, so the IO window covers only `tohost` itself and Sail reads test
 data out of real memory.  The verdict macros write the doubleword's upper
 word first and the verdict last, so the reference model TERMINATES on the
@@ -235,7 +235,7 @@ def find_sail(explicit):
     so the two checks are complementary and a direct ./test/cosim.py
     invocation only gets this one.
 
-    Opt-in by construction (ADR-0032): nothing in `make test` reaches this
+    Opt-in by construction: nothing in `make test` reaches this
     function, and when the binary is absent the message names the target that
     installs it rather than a build failure.
     """
@@ -282,7 +282,7 @@ def assemble(cc, src, outdir):
     the ELF (for Sail) plus the two objcopy images (for the cxxrtl runner).
 
     The reference model gets the SAME ELF, unmodified -- no stripped symbol,
-    no throwaway copy (ADR-0039). If the two legs ever stop building from
+    no throwaway copy. If the two legs ever stop building from
     identical bytes, this is the function that would have to say so."""
     base = os.path.splitext(os.path.basename(src))[0]
     elf = os.path.join(outdir, base + ".elf")
@@ -311,7 +311,7 @@ def sail_verdict(output):
     """The reference model's HTIF verdict, in the vocabulary test/cosim.cc
     prints for the core, or None if the run did not reach one.
 
-    Sail terminates on the doubleword `tohost` write (ADR-0039) and announces
+    Sail terminates on the doubleword `tohost` write and announces
     it: `SUCCESS` for the riscv-tests pass encoding, `FAILURE: <n>` for
     `(testnum << 1) | 1`, where n is the test number. There is deliberately no
     fallback to the process exit status -- it is 0 both for SUCCESS and for
@@ -430,7 +430,7 @@ def compare(sail_records, dut_records):
     `status` is "AGREE" or one of the DISAGREE labels test/run_cosim.sh
     baselines against test/COSIM_EXPECTED_FAIL. The labels distinguish HOW the
     two disagreed, so a baselined program that starts diverging somewhere else
-    is a red gate rather than a match (ADR-0035).
+    is a red gate rather than a match.
 
     `skipped` lists every change whose VALUE was not comparable -- a read of a
     NONCOMPARABLE_CSRS entry into a register. The caller prints it. Two cursors

--- a/test/cxxrtl.cc
+++ b/test/cxxrtl.cc
@@ -1,4 +1,4 @@
-// The cxxrtl test runner (ADR-0007, ADR-0008): loads a `.text` and a
+// The cxxrtl test runner: loads a `.text` and a
 // `.data`/`.rodata`/`.bss` image straight into test/testbench.v's `rom` and
 // `memory` arrays via debug_items, runs the design for a bounded number of
 // cycles, and watches `tohost` (test/asm/riscv_test.h) for the riscv-tests
@@ -7,16 +7,16 @@
 // Exit codes: 0 = pass, 1 = fail (test number printed), 2 = cycle-limit
 // timeout, 3 = usage/setup error (bad args, missing file, image too big for
 // the simulated memories), 4 = RVFI monitor error (a per-retire mismatch,
-// ADR-0006 — distinct from 1 because tohost never got a say: the failure is
+// distinct from 1 because tohost never got a say: the failure is
 // in the pipeline's own bookkeeping, not the test program's assertions),
-// 5 = trap taken with mtvec == 0 (ADR-0029 — the program has silently
+// 5 = trap taken with mtvec == 0 (the program has silently
 // restarted at `_start`; distinct from 2 because the timeout that would
 // otherwise result says nothing about the fault that caused it),
 // 6 = the per-retire monitor observed nothing: zero retires, or zero retires
 // whose values its spec model checked. See the counter block in
 // test/testbench.v for why that is a failure and not a curiosity — a monitor
 // that never fires leaves every program passing off `tohost` alone, which
-// ADR-0032 measured to be blind to real architectural corruption.
+// co-simulation measured to be blind to real architectural corruption.
 //
 // Every run that actually simulates prints one machine-readable line before
 // it exits:
@@ -112,7 +112,7 @@ bool load_image(cxxrtl::debug_items &items, const std::string &name,
   return true;
 }
 
-// The instruction ROM is two INTERLEAVED BANKS since ADR-0054: word W lives in
+// The instruction ROM is two INTERLEAVED BANKS: word W lives in
 // `imem rom_even` at index W/2 when W is even, and in `imem rom_odd` at the
 // same index when it is odd. Banking is what removed the duplicated ROM the SoC
 // needed for the dual-word fetch window, so the de-interleaving has to happen
@@ -255,7 +255,7 @@ int main(int argc, char **argv) {
   uint32_t *ram_data = memory_item.curr;
   const uint32_t tohost_index = 0;
 
-  // ADR-0006: test/testbench.v instantiates the RVFI monitor
+  // test/testbench.v instantiates the RVFI monitor
   // (test/monitor.v, riding along under -D RISCV_FORMAL) alongside the DUT,
   // so this leg is self-checking per-retire, not merely end-state-checking
   // via tohost above. "monitor errcode" is the top-level error code the
@@ -275,7 +275,7 @@ int main(int argc, char **argv) {
     return 3;
   }
 
-  // ADR-0029: `mtvec` resets to 0 and sections.lds links `.text` there, so a
+  // `mtvec` resets to 0 and sections.lds links `.text` there, so a
   // trap taken before a handler is installed restarts the program at `_start`
   // — a livelock that reads as a timeout with no hint of the fault behind it.
   // test/testbench.v raises this the cycle after any trap that redirects to
@@ -373,14 +373,14 @@ int main(int argc, char **argv) {
   // owes nothing to the monitor. Routing either through the silence gate would
   // replace a specific diagnosis with "the oracle was blind".
   //
-  // For exit 5 that is not hypothetical, it is the ADR-0029 case itself. Traps
-  // are detected and committed in DECODE (invariant 2) while a retire happens
+  // For exit 5 that is not hypothetical, it is the trap-to-zero case itself.
+  // Traps are detected and committed in DECODE while a retire happens
   // in writeback, so a fault in the first few instructions of `_start` raises
   // trap_to_zero several cycles before anything has retired. Measured: `ecall`
   // as the second instruction gives `RETIRES 0` and used to return 6, which
   // test/run_tests.sh labels MONITOR-SILENT — pointing at the monitor for a
   // program that faulted before installing `mtvec`, which is precisely the
-  // misattribution ADR-0029 added the TRAP-TO-ZERO label to prevent. The same
+  // misattribution the TRAP-TO-ZERO label exists to prevent. The same
   // `ecall` after six retiring instructions returned 5. A named failure path
   // that is unreachable in its own scenario is the defect this repo keeps
   // finding in its grading layer, one level down.

--- a/test/mem_tb.v
+++ b/test/mem_tb.v
@@ -16,7 +16,7 @@ module mem_tb;
   logic [31:0] mem_rdata;
 
   // BASE = 0 so the vectors below can address the array directly; the shipping
-  // instances use ADR-0008's non-zero RAM base. The property the out-of-range
+  // instances use a non-zero RAM base. The property the out-of-range
   // vectors check holds either way: an unmapped address must not alias a mapped
   // word.
   memory #(.BASE(32'h0), .RAM_WORDS(RAM_WORDS)) dut (
@@ -103,7 +103,7 @@ module mem_tb;
     // array to 128 `SB_RAM40_4K` -- four times the part's block RAM -- with no
     // diagnostic. Nothing in the pipeline observes the difference (rtl/accessor.v
     // reads mem_rdata only on a load's response cycle), so nothing but this
-    // vector would notice it being "fixed" back (ADR-0054).
+    // vector would notice it being "fixed" back.
     do_read(32'h00000004, got);
     check("read-port setup for the hold check", got, 32'hcafef00d);
     do_write(32'h00000008, 32'h0f0f0f0f);

--- a/test/monitor_tb.v
+++ b/test/monitor_tb.v
@@ -1,6 +1,6 @@
 // Unit bench for the generated RVFI monitor itself -- not for the core. The
 // monitor is an oracle both sim legs read, so a defect in it is a defect in
-// every `make test` result (ADR-0019). Each vector below is a hand-built RVFI
+// every `make test` result. Each vector below is a hand-built RVFI
 // retire whose correct verdict is known by construction.
 //
 // It compiles against test/monitor.sim.v, the sanitized derivative that
@@ -9,7 +9,7 @@
 
 module monitor_tb;
   localparam [31:0] MTVEC = 32'h0000_0100;  // where the trapping vectors redirect
-  localparam [31:0] RAM   = 32'h0001_0000;  // ADR-0008's RAM base
+  localparam [31:0] RAM   = 32'h0001_0000;  // RAM base in the test memory map
 
   reg clock = 0;
   reg reset = 1;
@@ -155,7 +155,7 @@ module monitor_tb;
     expect_errcode(16'd0, "correct add retire");
 
     // 2. lw x5, 1(x1) with x1 = RAM base -- address 0x00010001, misaligned, so
-    //    spec_trap holds. A correct core reports the ADR-0028 convention:
+    //    spec_trap holds. A correct core reports a trapping retire this way:
     //    rd_addr/rd_wdata/mem masks all zero, pc_wdata = mtvec. The spec model
     //    reports rd = x5, rd_wdata = the loaded word and pc_wdata = pc+4, so
     //    every one of those comparisons disagrees and only the `!spec_trap` gate

--- a/test/regfile_tb.v
+++ b/test/regfile_tb.v
@@ -63,7 +63,7 @@ module regfile_tb;
   // Nothing downstream would notice the two arrays drifting apart: test/cosim.cc
   // reads `regs_a` alone, and `reg_rs2` is the only consumer of `regs_b`. So
   // assert the duplication directly rather than trusting the write block by
-  // inspection (ADR-0042).
+  // inspection.
   task automatic check_mirrors(input string what);
     begin
       for (int i = 0; i < 32; i++) begin
@@ -126,8 +126,8 @@ module regfile_tb;
     // Write-first: the write lands in the FETCH cycle, on the same posedge that
     // captures the read. Without the write-first term in rtl/regfile.v the
     // captured word is the pre-write contents and the operand is exactly one
-    // writeback stale -- the ADR-0004 defect, a cycle earlier than the
-    // scoreboard can see.
+    // writeback stale -- a cycle earlier than the scoreboard can see, so the
+    // stall-only interlock never fires on it.
     drive(5'd5, 5'd5, 1'b1, 5'd5, 32'h44444444);   // fetch, writing x5
     drive(5'd5, 5'd5, 1'b0, 5'd0, 32'h0);          // use, no write
     check_hex("write-first capture in the fetch cycle (rs1)", reg_rs1, 32'h44444444);

--- a/test/sail/rv32imc_zicsr.json
+++ b/test/sail/rv32imc_zicsr.json
@@ -1,5 +1,5 @@
 // The Sail RISC-V model, configured as THIS core: RV32IMC_Zicsr, machine mode
-// only (ADR-0002). Passed as `sail_riscv_sim --config`, NOT `--rv32
+// only. Passed as `sail_riscv_sim --config`, NOT `--rv32
 // --config-override`, and that distinction is the point of the file.
 //
 // WHY A WHOLE CONFIG AND NOT AN OVERRIDE
@@ -26,9 +26,9 @@
 // A CONFIG OVERRIDE IS WHERE YOU CAN TALK THE ORACLE INTO AGREEING WITH YOU.
 // Sail is authoritative about RISC-V semantics but NOT about which
 // implementation-defined choice this core makes -- we tell it that. So every
-// knob below traces to a decision that predates the divergence it resolves:
-// ADR-0002 (the ISA target), ADR-0005 (traps and CSRs), ADR-0008 (the memory
-// map). Nothing here was chosen because it made a test pass.
+// knob below traces to the ISA target, the trap and CSR set, or the memory
+// map -- decisions that predate the divergence each one resolves. Nothing here
+// was chosen because it made a test pass.
 //
 // WHAT THIS FILE CANNOT SAY. Three implementation-defined values remain
 // different because sail-riscv 0.13.1 has no knob for them, and they are NOT
@@ -38,7 +38,7 @@
 //     in test/cosim.py's NONCOMPARABLE_CSRS, keyed on the CSR encoding and
 //     scoped to one register at one comparison point.
 //
-//   * `mie` (the model hardwires MSIE/MTIE/MEIE writable; ADR-0002 makes them
+//   * `mie` (the model hardwires MSIE/MTIE/MEIE writable; this core makes them
 //     read-only zero) and `mip` (the model's mtime keeps ticking with the
 //     CLINT unmapped and raises MTIP; this core has no timer) are NOT in
 //     NONCOMPARABLE_CSRS and cannot be -- a value exemption cannot help here,
@@ -60,7 +60,7 @@
     // core is a write to a read-only-value CSR, not a way to turn C off.
     "writable_misa": false,
 
-    // menvcfg.FIOM only exists with U-mode, which ADR-0002 excludes.
+    // menvcfg.FIOM only exists with U-mode, which this core does not have.
     "writable_fiom": false,
 
     // No Zihpm: mhpmcounter3..31 and mhpmevent3..31 do not exist here.
@@ -88,13 +88,13 @@
       "vectored": { "supported": true, "base_alignment": 2 }
     },
 
-    // Nothing to delegate to: no S-mode, no U-mode (ADR-0002). Both mask to
+    // Nothing to delegate to: no S-mode, no U-mode. Both mask to
     // zero, which makes medeleg/mideleg read-only zero in the model.
     "medeleg": { "delegatable_bits": { "len": 64,    "value": "0x0000_0000_0000_0000" } },
     "mideleg": { "delegatable_bits": { "len": "xlen", "value": "0x0000_0000" } },
 
     // rtl/csrs.v hardwires mtval to 0, which is spec-legal for every cause
-    // this core raises (ADR-0002). Every trap therefore writes mtval = 0.
+    // this core raises. Every trap therefore writes mtval = 0.
     "xtval_nonzero": {
       "illegal_instruction": false,
       "software_breakpoint": false,
@@ -147,7 +147,7 @@
     // permits with Sv32 enabled.
     "physaddr_bits": 32,
 
-    // No PMP (ADR-0002). `count: 0` makes every pmpcfg/pmpaddr read-only zero;
+    // No PMP. `count: 0` makes every pmpcfg/pmpaddr read-only zero;
     // the remaining keys describe a granularity that no entry can use.
     "pmp": {
       "grain": 0,
@@ -167,7 +167,7 @@
     // inferred: changing the region attribute leaves a misaligned `lw`
     // completing; setting this one redirects to mtvec.
     //
-    // `AlignmentException` is the value matching ADR-0005's causes: load
+    // `AlignmentException` is the value matching this core's causes: load
     // address misaligned = 4, store address misaligned = 6. `AccessFault`
     // would be causes 5 and 7 and is a different implementation choice this
     // core did not make. The `vector`, `amo` and `lrsc` entries belong to V
@@ -190,7 +190,7 @@
 
     // test/asm/sections.lds: rom at 0x0 (16K) + ram at 0x10000 (4K), rounded
     // up to a flat 1MB so the linker script can grow without this file having
-    // to (ADR-0008). The model's default RV32 map puts MainMemory at
+    // to. The model's default RV32 map puts MainMemory at
     // 0x8000_0000, where nothing this suite builds is executable or loadable.
     //
     // The default map's other two regions are deliberately absent. Its
@@ -201,7 +201,7 @@
     //
     // The model detects HTIF from the ELF's `tohost` symbol, reports "HTIF
     // located at 0x10000", and TERMINATES on this suite's verdict write --
-    // `SUCCESS`, or `FAILURE: <testnum>` (ADR-0039). `--inst-limit` is
+    // `SUCCESS`, or `FAILURE: <testnum>`. `--inst-limit` is
     // therefore a runaway bound, not a convergence criterion.
     "regions": [
       {
@@ -251,8 +251,8 @@
       "invalidate_on_same_hart_store": false
     },
 
-    // No CLINT and no interrupt generator: this core has neither, and
-    // ADR-0002 has no interrupt sources at all. Turning the CLINT off is what
+    // No CLINT and no interrupt generator: this core has neither, and no
+    // interrupt sources at all. Turning the CLINT off is what
     // lets the 0x0200_0000 IOMemory region go away.
     //
     // MEASURED CAVEAT, and the reason mip is in cosim.py's NONCOMPARABLE_CSRS:
@@ -286,8 +286,8 @@
     "max_time_to_wait": 10
   },
 
-  // EXTENSIONS -- the audit ADR-0002 defines. Enabled: I (the base), M, C and
-  // Zicsr, plus the two that are enabled for a stated reason rather than
+  // EXTENSIONS -- audited against the ISA target. Enabled: I (the base), M, C
+  // and Zicsr, plus the two that are enabled for a stated reason rather than
   // because the target names them:
   //
   //   Zca    is the C extension for this target. misa.C is set from Zca alone
@@ -305,7 +305,7 @@
   //          on. No program in test/asm reads them; there is no knob to
   //          separate the machine counters from the shadows.
   //   Zifencei is enabled because rtl/decoder.v decodes `fence.i` and retires
-  //          it as a NOP (ADR-0005: one hart, Harvard, nothing to invalidate).
+  //          it as a NOP (one hart, Harvard, nothing to invalidate).
   //          With it off the model would raise an illegal instruction where
   //          this core does not.
   //


### PR DESCRIPTION
Closes JEF-758.

Scope this run: `test/`, `soc/`, `.github/` and `Makefile`. **No `rtl/` or `formal/` file is touched** — those are a follow-up run, deliberately left to the agent measuring the decode head.

## What changed

Every ADR number in a **comment** across the scope is replaced with the mechanism in the comment's own words, or deleted where the code already says it. A citation reads as the explanation while carrying none: a reader who has not memorised the decision records learns nothing, and one who has still goes and looks.

Runtime strings are left alone — `$display`, `@echo`, `fprintf`, `sys.exit` messages, `probe` labels and one CI step name. Those are output, not commentary. 24 survive; all are listed at the bottom.

`.github/workflows/ci.yml`, `test/exec_tb.v`, `rtl/executor.v`, `rtl/csrs.v`, `formal/checks.cfg`, `formal/complete.sv` and `formal/Makefile` were checked with grep rather than taken on trust: every survivor in them is already a runtime string, so the earlier cleanup pass's claim holds and none needed re-editing.

## Five stale or false claims, found by reading each comment against the record it cited

1. **`test/EXPECTED_FAIL` and `test/COSIM_EXPECTED_FAIL`** each carried a paragraph justifying a `csrset.S` baseline entry **that no longer exists**. Both baselines are empty and `rtl/csrs.v` implements `mstatush` and `mconfigptr`. Worse, the reasoning they gave — that the CSR set is stated *exact*, so widening it is an ISA-scope decision — is the premise that was explicitly struck when those two landed. Both blocks deleted; `EXPECTED_FAIL`'s own header already forbids repeating history.

2. **`test/asm/csrset.S`** opened with `***THIS TEST IS BASELINED RED.***`, named its two (now absent) baseline lines, and closed with a burn-down for work already completed. The header now says what the file checks. The floor-not-a-closed-list warning is kept as a tripwire so the two arms are not removed again to shrink `rtl/csrs.v`.

3. **`test/asm/minstret.S`** said no trap can be taken "until trap entry lands, which is deliberately the next M3 step and not this one". M3 is reached and `test/asm/trap.S` takes eight traps.

4. **`.github/dependabot.yml`** hand-copied the required status checks as four names — `elaborate, test, components, monitor-freshness`. The API returns **seven**. This is precisely the drift its sibling `dependabot-automerge.yml` warns about in its own header ("It was, and it said four while the API returned six"). The list is removed rather than corrected; read it from the API.

5. **Three counts had rotted the way a count in a tripwire does.** `test/OBSERVED_FLOOR`'s "an exact ratchet over 52 numbers", `test/cosim.cc`'s "every cycle of all 52 programs", and `test/check_suite_shape.sh`'s "a suite that shrank from 52 to 12". The suite is 59. Each is restated without a number.

One further citation was simply misdirected: `soc/fit_report.py` cited ADR-0042 three times for the `FIT_MAX_LC` ratchet. That ADR is about the synchronous regfile read; it set the budget once, at a value since superseded.

## Comments and strings only — proven two ways

Both proofs cover all 39 files in scope.

**1. `-U0` diff.** No non-comment line changed. Every changed line is a `#`/`//` comment, a Python docstring body, or one Verilog trailing comment (`monitor_tb.v`'s `RAM` localparam) whose code prefix is byte-identical.

**2. Code-skeleton hashes.** Each file is compared against `HEAD` after stripping comments and blank lines, **with leading whitespace preserved** so re-indentation cannot hide a change. Python files go through the AST with docstrings dropped, so a docstring edit is invisible but any statement change is not.

```
39 files compared; 0 with a changed code skeleton: none
```

This second proof is not paperwork — an earlier bulk edit in this repo silently dropped an `else if` and an `out.rvfi <= in.rvfi;` from `rtl/decoder.v`, and only the hash check caught it. It also caught a bug in my own stripper (Verilog's `32'h...` tick read as a string delimiter), which is why the check is worth running rather than assuming.

## Checks

| Gate | Result |
|---|---|
| `make test` | **59/59**, both baselines empty, `Failure list matches test/EXPECTED_FAIL exactly` |
| `make test-units` | clean |
| `make lint` | `svlint: clean in both passes` |
| `make probe-gates` | `137 graded comparisons, every failure path executed` |
| `make monitor-check` | clean |
| `make fit` | **3880** of 4100 cells |
| `make soc-timing` | **12.74 MHz** against the 12.00 MHz floor |

`make fit` and `make soc-timing` are **unchanged**: I re-ran both on a stashed tree and got byte-identical numbers (3880 cells, 12.74 MHz), so the measurements are confirmed rather than merely still-passing.

The riscv-formal checks were **not** run locally — the diff touches zero `rtl/` and zero `formal/` files, and `test/monitor.v` and `test/sanitize_monitor.py` are untouched, so the generated checks read identical inputs. The `formal` job on this PR is the confirmation.

## Surviving runtime strings (24)

Criterion 1 permits these — they are code, not commentary.

- `test/probe_gates.sh` ×3 — probe labels (336, 631, 838)
- `test/testbench.v` ×1 — `$display` (320)
- `test/cxxrtl.cc` ×2 — `fprintf` (291, 466)
- `test/cosim.cc` ×1 — `fprintf` (283)
- `test/run_tests.sh` ×1 — `echo` (269)
- `test/sanitize_monitor.py` ×1 — stderr write (192)
- `test/exec_tb.v` ×3 — directed-vector labels (119–121), out of scope this run
- `soc/fit_report.py` ×2 — `print` / `sys.exit` (74, 83)
- `soc/rom_banks.py` ×1 — `sys.exit` (73)
- `Makefile` ×2 — `@echo` (536, 539)
- `.github/workflows/ci.yml` ×6 — five `echo`, one step name; out of scope this run

## Notes

- No ADR is needed for this; it applies a rule CLAUDE.md already states.
- `docs/adr/` and `CLAUDE.md` are out of scope and untouched. `test/monitor.v` and `test/monitor.sim.v` are generated and untouched.
- **Follow-up, not done here:** the words "ladder" and "drains" survive in ~15 comments across `test/` and `.github/`. I left them rather than widen a citation diff into a vocabulary diff, and only avoided them in prose I wrote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)