### PR TITLE
Record that the clock above 12 MHz is 24 (JEF-772)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,6 +172,11 @@ and times.
 - **12 MHz is a requirement, not a regression floor** (ADR-0066). `SOC_MIN_MHZ` is 12.0 — the board
   clock, whose next divider step down is 6 — and it does not slide. When it trips, fix the design,
   not the floor. The margin over the worst placement is deliberately tighter than the churn band.
+- **The clock above 12 is 24, and there is nothing in between.** The part's oscillator divides
+  48 MHz by 1, 2, 4 or 8 — 48 / 24 / 12 / 6. A design that places at 13 MHz runs at 12; so does one
+  that places at 18. So the target for Fmax work is 24 MHz — 41.67 ns, about half of today's period
+  — and 12 is already met. A few-percent idea can be read against 41.67 ns and declined in a minute,
+  instead of after four placements (ADR-0078).
 - **Read logic levels apart**: a LUT level costs ~3.3 ns (delay plus interconnect), a carry hop
   ~0.34 ns and no interconnect. A change that trades a carry hop for a LUT level gets shallower by
   icetime's count and slower in nanoseconds. The SoC is routing-dominated; wide flat muxes route


### PR DESCRIPTION
Closes JEF-772.

The up5k's oscillator divides 48 MHz by 1, 2, 4 or 8 — 48 / 24 / 12 / 6 — and the board crystal is 12. Between 12 and 24 there is nothing selectable: a design that places at 13 MHz runs at 12, and so does one at 18. Two measurement spikes rediscovered this independently this week and it decided both (the operand-fetch removal at 12.10–12.68 MHz, and the one-deep kill at 13.32 against the family's 16.32 ceiling), but neither ADR put it anywhere a future engineer would find it *before* starting. This adds it to `CLAUDE.md`'s Measurements and ratchets section, and names the bar nothing currently records: **the target for Fmax work is 24 MHz — 41.67 ns — and 12 is already met.**

## What changed

Five lines in `CLAUDE.md`, as a new bullet directly after the `SOC_MIN_MHZ` entry:

> - **The clock above 12 is 24, and there is nothing in between.** The part's oscillator divides 48 MHz by 1, 2, 4 or 8 — 48 / 24 / 12 / 6. A design that places at 13 MHz runs at 12; so does one that places at 18. So the target for Fmax work is 24 MHz — 41.67 ns, about half of today's period — and 12 is already met. A few-percent idea can be read against 41.67 ns and declined in a minute, instead of after four placements (ADR-0078).

**New bullet rather than an extension of the `SOC_MIN_MHZ` one.** That entry is about a number that must not slide — a floor and its margin. This is about what to aim at. Bolting the target onto a sentence whose subject is "it does not slide" would have read as a second prohibition, which is exactly what this is not. Kept separate, each bullet is one idea, and the existing step *down* to 6 is not restated as anything more than one item in the list of four. The ADR citation matches the neighbours' `(ADR-00NN)` form.

`SOC_MIN_MHZ` stays 12.0 and stays a requirement. No new ADR — this records a fact ADR-0074 and ADR-0078 already established.

## Testing

- `make test` — 59/59, both baselines matched by name and status (run before and after the cleanup pass).
- Diff is `CLAUDE.md` only, 5 insertions, 0 deletions — no `rtl/`, `formal/`, `test/` or workflow files. `make fit` and `make soc-timing` cannot move on a docs diff, so no place-and-route was spent proving it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJ77ZZJ6pDiL3vj3Qw9hKs