### PR TITLE
Correct the "nothing between 12 and 24 MHz" claim (JEF-774)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,11 +172,11 @@ and times.
 - **12 MHz is a requirement, not a regression floor** (ADR-0066). `SOC_MIN_MHZ` is 12.0 — the board
   clock, whose next divider step down is 6 — and it does not slide. When it trips, fix the design,
   not the floor. The margin over the worst placement is deliberately tighter than the churn band.
-- **The clock above 12 is 24, and there is nothing in between.** The part's oscillator divides
-  48 MHz by 1, 2, 4 or 8 — 48 / 24 / 12 / 6. A design that places at 13 MHz runs at 12; so does one
-  that places at 18. So the target for Fmax work is 24 MHz — 41.67 ns, about half of today's period
-  — and 12 is already met. A few-percent idea can be read against 41.67 ns and declined in a minute,
-  instead of after four placements (ADR-0078).
+- **The divider step above today's 12 is 24.** `SB_HFOSC` divides 48 MHz by 1, 2, 4 or 8 —
+  48 / 24 / 12 / 6. An `SB_PLL40` fed by the 12 MHz crystal can synthesize an intermediate clock
+  if a change ever earns one. The target for Fmax work is 24 MHz — 41.67 ns, about half of today's
+  period — and 12 is already met. A few-percent idea can be read against 41.67 ns and declined in a
+  minute, instead of after four placements (ADR-0078).
 - **Read logic levels apart**: a LUT level costs ~3.3 ns (delay plus interconnect), a carry hop
   ~0.34 ns and no interconnect. A change that trades a carry hop for a LUT level gets shallower by
   icetime's count and slower in nanoseconds. The SoC is routing-dominated; wide flat muxes route


### PR DESCRIPTION
Closes JEF-774.

`CLAUDE.md`'s *Measurements and ratchets* section claimed **"The clock above 12 is 24, and there is nothing in between."** That is true of the `SB_HFOSC` divider and false of the part: the up5k has an `SB_PLL40` that can be fed from the board's 12 MHz crystal and synthesize intermediate frequencies.

**This was the orchestrator's error, not the previous implementer's.** The ticket that produced that sentence was written from the oscillator-divider framing without checking the PLL, and #134 implemented exactly what its brief said. The brief was wrong; the implementation was faithful to it.

## Before

```
- **The clock above 12 is 24, and there is nothing in between.** The part's oscillator divides
  48 MHz by 1, 2, 4 or 8 — 48 / 24 / 12 / 6. A design that places at 13 MHz runs at 12; so does one
  that places at 18. So the target for Fmax work is 24 MHz — 41.67 ns, about half of today's period
  — and 12 is already met. A few-percent idea can be read against 41.67 ns and declined in a minute,
  instead of after four placements (ADR-0078).
```

## After

```
- **The divider step above today's 12 is 24.** `SB_HFOSC` divides 48 MHz by 1, 2, 4 or 8 —
  48 / 24 / 12 / 6. An `SB_PLL40` fed by the 12 MHz crystal can synthesize an intermediate clock
  if a change ever earns one. The target for Fmax work is 24 MHz — 41.67 ns, about half of today's
  period — and 12 is already met. A few-percent idea can be read against 41.67 ns and declined in a
  minute, instead of after four placements (ADR-0078).
```

The targeting half survives intact: 24 MHz / 41.67 ns as the bar, 12 already met, and the decline-in-a-minute point. "divider step" is the term the bullet directly above already uses ("whose next divider step down is 6"), so no new word is coined.

## How the PLL claim was verified

Checked on the open toolchain rather than inherited from the brief. All three parts hold:

1. **The primitive exists on up5k.** `nextpnr-ice40 --up5k --package sg48` places an `SB_PLL40_PAD` and reports `ICESTORM_PLL: 1/1 100%`, constrained to `X12/Y31/pll_3`, 0 errors. The part has exactly one PLL and it routed.
2. **It can be fed from the board crystal.** `PACKAGEPIN` was tied to sg48 pin 35 — the same pin `soc/littlesoc.pcf` assigns to the iCEBreaker's 12 MHz oscillator.
3. **It synthesizes frequencies off the divider steps.** `icepll -i 12 -o 18` returns an exact 18.000 MHz achieved (`DIVR=0, DIVF=47, DIVQ=5`, `FEEDBACK_PATH="SIMPLE"`). 18 is not one of 48 / 24 / 12 / 6.

Per "a grader that cannot fail is not a grader", `icepll` was also checked in the red direction so its acceptance means something: `icepll -i 2 -o 18` exits 1 with `PLL input frequency 2.000 MHz is outside range 10 MHz - 133 MHz!`. It validates rather than agreeing with anything.

This is consistent with ADR-0062, which already recorded that `SB_PLL40_*` "would synthesize an arbitrary clock" and was declined as unnecessary — the PLL was never claimed absent, only unneeded.

## Scope

- Diff is `CLAUDE.md` only, 5 lines for 5 — same length class as its neighbours. No new bullet, no new section.
- `SOC_MIN_MHZ` stays **12.0** and stays a requirement, untouched.
- The Design commitments header and preamble are untouched.
- **No declined ticket is reopened.** The one-deep kill was declined on its measured ceiling (16.32 MHz against the 41.67 ns needed) *and* on readability and the no-wrong-path-state commitment — not solely on a missing frequency. The wording is deliberately conditional ("if a change ever earns one") so it does not read as reopening that verdict.
- No ADR: this fixes a sentence, it decides nothing.

## Testing

- `make test` — **59/59 passed**, failure list matches `test/EXPECTED_FAIL` exactly. Run before and after the `/simplify` pass; green both times. This confirms the tree is otherwise untouched.
- `make fit` and `make soc-timing` were **not** run, deliberately: a docs-only diff cannot move a cell count or a placement, and spending a place-and-route to prove that is the four-placement cost this bullet exists to avoid.
- `/soundcheck:pr-review`: no Critical or High findings. `CLAUDE.md` is agent-readable instruction context, so `prompt-injection` was checked specifically — the added text is declarative hardware fact with no directive, tool instruction, or external reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJ77ZZJ6pDiL3vj3Qw9hKs
