### PR TITLE
State the SoC's memory sizes, and name the 128 KB confusion (JEF-773)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -295,9 +295,12 @@ that half.
 **So do not read empty baselines or an all-green `make -C formal check` as "the core is correct"** —
 an empty `formal/EXPECTED_FAIL` is necessary, not sufficient.
 
-The SoC places and meets 12 MHz but cannot yet run a program that reads its own `.data`: SPRAM
-cannot be initialised, and the bootloader (copy stub or SPI-flash boot) is deferred behind a future
-ADR, alongside the forwarding network, the radix-4 divider, and interrupts.
+The SoC is 8 KB of ROM in block RAM plus 64 KB of data RAM, which yosys maps to two of the part's
+four `SB_SPRAM256KA` at 256 kbit each. **128 KB is the up5k's whole SPRAM, not the SoC's.**
+`SOC_EXPECT_SPRAM` and `SOC_EXPECT_EBR` hold both counts exactly. It places and meets 12 MHz but
+cannot yet run a program that reads its own `.data`: SPRAM cannot be initialised, and the
+bootloader (copy stub or SPI-flash boot) is deferred behind a future ADR, alongside the forwarding
+network, the radix-4 divider, and interrupts.
 
 ## Pointers
 


### PR DESCRIPTION
Closes JEF-773.

## Neither document was wrong. The ticket's premise does not hold.

I counted the instantiations before changing anything, and the finding is the third
option the ticket allowed for: **`CLAUDE.md` never claimed 128 KB.** It claimed nothing
at all. `grep -c 128 CLAUDE.md` returns 0 at `0b151f4`, and
`git log -S "128 KB" -- CLAUDE.md` is empty for the whole life of the file — the string
has never once been in it. The brief that priced Doom did not read a wrong number out of
`CLAUDE.md`; it read a *missing* number out of it and filled the gap from the part.

### The count and the arithmetic

`SB_SPRAM256KA` is 256 kilo**bit** = 262144 bits = 32768 bytes = **32 KB each**.

| | cells | bytes |
|---|---|---|
| the up5k part has | 4 | **128 KB** |
| `littlesoc` uses | 2 | **64 KB** |

`rtl/littlesoc.v:91` has **one** `memory` instantiation, `.RAM_WORDS(16384)`.
16384 words x 4 bytes = 65536 bytes = 64 KB = two `SB_SPRAM256KA`. Note the "two" is a
*synthesis-inferred cell count*, not two module instantiations — `yosys -spram` splits the
one array. Five independent places agree on 2, and one of them is a gate:

- `rtl/littlesoc.v:90` — "16384 words = 64 KB = two `SB_SPRAM256KA` of the part's four"
- `rtl/memory.v:38` — same derivation on the parameter
- `Makefile:454` — `SOC_EXPECT_SPRAM := 2`, checked by `soc/cell_census.py` on every `make soc-timing`
- `test/probe_gates.sh:969` — the census's demonstrated red direction
- ADR-0054:147 — measured `ICESTORM_SPRAM: 2 / 4 50%`

So the RTL is right, the RTL's own comments are right, and the ratchet already holds the
number exactly. **Nothing needed fixing in `rtl/`.**

### Every other place the figure appears — all correct, none changed

I grepped `docs/adr/`, `docs/ideas/`, `soc/`, `rtl/`, the `Makefile` and `test/`. There is
no README. Every "128 KB" in the repo is a statement about the **part**, and every one is
arithmetically right:

- `docs/adr/0044:42` — "`SB_SPRAM256KA` (SPRAM) | 4 x 256 kbit = **128 KB**" — a hardware
  capability table. Correct. Left alone.
- `docs/adr/0044:53` — "AVAILABLE 128 + 15 = 143 KB" — same table's budget. Correct, and a
  record of a 2023-era placeholder analysis besides. Left alone.
- `docs/ideas/fit-the-core-on-the-up5k.md:372` — "half the up5k's 128 KB". Correct about
  the part. Left alone.
- `docs/ideas/one-address-space-over-two-memories.md:40,127` — "SPRAM 64 KB". Correct
  about the SoC. Left alone.

No ADR needed a "record of what was true then" exemption, because no ADR is stale on this.
The two figures were never in conflict — they answer different questions, and the repo
just never wrote down which question `CLAUDE.md`'s reader was asking.

## What I changed

Option 1, in substance: make the doc agree with the RTL. The gap was silence, so the fix
is to state the number once, in the `## State` section next to the sentence that already
discusses SPRAM, and to name the exact confusion so the next reader cannot repeat it.

```
The SoC is 8 KB of ROM in block RAM plus 64 KB of data RAM, which yosys maps to two of the part's
four `SB_SPRAM256KA` at 256 kbit each. **128 KB is the up5k's whole SPRAM, not the SoC's.**
`SOC_EXPECT_SPRAM` and `SOC_EXPECT_EBR` hold both counts exactly.
```

Three lines added, and the rest of the diff is reflowing the paragraph's existing tail.
The figure now in `CLAUDE.md` is one a build gate already enforces, so it cannot rot
silently the way a hand-maintained number would.

I did **not** take option 2. Instantiating the other two SPRAM buys nothing today — the
SoC cannot yet run a program that reads its own `.data`, so there is no consumer for more
RAM until the bootloader exists. `rtl/memory.v:39` already records that it "can double
without touching anything else" when there is a reason.

## Testing

Docs only, and **no build gate can move**: the diff touches one Markdown file, and
`git diff --name-only` matches nothing under `rtl/`, `formal/`, `test/` or `soc/`. Nothing
in the toolchain reads `CLAUDE.md`, so this change is genuinely untestable and I have not
invented a test for it.

Ran `make test` anyway to confirm the tree is otherwise untouched:

```
59/59 passed
Failure list matches test/EXPECTED_FAIL exactly (name and status).
```

No conflict with #135 — that edits *Measurements and ratchets*; this edits *State*.
