### PR TITLE
A crt0 copy stub, so the SoC can run a program that reads its own .data (JEF-778)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,16 +205,16 @@ Baselines and grading:
 
 ```sh
 make setup          # install the RISC-V toolchain (brew on macOS)
-make test           # the .S suite under cxxrtl + unit benches + probe-gates,
-                    # graded against EXPECTED_FAIL / OBSERVED_FLOOR
+make test           # the test/asm suite (.S and .c) under cxxrtl + unit benches +
+                    # probe-gates, graded against EXPECTED_FAIL / OBSERVED_FLOOR
 make test-units     # the unit benches alone; the bench list is checked against
                     # test/*_tb.v in both directions
 make probe-gates    # force every graded comparison red for its own reason; hermetic
-make cycles         # the .S suite again, every cycle charged to an issuing cycle or
+make cycles         # the suite again, every cycle charged to an issuing cycle or
                     # one of the six stall reasons; nonzero on a stalled cycle none
                     # of them explains. Not on CI -- there is no CPI ratchet
 make waves          # iverilog leg -> waves.vcd; one baked-in program, graded,
-                    # not the .S suite (test/testbench.v has no image loader)
+                    # not the test/asm suite (test/testbench.v has no image loader)
 make monitor-check  # regenerate test/monitor.v at the pin and diff
 make fit            # the core's area number; ratchet on FIT_MAX_LC
 make soc-timing     # the SoC place-and-time flow; requirement on SOC_MIN_MHZ.
@@ -297,10 +297,18 @@ an empty `formal/EXPECTED_FAIL` is necessary, not sufficient.
 
 The SoC is 8 KB of ROM in block RAM plus 64 KB of data RAM, which yosys maps to two of the part's
 four `SB_SPRAM256KA` at 256 kbit each. **128 KB is the up5k's whole SPRAM, not the SoC's.**
-`SOC_EXPECT_SPRAM` and `SOC_EXPECT_EBR` hold both counts exactly. It places and meets 12 MHz but
-cannot yet run a program that reads its own `.data`: SPRAM cannot be initialised, and the
-bootloader (copy stub or SPI-flash boot) is deferred behind a future ADR, alongside the forwarding
-network, the radix-4 divider, and interrupts.
+`SOC_EXPECT_SPRAM` and `SOC_EXPECT_EBR` hold both counts exactly. It places, meets 12 MHz, and runs
+a program that reads its own `.data`. SPRAM still cannot be initialised, so `.data` rides in the
+ROM at a load address `test/asm/boot.lds` puts there and `test/crt0.S` copies into RAM before
+`main`. That runtime costs 82 bytes and `test/asm/datainit.c`'s whole ROM image is 284 of 8192, so
+SPI-flash boot stays deferred, alongside the forwarding network, the radix-4 divider, and
+interrupts (ADR-0080).
+
+The suite is `test/asm/*.S` **and** `test/asm/*.c`, and `test/OBSERVED_FLOOR` names both. The two
+shapes differ only in how `.data` reaches RAM: an assembly program's is poked in by the harness,
+which is the thing the hardware cannot do, and a C program's is copied by the startup, which is the
+thing it can. A change to one program shape's build is a change in three places —
+`test/run_tests.sh`, `test/cosim.py`'s `assemble()` and the Makefile's `soc-rom`.
 
 ## Pointers
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -302,7 +302,7 @@ a program that reads its own `.data`. SPRAM still cannot be initialised, so `.da
 ROM at a load address `test/asm/boot.lds` puts there and `test/crt0.S` copies into RAM before
 `main`. That runtime costs 82 bytes and `test/asm/datainit.c`'s whole ROM image is 284 of 8192, so
 SPI-flash boot stays deferred, alongside the forwarding network, the radix-4 divider, and
-interrupts (ADR-0080).
+interrupts (ADR-0081).
 
 The suite is `test/asm/*.S` **and** `test/asm/*.c`, and `test/OBSERVED_FLOOR` names both. The two
 shapes differ only in how `.data` reaches RAM: an assembly program's is poked in by the harness,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,6 +197,13 @@ Baselines and grading:
   `test/OBSERVED_FLOOR`'s name set doubles as the suite manifest, checked both ways before anything
   runs, so a suite that shrank is red rather than a smaller table that still "passes". Before
   adding a co-sim baseline entry, read that file's header — it is the decision procedure.
+- **A `.c` entry's floor numbers are a silence bound, not an observation.** An assembly program's
+  retire count is fixed by its instruction sequence; a C program's is whatever that gcc inlined,
+  and the two toolchains here differ by about 1% on identical source — enough to trip a `>=` floor
+  copied from the table, for a reason the floor cannot tell apart from the monitor going blind. So
+  a `.c` line is 16, chosen because the recorded blindness defects produced 0 retires (already
+  exit 6) or 1. `test/run_tests.sh` rejects a `.c` floor above 64 rather than trusting the header
+  (ADR-0081).
 - **Never put a graded command in a pipeline in a CI `run:` block**: the default shell is errexit
   without pipefail, so the step's status becomes `tee`'s. This held the formal CI job accidentally
   green for its entire life.

--- a/Makefile
+++ b/Makefile
@@ -446,7 +446,12 @@ fit: fit.json
 # includes the ROM and the data RAM, so its cell count is bigger and the two
 # numbers are not comparable. This one also has to place, because icetime reads
 # the `.asc` file that only a finished placement writes.
-SOC_PROG      ?= add.S
+# A `.c` program is linked against test/asm/boot.lds and test/crt0.S, so its
+# ROM image carries `.data`'s initialiser after `.text` and the startup copies
+# it into SPRAM -- which no bitstream can initialise. That is the only image
+# shape this board can boot a program with globals from, so it is the default:
+# an image shape nothing builds is one nobody notices breaking.
+SOC_PROG      ?= datainit.c
 SOC_ROM_WORDS := 2048
 # Exact rather than budgeted the way FIT_MAX_LC is, because both are properties
 # of the RTL rather than of placement: 2 SPRAM for the 64 KB data RAM, and 16
@@ -476,9 +481,17 @@ soc-rom:
 	tmp=$$(mktemp -d "$${TMPDIR:-/tmp}/soc-rom.XXXXXX"); \
 	test -n "$$tmp" -a -d "$$tmp"; \
 	trap 'rm -rf "$$tmp"' EXIT; \
-	$$CC -march=rv32imc_zicsr_zifencei -mabi=ilp32 -nostdlib -I test/asm \
-	  -T test/asm/sections.lds -o "$$tmp/prog.elf" test/asm/$(SOC_PROG); \
-	$$OBJCOPY -O verilog --verilog-data-width=4 -j .text "$$tmp/prog.elf" "$$tmp/rom.hex"; \
+	case '$(SOC_PROG)' in \
+	  *.c) $$CC -march=rv32imc_zicsr_zifencei -mabi=ilp32 -nostdlib \
+	         -Os -std=c11 -ffreestanding -fno-tree-loop-distribute-patterns \
+	         -Wall -Wextra -Werror -I test/asm -T test/asm/boot.lds \
+	         -o "$$tmp/prog.elf" test/crt0.S test/asm/$(SOC_PROG); \
+	       sections='-j .text -j .data' ;; \
+	  *)   $$CC -march=rv32imc_zicsr_zifencei -mabi=ilp32 -nostdlib -I test/asm \
+	         -T test/asm/sections.lds -o "$$tmp/prog.elf" test/asm/$(SOC_PROG); \
+	       sections='-j .text' ;; \
+	esac; \
+	$$OBJCOPY -O verilog --verilog-data-width=4 $$sections "$$tmp/prog.elf" "$$tmp/rom.hex"; \
 	python3 soc/rom_banks.py "$$tmp/rom.hex" soc/rom_even.hex soc/rom_odd.hex \
 	  --rom-words $(SOC_ROM_WORDS)
 

--- a/docs/adr/0080-the-data-image-lives-in-rom-and-crt0-copies-it.md
+++ b/docs/adr/0080-the-data-image-lives-in-rom-and-crt0-copies-it.md
@@ -1,0 +1,109 @@
+# ADR-0080: The `.data` image lives in ROM and a `crt0` copies it, and the 8 KB budget is measured
+
+**Status:** Accepted · 2026-08-08 · *Closes the bootloader half that
+[ADR-0054](0054-the-memory-system-and-the-first-real-timing-number.md) deferred and
+[ADR-0044](0044-what-the-memory-system-has-to-be.md) named. Keeps ADR-0044's SPI-flash boot
+deferred, now against a measured number rather than a guess. Widens the suite contract in
+[ADR-0035](0035-the-baseline-pins-the-failure-mode.md) and `test/OBSERVED_FLOOR` from `.S`
+programs to programs. Amends `CLAUDE.md`'s State section. No `rtl/` or `formal/` change.*
+
+## The gap
+
+The SoC placed, met 12 MHz and could not run a program that reads its own `.data`. Its data RAM is
+SPRAM, and no bitstream initialises SPRAM: the only memory that comes up holding anything is the
+block RAM behind `.text`. So a global with an initialiser had no value at power-on, and the core
+that executes RV32IMC correctly still could not run a C program.
+
+The `.S` suite never saw this. Its programs' `.data` is linked at its virtual address in RAM and
+poked straight into the simulated RAM by `test/run_tests.sh` — which is precisely the thing the
+hardware cannot do. Every one of the 59 assembly programs passes on a machine that has no way to
+get a byte of `.data` into memory.
+
+## Decision
+
+The standard answer, and no RTL.
+
+1. `test/asm/boot.lds` links `.data`'s **load** address into `rom` (`AT>rom`) while its **virtual**
+   address stays in `ram`, and exports `__data_load_start`, `__data_start`, `__data_end`,
+   `__bss_start`, `__bss_end` and `__stack_top`.
+2. `test/crt0.S` sets `gp` and `sp`, copies `[__data_load_start, …)` to `__data_start`, zeroes
+   `.bss`, and calls `main`.
+3. `test/asm/datainit.c` is the first C program in the suite. It runs under `make test`, under
+   `make cosim-suite`, and it is now the default `SOC_PROG`, so the ROM image CI builds is the
+   shape the hardware can boot.
+
+The copy reads its source over the **data** bus at ROM addresses. That works because text on this
+core is readable and writable from that bus
+([ADR-0059](0059-text-is-writable-and-the-arbiter-lives-in-the-memory.md)); `test/asm/textload.S`
+is the program that already said so. Nothing in `rtl/` changed.
+
+### Two linker scripts, not one
+
+`test/asm/sections.lds` is untouched and the 59 assembly programs are byte-identical through it —
+`gcc -E` output, ROM image and RAM image, all 59, verified against `25cbce0`. They are freestanding
+and must not grow a copy loop they do not need, and a single script cannot give one program's
+`.data` a ROM load address and another's a RAM one. The cost is a duplicated four-line memory map,
+which each file names and points at the other about.
+
+The visible consequence is that the two shapes are extracted differently: a `.S` program's ROM
+image is `.text` and its RAM image is everything else, while a `.c` program's ROM image is `.text`
+plus `.data` and its RAM image is `.tohost` alone. `.tohost` stays loadable at its own address in
+`ram` because it is an IO window rather than program data — the runners watch the first word of RAM
+for a verdict from cycle 0, so it has to read zero before the copy has run.
+
+That build branch is now spelled out in three places: `test/run_tests.sh`, `test/cosim.py`'s
+`assemble()` and the Makefile's `soc-rom`. All three already carried their own copy of the single
+shape's build line, so this does not add a surface — but it does widen one, and consolidating the
+three is the obvious follow-up.
+
+## What the `.bss` test is worth, and why check 2 is not the one that grades it
+
+Simulated RAM comes up zeroed. A `.bss` that was never cleared therefore reads exactly like one
+that was, and a boot-time "is `.bss` zero?" check passes whether or not `crt0` ever ran a zeroing
+loop. That is a grader that cannot fail, which this repo has shipped five of.
+
+So `test/asm/datainit.c` scribbles `0xdeadbeef` over both tables and calls `runtime_init` again —
+the same routine the reset path ran, now over memory that is demonstrably not zero — and re-checks.
+`runtime_init` is separately callable for exactly this reason.
+
+Both red directions were run, not argued:
+
+| mutation of `test/crt0.S` | result |
+|---|---|
+| the `.bss` zeroing loop deleted | `FAIL 4`, 269 retires |
+| the `.data` copy loop deleted | `FAIL 1`, 67 retires |
+| neither | `PASS`, 400 retires |
+
+The `.bss` mutation fails at check 4 and not at check 2, which is the point: check 2 is the one
+that cannot fail here, and the table says so.
+
+## The number that decides whether SPI-flash boot becomes urgent
+
+Measured at `25cbce0` with `riscv64-elf-gcc`, `-Os`, on `test/asm/datainit.c`:
+
+| | bytes |
+|---|---|
+| `.text` | 252 |
+| — of it `test/crt0.S` (`_start` 22 + `runtime_init` 60) | 82 |
+| — of it the test program itself | 170 |
+| `.data` initialiser, carried in ROM | 32 |
+| **ROM image total** | **284** |
+| ROM (`SOC_ROM_WORDS` 2048, 16 EBR) | 8192 |
+| **left** | **7908 (96.5%)** |
+
+**The reusable runtime costs 82 bytes, one percent of the ROM.** There is no C prologue beyond it:
+no libc, no `.init_array`, no stack unwinder. On this evidence SPI-flash boot stays deferred — the
+8 KB ceiling is a real constraint on how much *program* fits, and it is not measurably a constraint
+on being able to boot one at all. The number to watch is the ROM image total, not the copy stub.
+
+`make soc-timing` measured 78.51 ns / 12.74 MHz for both `SOC_PROG=add.S` and
+`SOC_PROG=datainit.c` at the default seed — bit-identical, because a program only changes the
+block RAM's initial contents and nothing nextpnr places. Switching the default is therefore free,
+and it buys an image shape CI builds on every run instead of one nothing exercises.
+
+## What this does not do
+
+It is not the SPI-flash bootloader, and it does not make SPRAM initialisable. A program still
+cannot have more `.data` than fits in ROM alongside its `.text`, because the initialiser rides in
+the same 8 KB. `test/asm/datainit.c` is a test program, not a demonstration that a real C
+application fits; the next honest measurement is a program with actual work in it.

--- a/docs/adr/0081-the-data-image-lives-in-rom-and-crt0-copies-it.md
+++ b/docs/adr/0081-the-data-image-lives-in-rom-and-crt0-copies-it.md
@@ -1,4 +1,4 @@
-# ADR-0080: The `.data` image lives in ROM and a `crt0` copies it, and the 8 KB budget is measured
+# ADR-0081: The `.data` image lives in ROM and a `crt0` copies it, and the 8 KB budget is measured
 
 **Status:** Accepted · 2026-08-08 · *Closes the bootloader half that
 [ADR-0054](0054-the-memory-system-and-the-first-real-timing-number.md) deferred and

--- a/docs/adr/0081-the-data-image-lives-in-rom-and-crt0-copies-it.md
+++ b/docs/adr/0081-the-data-image-lives-in-rom-and-crt0-copies-it.md
@@ -77,6 +77,41 @@ Both red directions were run, not argued:
 The `.bss` mutation fails at check 4 and not at check 2, which is the point: check 2 is the one
 that cannot fail here, and the table says so.
 
+## A C entry's floor is a silence bound, not an observation
+
+`test/OBSERVED_FLOOR` was designed for assembly and does not transfer. An `.S` program assembles to
+a fixed instruction sequence, so its retire count holds across toolchains by construction — which
+is exactly why a `>=` floor over the measured number is a meaningful check there. A C program's
+count is whatever that gcc chose to inline and schedule. `test/asm/datainit.c` retired **400**
+under a local `riscv64-elf-gcc` and **395** on the CI runner, from identical source, and the first
+version of this change recorded 400 as its floor and went red on the gate.
+
+Lowering it to 395 would have made CI pass and left the defect. The floor exists to catch a program
+going **quiet**, and a number tracking a compiler's output conflates that with "a different gcc
+emitted five fewer instructions" — two failures the gate cannot tell apart. This repo already knows
+its toolchains disagree: `make fit` reads about 21 cells apart on identical RTL, and `CLAUDE.md`
+says to quote the CI number for that reason.
+
+So a `.c` line's two numbers are **16**, picked from the check rather than the measurement. Every
+recorded instance of the defect this file exists for produced zero retires — `rvfi_valid` never
+asserting, an `ifdef` dropping the shadow payload, `write_cxxrtl` optimising the monitor instance
+away — or one, the iverilog under-sensitivity defect measured at "0 writes and 1 retire". Zero is
+already `test/cxxrtl.cc`'s exit 6, so the bound only has to clear one; 16 is an order of magnitude
+above the defect, two below any C program's real count, and nothing a compiler chooses can move it.
+`spec-checked` has the same problem and takes the same bound — it tracked retires exactly here
+(395 of 395 on CI), so whatever moves one moves the other.
+
+Two options were rejected. **Pinning the toolchain for C** is heavier than this ticket and would
+buy reproducibility the check does not need. **Dropping `.c` from the floor entirely** relies on
+exit 6 alone, and exit 6 covers only *zero* — the one recorded defect that produced a nonzero count
+produced 1, which no `MONITOR-SILENT` path catches.
+
+The rule is enforced rather than left to the header: `test/run_tests.sh` rejects a `.c` floor above
+64 before it runs a program, with a message naming the reason. The header is a decision procedure
+someone follows under pressure, and its "copy the table's third column" instruction is what
+produced the red gate in the first place. The name set is untouched by any of this — a `.c` program
+that vanishes from the suite is red in both directions exactly as an `.S` one is.
+
 ## The number that decides whether SPI-flash boot becomes urgent
 
 Measured at `25cbce0` with `riscv64-elf-gcc`, `-Os`, on `test/asm/datainit.c`:

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -178,7 +178,7 @@ trades away simplicity the current design depends on.
   second ROM read did become interleaved banks — at **word** granularity, not the halfword split
   ADR-0044 named, because this core's fetch interface asks for two adjacent words and windows them
   itself. The bootloader is half-built: the `.data` copy stub landed with
-  [ADR-0080](0080-the-data-image-lives-in-rom-and-crt0-copies-it.md), so the SoC runs a C program
+  [ADR-0081](0081-the-data-image-lives-in-rom-and-crt0-copies-it.md), so the SoC runs a C program
   that reads its own globals. ADR-0044's SPI-flash path stays deferred, now against the measured
   ROM budget rather than a guess.
 - **Interrupts** (`mie`/`mip` real rather than read-only zero) — no interrupt sources exist.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -82,7 +82,7 @@ and what it costs. Reversing one is fine — write a new ADR that supersedes it.
 | [0078](0078-a-one-deep-kill-is-cheap-and-buys-a-clock-the-board-cannot-use.md) | A one-deep kill is cheap, and it buys a clock the board cannot use | Accepted · prices the no-wrong-path-state commitment; re-attributes 0076's 21%, graded by 0066 |
 | [0079](0079-all-six-m2-terms-are-re-measured-and-m2-is-declared.md) | All six M2 terms are re-measured against merged main, and M2 is declared | Accepted · rules on 0037's conjunction as amended by 0045, 0046, 0047, 0050, 0051 and 0052; narrows 0027 |
 | [0080](0080-twenty-four-megahertz-is-not-reachable-on-the-up5k.md) | Twenty-four megahertz is not reachable on the up5k, and the part is the constraint | Accepted · collects 0074, 0076 and 0078 into one verdict; measures the same RTL at 31 MHz on hx8k; narrows 0078's "nothing in between" |
-| [0080](0080-the-data-image-lives-in-rom-and-crt0-copies-it.md) | The `.data` image lives in ROM and a `crt0` copies it, and the 8 KB budget is measured | Accepted · closes the copy-stub half 0054 deferred; keeps 0044's SPI-flash boot deferred; widens 0035's suite contract |
+| [0081](0081-the-data-image-lives-in-rom-and-crt0-copies-it.md) | The `.data` image lives in ROM and a `crt0` copies it, and the 8 KB budget is measured | Accepted · closes the copy-stub half 0054 deferred; keeps 0044's SPI-flash boot deferred; widens 0035's suite contract |
 
 0001–0007 came from the design brief
 ([`docs/ideas/finish-the-rewrite.md`](../ideas/finish-the-rewrite.md)). 0008–0011 came out of

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -82,6 +82,7 @@ and what it costs. Reversing one is fine — write a new ADR that supersedes it.
 | [0078](0078-a-one-deep-kill-is-cheap-and-buys-a-clock-the-board-cannot-use.md) | A one-deep kill is cheap, and it buys a clock the board cannot use | Accepted · prices the no-wrong-path-state commitment; re-attributes 0076's 21%, graded by 0066 |
 | [0079](0079-all-six-m2-terms-are-re-measured-and-m2-is-declared.md) | All six M2 terms are re-measured against merged main, and M2 is declared | Accepted · rules on 0037's conjunction as amended by 0045, 0046, 0047, 0050, 0051 and 0052; narrows 0027 |
 | [0080](0080-twenty-four-megahertz-is-not-reachable-on-the-up5k.md) | Twenty-four megahertz is not reachable on the up5k, and the part is the constraint | Accepted · collects 0074, 0076 and 0078 into one verdict; measures the same RTL at 31 MHz on hx8k; narrows 0078's "nothing in between" |
+| [0080](0080-the-data-image-lives-in-rom-and-crt0-copies-it.md) | The `.data` image lives in ROM and a `crt0` copies it, and the 8 KB budget is measured | Accepted · closes the copy-stub half 0054 deferred; keeps 0044's SPI-flash boot deferred; widens 0035's suite contract |
 
 0001–0007 came from the design brief
 ([`docs/ideas/finish-the-rewrite.md`](../ideas/finish-the-rewrite.md)). 0008–0011 came out of
@@ -176,8 +177,10 @@ trades away simplicity the current design depends on.
   `make soc-timing` reports `icetime`'s critical path with its logic/routing split. ADR-0003's
   second ROM read did become interleaved banks — at **word** granularity, not the halfword split
   ADR-0044 named, because this core's fetch interface asks for two adjacent words and windows them
-  itself. What is still deferred is a bootloader: SPRAM cannot be initialised, so a real product
-  needs a `.data` copy stub or ADR-0044's SPI-flash path.
+  itself. The bootloader is half-built: the `.data` copy stub landed with
+  [ADR-0080](0080-the-data-image-lives-in-rom-and-crt0-copies-it.md), so the SoC runs a C program
+  that reads its own globals. ADR-0044's SPI-flash path stays deferred, now against the measured
+  ROM budget rather than a guess.
 - **Interrupts** (`mie`/`mip` real rather than read-only zero) — no interrupt sources exist.
 - ~~**Spike or Sail co-simulation**~~ — **resolved by [ADR-0032](0032-sail-co-simulation-is-worth-building-and-stays-opt-in.md).**
   The old test ("revisit only if formal and simulation ever disagree") could only fire on a bug both

--- a/test/OBSERVED_FLOOR
+++ b/test/OBSERVED_FLOOR
@@ -39,8 +39,9 @@
 #
 #     <program>  <retires>  <spec-checked retires>
 #
-# where `<program>` is a test/asm file name, `.S` or `.c`. The two differ only
-# in how test/run_tests.sh builds them; nothing here distinguishes them.
+# where `<program>` is a test/asm file name, `.S` or `.c`. The NAME half treats
+# the two identically. The NUMBERS do not, and the section below on C programs
+# is the part to read before writing a `.c` line.
 #
 # `retires` is the number of cycles the monitor examined (`rvfi_valid` high).
 # `spec-checked` is the subset of those whose VALUES it compared against its
@@ -52,18 +53,46 @@
 # and test/EXPECTED_FAIL or formal/EXPECTED_CHECKS, and it is deliberate. The
 # numbers move for legitimate reasons: the assembler is free to compress
 # differently, a test gains an instruction, a macro in test/asm/riscv_test.h
-# grows one, a different gcc lays a C program out differently. An exact ratchet
-# over every number in this file is one nobody
+# grows one. An exact ratchet over every number in this file is one nobody
 # would keep, and a ratchet nobody keeps gets raised until it means nothing.
 # What must not happen is a program going QUIET, and `>=` catches exactly that.
+#
+# A C PROGRAM'S TWO NUMBERS ARE A SILENCE BOUND, NOT AN OBSERVATION — and that
+# is the one place this file's format means different things on different lines.
+# An `.S` program assembles to a fixed instruction sequence, so recording what
+# it retired costs nothing and holds across toolchains by construction. A `.c`
+# program's count is whatever that gcc chose to inline and schedule:
+# test/asm/datainit.c retired 400 under a local riscv64-elf-gcc and 395 on the
+# CI runner, from identical source. Recorded as a floor, that difference is red
+# — and red for the wrong reason, because the floor exists to catch a program
+# going QUIET and cannot tell "the monitor stopped observing" from "a different
+# gcc emitted five fewer instructions". This repo already knows its two
+# toolchains disagree; `make fit` reads about 21 cells apart on identical RTL.
+#
+# So pick a `.c` line's numbers from what the CHECK needs, never from the table.
+# Every recorded instance of the defect this file exists for produced ZERO
+# retires — `rvfi_valid` never asserting, an `ifdef` dropping the shadow
+# payload, `write_cxxrtl` optimising the monitor instance away — or ONE, the
+# iverilog under-sensitivity defect, measured at "0 writes and 1 retire". Zero
+# is already the runner's own exit 6, so the bound only has to clear one.
+# **16** is the number these lines use: an order of magnitude above the defect,
+# two below any C program's real count, and nothing a compiler chooses can move
+# it. `spec-checked` has the same problem and takes the same bound — it tracked
+# retires exactly on datainit.c (395 of 395 on CI), so whatever moves one moves
+# the other.
+#
+# test/run_tests.sh REJECTS a `.c` floor above 64 rather than trusting this
+# paragraph, because a paragraph is exactly what the next person will not read
+# and "copy the third column" is the instruction that produced the red gate.
 #
 # The NAME set, on the other hand, IS a set equality in both directions, the
 # same contract the two files above carry — that is the manifest
 # half, described at the top. It is checked by test/check_suite_shape.sh BEFORE
 # either leg assembles anything, so a mismatch in either direction names the
 # programs involved and stops, rather than being discovered after a full run
-# that was never going to be gradeable. Adding a program to test/asm means
-# adding its measured line here, in the same commit.
+# that was never going to be gradeable. That is true of `.c` names exactly as it
+# is of `.S` ones — the numbers are what differ, never the manifest. Adding a
+# program to test/asm means adding its line here, in the same commit.
 #
 # ZERO IS NEVER A FLOOR. Zero of either count is MONITOR-SILENT — the runner's
 # own exit 6 — before this file is ever consulted, so a line of `0 0` cannot
@@ -81,16 +110,17 @@
 # bug in this core. Whoever first sees a low number here should not have to
 # rediscover that.
 #
-# HOW TO RE-MEASURE. Run `make test` and copy the table's third column. Record
-# the commit SHA it was measured at in the PR that changes a number, the way
-# every other measurement in this repo is recorded. Numbers only ever go DOWN
-# by accident; if one legitimately drops (a different binutils compressing more
-# aggressively, a test deliberately shortened), lower it in the same commit as
-# the change that caused it and say which.
+# HOW TO RE-MEASURE, FOR `.S` LINES ONLY. Run `make test` and copy the table's
+# third column. Record the commit SHA it was measured at in the PR that changes
+# a number, the way every other measurement in this repo is recorded. Numbers
+# only ever go DOWN by accident; if one legitimately drops (a different binutils
+# compressing more aggressively, a test deliberately shortened), lower it in the
+# same commit as the change that caused it and say which. A `.c` line has
+# nothing to re-measure: it is 16 because 16 is what the silence check needs,
+# and it stays 16 when the compiler changes its mind.
 #
 # Measured at 18d17a2 (the branch point) with riscv64-elf-gcc, the pinned
-# riscv-formal monitor, and CYCLES=5000 in test/run_tests.sh. datainit.c, the
-# first C program here, was measured at 25cbce0 the same way.
+# riscv-formal monitor, and CYCLES=5000 in test/run_tests.sh.
 add.S               429    429
 addi.S              206    206
 and.S               449    449
@@ -106,7 +136,7 @@ cebreak.S            161    138
 contend.S           113    113
 csr.S               108     82
 csrset.S              72     62
-datainit.c          400    400
+datainit.c           16     16   # a silence bound; it retires ~400, and that is not a contract
 div.S                60     60
 divu.S               61     61
 fencenop.S            40     35

--- a/test/OBSERVED_FLOOR
+++ b/test/OBSERVED_FLOOR
@@ -1,5 +1,5 @@
-# The `.S` suite's MANIFEST, and how much the per-retire RVFI monitor was
-# OBSERVED to do on each program.
+# The suite's MANIFEST -- test/asm/*.S and test/asm/*.c -- and how much the
+# per-retire RVFI monitor was OBSERVED to do on each program.
 #
 # TWO JOBS, ONE LIST, DELIBERATELY. This file is the list of programs the suite
 # must contain, and it is the list of what each of them was measured to retire.
@@ -37,7 +37,10 @@
 #
 # FORMAT — three fields:
 #
-#     <test>.S  <retires>  <spec-checked retires>
+#     <program>  <retires>  <spec-checked retires>
+#
+# where `<program>` is a test/asm file name, `.S` or `.c`. The two differ only
+# in how test/run_tests.sh builds them; nothing here distinguishes them.
 #
 # `retires` is the number of cycles the monitor examined (`rvfi_valid` high).
 # `spec-checked` is the subset of those whose VALUES it compared against its
@@ -49,7 +52,8 @@
 # and test/EXPECTED_FAIL or formal/EXPECTED_CHECKS, and it is deliberate. The
 # numbers move for legitimate reasons: the assembler is free to compress
 # differently, a test gains an instruction, a macro in test/asm/riscv_test.h
-# grows one. An exact ratchet over every number in this file is one nobody
+# grows one, a different gcc lays a C program out differently. An exact ratchet
+# over every number in this file is one nobody
 # would keep, and a ratchet nobody keeps gets raised until it means nothing.
 # What must not happen is a program going QUIET, and `>=` catches exactly that.
 #
@@ -85,7 +89,8 @@
 # the change that caused it and say which.
 #
 # Measured at 18d17a2 (the branch point) with riscv64-elf-gcc, the pinned
-# riscv-formal monitor, and CYCLES=5000 in test/run_tests.sh.
+# riscv-formal monitor, and CYCLES=5000 in test/run_tests.sh. datainit.c, the
+# first C program here, was measured at 25cbce0 the same way.
 add.S               429    429
 addi.S              206    206
 and.S               449    449
@@ -101,6 +106,7 @@ cebreak.S            161    138
 contend.S           113    113
 csr.S               108     82
 csrset.S              72     62
+datainit.c          400    400
 div.S                60     60
 divu.S               61     61
 fencenop.S            40     35

--- a/test/asm/boot.lds
+++ b/test/asm/boot.lds
@@ -1,0 +1,82 @@
+/*
+ * The linker script for the C programs in this directory. The assembly
+ * programs use sections.lds instead, and the difference between the two files
+ * is one line: `.data` here has its LOAD address in `rom` and its virtual
+ * address in `ram`.
+ *
+ * That is the whole bootstrap problem. The SoC's data RAM is SPRAM, and no
+ * bitstream can initialise SPRAM; block RAM behind `.text` is the only memory
+ * that comes up holding anything. A program whose `.data` exists only at its
+ * virtual address therefore has no initialised globals on real hardware, which
+ * is why the SoC could not run one. test/crt0.S copies
+ * [__data_load_start, __data_load_start + (__data_end - __data_start)) into
+ * __data_start before main, and zeroes .bss after it.
+ *
+ * The memory map is sections.lds' -- same Harvard split, same reason `ram` sits
+ * past `rom`'s ceiling to keep GNU ld's single flat address space happy. The
+ * two files have to agree about it; test/testbench.v's RAM_BASE and
+ * test/cxxrtl.cc's kRamBase are the third and fourth copies.
+ *
+ * `.tohost` is the one output section that stays loadable at its own address in
+ * `ram`. It is an IO window, not program data: the runners watch the first word
+ * of RAM for the verdict from the first cycle, so it must read zero before the
+ * copy has run, and re-running the copy mid-program must not clear a verdict
+ * already written.
+ *
+ * `.rodata` stays in `rom` and is read over the data bus, which this core
+ * allows (test/asm/textload.S is the program that says so). Copying it would
+ * cost the same ROM plus the RAM to land in.
+ */
+MEMORY {
+    rom(rx)  : ORIGIN = 0x00000000, LENGTH = 16K
+    ram(!rx) : ORIGIN = 0x00010000, LENGTH = 4K
+}
+
+SECTIONS {
+    .text : {
+        *(.text.init);
+        *(.text);
+        *(.text.*);
+        *(.rodata);
+        *(.rodata.*);
+        *(.srodata);
+        *(.srodata.*);
+        . = ALIGN(4);
+    } >rom
+
+    .tohost : {
+        *(.tohost);
+        . = ALIGN(4);
+    } >ram
+
+    /*
+     * __data_start is the FIRST thing in this section, so LOADADDR(.data)
+     * below is the load address of that symbol and not of some padding in
+     * front of it. Put anything -- an ALIGN, a symbol, a literal -- above it
+     * and the copy reads from the wrong place by however many bytes it added.
+     */
+    .data : {
+        __data_start = .;
+        __global_pointer$ = . + 0x800;
+        *(.sdata);
+        *(.sdata.*);
+        *(.data);
+        *(.data.*);
+        . = ALIGN(4);
+        __data_end = .;
+    } >ram AT>rom
+    __data_load_start = LOADADDR(.data);
+
+    .bss (NOLOAD) : {
+        __bss_start = .;
+        *(.sbss);
+        *(.sbss.*);
+        *(.bss);
+        *(.bss.*);
+        *(COMMON);
+        . = ALIGN(4);
+        __bss_end = .;
+    } >ram
+
+    __stack_top = ORIGIN(ram) + LENGTH(ram);
+}

--- a/test/asm/datainit.c
+++ b/test/asm/datainit.c
@@ -1,0 +1,83 @@
+// The first C program in this suite, and the thing the SoC could not run: it
+// reads globals whose values exist only in the ROM image until test/crt0.S
+// copies them into RAM, and globals that are only correct because that same
+// startup zeroed them.
+//
+// Four numbered checks, in the riscv-tests verdict encoding the assembly
+// programs use, so a failure names which one:
+//
+//   1  .data holds its initialisers after the reset path ran
+//   2  .bss reads zero after the reset path ran
+//   3  .data is restored when the copy runs over memory holding something else
+//   4  .bss is cleared when the zeroing runs over memory holding something else
+//
+// Checks 3 and 4 exist because the simulated RAM comes up zeroed. Check 2 alone
+// passes whether or not test/crt0.S ever cleared anything, and a check that
+// cannot fail is not a check; scribbling first and calling `runtime_init` again
+// runs the same code the reset path ran, over memory that is demonstrably not
+// zero. Deleting the zeroing loop from test/crt0.S fails check 4, and deleting
+// the copy loop fails check 1.
+
+// The riscv-tests HTIF window, at the base of RAM. Two 32-bit halves rather
+// than one 64-bit store so the order is this file's to choose: the upper word
+// first and the verdict last, because Sail's HTIF fires on whichever half-write
+// completes the pair and the verdict has to be the store that stops it. Same
+// reasoning as riscv_test.h's RVTEST_PASS.
+volatile unsigned tohost[2] __attribute__((section(".tohost"), aligned(8), used));
+
+// test/crt0.S's copy-and-zero routine, which it also runs before main.
+void runtime_init(void);
+
+#define TABLE_WORDS 8
+
+// A distinct nonzero value per slot, checked slot by slot, so a copy that ran
+// with the wrong length, the wrong source or the wrong stride fails on the
+// element it got wrong rather than on an aggregate that could coincide.
+#define ENTRY(i) ((unsigned)(0x9e3779b9u * ((i) + 1u)))
+
+unsigned initialised[TABLE_WORDS] = {
+  ENTRY(0), ENTRY(1), ENTRY(2), ENTRY(3),
+  ENTRY(4), ENTRY(5), ENTRY(6), ENTRY(7),
+};
+
+unsigned uninitialised[TABLE_WORDS];
+
+__attribute__((noreturn)) static void finish(unsigned tohost_word) {
+  tohost[1] = 0;
+  tohost[0] = tohost_word;
+  for (;;) {
+  }
+}
+
+// The encoding riscv_test.h's RVTEST_FAIL writes: test/cxxrtl.cc reports the
+// test number as `tohost >> 1`.
+__attribute__((noreturn)) static void fail(unsigned testnum) {
+  finish((testnum << 1) | 1u);
+}
+
+// `testnum` grades `.data`, `testnum + 1` grades `.bss`.
+static void check(unsigned testnum) {
+  for (unsigned i = 0; i < TABLE_WORDS; i++) {
+    if (initialised[i] != ENTRY(i)) {
+      fail(testnum);
+    }
+    if (uninitialised[i] != 0) {
+      fail(testnum + 1);
+    }
+  }
+}
+
+static void scribble(void) {
+  for (unsigned i = 0; i < TABLE_WORDS; i++) {
+    initialised[i] = 0xdeadbeefu;
+    uninitialised[i] = 0xdeadbeefu;
+  }
+}
+
+int main(void) {
+  check(1);
+  scribble();
+  runtime_init();
+  check(3);
+  finish(1);
+}

--- a/test/asm/sections.lds
+++ b/test/asm/sections.lds
@@ -19,6 +19,12 @@
  * comment there); the cxxrtl runner subtracts `ram`'s ORIGIN back out when
  * it pokes RAM contents via debug_items, and the iverilog leg's live bus
  * decode does the same at runtime.
+ *
+ * This is the script for the assembly programs, and their `.data` reaches RAM
+ * only because a harness put it there. The C programs use test/asm/boot.lds,
+ * which links the same map with `.data`'s load address in `rom` so the startup
+ * can copy it -- the only shape the SoC can boot, since its SPRAM cannot be
+ * initialised from a bitstream.
  */
 MEMORY {
     rom(rx)  : ORIGIN = 0x00000000, LENGTH = 16K

--- a/test/check_suite_shape.sh
+++ b/test/check_suite_shape.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
-# Asserts that the .S suite CONTAINS what it is supposed to contain, before
-# either sim leg runs a single program.
+# Asserts that the suite CONTAINS what it is supposed to contain, before either
+# sim leg runs a single program.
+#
+# The suite is test/asm/*.S and test/asm/*.c. Both are programs and both are
+# graded; they differ only in how test/run_tests.sh builds them, and nothing
+# here needs to know which is which.
 #
 # Usage: check_suite_shape.sh <asm-dir> <manifest>
 #
@@ -34,7 +38,7 @@
 #     would make the set comparison below quietly non-symmetric.
 #
 # BOTH DIRECTIONS, and the second one is the one worth arguing for. A program
-# present in the tree but absent from the manifest is red, so a .S that lands
+# present in the tree but absent from the manifest is red, so a program that lands
 # without being wired into the floor file fails immediately rather than joining
 # the suite unmeasured. That is why the ladder's version is bidirectional too.
 #
@@ -76,12 +80,14 @@ if [ -z "$listed" ]; then
   exit 1
 fi
 
-# A name that is not a .S is a typo or a stray field, and it would show up below
-# as a phantom "missing from the tree" entry rather than as what it is.
-not_dot_s=$(printf '%s\n' "$listed" | awk '$1 !~ /\.S$/ { print }')
-if [ -n "$not_dot_s" ]; then
-  echo "error: $MANIFEST has entries whose first field is not a '<test>.S' name:" >&2
-  printf '%s\n' "$not_dot_s" | sed -e 's|^|  |' >&2
+# A name that is neither a .S nor a .c is a typo or a stray field, and it would
+# show up below as a phantom "missing from the tree" entry rather than as what
+# it is.
+not_a_program=$(printf '%s\n' "$listed" | awk '$1 !~ /\.[Sc]$/ { print }')
+if [ -n "$not_a_program" ]; then
+  echo "error: $MANIFEST has entries whose first field is not a '<test>.S' or" >&2
+  echo "'<test>.c' name:" >&2
+  printf '%s\n' "$not_a_program" | sed -e 's|^|  |' >&2
   exit 1
 fi
 
@@ -96,10 +102,10 @@ if [ -n "$duplicates" ]; then
 fi
 
 shopt -s nullglob
-programs=("$ASM_DIR"/*.S)
+programs=("$ASM_DIR"/*.S "$ASM_DIR"/*.c)
 shopt -u nullglob
 if [ "${#programs[@]}" -eq 0 ]; then
-  echo "error: no .S programs found in '$ASM_DIR'." >&2
+  echo "error: no programs found in '$ASM_DIR'." >&2
   echo "The manifest $MANIFEST names $(printf '%s\n' "$listed" | wc -l | tr -d ' ')." >&2
   exit 1
 fi

--- a/test/cosim.py
+++ b/test/cosim.py
@@ -278,8 +278,14 @@ def find_sail(explicit):
 
 
 def assemble(cc, src, outdir):
-    """Assemble one test/asm/*.S exactly as test/run_tests.sh does, and emit
-    the ELF (for Sail) plus the two objcopy images (for the cxxrtl runner).
+    """Build one program from test/asm exactly as test/run_tests.sh does, and
+    emit the ELF (for Sail) plus the two objcopy images (for the cxxrtl runner).
+
+    A `.c` program is linked against test/asm/boot.lds and test/crt0.S, which
+    puts `.data`'s load address in ROM and copies it into RAM before main; a
+    `.S` program is freestanding and has its `.data` poked straight into the
+    simulated RAM. Sail is a real ELF loader, so it honours the load addresses
+    and needs no help with either shape.
 
     The reference model gets the SAME ELF, unmodified -- no stripped symbol,
     no throwaway copy. If the two legs ever stop building from
@@ -289,17 +295,25 @@ def assemble(cc, src, outdir):
     rom = os.path.join(outdir, base + ".rom.hex")
     ram = os.path.join(outdir, base + ".ram.hex")
     objcopy = cc[: -len("gcc")] + "objcopy"
-    log = subprocess.run(
-        [cc, "-march=rv32imc_zicsr_zifencei", "-mabi=ilp32", "-nostdlib", "-I", ASM_DIR,
-         "-T", os.path.join(ASM_DIR, "sections.lds"), src, "-o", elf],
-        capture_output=True, text=True,
-    )
+    if src.endswith(".c"):
+        build = [cc, "-march=rv32imc_zicsr_zifencei", "-mabi=ilp32", "-nostdlib",
+                 "-Os", "-std=c11", "-ffreestanding",
+                 "-fno-tree-loop-distribute-patterns",
+                 "-Wall", "-Wextra", "-Werror", "-I", ASM_DIR,
+                 "-T", os.path.join(ASM_DIR, "boot.lds"),
+                 os.path.join(REPO, "test", "crt0.S"), src, "-o", elf]
+        rom_args = ["--only-section=.text", "--only-section=.data"]
+        ram_args = ["--only-section=.tohost"]
+    else:
+        build = [cc, "-march=rv32imc_zicsr_zifencei", "-mabi=ilp32", "-nostdlib",
+                 "-I", ASM_DIR,
+                 "-T", os.path.join(ASM_DIR, "sections.lds"), src, "-o", elf]
+        rom_args = ["--only-section=.text"]
+        ram_args = ["--remove-section=.text"]
+    log = subprocess.run(build, capture_output=True, text=True)
     if log.returncode != 0:
         raise Fatal(f"assembling {src} failed:\n{log.stdout}{log.stderr}")
-    for args, out in (
-        (["--only-section=.text"], rom),
-        (["--remove-section=.text"], ram),
-    ):
+    for args, out in ((rom_args, rom), (ram_args, ram)):
         subprocess.run(
             [objcopy, "-O", "verilog", "--verilog-data-width=4", *args, elf, out],
             check=True, capture_output=True,
@@ -526,7 +540,7 @@ def emit(status):
 def main():
     ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
     ap.add_argument("program", nargs="?", default="add.S",
-                    help="a test/asm/*.S file name (default: add.S)")
+                    help="a test/asm/*.S or *.c file name (default: add.S)")
     ap.add_argument("--cosim-binary", default=os.path.join(REPO, "cosim"))
     ap.add_argument("--sail", default=None, help="path to sail_riscv_sim")
     ap.add_argument("--cycles", type=int, default=5000,

--- a/test/crt0.S
+++ b/test/crt0.S
@@ -1,0 +1,58 @@
+// Startup for the C programs in test/asm. It exists because the SoC's data RAM
+// is SPRAM, which the bitstream cannot initialise: the only memory that comes
+// up holding anything is the block RAM behind `.text`. So test/asm/boot.lds
+// links `.data`'s LOAD address into ROM and its virtual address into RAM, and
+// the copy below is what moves it before `main` runs.
+//
+// The assembly programs do not use any of this. Their `.data` is poked straight
+// into the simulated RAM by the runner, which is exactly the thing the hardware
+// cannot do, and they keep test/asm/sections.lds unchanged.
+//
+// This lives in test/ rather than test/asm/ because both sim legs take
+// test/asm/*.S to BE the suite: a startup file there would be run as a program
+// and graded as one.
+//
+// `runtime_init` is separately callable on purpose. Simulated RAM comes up
+// zeroed, so a `.bss` that was never cleared reads the same as one that was,
+// and the boot-time pass alone cannot fail. test/asm/datainit.c scribbles over
+// both regions and calls this again, which is the same code the reset path ran
+// and does have a red direction.
+
+  .section .text.init,"ax",@progbits
+  .globl _start
+_start:
+  // gp first: the linker relaxes nearby data accesses to gp-relative, including
+  // ones in runtime_init below. `norelax` stops it relaxing this very sequence
+  // into `addi gp, gp, 0`.
+  .option push
+  .option norelax
+  la      gp, __global_pointer$
+  .option pop
+  la      sp, __stack_top
+  call    runtime_init
+  call    main
+1:
+  j       1b
+
+  .globl runtime_init
+runtime_init:
+  la      a0, __data_load_start
+  la      a1, __data_start
+  la      a2, __data_end
+1:
+  beq     a1, a2, 2f
+  lw      a3, 0(a0)
+  sw      a3, 0(a1)
+  addi    a0, a0, 4
+  addi    a1, a1, 4
+  j       1b
+2:
+  la      a1, __bss_start
+  la      a2, __bss_end
+3:
+  beq     a1, a2, 4f
+  sw      x0, 0(a1)
+  addi    a1, a1, 4
+  j       3b
+4:
+  ret

--- a/test/probe_gates.sh
+++ b/test/probe_gates.sh
@@ -27,7 +27,7 @@ REPO=$(cd "$HERE/.." && pwd)
 # Pinned as a literal: a probe that is deleted, or that stops being reached by
 # an early `return`, would otherwise cut this file's coverage while it kept
 # printing a green summary.
-PROBES_EXPECTED=144
+PROBES_EXPECTED=145
 
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/littlecpu-probe.XXXXXX") || {
   echo "error: could not create a temporary directory under ${TMPDIR:-/tmp}." >&2
@@ -342,6 +342,12 @@ probe "a floor line this loop cannot parse is a floor that is not enforced" 1 \
 d=$(rt_fixture); printf 'add.S ten 10\n' > "$d/FLOOR"
 probe "a non-numeric floor is named rather than compared arithmetically" 1 \
   "are not '<program> <retires> <spec-checked>'" "$(rt "$d")"
+
+# The manifest check runs first, so the fixture needs the .c to exist as well.
+d=$(rt_fixture); : > "$d/asm/boot.c"
+printf 'add.S 10 10\nboot.c 400 400\n' > "$d/FLOOR"
+probe "a C floor copied out of the measured table is rejected, not honoured" 1 \
+  "gives a C program a floor above" "$(rt "$d")"
 
 d=$(rt_fixture); printf 'add.S\n' > "$d/BASELINE"
 probe "a pre-ADR-0035 one-field baseline line is rejected, not half-matched" 1 \

--- a/test/probe_gates.sh
+++ b/test/probe_gates.sh
@@ -27,7 +27,7 @@ REPO=$(cd "$HERE/.." && pwd)
 # Pinned as a literal: a probe that is deleted, or that stops being reached by
 # an early `return`, would otherwise cut this file's coverage while it kept
 # printing a green summary.
-PROBES_EXPECTED=142
+PROBES_EXPECTED=144
 
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/littlecpu-probe.XXXXXX") || {
   echo "error: could not create a temporary directory under ${TMPDIR:-/tmp}." >&2
@@ -244,11 +244,14 @@ begin_group "test/check_suite_shape.sh"
 
 SHAPE="$HERE/check_suite_shape.sh"
 
+# Both program shapes, because the glob and the manifest's name check each have
+# to see .c as well as .S. A fixture with only .S would let either one go back
+# to being .S-only and stay green.
 shape_fixture() {
   local d; d=$(new_case)
   mkdir -p "$d/asm"
-  : > "$d/asm/add.S"; : > "$d/asm/lw.S"
-  printf '# a comment\nadd.S 10 10\nlw.S 5 5\n' > "$d/MANIFEST"
+  : > "$d/asm/add.S"; : > "$d/asm/lw.S"; : > "$d/asm/boot.c"
+  printf '# a comment\nadd.S 10 10\nlw.S 5 5\nboot.c 7 7\n' > "$d/MANIFEST"
   printf '%s' "$d"
 }
 
@@ -270,23 +273,31 @@ probe "an empty manifest matches an empty suite and is rejected" 1 \
   "names no programs" "$SHAPE '$d/asm' '$d/MANIFEST'"
 
 d=$(shape_fixture); printf 'add.S 10 10\nnot-a-program 5 5\n' > "$d/MANIFEST"
-probe "a manifest entry that is not a .S name is a typo, not a phantom" 1 \
-  "is not a '<test>.S' name" "$SHAPE '$d/asm' '$d/MANIFEST'"
+probe "a manifest entry that names no program is a typo, not a phantom" 1 \
+  "is not a '<test>.S' or" "$SHAPE '$d/asm' '$d/MANIFEST'"
 
 d=$(shape_fixture); printf 'add.S 10 10\nadd.S 10 10\nlw.S 5 5\n' > "$d/MANIFEST"
 probe "a duplicated manifest line would make comm non-symmetric" 1 \
   "names the same program more than once" "$SHAPE '$d/asm' '$d/MANIFEST'"
 
-d=$(shape_fixture); rm "$d/asm/add.S" "$d/asm/lw.S"
+d=$(shape_fixture); rm "$d/asm/add.S" "$d/asm/lw.S" "$d/asm/boot.c"
 probe "an empty asm directory is red rather than a suite of size zero" 1 \
-  "no .S programs found" "$SHAPE '$d/asm' '$d/MANIFEST'"
+  "no programs found" "$SHAPE '$d/asm' '$d/MANIFEST'"
 
 d=$(shape_fixture); rm "$d/asm/lw.S"
 probe "a SHRUNK suite: the manifest names a program the tree does not have" 1 \
   "The suite has SHRUNK" "$SHAPE '$d/asm' '$d/MANIFEST'"
 
+d=$(shape_fixture); rm "$d/asm/boot.c"
+probe "a SHRUNK suite is caught when the missing program is the C one" 1 \
+  "The suite has SHRUNK" "$SHAPE '$d/asm' '$d/MANIFEST'"
+
 d=$(shape_fixture); : > "$d/asm/unlisted.S"
 probe "the other direction: a .S that landed without a manifest line" 1 \
+  "runs unmeasured" "$SHAPE '$d/asm' '$d/MANIFEST'"
+
+d=$(shape_fixture); : > "$d/asm/unlisted.c"
+probe "the other direction for a .c: the glob has to see it too" 1 \
   "runs unmeasured" "$SHAPE '$d/asm' '$d/MANIFEST'"
 
 begin_group "test/run_tests.sh"
@@ -326,11 +337,11 @@ probe "the suite's shape is asserted before a single program is assembled" 1 \
 
 d=$(rt_fixture); printf 'add.S 10\n' > "$d/FLOOR"
 probe "a floor line this loop cannot parse is a floor that is not enforced" 1 \
-  "are not '<test>.S <retires> <spec-checked>'" "$(rt "$d")"
+  "are not '<program> <retires> <spec-checked>'" "$(rt "$d")"
 
 d=$(rt_fixture); printf 'add.S ten 10\n' > "$d/FLOOR"
 probe "a non-numeric floor is named rather than compared arithmetically" 1 \
-  "are not '<test>.S <retires> <spec-checked>'" "$(rt "$d")"
+  "are not '<program> <retires> <spec-checked>'" "$(rt "$d")"
 
 d=$(rt_fixture); printf 'add.S\n' > "$d/BASELINE"
 probe "a pre-ADR-0035 one-field baseline line is rejected, not half-matched" 1 \

--- a/test/run_cosim.sh
+++ b/test/run_cosim.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Runs every test/asm/*.S under Sail co-simulation (test/cosim.py) and grades
+# Runs every program in test/asm under Sail co-simulation (test/cosim.py) and grades
 # the table against test/COSIM_EXPECTED_FAIL, under the same contract
 # test/run_tests.sh applies to test/EXPECTED_FAIL. Invoked by `make cosim-suite`.
 #
@@ -55,7 +55,7 @@ fi
 # suite of size zero and does nothing about one that shrank to a dozen programs,
 # which prints "12/12 agreed", matches an empty baseline exactly and exits 0.
 if ! "$HERE/check_suite_shape.sh" "$ASM_DIR" "$MANIFEST"; then
-  echo "error: the .S suite does not match its manifest; nothing was run." >&2
+  echo "error: the suite does not match its manifest; nothing was run." >&2
   exit 1
 fi
 echo
@@ -67,7 +67,7 @@ fi
 echo
 
 shopt -s nullglob
-programs=("$ASM_DIR"/*.S)
+programs=("$ASM_DIR"/*.S "$ASM_DIR"/*.c)
 shopt -u nullglob
 
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/littlecpu-cosim.XXXXXX") || {
@@ -86,7 +86,7 @@ agreed=0
 
 for src in "${programs[@]}"; do
   name=$(basename "$src")
-  base=${name%.S}
+  base=${name%.*}
   log="$tmp/$base.log"
 
   # Lifted for exactly this call: cosim.py's nonzero exits are verdicts.

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -1,6 +1,16 @@
 #!/bin/bash
-# Assembles every test/asm/*.S, runs it under the cxxrtl runner (`sim`), and
+# Builds every program in test/asm, runs it under the cxxrtl runner (`sim`), and
 # grades the pass/fail table against test/EXPECTED_FAIL. Invoked by `make test`.
+#
+# TWO PROGRAM SHAPES, and the difference is which memory holds `.data` at
+# power-on. A `.S` program is freestanding: test/asm/sections.lds links `.data`
+# at its virtual address in RAM and the loop below pokes it straight into the
+# simulated RAM, which is a thing a harness can do and the SoC cannot. A `.c`
+# program is linked by test/asm/boot.lds with `.data`'s LOAD address in ROM and
+# entered through test/crt0.S, which copies it into RAM and zeroes `.bss` before
+# main -- the image the hardware can actually boot from. test/cosim.py's
+# assemble() and the Makefile's soc-rom target build the same two shapes from
+# the same inputs; a change here is a change in all three.
 #
 # Usage: run_tests.sh <sim-binary> <asm-dir> <expected-fail-file> <floor-file>
 #
@@ -53,7 +63,7 @@ fi
 # It is a separate script so test/run_cosim.sh can run the same check on the
 # same file, rather than the two legs each deciding what the suite is.
 if ! "$HERE/check_suite_shape.sh" "$ASM_DIR" "$OBSERVED_FLOOR"; then
-  echo "error: the .S suite does not match its manifest; nothing was run." >&2
+  echo "error: the suite does not match its manifest; nothing was run." >&2
   exit 1
 fi
 
@@ -62,7 +72,7 @@ fi
 floors=$(sed -e 's/#.*//' "$OBSERVED_FLOOR" | awk 'NF { $1=$1; print }')
 malformed_floor=$(printf '%s\n' "$floors" | awk 'NF && (NF != 3 || $2 !~ /^[0-9]+$/ || $3 !~ /^[0-9]+$/) { print }')
 if [ -n "$malformed_floor" ]; then
-  echo "error: $OBSERVED_FLOOR has lines that are not '<test>.S <retires> <spec-checked>':" >&2
+  echo "error: $OBSERVED_FLOOR has lines that are not '<program> <retires> <spec-checked>':" >&2
   printf '  %s\n' "$malformed_floor" >&2
   exit 1
 fi
@@ -112,21 +122,41 @@ if [ "$STALL_REPORT" = "1" ]; then
   sim_stall_flag="--stalls"
 fi
 
-for src in "$ASM_DIR"/*.S; do
+shopt -s nullglob
+programs=("$ASM_DIR"/*.S "$ASM_DIR"/*.c)
+shopt -u nullglob
+
+for src in "${programs[@]}"; do
   name=$(basename "$src")
-  base=${name%.S}
+  base=${name%.*}
   elf="$tmp/$base.elf"
   build_log="$tmp/$base.build.log"
   rom_hex="$tmp/$base.rom.hex"
   ram_hex="$tmp/$base.ram.hex"
+
+  case $name in
+    *.c)
+      build=("$CC" -march=rv32imc_zicsr_zifencei -mabi=ilp32 -nostdlib
+             -Os -std=c11 -ffreestanding -fno-tree-loop-distribute-patterns
+             -Wall -Wextra -Werror -I "$ASM_DIR"
+             -T "$ASM_DIR/boot.lds" "$HERE/crt0.S" "$src" -o "$elf")
+      rom_flags=(--only-section=.text --only-section=.data)
+      ram_flags=(--only-section=.tohost)
+      ;;
+    *)
+      build=("$CC" -march=rv32imc_zicsr_zifencei -mabi=ilp32 -nostdlib
+             -I "$ASM_DIR" -T "$ASM_DIR/sections.lds" "$src" -o "$elf")
+      rom_flags=(--only-section=.text)
+      ram_flags=(--remove-section=.text)
+      ;;
+  esac
 
   status="PASS"
   # Cleared every time round. Left over from the previous program, these would
   # be checked against this program's floor.
   retires=""
   spec_retires=""
-  if ! "$CC" -march=rv32imc_zicsr_zifencei -mabi=ilp32 -nostdlib -I "$ASM_DIR" \
-       -T "$ASM_DIR/sections.lds" "$src" -o "$elf" > "$build_log" 2>&1; then
+  if ! "${build[@]}" > "$build_log" 2>&1; then
     status="ASSEMBLE-ERROR"
   elif [ -s "$build_log" ]; then
     status="ASSEMBLE-WARNING"
@@ -138,14 +168,14 @@ for src in "$ASM_DIR"/*.S; do
   if [ "$status" = "PASS" ]; then
     for region in rom ram; do
       if [ "$region" = rom ]; then
-        section_flag="--only-section=.text"
+        section_flags=("${rom_flags[@]}")
         image=$rom_hex
       else
-        section_flag="--remove-section=.text"
+        section_flags=("${ram_flags[@]}")
         image=$ram_hex
       fi
       rm -f "$image"
-      if ! "$OBJCOPY" -O verilog --verilog-data-width=4 "$section_flag" \
+      if ! "$OBJCOPY" -O verilog --verilog-data-width=4 "${section_flags[@]}" \
            "$elf" "$image" >> "$build_log" 2>&1; then
         status="OBJCOPY-ERROR $region"
         break

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -77,6 +77,25 @@ if [ -n "$malformed_floor" ]; then
   exit 1
 fi
 
+# A C program's floor is a silence bound, not an observation: its instruction
+# count is whatever that gcc chose to inline, and the two toolchains this repo
+# builds with disagree by about 1% on identical source. Recorded as a floor,
+# that disagreement is red for a reason the floor cannot distinguish from the
+# one it exists for. This rejects a number copied out of the table rather than
+# leaving it to the header of $OBSERVED_FLOOR, which is what "copy the third
+# column" already talked someone past once.
+C_FLOOR_MAX=64
+overspecified=$(printf '%s\n' "$floors" \
+  | awk -v max="$C_FLOOR_MAX" '$1 ~ /\.c$/ && ($2 > max || $3 > max) { print }')
+if [ -n "$overspecified" ]; then
+  echo "error: $OBSERVED_FLOOR gives a C program a floor above $C_FLOOR_MAX:" >&2
+  printf '  %s\n' "$overspecified" >&2
+  echo "That is a measurement of one compiler's output, not a bound on the" >&2
+  echo "monitor going quiet, and it goes red when the other toolchain builds" >&2
+  echo "the same source. Read the section on C programs in that file." >&2
+  exit 1
+fi
+
 CC=""
 for candidate in riscv64-elf-gcc riscv64-unknown-elf-gcc; do
   if command -v "$candidate" >/dev/null 2>&1; then


### PR DESCRIPTION
Closes JEF-778.

## The gap

The SoC placed, met 12 MHz and could not run a program that reads its own `.data`. Its data RAM is SPRAM and no bitstream initialises SPRAM, so a global with an initialiser had no value at power-on.

The `.S` suite never saw this: its programs' `.data` is linked at its virtual address in RAM and poked straight into the simulated RAM by `test/run_tests.sh` — precisely the thing the hardware cannot do. All 59 assembly programs pass on a machine that has no way to get a byte of `.data` into memory.

## What changed — the standard answer, no RTL

- **`test/asm/boot.lds`** (new) links `.data`'s **load** address into `rom` (`AT>rom`) while its **virtual** address stays in `ram`, and exports `__data_load_start`, `__data_start`, `__data_end`, `__bss_start`, `__bss_end`, `__stack_top`.
- **`test/crt0.S`** (new) sets `gp`/`sp`, copies `[__data_load_start, …)` to `__data_start`, zeroes `.bss`, calls `main`. It lives in `test/` rather than `test/asm/` because both sim legs take `test/asm/*.S` to *be* the suite.
- **`test/asm/datainit.c`** (new) is the first C program in the suite.
- The suite is now `test/asm/*.S` **and** `test/asm/*.c`: `check_suite_shape.sh`, `run_tests.sh`, `run_cosim.sh`, `cosim.py` and `OBSERVED_FLOOR` take both.
- **`docs/adr/0081`** records the decision, the budget, the floor semantics, and that SPI-flash boot stays deferred.

The copy reads over the **data** bus at ROM addresses, which works because text on this core is readable from that bus (ADR-0059; `test/asm/textload.S` already said so). **Nothing in `rtl/` or `formal/` changed.**

## The `.bss` test, and the failing version I saw fail first

Simulated RAM comes up zeroed, so a boot-time "is `.bss` zero?" check passes whether or not `crt0` ever cleared anything — a grader that cannot fail. `datainit.c` therefore scribbles `0xdeadbeef` over both tables, calls `runtime_init` again (the same routine the reset path ran, now over memory that is demonstrably not zero) and re-checks. Four numbered checks: 1/2 after the reset path, 3/4 after the scribble.

Both red directions were run, not argued:

| mutation of `test/crt0.S` | result |
|---|---|
| the `.bss` zeroing loop deleted | `FAIL 4`, 269 retires |
| the `.data` copy loop deleted | `FAIL 1`, 67 retires |
| neither | `PASS`, 400 retires |

The `.bss` mutation fails at check **4** and not at check 2 — which is the point, and the ADR says so.

## A C entry's floor is a silence bound, not a measurement

The first version of this branch recorded `datainit.c 400 400` in `test/OBSERVED_FLOOR` and **went red on CI**: the runner's gcc emitted five fewer instructions and reported 395, so the `>=` floor tripped and the set-equality gate failed.

Lowering the floor to 395 would have made CI pass and left the defect in place. **`OBSERVED_FLOOR` was designed for `.S` and does not transfer to `.c`.** An assembly program assembles to a fixed instruction sequence, so recording what it retired holds across toolchains *by construction* — which is exactly why a `>=` floor is meaningful there. A C program's count is whatever that gcc chose to inline and schedule. As a floor it conflates the failure it exists for — *the monitor stopped observing* — with *a different gcc emitted five fewer instructions*. This repo already knows its toolchains disagree; `make fit` reads about 21 cells apart on identical RTL.

**Option taken: (1), a low floor derived from the check.** A `.c` line's two numbers are **16**. Every recorded instance of the blindness defect produced **zero** retires (`rvfi_valid` never asserting, an `ifdef` dropping the shadow payload, `write_cxxrtl` optimising the monitor instance away) or **one** (the iverilog under-sensitivity defect, measured at "0 writes and 1 retire"). Zero is already `test/cxxrtl.cc`'s exit 6, so the bound only has to clear one; 16 is an order of magnitude above the defect, two below any C program's real count, and nothing a compiler chooses can move it.

**`spec-checked` has the same problem and takes the same bound** — it tracked retires exactly here (395 of 395 on CI), so whatever moves one moves the other.

Options 2 and 3 were rejected: pinning the toolchain for C is heavier than this ticket and buys reproducibility the check does not need; dropping `.c` from the floor entirely relies on exit 6, which covers only *zero* — and the one recorded defect with a nonzero count produced 1, which no `MONITOR-SILENT` path catches.

**Mechanised, not left to the header.** `test/run_tests.sh` now rejects a `.c` floor above 64 before it runs a program, with a probe (`make probe-gates` is 145 now). Feeding it the exact mistake reproduces as a diagnosis rather than a mystery:

```
error: test/OBSERVED_FLOOR gives a C program a floor above 64:
  datainit.c 400 400
That is a measurement of one compiler's output, not a bound on the
monitor going quiet, and it goes red when the other toolchain builds
the same source. Read the section on C programs in that file.
```

**The name set is untouched.** A `.c` program that vanishes from the suite is still red in both directions, `check_suite_shape.sh` still runs before anything is built, and two of the new probes cover exactly that (`a SHRUNK suite is caught when the missing program is the C one`, `the other direction for a .c: the glob has to see it too`). Only the *number* semantics changed.

### The exact header wording added to `test/OBSERVED_FLOOR`

> `A C PROGRAM'S TWO NUMBERS ARE A SILENCE BOUND, NOT AN OBSERVATION` — and that is the one place this file's format means different things on different lines. An `.S` program assembles to a fixed instruction sequence, so recording what it retired costs nothing and holds across toolchains by construction. A `.c` program's count is whatever that gcc chose to inline and schedule: `test/asm/datainit.c` retired 400 under a local `riscv64-elf-gcc` and 395 on the CI runner, from identical source. Recorded as a floor, that difference is red — and red for the wrong reason, because the floor exists to catch a program going QUIET and cannot tell "the monitor stopped observing" from "a different gcc emitted five fewer instructions". This repo already knows its two toolchains disagree; `make fit` reads about 21 cells apart on identical RTL.
>
> So pick a `.c` line's numbers from what the CHECK needs, never from the table. Every recorded instance of the defect this file exists for produced ZERO retires — `rvfi_valid` never asserting, an `ifdef` dropping the shadow payload, `write_cxxrtl` optimising the monitor instance away — or ONE, the iverilog under-sensitivity defect, measured at "0 writes and 1 retire". Zero is already the runner's own exit 6, so the bound only has to clear one. **16** is the number these lines use: an order of magnitude above the defect, two below any C program's real count, and nothing a compiler chooses can move it. `spec-checked` has the same problem and takes the same bound — it tracked retires exactly on `datainit.c` (395 of 395 on CI), so whatever moves one moves the other.
>
> `test/run_tests.sh` REJECTS a `.c` floor above 64 rather than trusting this paragraph, because a paragraph is exactly what the next person will not read and "copy the third column" is the instruction that produced the red gate.

The `HOW TO RE-MEASURE` section is now `HOW TO RE-MEASURE, FOR .S LINES ONLY`, ending: *"A `.c` line has nothing to re-measure: it is 16 because 16 is what the silence check needs, and it stays 16 when the compiler changes its mind."* The manifest paragraph gained: *"That is true of `.c` names exactly as it is of `.S` ones — the numbers are what differ, never the manifest."*

## The text-size number

Measured with `riscv64-elf-gcc`, `-Os`:

| | bytes |
|---|---|
| `.text` | 252 |
| — of it `test/crt0.S` (`_start` 22 + `runtime_init` 60) | **82** |
| — of it the test program itself | 170 |
| `.data` initialiser, carried in ROM | 32 |
| **ROM image total** | **284** |
| ROM (`SOC_ROM_WORDS` 2048, 16 EBR) | 8192 |
| **left** | **7908 — 96.5%** |

**The reusable runtime costs 82 bytes, one percent of the ROM,** and there is no C prologue beyond it (no libc, no `.init_array`, no unwinder). On this evidence SPI-flash boot stays deferred: the 8 KB ceiling constrains how much *program* fits, not whether one can boot at all.

`SOC_PROG` now defaults to `datainit.c`, because `make soc-timing` measured **78.51 ns / 12.74 MHz bit-identically** for `SOC_PROG=add.S` and `SOC_PROG=datainit.c` — a program only changes block RAM initial contents and nothing nextpnr places. So the switch is free and CI builds the bootable image shape on every run.

## The 59 assembly programs are unaffected — proved, not asserted

`test/asm/sections.lds` gains a comment and nothing else; `riscv_test.h` is untouched, so `RVTEST_CODE_BEGIN` is unchanged. Proved anyway, for all 59 programs:

- `gcc -E` preprocessed source — identical
- `objcopy --only-section=.text` ROM image — identical
- `objcopy --remove-section=.text` RAM image — identical

`diff -r` over 177 files reports no difference.

## Checks

| gate | result |
|---|---|
| CI, all required jobs | **green** (`test`, `formal`, `components`, `nonperturbation`, `elaborate`, `fit`, `lint`, `monitor-freshness`, `soc-timing`, `review`) |
| `make test` | **60/60 passed**, `EXPECTED_FAIL` and `OBSERVED_FLOOR` both matched |
| `make test-units` | 8 benches, all vectors passed |
| `make probe-gates` | **145** graded comparisons, every failure path executed (was 142; +3 for the two `.c` manifest directions and the C-floor ceiling) |
| `make cosim-suite` | **60/60 agreed**, `COSIM_EXPECTED_FAIL` matched — Sail loads by `p_paddr`, so it exercises the copy stub too |
| `make cycles` | 60 programs, 29516 cycles, CPI 2.07, **0 unattributed** |
| `make soc-rom` | 71 words → both banks |
| `make soc-timing` | 78.51 ns / **12.74 MHz** against the 12.00 MHz floor, SPRAM 2 / EBR 20 as declared |
| `make waves` | iverilog leg green, 79 retires / 20 writes |

`SOC_MIN_MHZ` untouched. No `rtl/` or `formal/` file changed.

## Decisions made without asking

- **Two linker scripts rather than one.** A single script cannot give one program's `.data` a ROM load address and another's a RAM one, and the 59 must not grow a copy loop they do not need. Cost: a duplicated four-line memory map, which each file names and points at the other about.
- **`.tohost` stays loadable at its own address in `ram`** for C programs. It is an IO window, not program data: the runners watch RAM word 0 for a verdict from cycle 0, so it must read zero before the copy has run, and re-running the copy must not clear a verdict already written.
- **`.rodata` stays in ROM** and is read over the data bus. Copying it would cost the same ROM plus the RAM to land in.
- **DECISION NEEDED (low stakes):** the two-shape build branch is now spelled out in **three** places — `test/run_tests.sh`, `test/cosim.py`'s `assemble()`, and the Makefile's `soc-rom`. All three already carried their own copy of the single shape's build line, so this widens an existing surface rather than creating one, and `CLAUDE.md` and the ADR both name it. Consolidating them behind one `test/build_program.sh` is the obvious follow-up, but it moves `run_tests.sh`'s `ASSEMBLE-ERROR` / `ASSEMBLE-WARNING` / `OBJCOPY-*` status ladder — which `probe_gates.sh` fixtures against stubbed `gcc`/`objcopy` — so it is a refactor of its own, not a rider on this ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJ77ZZJ6pDiL3vj3Qw9hKs
