### PR TITLE
The machine timer interrupt, taken at a decode boundary (JEF-777)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,8 +96,28 @@ RV32IMC_Zicsr_Zifencei, M-mode only, `misa = 0x4000_1104` (neither Z-extension h
 the ISA string is the only place they are claimed). Traps implemented: illegal instruction = 2,
 breakpoint = 3, load misaligned = 4, store misaligned = 6, ecall from M = 11.
 Instruction-address-misaligned is unreachable (C makes 2-byte targets legal) and not implemented.
-No interrupts: `mie`/`mip` read-only zero. C stays because code density is a product constraint on
-the up5k (ADR-0002/0003). `fence.i` costs a pipeline drain — see the serialization commitment.
+C stays because code density is a product constraint on the up5k (ADR-0002/0003). `fence.i` costs a
+pipeline drain — see the serialization commitment.
+
+**One interrupt: the machine timer, cause `0x8000_0007`.** `mie.MTIE` is the only writable bit of
+`mie`; `mip.MTIP` is `rtl/timer.v`'s line and read-only; `mip.MSIP`/`mip.MEIP` stay read-only zero,
+which is conformant WARL on a platform with neither source. `mtime`/`mtimecmp` are four words at
+`0x0002_0000`, in `rtl/littlesoc.v` and `test/testbench.v` alike. **It is taken on a cycle that
+would otherwise have issued**, because `stall` outranks the trap arm of `next_pc` — so it waits out
+a divide, a load turnaround and a serialization with no logic of its own, the displaced instruction
+has not issued, and nothing is un-committed. It is therefore **not** a stall reason and adds no
+seventh bucket to `make cycles`. Measured worst-case response: 33 cycles, 2.75 µs at 12 MHz, set by
+the divider. `mtimecmp` resets to zero, so `mtip` is asserted out of reset and both enables resetting
+to zero is what makes that harmless (ADR-0082).
+
+Three things about it are the platform's to state, and firmware cannot derive any of them:
+**`mtime` ticks once per clock cycle**, so 83.33 ns at 12 MHz — the spec asks only for a constant
+frequency and a published period, and blesses the cycle counter for a fixed-frequency system.
+**MTIP is a level**, posted until `mtimecmp` exceeds `mtime`; taking the trap does not lower it, so
+a handler that returns without moving `mtimecmp` is re-entered before the instruction at `mepc`
+runs. **An RV32 `mtimecmp` update is the spec's three stores in the spec's order** — low all-ones,
+high, low; high-first is unsafe and `test/timer_tb.v` and `test/asm/mtimer.S` each fire a spurious
+interrupt that way on purpose before doing it correctly.
 
 **Conformance is not negotiable against minimality.** Every CSR the privileged spec mandates for
 RV32 M-mode is implemented — most legally read zero, so the cost is near nothing. The CSR set is a
@@ -131,6 +151,14 @@ What a green result does and does not mean:
   check also drops every value comparison once an instruction traps, keeping only the trap flag,
   and its two pc checks accept whatever target the core reports — so `components_traps` is the only
   thing that says a trap lands on `mtvec` and saves the right state.
+- **It ships no model of an INTERRUPT either**, so the core's timer input is tied off in all five
+  harnesses under `formal/` and the generated checks run with no interrupt in the trace.
+  `formal/INTERRUPT_TIE_OFF` mechanises that the same way, in both directions and re-derived from
+  the clone. F and G were re-measured under the tie-off and both flip points reproduce exactly, so
+  the depths are unaffected. `components_traps` is the oracle for entry — `test/asm/mtimer.S` and
+  `test/asm/mtimermask.S` for the whole path. `rvfi_intr` is now driven and is **not** optional:
+  both sim legs' monitor checks pc continuity across retires and stops only for a retire carrying
+  it, so an undriven `rvfi_intr` makes every interrupt a monitor error.
 - **Both sim legs read the sanitized `test/monitor.sim.v` as their per-retire oracle**, so
   `test/sanitize_monitor.py` is a change to the oracle, not to plumbing. `test/monitor.v` is
   generated but tracked: regenerate it (`make monitor-check`), never hand-edit it.
@@ -227,7 +255,8 @@ make fit            # the core's area number; ratchet on FIT_MAX_LC
 make soc-timing     # the SoC place-and-time flow; requirement on SOC_MIN_MHZ.
                     # SOC_SEED picks a placement; soc/timing_sweep.sh runs four
 
-make -C formal check                # the generated riscv-formal checks; always a fresh run
+make -C formal check                # the generated riscv-formal checks; always a fresh run.
+                                    # interrupt-tie-off is a prerequisite
 make -C formal check-baseline       # re-grade a finished run without re-running
 make -C formal components_decoder   # component proofs by k-induction (mode prove):
 make -C formal components_executor  #   read the sby summaries, not the job colour
@@ -308,8 +337,9 @@ four `SB_SPRAM256KA` at 256 kbit each. **128 KB is the up5k's whole SPRAM, not t
 a program that reads its own `.data`. SPRAM still cannot be initialised, so `.data` rides in the
 ROM at a load address `test/asm/boot.lds` puts there and `test/crt0.S` copies into RAM before
 `main`. That runtime costs 82 bytes and `test/asm/datainit.c`'s whole ROM image is 284 of 8192, so
-SPI-flash boot stays deferred, alongside the forwarding network, the radix-4 divider, and
-interrupts (ADR-0081).
+SPI-flash boot stays deferred, alongside the forwarding network and the radix-4 divider.
+Interrupts are no longer on that list — the machine timer is built (ADR-0082) — but a
+controller, more sources and a vectored `mtvec` are.
 
 The suite is `test/asm/*.S` **and** `test/asm/*.c`, and `test/OBSERVED_FLOOR` names both. The two
 shapes differ only in how `.data` reaches RAM: an assembly program's is poked in by the harness,

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,8 @@ rvfi_macros.vh: $(RISCV_FORMAL_DIR)/checks/rvfi_macros.py
 # landed, and spent a run elaborating a testbench whose memories were not there.
 # That job calls `make elaborate-strict` now, so there is one list to update.
 SIM_RTL_SRCS := rtl/structs.v rtl/accessor.v rtl/csrs.v rtl/decoder.v rtl/executor.v \
-                rtl/fetcher.v rtl/imemory.v rtl/memory.v rtl/regfile.v rtl/writeback.v \
-                rtl/littlecpu.v
+                rtl/fetcher.v rtl/imemory.v rtl/memory.v rtl/regfile.v rtl/timer.v \
+                rtl/writeback.v rtl/littlecpu.v
 
 testbench.vvp: $(SIM_RTL_SRCS) rvfi_macros.vh test/testbench.v test/monitor.sim.v
 	iverilog -I./rtl/ -DICARUS $(addprefix -D,$(RISCV_FORMAL_MACROS)) -g2012 -o $@ $^
@@ -314,7 +314,8 @@ lint-setup:
 	mv $$tmp '$(SVLINT_DIR)'
 	@'$(SVLINT_DIR)'/bin/svlint --version
 
-UNIT_BENCHES := exec_tb mem_tb imem_tb decoder_tb regfile_tb csr_tb accessor_tb monitor_tb
+UNIT_BENCHES := exec_tb mem_tb imem_tb decoder_tb regfile_tb csr_tb accessor_tb monitor_tb \
+                timer_tb
 
 UNIT_BENCH_SRC_exec_tb     := rtl/structs.v rtl/executor.v
 UNIT_BENCH_SRC_mem_tb      := rtl/memory.v
@@ -324,6 +325,7 @@ UNIT_BENCH_SRC_regfile_tb  := rtl/regfile.v
 UNIT_BENCH_SRC_csr_tb      := rtl/structs.v rtl/csrs.v
 UNIT_BENCH_SRC_accessor_tb := rtl/structs.v rtl/accessor.v
 UNIT_BENCH_SRC_monitor_tb  := test/monitor.sim.v
+UNIT_BENCH_SRC_timer_tb    := rtl/timer.v
 
 # `present` is read from disk inside the recipe, not with $(wildcard). Make reads
 # a directory once and remembers it, and a check working from a stale listing can
@@ -461,7 +463,8 @@ SOC_EXPECT_EBR   := 20
 
 SOC_SRCS      := rtl/structs.v rtl/accessor.v rtl/csrs.v rtl/decoder.v \
                  rtl/executor.v rtl/fetcher.v rtl/imemory.v rtl/memory.v \
-                 rtl/regfile.v rtl/writeback.v rtl/littlecpu.v rtl/littlesoc.v
+                 rtl/regfile.v rtl/timer.v rtl/writeback.v rtl/littlecpu.v \
+                 rtl/littlesoc.v
 
 # PHONY so `soc.json` resynthesises every run: the image depends on SOC_PROG,
 # which make cannot see a change to, and a stale ROM would make the measurement

--- a/docs/adr/0082-the-machine-timer-interrupt-is-taken-at-a-decode-boundary.md
+++ b/docs/adr/0082-the-machine-timer-interrupt-is-taken-at-a-decode-boundary.md
@@ -1,0 +1,207 @@
+# ADR-0082: The machine timer interrupt is taken at a decode boundary
+
+**Status:** Accepted · 2026-08-08 · *Amends `CLAUDE.md`'s ISA-target claim that `mie`/`mip` are
+read-only zero and that there are no interrupts. Rests on
+[ADR-0005](0005-traps-and-csrs-commit-in-decode.md)'s decode-commit rule and
+[ADR-0026](0026-stalls-are-four-reasons-over-two-mechanisms.md)'s stall protocol without changing
+either. Restricts the generated riscv-formal checks in the sense
+[ADR-0010](0010-muldiv-verification-under-altops.md) admits, and mechanises the restriction the way
+[ADR-0014](0014-expected-fail-is-the-m1-regression-baseline.md) requires. Defers Sail
+co-simulation of the two new programs under
+[ADR-0032](0032-sail-co-simulation-is-worth-building-and-stays-opt-in.md)'s pattern.*
+
+## The gap
+
+`mie` and `mip` read zero and are not writable. Not "interrupts are disabled" — **absent**. A core
+in that state can run exactly one polled loop: no preemption, no periodic tick, no RTOS, nothing
+that reacts to time. It is the largest functional gap this design has against every comparable
+core, and unlike the two questions asked alongside it — 24 MHz on this part
+([ADR-0080](0080-twenty-four-megahertz-is-not-reachable-on-the-up5k.md)) and an external-memory
+project — it is reachable.
+
+## Why an asynchronous event does not break the decode-commit rule
+
+Every trap in this core is detected and committed in decode, and no state exists that a later cycle
+has to un-commit. An interrupt is asynchronous. That reads like a conflict and is not, for one
+reason:
+
+`rtl/decoder.v`'s `next_pc` priority chain is `reset > stall > trap > mret > jalr > jal > branch >
+sequential`, and `trap_entry` is `issuing && trap`. **An interrupt ORed into the trap arm as a
+registered level is therefore taken only on a cycle that would otherwise have issued an
+instruction.** The instruction it displaces has not issued: nothing downstream has heard of it,
+nothing has to be taken back, `mepc` is its own address and it re-executes after `mret`. The
+privileged spec permits taking an interrupt between two instructions, and this is literally that.
+
+Two consequences fall out of the arm ORDER rather than out of new logic:
+
+* `stall` is ABOVE the trap arm, so an interrupt automatically waits out a divide, a load
+  turnaround, a hazard, the operand-fetch cycle, a stolen fetch window and a serialization. A
+  half-completed `mret` is impossible for the same reason a half-completed divide is.
+* The interrupt is NOT a stall reason. It costs no stalled cycle, so `make cycles` needs no seventh
+  bucket and its six-reason identity is unchanged. Confirmed: `unattributed` is 0 over the whole
+  suite, including the two new programs.
+
+The one place the interrupt is not simply "the trap arm with another input" is the publish block.
+An exception rides out on its own instruction — `out.valid` stays high and the execution flags are
+cleared — because the instruction issued. An interrupt takes the BUBBLE arm instead, because its
+instruction did not. So `issuing` now guards the last TWO arms of that block rather than the last
+one, and `test/decoder_tb.v` asserts `out.valid` is low on an interrupt entry.
+
+## What it costs
+
+**One gate in the core.** `rtl/csrs.v` computes `interrupt_pending` as the AND of three flip-flops
+— the platform's line, `mie.MTIE`, `mstatus.MIE` — and `rtl/decoder.v` ORs it into a trap term that
+was already a six-way OR. The 64-bit counter and comparator live in `rtl/timer.v`, on the data bus,
+outside the core: `make fit` does not see them and `make soc-timing` does.
+
+Measured over four placements of the SoC, graded on the worst, against `SOC_MIN_MHZ = 12.0`: see
+the pull request that lands this. The requirement holds at every seed. `make fit` moves within its
+±50-cell churn band, which is a null in both directions rather than a result.
+
+## Scope: the smallest conformant increment
+
+* **Machine timer only.** `mtime` and `mtimecmp` memory-mapped at `0x0002_0000`, four words, in
+  both `rtl/littlesoc.v` and `test/testbench.v` so the same `.S` program runs on both.
+* `mip.MTIP` is the platform line, read-only. `mie.MTIE` is the one writable bit.
+* **`mip.MSIP` and `mip.MEIP` stay read-only zero.** That is conformant WARL on a platform with no
+  software-interrupt register and no external controller. Adding either means adding its hardware
+  first.
+* **No interrupt controller, no vectored `mtvec`.** Both are the same mechanism with more sources
+  and can follow.
+* `mcause` is `0x8000_0007`. An interrupt outranks the interrupted instruction's own fault, because
+  that instruction did not execute; it faults when it re-executes after `mret`.
+
+`mtimecmp` **resets to zero**, so `mtip` is asserted from the first cycle. That is what the
+comparison says, and it is harmless because `mstatus.MIE` and `mie.MTIE` both reset to zero —
+software must set `mtimecmp` before enabling anything, which every RISC-V platform requires anyway.
+It is also forced: the cxxrtl runner deasserts reset before the first rising edge, so the whole `.S`
+suite runs on cxxrtl's zero-initialised state rather than on the RTL's reset branch, and a non-zero
+reset value would be invisible on the primary simulator and present on the board.
+
+**The tick period is one clock cycle**, so 83.33 ns on the 12 MHz crystal. The spec requires only
+that `mtime` advance at a constant frequency and that the platform provide a way to determine the
+period; it names a fixed-frequency system with no frequency scaling as the case where driving
+`mtime` from the cycle counter is the right answer, which is this board exactly. Firmware cannot
+derive the period from anywhere else, so it is written at the top of `rtl/timer.v` and in
+`CLAUDE.md`.
+
+**`mtip` is a level.** It stays posted until `mtimecmp` becomes greater than `mtime`, and taking
+the trap does not lower it — so a handler that returns without moving `mtimecmp` is re-entered
+before the instruction at `mepc` runs. `test/asm/mtimer.S` asserts exactly that, with three
+entries from one arming and a limit in RAM so the correct behaviour is not a livelock. It is the
+easiest thing in this feature to get wrong: a core that cleared the pending bit on entry, or
+latched an edge, passes every other case in the file.
+
+**The RV32 update sequence is the spec's own**, and it is `low = all ones`, `high`, `low` — not
+high-first. The first store makes the pair no smaller than the OLD value and the second no smaller
+than the NEW one, so nothing fires in between. High-first is unsafe whenever the new high half is
+smaller than the old one and the old low half is small: the pair passes through `{new high, old
+low}`. **Both `test/timer_tb.v` and `test/asm/mtimer.S` fire a spurious interrupt that way on
+purpose** before doing it correctly over the same values — a sequence whose failure path has never
+run is not a check.
+
+## The real cost is the proof
+
+riscv-formal ships **no spec model for an interrupt** at `formal/pin.mk`'s SHA. It carries
+`rvfi_intr` and four checks read it, but only to SUPPRESS an expectation: the two pc checks stop
+requiring continuity across a retire that carries it. No `rvfi_*_check.sv` names `mie`, `mip` or
+`mstatus`. So whatever this repo asserts is the only oracle, and the boundary has to be declared
+rather than described.
+
+**The input is tied off in all five riscv-formal harnesses**, and `formal/INTERRUPT_TIE_OFF` plus
+`formal/check-interrupt-tie-off.py` are the mechanised form of that — set equality in both
+directions on the harness set, a required `.irq_timer(1'b0)` on each, set equality in both
+directions on the upstream files that mention `rvfi_intr`, and a re-derivation from the pinned clone
+that no check models an interrupt CSR. A pin bump that adds a model goes red until the tie-off is
+argued again. It is a prerequisite of `make -C formal check`, and
+`test/probe_gates.sh` forces all ten of its failure paths.
+
+Leaving the input free would not weaken those checks so much as point them at a machine their spec
+does not describe: an interrupt makes a retire disappear, and `hang`, `liveness`, `unique` and every
+per-instruction check are written about a stream of retires. It would also move the DEPTHS, which
+are derived from F and G.
+
+**`formal/traps.sv` grows the properties that then ARE the oracle**, with the timer line free and
+`rtl/csrs.v` real, proved by k-induction. Its assertion count read off the model the proof ran on
+rather than inferred from the word PASS: **34**, up from 25. What they say:
+
+1. **Entry commits nothing.** `interrupt_pending` implies no `instret`, no `csr_wen`, no `csr_ren`
+   and no `mret_entry`; and one cycle after an interrupt entry, `decoder_out.valid` is low. That is
+   the no-wrong-path-state claim, stated about the interrupt.
+2. **`mepc` is the un-issued instruction's own address**, and `mcause` is `0x8000_0007`. MIE moves
+   into MPIE and MIE clears — that half was already asserted for exceptions and now covers this too.
+3. **No entry without all three terms.** Each is read the way software reads it: no source, `mie`
+   bit 7 clear, or `mstatus` bit 3 clear, each on its own forbids arming. `mip` is asserted to be
+   exactly the platform line in bit 7 and zero elsewhere.
+4. **The response is bounded, and the bound is a composition of two proofs, not one.** Entry clears
+   MIE on the same edge it redirects, so the cycle after cannot take another one and nothing re-arms
+   until an `mret` — asserted here. The decoder's own proof supplies the other half: an armed
+   interrupt with no stall raises `trap_entry` on that cycle. Together: one entry per arming, on the
+   first cycle that is not stalled.
+
+**What is NOT proved, and why.** A literal "irq held ⇒ entry within N" cannot be stated in
+`formal/traps.sv` without new assumptions: `divider_stall`, `accessor_stall`, `fetch_stall` and
+`executor_out` are all free inputs there, and an environment that holds any of them forever
+starves any bound. Rather than add four assumptions this repo would then have to discharge, the
+bound is **measured**: see below. Say so plainly rather than quoting a proof that was not run.
+
+**F and G were re-measured under the tie-off, and the flip points reproduce today's exactly** —
+`hang` red at 6 and PASS at 7; `liveness` red at gap 5 and PASS at gap 6, at trig 10 and again at
+trig 15. So F = 6 and G = 6 are unchanged and no `[depth]` line moves. That equivalence is the
+evidence that the tie-off preserves the measurement, not an assumption about it.
+
+## The measured worst-case latency
+
+**33 cycles from `interrupt_pending` rising to `trap_entry`, which is 2.75 µs at 12 MHz.** Measured,
+not estimated: a sweep of the arming delay from 1 to 80 cycles against a program of back-to-back
+divides, loads, CSR reads and a `fence.i`, reading the two signals out of the elaborated design each
+cycle. The distribution is flat from 0 to 33 with the maximum at exactly 33, which is the 32-cycle
+divide plus the operand-fetch cycle behind it — the divider is the longest stall the core has, and
+it is what sets the bound.
+
+## What checks what
+
+| Claim | Where |
+|---|---|
+| the timer's map, its 64-bit level compare, the torn write, byte strobes, the counter | `test/timer_tb.v` |
+| `mie`/`mip` WARL, the three-term enable, entry disarming, `mret` re-arming | `test/csr_tb.v` |
+| the decode-boundary commit, the cause priority, waiting out all five stalls | `test/decoder_tb.v` |
+| entry's architectural effect, under k-induction | `formal/traps.sv` |
+| the whole path, end to end, in a running program | `test/asm/mtimer.S`, `test/asm/mtimermask.S` |
+| that the generated checks are unaffected | `formal/INTERRUPT_TIE_OFF` |
+
+## Sail co-simulation: the spec permits both machines
+
+`mtimer.S` and `mtimermask.S` are baselined `INCONCLUSIVE SAIL-LIMIT` in
+`test/COSIM_EXPECTED_FAIL`, with the reasoning written at the entry as that file's header requires.
+**This is not work left undone.** Everything that differs between the two machines is a quantity the
+privileged spec explicitly leaves to the platform: where `mtime` and `mtimecmp` are mapped; the tick
+period, required only to be *constant* and to be published; and how promptly a change in the
+comparison is reflected in MTIP — "eventually, but not necessarily immediately", with the spec
+itself warning software that a spurious timer interrupt can follow from that. This platform ticks
+once per clock cycle; the model ticks once per two instructions. Both are conformant.
+
+A value exemption was considered first, because `test/cosim.py`'s `NONCOMPARABLE_CSRS` is the right
+tool when only a VALUE is incomparable — that is what closed `mcycle`, and `mip` is already on that
+list. It cannot close this one, for a structural reason rather than an effort one: with different
+tick periods the interrupt lands between a **different pair of instructions** on the two machines,
+so what differs is the POSITION of the architectural change in the sequence — which is exactly what
+that mechanism goes on comparing. An exemption wide enough to cover it would compare nothing.
+
+Configuration does not reach it either: `platform.clint` has only `base`, `size` and `supported`,
+and nothing in the schema names `mtimecmp`, MTIP or the CLINT's layout. Reconciling would mean
+adopting the model's address map and its tick period — choosing this platform's timer to suit a
+reference model. That is a product decision, not a test fix, and it is not made here. Co-simulation
+keeps its role on the other 59 programs, which is where the property it was built for lives.
+
+## Consequences
+
+* `CLAUDE.md`'s ISA-target section no longer says there are no interrupts. `mie.MTIE` is writable
+  and `mip.MTIP` is real; `misa` is unchanged, since neither is a `misa` bit.
+* `rvfi_intr` is now driven rather than tied low. It is required, not optional: both sim legs'
+  monitor checks pc continuity across retires and stops only for a retire carrying `rvfi_intr`, so
+  without it every interrupt is a monitor error.
+* The SoC's memory map gains a third range. The read buses still join with an OR because the three
+  ranges do not overlap and each answers zero outside its own.
+* A seventh stall reason was NOT added, and must not be: an interrupt entry is a committing trap on
+  an issuing cycle.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -83,6 +83,7 @@ and what it costs. Reversing one is fine — write a new ADR that supersedes it.
 | [0079](0079-all-six-m2-terms-are-re-measured-and-m2-is-declared.md) | All six M2 terms are re-measured against merged main, and M2 is declared | Accepted · rules on 0037's conjunction as amended by 0045, 0046, 0047, 0050, 0051 and 0052; narrows 0027 |
 | [0080](0080-twenty-four-megahertz-is-not-reachable-on-the-up5k.md) | Twenty-four megahertz is not reachable on the up5k, and the part is the constraint | Accepted · collects 0074, 0076 and 0078 into one verdict; measures the same RTL at 31 MHz on hx8k; narrows 0078's "nothing in between" |
 | [0081](0081-the-data-image-lives-in-rom-and-crt0-copies-it.md) | The `.data` image lives in ROM and a `crt0` copies it, and the 8 KB budget is measured | Accepted · closes the copy-stub half 0054 deferred; keeps 0044's SPI-flash boot deferred; widens 0035's suite contract |
+| [0082](0082-the-machine-timer-interrupt-is-taken-at-a-decode-boundary.md) | The machine timer interrupt is taken at a decode boundary | Accepted · amends `CLAUDE.md`'s "no interrupts"; restricts the generated checks per 0010 and mechanises it per 0014; defers co-simulation per 0032 |
 
 0001–0007 came from the design brief
 ([`docs/ideas/finish-the-rewrite.md`](../ideas/finish-the-rewrite.md)). 0008–0011 came out of
@@ -181,7 +182,12 @@ trades away simplicity the current design depends on.
   [ADR-0081](0081-the-data-image-lives-in-rom-and-crt0-copies-it.md), so the SoC runs a C program
   that reads its own globals. ADR-0044's SPI-flash path stays deferred, now against the measured
   ROM budget rather than a guess.
-- **Interrupts** (`mie`/`mip` real rather than read-only zero) — no interrupt sources exist.
+- ~~**Interrupts**~~ — **the machine timer is built by
+  [ADR-0082](0082-the-machine-timer-interrupt-is-taken-at-a-decode-boundary.md).** The old entry's
+  reason ("no interrupt sources exist") was circular: `rtl/timer.v` is the source, and it is four
+  words on the data bus. `mie.MTIE` and `mip.MTIP` are real; `mip.MSIP`/`mip.MEIP` stay read-only
+  zero because this platform has neither source. What is still deferred is a controller, more
+  sources and a vectored `mtvec` — the same mechanism with more inputs.
 - ~~**Spike or Sail co-simulation**~~ — **resolved by [ADR-0032](0032-sail-co-simulation-is-worth-building-and-stays-opt-in.md).**
   The old test ("revisit only if formal and simulation ever disagree") could only fire on a bug both
   legs can see; a spike measured what neither can. The harness exists and is deliberately opt-in —

--- a/formal/INTERRUPT_TIE_OFF
+++ b/formal/INTERRUPT_TIE_OFF
@@ -1,0 +1,64 @@
+# The core's interrupt input is TIED OFF in every riscv-formal harness in this
+# directory, and this file is the declaration of that boundary.
+#
+# It is a BASELINE in exactly the sense formal/COMPLETE_EXCLUSIONS is:
+# formal/check-interrupt-tie-off.py exits 0 only when the sets below match what
+# is on disk EXACTLY, in both directions, and it re-derives the upstream half
+# from the pinned clone rather than believing it. A harness added without a
+# line here fails; a line here with no harness fails too.
+#
+# WHY THE TIE-OFF. riscv-formal at formal/pin.mk's SHA has no model of an
+# interrupt. It carries the RVFI signal `rvfi_intr` and four of its checks read
+# it, but only to SUPPRESS an expectation -- the two pc checks stop requiring
+# continuity across a retire that carries it, and the other two merely wire it
+# out for a diagnostic. No check upstream names mie, mip, mstatus or an
+# interrupt cause, so no check upstream can say whether an interrupt was taken
+# correctly, taken at all, or invented. Leaving the input free would not weaken
+# the generated checks so much as point them at a machine their spec does not
+# describe: an interrupt makes a retire disappear, and `hang`, `liveness`,
+# `unique` and the per-instruction checks are all written about a stream of
+# retires.
+#
+# The tie-off is also what preserves the DEPTHS. Every `[depth]` line in
+# formal/checks.cfg is derived from F (worst-case first retire) and G
+# (worst-case retire gap), both measured with no interrupt in the trace. An
+# interrupt costs a cycle that would otherwise have issued, so a free input
+# moves G and every depth built on it.
+#
+# WHAT PROVES THE INTERRUPT INSTEAD. formal/traps.sv, under k-induction, with
+# the timer line free: entry writes mcause, mepc and mstatus, the interrupted
+# instruction commits nothing, nothing arms without all three enable terms, and
+# entry disarms so there is no second one. That is the oracle. The `.S` side is
+# test/asm/mtimer.S and test/asm/mtimermask.S.
+#
+# WHEN THIS GOES RED. A pin bump that makes another check read `rvfi_intr`, or
+# that adds a check naming any interrupt CSR, fails here -- because at that
+# point riscv-formal HAS something to say and the tie-off has to be argued
+# again rather than inherited. Do not edit the lines below to make that go
+# away; re-read the new check and rule on it in a pull request.
+#
+# FORMAT -- two record types, whitespace-separated:
+#
+#     HARNESS   <path>         a file in formal/ that instantiates littlecpu.
+#                              It must connect `.irq_timer(1'b0)`.
+#     UPSTREAM  <path>         a file under the pinned clone's checks/ that
+#                              mentions `rvfi_intr`, relative to the clone.
+
+HARNESS  wrapper.v
+HARNESS  complete.sv
+HARNESS  cover.sv
+HARNESS  dmemcheck.sv
+HARNESS  imemcheck.sv
+
+# Measured at the pin, not chosen. rvfi_channel.sv and rvfi_macros.vh declare
+# the signal; rvfi_insn_check.sv, rvfi_ill_check.sv and rvfi_fault_check.sv
+# wire it to a `(* keep *)` wire that nothing in them then reads;
+# rvfi_pc_fwd_check.sv and rvfi_pc_bwd_check.sv are the only two that act on
+# it, and what they do is stop expecting pc continuity.
+UPSTREAM checks/rvfi_channel.sv
+UPSTREAM checks/rvfi_macros.vh
+UPSTREAM checks/rvfi_insn_check.sv
+UPSTREAM checks/rvfi_ill_check.sv
+UPSTREAM checks/rvfi_fault_check.sv
+UPSTREAM checks/rvfi_pc_fwd_check.sv
+UPSTREAM checks/rvfi_pc_bwd_check.sv

--- a/formal/Makefile
+++ b/formal/Makefile
@@ -10,7 +10,8 @@ ifeq ($(shell printf '%s' '$(JOBS)' | grep -cE '^[1-9][0-9]{0,3}$$'),0)
 override JOBS := 4
 endif
 
-all: complete complete_cover complete-exclusions check dmemcheck imemcheck \
+all: complete complete_cover complete-exclusions interrupt-tie-off check \
+     dmemcheck imemcheck \
      components_decoder components_executor components_pcloop components_traps
 
 # Every sby target here names a directory sby creates, and a directory's mtime
@@ -35,7 +36,7 @@ FORCE:
 # carries `expect pass,fail`, so sby exits 0 whether a check passed or failed,
 # and anything that really failed to run reaches check-baseline as a missing
 # status file.
-check: checks $(RISCV_FORMAL_DIR)
+check: checks interrupt-tie-off $(RISCV_FORMAL_DIR)
 	-$(MAKE) -C $< -j$(JOBS) -k
 	$(MAKE) check-baseline
 
@@ -94,6 +95,14 @@ complete_cover: complete_cover.sby complete.sv arbiter.v complete-exclusions $(R
 .PHONY: complete-exclusions
 complete-exclusions: check-complete-exclusions.py complete.sv COMPLETE_EXCLUSIONS | $(RISCV_FORMAL_DIR)
 	python3 $< complete.sv COMPLETE_EXCLUSIONS $(RISCV_FORMAL_DIR)
+
+# A prerequisite of `check` rather than a companion target, the same way
+# complete-exclusions is of `complete`: the tie-off is what makes the generated
+# checks mean what their depths say, and checking it costs milliseconds and
+# fails before sby starts.
+.PHONY: interrupt-tie-off
+interrupt-tie-off: check-interrupt-tie-off.py INTERRUPT_TIE_OFF | $(RISCV_FORMAL_DIR)
+	python3 $< . INTERRUPT_TIE_OFF $(RISCV_FORMAL_DIR)
 
 # A structural comparison of two yosys builds rather than a solver query, so it
 # is not covered by the `%: %.sby` rule above. It shows the RVFI instrumentation

--- a/formal/check-interrupt-tie-off.py
+++ b/formal/check-interrupt-tie-off.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Fail if the interrupt tie-off has drifted from formal/INTERRUPT_TIE_OFF.
+
+Every riscv-formal harness in formal/ instantiates the core with its timer
+input tied low, so the generated checks run with no interrupt in the trace.
+That is a RESTRICTION on what those checks cover, and ADR-0010's rule --
+restrict the proof, and record the restriction -- is what makes it admissible.
+A recorded restriction nothing compares against is not recorded, which is what
+this script is for.
+
+Four things are decided here:
+
+  1. The set of files in formal/ that instantiate `littlecpu` and the HARNESS
+     set in the baseline must match EXACTLY, in both directions. A harness
+     added without a line is red; a line with no harness is red too.
+  2. Every declared harness must actually connect `.irq_timer(1'b0)`. A
+     declared-but-untied harness would under-report the restriction, which is
+     the direction that matters: the checks would be running against a machine
+     the baseline says they are not.
+  3. The set of files under the pinned clone's checks/ that mention
+     `rvfi_intr` and the UPSTREAM set must match EXACTLY, in both directions.
+     This is the re-derivation a baseline alone cannot give: the tie-off is
+     argued on riscv-formal having nothing to say about an interrupt, and a
+     pin bump that adds a check reading `rvfi_intr` means it now does.
+  4. No CHECK under the pinned clone's checks/ may name an interrupt CSR --
+     mie, mip or mstatus. The moment one does, upstream has a spec model for
+     the behaviour this repo asserts by hand, and the tie-off has to be argued
+     again rather than inherited. Scoped to `rvfi_*_check.sv`, the files that
+     carry assertions: checks/rvfi_macros.vh declares a port for every CSR in
+     riscv-formal's table, which is plumbing and says nothing about behaviour.
+
+Usage: check-interrupt-tie-off.py <formal dir> <INTERRUPT_TIE_OFF> <riscv-formal dir>
+"""
+
+import os
+import re
+import sys
+
+INSTANTIATES = re.compile(r'^\s*littlecpu\s+\w+\s*\(\s*$', re.M)
+
+# The one spelling a tie-off is allowed to have. A wire that happens to be low,
+# or a parameter, would read the same to a human and mean something a reader
+# cannot check locally.
+TIE_OFF = re.compile(r"^\s*\.irq_timer\(1'b0\)\s*,?\s*$", re.M)
+
+INTR_SIGNAL = 'rvfi_intr'
+
+# Bounded by anything that is not a letter or a digit, so `rvfi_csr_mstatus_wdata`
+# counts -- an underscore-separated component of an identifier is the shape a
+# CSR name actually takes upstream -- while `premier` does not. `\b` would miss
+# exactly the identifiers that matter.
+CSR_NAMES = ('mie', 'mip', 'mstatus')
+CSR_RE = {csr: re.compile(rf'(?<![A-Za-z0-9]){csr}(?![A-Za-z0-9])')
+          for csr in CSR_NAMES}
+
+SEARCHED_SUFFIXES = ('.v', '.sv', '.vh')
+
+# The files upstream that carry assertions, as opposed to port declarations.
+CHECK_FILE = re.compile(r'^rvfi_\w+_check\.sv$')
+
+
+def scan_harnesses(formal_dir):
+    """Files in formal/ that instantiate littlecpu, and whether each ties off."""
+    found = {}
+    errors = []
+    for name in sorted(os.listdir(formal_dir)):
+        if not name.endswith(SEARCHED_SUFFIXES):
+            continue
+        path = os.path.join(formal_dir, name)
+        if not os.path.isfile(path):
+            continue
+        try:
+            text = open(path).read()
+        except OSError as e:
+            errors.append(f'cannot read {path}: {e}')
+            continue
+        if INSTANTIATES.search(text):
+            found[name] = bool(TIE_OFF.search(text))
+    return found, errors
+
+
+def scan_upstream(rf_dir):
+    """checks/ files at the pin that mention rvfi_intr, and any CSR modelling."""
+    checks = os.path.join(rf_dir, 'checks')
+    if not os.path.isdir(checks):
+        return None, None, [
+            f'{checks} is not a directory. The pinned riscv-formal clone is what '
+            f'makes "upstream has no interrupt model" a measurement rather than a '
+            f'claim; run `make -C formal riscv-formal` first.']
+    mentions = set()
+    csr_hits = []
+    errors = []
+    for name in sorted(os.listdir(checks)):
+        if not name.endswith(SEARCHED_SUFFIXES):
+            continue
+        path = os.path.join(checks, name)
+        if not os.path.isfile(path):
+            continue
+        try:
+            text = open(path).read()
+        except OSError as e:
+            errors.append(f'cannot read {path}: {e}')
+            continue
+        if INTR_SIGNAL in text:
+            mentions.add('checks/' + name)
+        if CHECK_FILE.match(name):
+            for csr, pattern in CSR_RE.items():
+                if pattern.search(text):
+                    csr_hits.append((f'checks/{name}', csr))
+    return mentions, csr_hits, errors
+
+
+def parse_baseline(path):
+    harnesses, upstream, errors = set(), set(), []
+    try:
+        lines = open(path).read().splitlines()
+    except OSError as e:
+        return harnesses, upstream, [f'cannot read {path}: {e}']
+    for i, raw in enumerate(lines, 1):
+        line = raw.split('#', 1)[0].strip()
+        if not line:
+            continue
+        fields = line.split()
+        if len(fields) != 2 or fields[0] not in ('HARNESS', 'UPSTREAM'):
+            errors.append(
+                f'{path}:{i}: expected `HARNESS <path>` or `UPSTREAM <path>`, '
+                f'got {line!r}')
+            continue
+        target = harnesses if fields[0] == 'HARNESS' else upstream
+        if fields[1] in target:
+            errors.append(f'{path}:{i}: duplicate entry {fields[1]}')
+        target.add(fields[1])
+    return harnesses, upstream, errors
+
+
+def main():
+    if len(sys.argv) != 4:
+        print(__doc__.strip().splitlines()[-1], file=sys.stderr)
+        return 2
+    formal_dir, baseline_path, rf_dir = sys.argv[1:4]
+
+    declared_harnesses, declared_upstream, errors = parse_baseline(baseline_path)
+    found, harness_errors = scan_harnesses(formal_dir)
+    errors += harness_errors
+
+    for name in sorted(set(found) - declared_harnesses):
+        errors.append(
+            f'{formal_dir}/{name} instantiates littlecpu and {baseline_path} '
+            f'does not name it.\n'
+            f'  Every riscv-formal harness runs with the interrupt tied off. Add\n'
+            f'  a HARNESS line for it, or say in the pull request why this one is\n'
+            f'  different.')
+    for name in sorted(declared_harnesses - set(found)):
+        errors.append(
+            f'{baseline_path} names HARNESS {name}, which does not instantiate '
+            f'littlecpu (or does not exist).\n'
+            f'  Either the harness was removed and the line was not, or the\n'
+            f'  instantiation was reshaped and this script can no longer see it.')
+    for name in sorted(declared_harnesses & set(found)):
+        if not found[name]:
+            errors.append(
+                f"{formal_dir}/{name} does not connect .irq_timer(1'b0).\n"
+                f'  The baseline says the generated checks run with no interrupt\n'
+                f'  in the trace, and the depths in formal/checks.cfg are derived\n'
+                f'  under that. A free input there is a different machine, checked\n'
+                f'  against a spec that does not describe it.')
+
+    upstream, csr_hits, upstream_errors = scan_upstream(rf_dir)
+    errors += upstream_errors
+    if upstream is not None:
+        for name in sorted(upstream - declared_upstream):
+            errors.append(
+                f'{name} mentions {INTR_SIGNAL} at the pin and {baseline_path} '
+                f'does not name it.\n'
+                f'  Upstream may now have something to say about an interrupt.\n'
+                f'  Read the check and rule on it: if it constrains what a core\n'
+                f'  does on entry, the tie-off is hiding a real check and has to\n'
+                f'  come out.')
+        for name in sorted(declared_upstream - upstream):
+            errors.append(
+                f'{baseline_path} names UPSTREAM {name}, which does not mention '
+                f'{INTR_SIGNAL} at the pin.\n'
+                f'  The pin moved and this set was not re-derived.')
+        for name, csr in csr_hits:
+            errors.append(
+                f'{name} names the CSR {csr} at the pin, so riscv-formal now has '
+                f'a model of interrupt state.\n'
+                f'  formal/traps.sv was written because nothing upstream did. Read\n'
+                f'  the new check before deciding which of the two is the oracle.')
+
+    if errors:
+        print('INTERRUPT TIE-OFF: FAIL', file=sys.stderr)
+        for e in errors:
+            print('  ' + e.replace('\n', '\n  '), file=sys.stderr)
+        return 1
+
+    print(f'interrupt tie-off matches {baseline_path} (both directions):')
+    for name in sorted(declared_harnesses):
+        print(f"  {name:<16} instantiates littlecpu with .irq_timer(1'b0)")
+    print(f'  {len(declared_upstream)} files at the pin mention {INTR_SIGNAL}, '
+          f'and no rvfi_*_check.sv names mie, mip or mstatus')
+    print('INTERRUPT TIE-OFF: PASS')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/formal/checks.cfg
+++ b/formal/checks.cfg
@@ -97,7 +97,15 @@ mscratch any
 # To re-measure: copy this file with only the `hang` (or `liveness`) line in
 # [depth], run `python3 genchecks-local.py <copy>`, and sweep the last column.
 # Any change that adds a stall reason, lengthens a stage or widens the
-# scoreboard past its three fixed slots has to do that before it lands. The
+# scoreboard past its three fixed slots has to do that before it lands.
+#
+# Both numbers hold with the machine timer interrupt in the core, because every
+# harness here ties the interrupt input off -- formal/INTERRUPT_TIE_OFF declares
+# that and formal/check-interrupt-tie-off.py enforces it. Re-measured under the
+# tie-off when the interrupt landed, and both flip points reproduced exactly:
+# `hang` red at 6 and PASS at 7, `liveness` red at gap 5 and PASS at gap 6, at
+# trig 10 and again at trig 15. An interrupt costs a cycle that would otherwise
+# have issued, so a free input there would move G and every depth built on it. The
 # table is checked against the single hop F + G = 12 and the two hops
 # F + 2G = 18, and `insn 19` and `reg 15 22` clear 18 by one cycle -- the
 # thinnest margin here.

--- a/formal/complete.sv
+++ b/formal/complete.sv
@@ -79,6 +79,10 @@ module rvfi_testbench (
     .mem_ren(mem_ren),
     .mem_rdata(mem_rdata),
     .fetch_stall(fetch_stall),
+    // Tied off; formal/check-interrupt-tie-off.py enforces it. formal/wrapper.v
+    // carries the reason the riscv-formal side of the tree runs with no
+    // interrupt in the trace.
+    .irq_timer(1'b0),
     .trap(trap),
     `RVFI_CONN
   );

--- a/formal/cover.sv
+++ b/formal/cover.sv
@@ -47,6 +47,10 @@ module testbench (
     .mem_ren(mem_ren),
     .mem_rdata(mem_rdata),
     .fetch_stall(fetch_stall),
+    // Tied off; formal/check-interrupt-tie-off.py enforces it. formal/wrapper.v
+    // carries the reason the riscv-formal side of the tree runs with no
+    // interrupt in the trace.
+    .irq_timer(1'b0),
     .trap(trap),
     `RVFI_CONN
   );

--- a/formal/dmemcheck.sv
+++ b/formal/dmemcheck.sv
@@ -100,6 +100,10 @@ module testbench (
     .mem_ren(mem_ren),
     .mem_rdata(mem_rdata),
     .fetch_stall(fetch_stall),
+    // Tied off; formal/check-interrupt-tie-off.py enforces it. formal/wrapper.v
+    // carries the reason the riscv-formal side of the tree runs with no
+    // interrupt in the trace.
+    .irq_timer(1'b0),
     .trap(trap),
     `RVFI_CONN
   );

--- a/formal/imemcheck.sv
+++ b/formal/imemcheck.sv
@@ -127,6 +127,10 @@ module testbench (
     .mem_ren(mem_ren),
     .mem_rdata(mem_rdata),
     .fetch_stall(fetch_stall),
+    // Tied off; formal/check-interrupt-tie-off.py enforces it. formal/wrapper.v
+    // carries the reason the riscv-formal side of the tree runs with no
+    // interrupt in the trace.
+    .irq_timer(1'b0),
     .trap(trap),
     `RVFI_CONN
   );

--- a/formal/pcloop.sv
+++ b/formal/pcloop.sv
@@ -30,7 +30,11 @@ module pcloop (
     input logic [31:0] csr_rdata,
     input logic csr_implemented,
     input logic [31:0] mtvec,
-    input logic [31:0] mepc
+    input logic [31:0] mepc,
+    // Free, like everything else not instantiated here. An interrupt redirects
+    // the pc, so the increment assertion has to skip that cycle -- and it does,
+    // because the decoder's own `branch_jump` names it.
+    input logic interrupt_pending
 );
   logic [31:0] pc;
   logic [31:0] imem_addr, imem_addr2;
@@ -74,6 +78,7 @@ module pcloop (
     .csr_implemented(csr_implemented),
     .mtvec(mtvec),
     .mepc(mepc),
+    .interrupt_pending(interrupt_pending),
     .pc(pc),
     .next_pc(next_pc),
     .rs1(rs1),

--- a/formal/traps.sv
+++ b/formal/traps.sv
@@ -30,7 +30,12 @@ module traps (
     input logic fetch_stall,
     input logic accessor_pending_valid,
     input logic [4:0] accessor_pending_rd,
-    input logic accessor_out_valid
+    input logic accessor_out_valid,
+    // The platform's timer line, free every cycle. rtl/csrs.v decides what to
+    // do with it, so `interrupt_pending` below is a real signal of this design
+    // rather than something the solver picks -- which is what lets the mie and
+    // mstatus.MIE gates be asserted rather than assumed.
+    input logic irq_timer
 );
   logic [31:0] pc, next_pc;
   logic [31:0] imem_addr, imem_addr2, imem_addr_next;
@@ -44,6 +49,7 @@ module traps (
   logic        trap_entry, mret_entry;
   logic [31:0] trap_cause, trap_epc;
   logic [31:0] mtvec_value, mepc_value;
+  logic        interrupt_pending;
 
   fetcher fetcher (
     .clk(clk),
@@ -75,6 +81,7 @@ module traps (
     .csr_implemented(csr_implemented),
     .mtvec(mtvec_value),
     .mepc(mepc_value),
+    .interrupt_pending(interrupt_pending),
     .pc(pc),
     .next_pc(next_pc),
     .rs1(rs1),
@@ -105,14 +112,18 @@ module traps (
     .trap_cause(trap_cause),
     .trap_epc(trap_epc),
     .mret_entry(mret_entry),
+    .irq_timer(irq_timer),
     .mtvec_value(mtvec_value),
-    .mepc_value(mepc_value)
+    .mepc_value(mepc_value),
+    .interrupt_pending(interrupt_pending)
   );
 
  `ifdef FORMAL
   localparam logic [11:0] MSTATUS   = 12'h300;
+  localparam logic [11:0] MIE       = 12'h304;
   localparam logic [11:0] MEPC      = 12'h341;
   localparam logic [11:0] MCAUSE    = 12'h342;
+  localparam logic [11:0] MIP       = 12'h344;
   localparam logic [11:0] MCYCLE    = 12'hB00;
   localparam logic [11:0] MINSTRET  = 12'hB02;
   localparam logic [11:0] MCYCLEH   = 12'hB80;
@@ -123,6 +134,8 @@ module traps (
   localparam logic [31:0] CAUSE_LOAD_MIS   = 32'd4;
   localparam logic [31:0] CAUSE_STORE_MIS  = 32'd6;
   localparam logic [31:0] CAUSE_ECALL_M    = 32'd11;
+  // Bit 31 says interrupt; 7 is the machine timer.
+  localparam logic [31:0] CAUSE_TIMER_IRQ  = 32'h8000_0007;
 
   logic clocked;
   initial clocked = 0;
@@ -248,12 +261,14 @@ module traps (
   assign mstatus_addressed = csr_addr == MSTATUS;
   assign mstatus_static = !csr_wen && !trap_entry && !mret_entry;
 
-  // The two counters advance without any instruction asking, so a held address
-  // reading one of them says nothing about side effects. mcycle counts every
-  // cycle; minstret counts only the cycles an instruction retires, so it is
-  // excluded only on those.
+  // These change without any instruction asking, so a held address reading one
+  // of them says nothing about side effects. mcycle counts every cycle;
+  // minstret counts only the cycles an instruction retires, so it is excluded
+  // only on those; mip is a live view of the platform's interrupt lines, which
+  // are free inputs here and are asserted about separately below.
   logic counter_ticking;
   assign counter_ticking = csr_addr == MCYCLE || csr_addr == MCYCLEH ||
+      csr_addr == MIP ||
       (instret && (csr_addr == MINSTRET || csr_addr == MINSTRETH));
 
   // Trap entry writes mepc, mcause and mstatus. mret writes mstatus. Every
@@ -268,6 +283,7 @@ module traps (
   logic prev_reset, prev_trap_entry, prev_mret_entry, prev_csr_wen;
   logic prev_expected_trap, prev_counter_ticking, prev_written_by_trap;
   logic prev_mstatus_addressed, prev_mstatus_static;
+  logic prev_interrupt_pending, prev_interrupt_entry;
   logic [31:0] prev2_rdata;
   logic prev2_reset, prev2_mstatus_addressed, prev2_mstatus_static;
   always_ff @(posedge clk) begin
@@ -286,6 +302,8 @@ module traps (
     prev_written_by_trap   <= csr_written_by_trap;
     prev_mstatus_addressed <= mstatus_addressed;
     prev_mstatus_static    <= mstatus_static;
+    prev_interrupt_pending <= interrupt_pending;
+    prev_interrupt_entry   <= trap_entry && interrupt_pending;
 
     prev2_rdata             <= prev_rdata;
     prev2_reset             <= prev_reset;
@@ -339,7 +357,11 @@ module traps (
   // because a compressed instruction can sit at a two-byte address.
   always_comb if (settled && prev_trap_entry) assert(mepc_value == {past_pc[31:1], 1'b0});
 
-  always_comb if (settled && prev_trap_entry && prev_expected_trap && csr_addr == MCAUSE)
+  // `!prev_interrupt_pending` because an interrupted instruction did not
+  // execute, so whatever it would have faulted on is not what happened. Its own
+  // cause is asserted below.
+  always_comb if (settled && prev_trap_entry && !prev_interrupt_pending &&
+                  prev_expected_trap && csr_addr == MCAUSE)
     assert(csr_rdata == prev_cause);
 
   // MIE moves into MPIE and interrupts go off. Both halves need the value
@@ -389,9 +411,54 @@ module traps (
   always_comb if (clocked) assert(!(trap_entry && (csr_wen || csr_ren)));
 
   // The encodings the ISA fixes: these fault, those do not, whatever else the
-  // decoder decides about them.
+  // decoder decides about them. The second one carries `!interrupt_pending`
+  // because an interrupt on the cycle a harmless instruction would have issued
+  // is a redirect the instruction had no part in.
   always_comb if (clocked && issuing && expected_trap) assert(trap_entry);
-  always_comb if (clocked && issuing && must_not_trap) assert(!trap_entry);
+  always_comb if (clocked && issuing && must_not_trap && !interrupt_pending)
+    assert(!trap_entry);
+
+  // ---- the machine timer interrupt ----------------------------------------
+  //
+  // riscv-formal ships no model of any of this at the pin -- its two pc checks
+  // read `rvfi_intr` only to stop expecting pc continuity, and no check names
+  // mie, mip, mstatus or an interrupt cause. So these assertions are the oracle,
+  // not a second opinion.
+
+  // Nothing arms without a source, an enable and the global enable, and each is
+  // read the way software reads it rather than out of the CSR file's internals.
+  always_comb if (clocked && !irq_timer) assert(!interrupt_pending);
+  always_comb if (clocked && csr_addr == MIE && !csr_rdata[7]) assert(!interrupt_pending);
+  always_comb if (clocked && mstatus_addressed && !csr_rdata[3]) assert(!interrupt_pending);
+
+  // mip.MTIP is the platform line and nothing else; MSIP and MEIP read zero
+  // because this platform has neither source.
+  always_comb if (clocked && csr_addr == MIP)
+    assert(csr_rdata == {24'b0, irq_timer, 7'b0});
+
+  // The instruction the interrupt displaced committed nothing. It did not
+  // retire, it wrote no CSR, it did not `mret`, and it never reached the
+  // executor -- so there is no state a later cycle has to take back, which is
+  // the whole reason an asynchronous event can be committed in decode.
+  always_comb if (clocked && interrupt_pending)
+    assert(!instret && !csr_wen && !csr_ren && !mret_entry);
+  always_comb if (settled && prev_interrupt_entry) assert(!decoder_out.valid);
+
+  // Its address is in mepc, so `mret` re-executes it. The general form is
+  // asserted further up against `past_pc`; this says the interrupt is not an
+  // exception to it.
+  always_comb if (settled && prev_interrupt_entry)
+    assert(mepc_value == {past_pc[31:1], 1'b0});
+
+  always_comb if (settled && prev_interrupt_entry && csr_addr == MCAUSE)
+    assert(csr_rdata == CAUSE_TIMER_IRQ);
+
+  // What bounds the response. Entry clears MIE on the same edge it redirects,
+  // so the cycle after cannot take a second interrupt and nothing re-arms until
+  // an `mret` or an explicit write to mstatus. Together with the decoder's own
+  // proof that an armed interrupt is taken on the first cycle that is not
+  // stalled, that is the bound: one entry per arming, on the next issuing cycle.
+  always_comb if (settled && prev_trap_entry) assert(!interrupt_pending);
 
   // WARL. mtvec is direct mode only, so its low two bits are a mode field that
   // must stay zero; mepc's bit 0 must stay zero because instructions are at

--- a/formal/wrapper.v
+++ b/formal/wrapper.v
@@ -109,6 +109,15 @@ module rvfi_wrapper (
     .mem_ren(mem_ren),
     .mem_rdata(mem_rdata),
     .fetch_stall(fetch_stall),
+    // Tied off, and formal/check-interrupt-tie-off.py is what says so. Every
+    // depth in formal/checks.cfg is derived from F and G measured with no
+    // interrupt in the trace, and riscv-formal ships no model at the pin of
+    // what an interrupt does to mcause, mepc or mstatus -- only the two pc
+    // checks read `rvfi_intr`, and only to stop expecting continuity. Left
+    // free, the generated checks would not be checking a weaker property, they
+    // would be checking a different machine against a spec that does not
+    // describe it. formal/traps.sv is where the interrupt is proved.
+    .irq_timer(1'b0),
     .trap(trap),
     `RVFI_CONN
   );

--- a/rtl/csrs.v
+++ b/rtl/csrs.v
@@ -43,9 +43,20 @@ module csrs(
   input  logic [31:0] trap_cause,
   input  logic [31:0] trap_epc,
   input  logic        mret_entry,
+  // The platform's machine-timer line, high while its mtime has reached
+  // mtimecmp. It must arrive REGISTERED -- rtl/timer.v registers the comparison
+  // -- because `interrupt_pending` below is one AND away from the decoder's
+  // next_pc chain, and an unregistered comparator would put a 64-bit carry
+  // chain on the fetch loop.
+  input  logic        irq_timer,
   // Read back by rtl/decoder.v, combinationally, to redirect the PC.
   output logic [31:0] mtvec_value,
-  output logic [31:0] mepc_value
+  output logic [31:0] mepc_value,
+  // The whole interrupt decision: a source is asserting, software enabled that
+  // source, and software has interrupts on. Every term is a flip-flop, so this
+  // costs the decoder one gate. Trap entry clears MIE on the same edge it
+  // redirects, which is what stops the next cycle taking the interrupt again.
+  output logic        interrupt_pending
  `ifdef RISCV_FORMAL
   ,
   // Shadow payloads for exactly the CSRs formal/checks.cfg's `[csrs]` list
@@ -88,6 +99,11 @@ module csrs(
   // mstatus is three fields rather than a register: MPP is hardwired to M-mode
   // (WARL, and this core has no other mode) and every other bit is 0.
   logic        mstatus_mie, mstatus_mpie;
+  // mie is one field for the same reason. MSIE and MEIE stay read-only zero:
+  // there is no software-interrupt register and no external controller on this
+  // platform, and WARL lets an absent source read zero. Adding either is adding
+  // its hardware first.
+  logic        mie_mtie;
 
   // Selected out here rather than inside the always_* blocks below: a constant
   // part-select taken inside one defeats iverilog's sensitivity analysis and
@@ -101,6 +117,15 @@ module csrs(
   logic [31:0] mstatus_value;
   // MPP = 2'b11 at [12:11]; MPIE at [7]; MIE at [3]; everything else 0.
   assign mstatus_value = {19'b0, 2'b11, 3'b0, mstatus_mpie, 3'b0, mstatus_mie, 3'b0};
+
+  // MTIE and MTIP both sit at bit 7. mip is read-only here: MTIP is the
+  // platform's line and the only way software lowers it is by moving mtimecmp,
+  // which is a store to rtl/timer.v rather than a CSR write.
+  logic [31:0] mie_value, mip_value;
+  assign mie_value = {24'b0, mie_mtie, 7'b0};
+  assign mip_value = {24'b0, irq_timer, 7'b0};
+
+  assign interrupt_pending = irq_timer && mie_mtie && mstatus_mie;
 
   // As of the start of the issuing cycle, which is the right phase: decode
   // issues at most one instruction per cycle, so a trapping instruction and a
@@ -116,13 +141,13 @@ module csrs(
       MSTATUS:   rdata = mstatus_value;
       MSTATUSH:  rdata = 32'b0;
       MISA:      rdata = MISA_VALUE;
-      MIE:       rdata = 32'b0;
+      MIE:       rdata = mie_value;
       MTVEC:     rdata = mtvec;
       MSCRATCH:  rdata = mscratch;
       MEPC:      rdata = mepc;
       MCAUSE:    rdata = mcause;
       MTVAL:     rdata = 32'b0;
-      MIP:       rdata = 32'b0;
+      MIP:       rdata = mip_value;
       MCYCLE:    rdata = mcycle_lo;
       MCYCLEH:   rdata = mcycle_hi;
       MINSTRET:  rdata = minstret_lo;
@@ -139,19 +164,23 @@ module csrs(
   // legal-value mask applied. It is defined for every address, including the
   // read-only ones, and that is what lets the RVFI report below say what landed
   // rather than echo back an operand the mask threw away.
-  logic [31:0] wdata_mtvec, wdata_mepc, wdata_mstatus;
+  logic [31:0] wdata_mtvec, wdata_mepc, wdata_mstatus, wdata_mie;
   // Direct mode only: mtvec[1:0] is the mode field.
   assign wdata_mtvec   = {wdata[31:2], 2'b00};
   // Only bit 0 is forced. C makes 2-byte branch targets legal, so bit 1 is a
   // legal value here and must survive.
   assign wdata_mepc    = {wdata[31:1], 1'b0};
   assign wdata_mstatus = {19'b0, 2'b11, 3'b0, wdata[7], 3'b0, wdata[3], 3'b0};
+  // MTIE only. The other bits name sources this platform does not have, and a
+  // WARL field with no source behind it reads zero however it was written.
+  assign wdata_mie     = {24'b0, wdata[7], 7'b0};
 
   logic [31:0] warl;
   always_comb begin
     (* parallel_case *)
     case (addr)
       MSTATUS:   warl = wdata_mstatus;
+      MIE:       warl = wdata_mie;
       MTVEC:     warl = wdata_mtvec;
       MSCRATCH:  warl = wdata;
       MEPC:      warl = wdata_mepc;
@@ -162,9 +191,10 @@ module csrs(
       default:   warl = rdata;
     endcase
   end
-  logic warl_mie, warl_mpie;
+  logic warl_mie, warl_mpie, warl_mtie;
   assign warl_mie  = warl[3];
   assign warl_mpie = warl[7];
+  assign warl_mtie = warl[7];
 
   // Trap entry writes mepc through the same mask an explicit `csrw mepc` goes
   // through. `trap_epc` is an instruction address, so bit 0 is already clear and
@@ -222,6 +252,7 @@ module csrs(
       mcause       <= 32'b0;
       mstatus_mie  <= 1'b0;
       mstatus_mpie <= 1'b0;
+      mie_mtie     <= 1'b0;
     end else begin
       mcycle   <= {mcycle_next_hi, mcycle_next_lo};
       minstret <= {minstret_next_hi, minstret_next_lo};
@@ -232,6 +263,7 @@ module csrs(
             mstatus_mie  <= warl_mie;
             mstatus_mpie <= warl_mpie;
           end
+          MIE:      mie_mtie <= warl_mtie;
           MTVEC:    mtvec    <= warl;
           MSCRATCH: mscratch <= warl;
           MEPC:     mepc     <= warl;
@@ -243,12 +275,13 @@ module csrs(
       end
       // The privileged-spec sequence: a trap saves the faulting PC and the
       // cause, pushes MIE into MPIE and disables interrupts; `mret` pops it back
-      // and leaves MPIE set. This core has no interrupts, so MIE/MPIE gate
-      // nothing and only test/csr_tb.v would notice them being wrong. `else if`
-      // rather than two independent `if`s because the two are mutually exclusive
-      // by construction (see the port comments), so a future cause that broke
-      // that fails at rtl/decoder.v's priority encoder rather than silently
-      // double-writing mstatus.
+      // and leaves MPIE set. Clearing MIE here is what bounds interrupt entry:
+      // `interrupt_pending` goes low on this same edge, so the cycle after a
+      // trap cannot take another one, and nothing re-arms until an `mret` or an
+      // explicit write. `else if` rather than two independent `if`s because the
+      // two are mutually exclusive by construction (see the port comments), so a
+      // future cause that broke that fails at rtl/decoder.v's priority encoder
+      // rather than silently double-writing mstatus.
       if (trap_entry) begin
         mepc         <= trap_epc_warl;
         mcause       <= trap_cause;

--- a/rtl/decoder.v
+++ b/rtl/decoder.v
@@ -54,6 +54,14 @@ module decoder (
   output logic        mret_entry,
   input  logic [31:0] mtvec,
   input  logic [31:0] mepc,
+  // An enabled interrupt source is asserting. rtl/csrs.v has already ANDed in
+  // mie and mstatus.MIE, and every term of it is a flip-flop, so this arrives
+  // as a registered level. It joins the trap arm of the `next_pc` chain below,
+  // which is BELOW the stall arm -- so an interrupt waits out a divide, a load
+  // turnaround and a serialization the same way everything else does, and is
+  // taken only on a cycle that would otherwise have issued an instruction. The
+  // instruction it displaces has not issued, so there is nothing to un-commit.
+  input  logic        interrupt_pending,
  `ifdef RISCV_FORMAL
   input  rvfi_csr64   csr_rvfi_mcycle,
   input  rvfi_csr64   csr_rvfi_minstret,
@@ -364,18 +372,29 @@ module decoder (
   localparam logic [31:0] CAUSE_LOAD_MISALIGNED     = 32'd4;
   localparam logic [31:0] CAUSE_STORE_MISALIGNED    = 32'd6;
   localparam logic [31:0] CAUSE_ECALL_M             = 32'd11;
+  // Bit 31 says interrupt; 7 is the machine timer.
+  localparam logic [31:0] CAUSE_MACHINE_TIMER       = 32'h8000_0007;
 
   logic trap_pending;
   assign trap_pending = instr_illegal || instr_ebreak || instr_ecall ||
                         load_misaligned || store_misaligned;
 
-  // No `(* parallel_case *)` here. No two of these five can be true at once
-  // today, so the priority never matters. But marking the case one-hot tells
-  // synthesis it may assume that. Add a sixth cause that overlaps an existing
-  // one and you get whatever the optimiser chose, instead of a failed
-  // assertion. The `ifdef FORMAL` block below checks it can't happen.
+  // The instruction's own fault and an interrupt really can be true together,
+  // and the interrupt wins: the instruction does not execute, so its fault does
+  // not happen. It faults instead when it re-executes after the handler's
+  // `mret`, which is why nothing is lost by taking the interrupt first.
+  logic trap_taken;
+  assign trap_taken = trap_pending || interrupt_pending;
+
+  // No `(* parallel_case *)` here. No two of the five synchronous causes can be
+  // true at once today, so their order never matters -- but marking the case
+  // one-hot tells synthesis it may assume that, and the interrupt arm on top
+  // genuinely overlaps them. Add a cause that overlaps an existing one and you
+  // get whatever the optimiser chose, instead of a failed assertion. The
+  // `ifdef FORMAL` block below checks the five can't overlap each other.
   always_comb begin
     case (1'b1)
+      interrupt_pending: trap_cause = CAUSE_MACHINE_TIMER;
       instr_illegal:    trap_cause = CAUSE_ILLEGAL_INSTRUCTION;
       instr_ebreak:     trap_cause = CAUSE_BREAKPOINT;
       instr_ecall:      trap_cause = CAUSE_ECALL_M;
@@ -386,7 +405,8 @@ module decoder (
   end
 
   // The faulting instruction's address, not the next one's -- that is what lets
-  // a handler fix up and resume.
+  // a handler fix up and resume. For an interrupt it is the address of the
+  // instruction that did not issue, so `mret` re-executes it.
   assign trap_epc = fetcher_pc;
 
   always_comb begin
@@ -542,13 +562,15 @@ module decoder (
   end
 
   // Every way the PC can change, in one priority chain. No `(* parallel_case *)`
-  // here: `stall` and `trap_pending` really can both be true, so the order
-  // matters and synthesis must not assume otherwise.
+  // here: `stall` and `trap_taken` really can both be true, so the order
+  // matters and synthesis must not assume otherwise. `stall` above the trap arm
+  // is also what makes an interrupt wait for the pipeline instead of cutting
+  // into it.
   always_comb begin
     case (1'b1)
       reset:                     next_pc = 32'b0;
       stall:                     next_pc = pc;
-      trap_pending:              next_pc = mtvec;
+      trap_taken:                next_pc = mtvec;
       instr_mret:                next_pc = mepc;
       instr_jalr:                next_pc = ($signed(immediate) + $signed(reg_rs1)) & 32'hfffffffe;
       instr_jal:                 next_pc = $signed(fetcher_pc) + $signed(immediate);
@@ -558,23 +580,40 @@ module decoder (
     endcase
   end
 
-  // Keep this exactly the same as the final `else` guard below, term for term.
-  // In particular do not add `&& in.valid`: that arm does not test it either. If
-  // the two ever disagree a CSR write fires once per stalled cycle instead of
-  // once per instruction, and nothing says so.
+  // `issuing` is a cycle the fetch window is consumed: no reset, no stall. It
+  // is the guard on the last two arms of the publish block below taken
+  // together, term for term -- an interrupt consumes the cycle and reaches the
+  // bubble arm, everything else reaches the final one. In particular do not add
+  // `&& in.valid`: those arms do not test it either. If they ever disagree a
+  // CSR write fires once per stalled cycle instead of once per instruction, and
+  // nothing says so.
   logic issuing;
   assign issuing = !reset && !stall;
 
   logic committing;
-  assign committing = issuing && !trap_pending;
+  assign committing = issuing && !trap_taken;
   assign csr_ren = committing && csr_read_op;
   assign csr_wen = committing && csr_write_op;
   // A trapping instruction still issues, and RVFI still reports it, but it
-  // changed nothing. It must not be counted.
+  // changed nothing. It must not be counted. An interrupted one did not even
+  // issue.
   assign instret = committing;
 
-  assign trap_entry = issuing && trap_pending;
+  assign trap_entry = issuing && trap_taken;
   assign mret_entry = committing && instr_mret;
+
+ `ifdef RISCV_FORMAL
+  // RVFI's flag for "this retire is the first instruction of a handler the
+  // previous retire did not hand off to". An exception reports its own redirect
+  // in `pc_wdata`, so only an interrupt breaks the chain and only an interrupt
+  // sets this. Both sim legs' monitor stops checking pc continuity across a
+  // retire that carries it; without it, every interrupt is a monitor error.
+  logic intr_report;
+  always_ff @(posedge clk) begin
+    if (reset) intr_report <= 1'b0;
+    else if (issuing) intr_report <= interrupt_pending;
+  end
+ `endif
 
   always_ff @(posedge clk) pc <= next_pc;
 
@@ -589,10 +628,12 @@ module decoder (
       // two arms changes that and nothing would say so, which is why the
       // `ifdef FORMAL` block below checks both cases.
       out <= out;
-    end else if (hazard || operand_stall || fetch_stall) begin
+    end else if (hazard || operand_stall || fetch_stall || interrupt_pending) begin
       // These zero `out` instead of holding it. The executor reads `in` every
       // cycle, so a held `out` would be executed again and again while the
-      // stalled instruction waits.
+      // stalled instruction waits. The interrupt is here rather than in the arm
+      // below because the instruction it displaces did not issue: it publishes
+      // nothing, retires nothing and re-executes after `mret`.
       out <= '0;
     end else begin
       // This arm runs on exactly the cycles an instruction issues. Committing
@@ -613,6 +654,7 @@ module decoder (
       out.rvfi.insn <= instr;
       out.rvfi.pc_rdata <= fetcher_pc;
       out.rvfi.trap <= trap_pending;
+      out.rvfi.intr <= intr_report;
       out.rvfi.rs1_addr <= rvfi_rs1_valid ? rs1 : 5'b0;
       out.rvfi.rs2_addr <= rvfi_rs2_valid ? rs2 : 5'b0;
       out.rvfi.rs1_rdata <= rvfi_rs1_valid ? reg_rs1 : 32'b0;
@@ -736,12 +778,14 @@ module decoder (
   // Each of these keeps its own copy of last cycle's value instead of using
   // $past(). `in.pc` and `instr` are free inputs here, and $past() through
   // another register would let the solver fill in a value from before reset that
-  // this proof cannot rule out. `trap_pending` and `instr_mret` belong in
-  // `branch_jump` because both change the pc. Leave either out and the proof
-  // stops believing a trap is a branch while the RTL still treats it as one.
+  // this proof cannot rule out. `trap_taken` and `instr_mret` belong in
+  // `branch_jump` because both change the pc, and `trap_taken` rather than
+  // `trap_pending` so an interrupt counts too. Leave any of them out and the
+  // proof stops believing a redirect is a branch while the RTL still treats it
+  // as one.
   logic branch_jump;
   always_ff @(posedge clk) if (reset) branch_jump <= 1'b0;
-    else branch_jump <= instr_jal || instr_jalr || instr_beq || instr_bne || instr_blt || instr_bltu || instr_bge || instr_bgeu || trap_pending || instr_mret;
+    else branch_jump <= instr_jal || instr_jalr || instr_beq || instr_bne || instr_blt || instr_bltu || instr_bge || instr_bgeu || trap_taken || instr_mret;
   logic [31:0] past_pc;
   logic prev_reset, prev_stall, prev_uncompressed;
   always_ff @(posedge clk) begin
@@ -845,13 +889,17 @@ module decoder (
                                load_misaligned, store_misaligned}));
 
   // One line per cause, not a copy of the case statement, so reordering its arms
-  // trips these instead of changing them to match.
-  always_comb if (instr_illegal)    assert(trap_cause == CAUSE_ILLEGAL_INSTRUCTION);
-  always_comb if (instr_ebreak)     assert(trap_cause == CAUSE_BREAKPOINT);
-  always_comb if (instr_ecall)      assert(trap_cause == CAUSE_ECALL_M);
-  always_comb if (load_misaligned)  assert(trap_cause == CAUSE_LOAD_MISALIGNED);
-  always_comb if (store_misaligned) assert(trap_cause == CAUSE_STORE_MISALIGNED);
-  always_comb if (!trap_pending)    assert(trap_cause == 32'b0);
+  // trips these instead of changing them to match. The five synchronous causes
+  // are each stated under `!interrupt_pending`, which is the priority the arm
+  // above them buys: the interrupted instruction did not execute, so its own
+  // fault is not what happened.
+  always_comb if (interrupt_pending) assert(trap_cause == CAUSE_MACHINE_TIMER);
+  always_comb if (!interrupt_pending && instr_illegal)    assert(trap_cause == CAUSE_ILLEGAL_INSTRUCTION);
+  always_comb if (!interrupt_pending && instr_ebreak)     assert(trap_cause == CAUSE_BREAKPOINT);
+  always_comb if (!interrupt_pending && instr_ecall)      assert(trap_cause == CAUSE_ECALL_M);
+  always_comb if (!interrupt_pending && load_misaligned)  assert(trap_cause == CAUSE_LOAD_MISALIGNED);
+  always_comb if (!interrupt_pending && store_misaligned) assert(trap_cause == CAUSE_STORE_MISALIGNED);
+  always_comb if (!trap_taken)       assert(trap_cause == 32'b0);
 
   // `mtvec`/`mepc` are free inputs here, so these are registered copies rather
   // than reads of the live input.
@@ -878,7 +926,20 @@ module decoder (
 
   // Gating these on `instr_valid` instead would look right and be weaker: an
   // instruction can decode fine and still trap. This catches that.
-  always_comb if (trap_pending) assert(!instret && !csr_wen && !csr_ren);
+  always_comb if (trap_taken) assert(!instret && !csr_wen && !csr_ren);
   always_comb assert(!(trap_entry && mret_entry));
+
+  // An interrupt is only ever taken on a cycle that would otherwise have issued
+  // an instruction. Below the stall arm, so a divide, a load turnaround, a
+  // hazard, a serialization drain and the operand-fetch cycle each hold it off.
+  always_comb if (interrupt_pending && !stall && !reset) assert(trap_entry);
+  always_comb if (stall || reset) assert(!trap_entry);
+
+  // ...and it publishes nothing. The instruction it displaced has not issued,
+  // so nothing downstream ever hears about it and there is nothing to take
+  // back. `out` is registered, hence the one-cycle delay.
+  logic prev_interrupt_entry;
+  always_ff @(posedge clk) prev_interrupt_entry <= !reset && !stall && interrupt_pending;
+  always_comb if (clocked && !prev_reset && prev_interrupt_entry) assert(!out.valid);
  `endif
 endmodule

--- a/rtl/littlecpu.v
+++ b/rtl/littlecpu.v
@@ -24,6 +24,10 @@ module littlecpu(
   output logic        mem_ren,
   input  logic [31:0] mem_rdata,
   input  logic        fetch_stall,
+  // The platform's machine-timer line. Registered at its source (rtl/timer.v
+  // does it), because inside the core it is one gate away from the fetch loop.
+  // A platform with no timer ties it low and the core never takes an interrupt.
+  input  logic        irq_timer,
   output logic trap
   `ifdef RISCV_FORMAL
   ,
@@ -119,6 +123,7 @@ module littlecpu(
   logic        csr_trap_entry, csr_mret_entry;
   logic [31:0] csr_trap_cause, csr_trap_epc;
   logic [31:0] csr_mtvec, csr_mepc;
+  logic        csr_interrupt_pending;
  `ifdef RISCV_FORMAL
   rvfi_csr64 csr_rvfi_mcycle, csr_rvfi_minstret;
   rvfi_csr32 csr_rvfi_mscratch;
@@ -141,6 +146,7 @@ module littlecpu(
     .csr_implemented(csr_implemented),
     .mtvec(csr_mtvec),
     .mepc(csr_mepc),
+    .interrupt_pending(csr_interrupt_pending),
    `ifdef RISCV_FORMAL
     .csr_rvfi_mcycle(csr_rvfi_mcycle),
     .csr_rvfi_minstret(csr_rvfi_minstret),
@@ -174,10 +180,12 @@ module littlecpu(
     .trap_cause(csr_trap_cause),
     .trap_epc(csr_trap_epc),
     .mret_entry(csr_mret_entry),
+    .irq_timer(irq_timer),
     .rdata(csr_rdata),
     .implemented(csr_implemented),
     .mtvec_value(csr_mtvec),
-    .mepc_value(csr_mepc)
+    .mepc_value(csr_mepc),
+    .interrupt_pending(csr_interrupt_pending)
    `ifdef RISCV_FORMAL
     ,
     .rvfi_mcycle(csr_rvfi_mcycle),
@@ -223,6 +231,7 @@ module littlecpu(
     ,
     .rvfi_valid(rvfi_valid),
     .rvfi_trap(rvfi_trap),
+    .rvfi_intr(rvfi_intr),
     .rvfi_order(rvfi_order),
     .rvfi_insn(rvfi_insn),
     .rvfi_rs1_addr(rvfi_rs1_addr),
@@ -254,11 +263,11 @@ module littlecpu(
   );
 
  `ifdef RISCV_FORMAL
-  // These four never change. There is one privilege mode, registers are 32 bits
-  // wide, there are no interrupts and the core cannot be halted, so none of them
-  // depends on which instruction just finished.
+  // These three never change. There is one privilege mode, registers are 32
+  // bits wide and the core cannot be halted, so none of them depends on which
+  // instruction just finished. `rvfi_intr` does, and comes out of writeback
+  // with the rest of the retire.
   assign rvfi_halt = 1'b0;
-  assign rvfi_intr = 1'b0;
   assign rvfi_mode = 2'd3;
   assign rvfi_ixl = 2'd1;
  `endif

--- a/rtl/littlesoc.v
+++ b/rtl/littlesoc.v
@@ -42,9 +42,9 @@ module littlesoc (
 
   logic        trap;
   logic [31:0] mem_addr, mem_wdata, mem_rdata;
-  logic [31:0] imem_mem_rdata, dmem_mem_rdata;
+  logic [31:0] imem_mem_rdata, dmem_mem_rdata, timer_mem_rdata;
   logic [3:0]  mem_wstrb;
-  logic        mem_ren, fetch_stall;
+  logic        mem_ren, fetch_stall, irq_timer;
   logic [31:0] imem_addr, imem_addr2, imem_addr_next;
   logic [31:0] imem_data, imem_data2;
 
@@ -62,6 +62,7 @@ module littlesoc (
     .mem_ren(mem_ren),
     .mem_rdata(mem_rdata),
     .fetch_stall(fetch_stall),
+    .irq_timer(irq_timer),
     .trap(trap)
   );
 
@@ -96,10 +97,23 @@ module littlesoc (
     .mem_rdata(dmem_mem_rdata)
   );
 
-  // An OR instead of a mux, which is one less level of logic here. The two
+  // The machine timer, just above the data RAM. This is the only interrupt
+  // source on this platform, so `mip.MSIP` and `mip.MEIP` stay read-only zero
+  // in rtl/csrs.v.
+  timer #(.BASE(32'h0002_0000)) mtimer (
+    .clk(clk),
+    .reset(reset),
+    .mem_addr(mem_addr),
+    .mem_wdata(mem_wdata),
+    .mem_wstrb(mem_wstrb),
+    .mem_rdata(timer_mem_rdata),
+    .mtip(irq_timer)
+  );
+
+  // An OR instead of a mux, which is one less level of logic here. The three
   // ranges do not overlap. On a store the RAM holds its last read value and the
-  // ROM gives zero, so this can never mix two real values together.
-  assign mem_rdata = imem_mem_rdata | dmem_mem_rdata;
+  // other two give zero, so this can never mix two real values together.
+  assign mem_rdata = imem_mem_rdata | dmem_mem_rdata | timer_mem_rdata;
 
   logic store_bit, trap_seen;
   always_ff @(posedge clk) begin

--- a/rtl/structs.v
+++ b/rtl/structs.v
@@ -58,6 +58,12 @@ typedef struct packed {
   // retires having
   // architecturally done nothing except redirect the PC.
   logic        trap;
+  // `rvfi_intr`: this instruction is the first of a handler that no earlier
+  // retire handed off to. Only an interrupt sets it -- an exception rides out
+  // on the faulting instruction's own retire, which reports mtvec in pc_wdata
+  // and leaves the chain unbroken. Both sim legs' monitor and riscv-formal's
+  // two pc checks read it to stop expecting continuity across that gap.
+  logic        intr;
   // Exactly the CSRs formal/checks.cfg's `[csrs]` list names, captured in
   // decode -- the one stage that knows them, since ADR-0005 reads and
   // commits every CSR access there -- and forwarded on the same valid-bit

--- a/rtl/timer.v
+++ b/rtl/timer.v
@@ -1,0 +1,145 @@
+`timescale 1 ns / 1 ps
+`default_nettype none
+// The machine timer, on the data bus rather than in the CSR file. `mtime` is a
+// free-running 64-bit counter and `mtimecmp` is the value it is compared
+// against, unsigned; `mtip` is high for as long as `mtime >= mtimecmp`. That is
+// a LEVEL, not a pulse: it stays posted until `mtimecmp` becomes greater than
+// `mtime`, and taking the trap does not lower it. Moving `mtimecmp` forward is
+// the only thing that does, which is why a handler that returns without doing
+// so is re-entered at once.
+//
+// THE TICK PERIOD IS ONE CLOCK CYCLE, so on the shipping SoC's 12 MHz crystal
+// an `mtime` tick is 83.33 ns. The privileged spec requires only that `mtime`
+// advance at a constant frequency and that the platform publish the period; it
+// names a fixed-frequency system with no frequency scaling as the case where
+// driving it from the cycle counter is the right answer, which is this board.
+// Firmware cannot work the period out from anywhere else, so it is written
+// here.
+//
+// Four words, low half first:
+//
+//   BASE+0  mtime      BASE+4  mtimeh
+//   BASE+8  mtimecmp   BASE+c  mtimecmph
+//
+// A 32-bit store touches one half, so an update to `mtimecmp` is a sequence and
+// its order matters. The spec's own RV32 sample writes the low half all ones,
+// then the high half, then the low half; test/timer_tb.v fires a spurious
+// interrupt with the naive order to show the difference is real.
+//
+// `mtip` is REGISTERED, and that is what keeps this cheap. It reaches the core
+// as one input of the decoder's trap term, which is on the fetch loop; an
+// unregistered comparison would put a 64-bit carry chain there instead. Any
+// other platform driving `irq_timer` owes the core the same.
+//
+// A write beats that cycle's increment of `mtime`, for the reason rtl/csrs.v
+// gives about `mcycle`: the two halves are one register, so a write to either
+// suppresses the carry as well as the half it names.
+module timer #(
+  // Above rtl/memory.v's 64 KB at 0x0001_0000, so the three ranges on the
+  // shared bus do not overlap and the read buses can be ORed together.
+  parameter logic [31:0] BASE = 32'h0002_0000
+) (
+  input  logic        clk,
+  input  logic        reset,
+  input  logic [31:0] mem_addr,
+  input  logic [31:0] mem_wdata,
+  input  logic [3:0]  mem_wstrb,
+  output logic [31:0] mem_rdata,
+  output logic        mtip
+);
+  logic [63:0] mtime, mtimecmp;
+
+  logic [31:0] offset;
+  assign offset = mem_addr - BASE;
+  logic in_range;
+  assign in_range = mem_addr >= BASE && offset < 32'd16;
+  logic [1:0] word;
+  assign word = offset[3:2];
+
+  logic writing;
+  assign writing = in_range && |mem_wstrb;
+
+  logic wr_time_lo, wr_time_hi, wr_cmp_lo, wr_cmp_hi;
+  assign wr_time_lo = writing && word == 2'd0;
+  assign wr_time_hi = writing && word == 2'd1;
+  assign wr_cmp_lo  = writing && word == 2'd2;
+  assign wr_cmp_hi  = writing && word == 2'd3;
+
+  // Selected out here rather than inside the always blocks below: a constant
+  // part-select taken inside one defeats iverilog's sensitivity analysis and
+  // draws a `sorry:` note. Use a named continuous assign for any added later.
+  logic [31:0] mtime_lo, mtime_hi, mtimecmp_lo, mtimecmp_hi;
+  assign mtime_lo    = mtime[31:0];
+  assign mtime_hi    = mtime[63:32];
+  assign mtimecmp_lo = mtimecmp[31:0];
+  assign mtimecmp_hi = mtimecmp[63:32];
+
+  logic [31:0] read_word;
+  always_comb begin
+    (* parallel_case *)
+    case (word)
+      2'd0:    read_word = mtime_lo;
+      2'd1:    read_word = mtime_hi;
+      2'd2:    read_word = mtimecmp_lo;
+      default: read_word = mtimecmp_hi;
+    endcase
+  end
+
+  logic [63:0] mtime_next;
+  assign mtime_next = (wr_time_lo || wr_time_hi) ? mtime : mtime + 64'd1;
+
+  always_ff @(posedge clk) begin
+    if (reset) begin
+      mtime    <= 64'b0;
+      // Zero, which means `mtip` is asserted from the first cycle. That is what
+      // the comparison says, and it is harmless: mstatus.MIE and mie.MTIE both
+      // reset to zero in rtl/csrs.v, so nothing is taken until software has
+      // enabled it -- and software must set mtimecmp before it does, which is
+      // the ordering every RISC-V platform requires anyway.
+      //
+      // Every reset value in this file is zero for a second reason: the cxxrtl
+      // runner deasserts reset before the first rising edge, so the whole `.S`
+      // suite runs on cxxrtl's zero-initialised state rather than on this
+      // branch. A non-zero reset value here would be invisible on the primary
+      // simulator and present on the board.
+      mtimecmp  <= 64'b0;
+      mtip      <= 1'b0;
+      mem_rdata <= 32'b0;
+    end else begin
+      mtime <= mtime_next;
+      if (wr_time_lo) begin
+        if (mem_wstrb[0]) mtime[7:0]    <= mem_wdata[7:0];
+        if (mem_wstrb[1]) mtime[15:8]   <= mem_wdata[15:8];
+        if (mem_wstrb[2]) mtime[23:16]  <= mem_wdata[23:16];
+        if (mem_wstrb[3]) mtime[31:24]  <= mem_wdata[31:24];
+      end
+      if (wr_time_hi) begin
+        if (mem_wstrb[0]) mtime[39:32]  <= mem_wdata[7:0];
+        if (mem_wstrb[1]) mtime[47:40]  <= mem_wdata[15:8];
+        if (mem_wstrb[2]) mtime[55:48]  <= mem_wdata[23:16];
+        if (mem_wstrb[3]) mtime[63:56]  <= mem_wdata[31:24];
+      end
+      if (wr_cmp_lo) begin
+        if (mem_wstrb[0]) mtimecmp[7:0]   <= mem_wdata[7:0];
+        if (mem_wstrb[1]) mtimecmp[15:8]  <= mem_wdata[15:8];
+        if (mem_wstrb[2]) mtimecmp[23:16] <= mem_wdata[23:16];
+        if (mem_wstrb[3]) mtimecmp[31:24] <= mem_wdata[31:24];
+      end
+      if (wr_cmp_hi) begin
+        if (mem_wstrb[0]) mtimecmp[39:32] <= mem_wdata[7:0];
+        if (mem_wstrb[1]) mtimecmp[47:40] <= mem_wdata[15:8];
+        if (mem_wstrb[2]) mtimecmp[55:48] <= mem_wdata[23:16];
+        if (mem_wstrb[3]) mtimecmp[63:56] <= mem_wdata[31:24];
+      end
+      // Both sides come out of flip-flops, so a write to `mtimecmp` is visible
+      // here one cycle later. Comparing against the value the write is
+      // installing would put `mem_wdata` in front of a 64-bit carry chain, and
+      // the cycle buys nothing: an `mret` cannot commit until the pipeline is
+      // empty, which is several cycles after the handler's store lands.
+      mtip <= mtime_next >= mtimecmp;
+      // An out-of-range access reads zero, so the three memories on this bus
+      // join with an OR rather than a mux.
+      mem_rdata <= in_range ? read_word : 32'b0;
+    end
+  end
+endmodule

--- a/rtl/writeback.v
+++ b/rtl/writeback.v
@@ -14,6 +14,7 @@ module writeback(
   ,
   output logic        rvfi_valid,
   output logic        rvfi_trap,
+  output logic        rvfi_intr,
   output logic [63:0] rvfi_order,
   output logic [31:0] rvfi_insn,
   output logic [ 4:0] rvfi_rs1_addr,
@@ -82,6 +83,8 @@ module writeback(
   // The fallback is safe, but it is still a diagnostic. Keeping this read out
   // of the always_comb is what stops one more being emitted.
   assign rvfi_trap = in.rvfi.trap;
+  // Same continuous-assign reason as rvfi_trap above.
+  assign rvfi_intr = in.rvfi.intr;
 
   always_comb begin
     rvfi_valid = !reset && in.valid;

--- a/test/COSIM_EXPECTED_FAIL
+++ b/test/COSIM_EXPECTED_FAIL
@@ -65,3 +65,69 @@
 # different paths, no value exemption can help, and the assertion belongs in a
 # bench with no reference model in it? Only when none of the three fit is it a
 # baseline entry, and then it needs a paragraph here, not a line.
+#
+# THE TWO TIMER-INTERRUPT PROGRAMS: THE SPEC PERMITS BOTH MACHINES, AND THAT IS
+# THE FINDING. mtimer.S and mtimermask.S arm this platform's machine timer
+# through its memory map and wait for the interrupt. Sail has a timer too. It is
+# a different one, and everything that differs is a quantity the privileged spec
+# explicitly leaves to the platform:
+#
+#   * THE ADDRESS. mtime and mtimecmp are memory-mapped, and the spec does not
+#     say where. This platform puts four words at 0x0002_0000 (rtl/timer.v,
+#     wired identically in rtl/littlesoc.v and test/testbench.v); Sail puts a
+#     CLINT at its own base with its own layout. A store that arms this timer
+#     lands nowhere on the model, so the model never takes an interrupt and
+#     spins in the wait loop until its instruction budget runs out. That is the
+#     INCONCLUSIVE SAIL-LIMIT below: NOTHING WAS COMPARED, which is a weaker
+#     entry than a divergence and is recorded as such.
+#   * THE TICK PERIOD. The spec requires only that mtime advance at a CONSTANT
+#     frequency and that the platform publish the period; it names a
+#     fixed-frequency system as the case where driving mtime from the cycle
+#     counter is right, which is this board. So mtime here ticks once per clock
+#     cycle. The model's ticks once per two instructions
+#     (`instructions_per_tick: 2` in test/sail/rv32imc_zicsr.json). Both are
+#     constant. Both are conformant. They are not the same clock.
+#   * WHEN MTIP FOLLOWS THE COMPARISON. "If the result of the comparison between
+#     mtime and mtimecmp changes, it is guaranteed to be reflected in MTIP
+#     eventually, but not necessarily immediately." The spec then warns software
+#     that a spurious timer interrupt can follow an increment-and-return for
+#     exactly this reason. Two implementations may reflect it at different
+#     granularities and both be right.
+#
+# WHY A VALUE EXEMPTION IS THE WRONG TOOL HERE, having been considered first.
+# test/cosim.py's NONCOMPARABLE_CSRS is the right mechanism for a register whose
+# VALUE is incomparable while both sides still take the same branches — that is
+# what closed mcycle, and mip is already on that list. It cannot close this one,
+# and the reason is structural rather than a matter of effort: with different
+# tick periods the interrupt lands between a DIFFERENT PAIR OF INSTRUCTIONS on
+# the two machines. What differs is the POSITION of the architectural change in
+# the sequence, and the position is precisely what that mechanism keeps
+# comparing. An exemption wide enough to cover it would be an exemption that
+# compared nothing.
+#
+# SO THIS IS QUESTION 3, ANSWERED HONESTLY. The programs assert against
+# implementation-defined platform quantities; the model is entitled to answer
+# differently; the two runs take different paths. No configuration reaches it
+# either: `platform.clint` has exactly `base`, `size` and `supported`, and
+# nothing in the schema names mtimecmp, MTIP or the CLINT's internal layout.
+# Reconciling the two would mean adopting the model's address map AND its tick
+# period, i.e. choosing this platform's timer to make a reference model happy.
+# That is a product decision, not a test fix, and it is not being made here.
+#
+# WHAT COVERS THEM MEANWHILE, since "co-sim is blind here" is only admissible
+# with an answer: the interrupt's architectural effect is asserted by
+# formal/traps.sv under k-induction (entry writes mcause, mepc and mstatus, and
+# the interrupted instruction commits nothing), by test/decoder_tb.v at the
+# decode boundary, by test/csr_tb.v on the three enable terms, and by
+# test/timer_tb.v on the timer itself — including the level property and the
+# torn write, each with a demonstrated red direction. What co-sim uniquely
+# catches — an architectural register write no self-reporting oracle sees — is
+# still checked on the other 59 programs, which is where the property it was
+# built for lives.
+#
+# THE FAILURE DIRECTION IS STILL LIVE. These are name-and-status pairs under set
+# equality, so if a future change makes either program AGREE, or makes it
+# diverge some other way, this gate goes red and these paragraphs get re-read.
+
+mtimer.S      INCONCLUSIVE SAIL-LIMIT
+mtimermask.S  INCONCLUSIVE SAIL-LIMIT

--- a/test/OBSERVED_FLOOR
+++ b/test/OBSERVED_FLOOR
@@ -150,6 +150,8 @@ lhu.S               228    228
 lui.S                29     29
 lw.S                231    231
 minstret.S           42     31
+mtimer.S           1104   1075
+mtimermask.S        297    264
 mul.S               423    423
 mulh.S              423    423
 mulhsu.S            423    423

--- a/test/asm/mtimer.S
+++ b/test/asm/mtimer.S
@@ -1,0 +1,306 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# mtimer.S
+#-----------------------------------------------------------------------------
+#
+# The machine timer interrupt, taken end to end: armed from software, asserted
+# by rtl/timer.v, gated by mie.MTIE and mstatus.MIE, and committed at a decode
+# boundary.
+#
+# THIS FILE AND test/asm/mtimermask.S ARE THE ONLY PROGRAM-LEVEL ORACLE FOR ANY
+# OF IT. riscv-formal ships no spec model for an interrupt at the pinned SHA --
+# its two pc checks read `rvfi_intr` and use it only to stop expecting pc
+# continuity, and nothing upstream names mie, mip, mstatus or an interrupt
+# cause -- and the generated checks tie the core's timer input off, so they say
+# nothing about this either way. What is checked where: rtl/timer.v's own
+# behaviour in test/timer_tb.v, the three-term enable in test/csr_tb.v, the
+# decode-boundary commit in test/decoder_tb.v and formal/traps.sv, and the
+# whole path only here.
+#
+# The one property worth stating twice, because everything else follows from
+# it: an interrupt is taken on a cycle that would OTHERWISE HAVE ISSUED an
+# instruction. The instruction it displaces has not issued, so `mepc` is that
+# instruction's own address and the handler resumes AT it -- which is why
+# RVTEST_TIMER_HANDLER does not advance mepc the way RVTEST_TRAP_HANDLER does.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  # mtvec resets to 0, which is _start. Install before arming anything.
+  RVTEST_INSTALL_TIMER_HANDLER
+
+  #-------------------------------------------------------------
+  # Nothing fires until it is armed AND enabled. This runs before any of the
+  # cases below so a stray entry cannot be mistaken for one of them.
+  #
+  # mtimecmp resets to zero, so mtip is already asserted here. Both enables
+  # reset to zero as well, which is what makes that harmless -- and disarming
+  # before enabling is the ordering any boot path owes the timer.
+  #-------------------------------------------------------------
+
+  RVTEST_DISARM_TIMER
+  RVTEST_ENABLE_MTIE
+  RVTEST_ENABLE_MIE
+
+  TEST_CASE( 2, a4, 0, \
+    nop; nop; nop; nop; nop; nop; nop; nop; \
+    la a3, irq_count; lw a4, 0(a3); )
+
+  # mip.MTIP is the platform's line, and it is low while mtimecmp is out of
+  # reach. mie.MTIE is what this test just set, and it reads back.
+  TEST_CASE( 3, a0, 0,    csrr a0, mip; )
+  TEST_CASE( 4, a0, 0x80, csrr a0, mie; )
+
+  #-------------------------------------------------------------
+  # Armed: the interrupt arrives inside a spin loop.
+  #
+  # The loop is deliberately made of instructions that are all the same length
+  # and all in one basic block, so `mepc` can be asserted to lie inside it --
+  # that is the claim that the interrupt was taken between two instructions of
+  # the interrupted code, rather than somewhere the core invented.
+  #-------------------------------------------------------------
+
+  RVTEST_ARM_TIMER( 40 )
+
+spin_start:
+  .option push
+  .option norvc
+  li    a5, 0
+1:
+  addi  a5, a5, 1
+  li    a6, 60
+  blt   a5, a6, 1b
+  .option pop
+spin_end:
+
+  TEST_CASE( 5, a4, 1, la a3, irq_count; lw a4, 0(a3); )
+
+  # Interrupt, machine timer: bit 31 set, exception code 7.
+  TEST_CASE( 6, a4, 0x80000007, la a3, irq_cause; lw a4, 0(a3); )
+
+  # mepc lands inside the spin loop. A handler that resumed at mepc+4 would
+  # still pass this -- what it could not pass is test 8.
+test_7:
+  la    a3, irq_epc
+  lw    a4, 0(a3)
+  la    x29, spin_start
+  li    TESTNUM, 7
+  bltu  a4, x29, fail
+  la    x29, spin_end
+  li    TESTNUM, 7
+  bgeu  a4, x29, fail
+
+  # The loop still ran to completion, so the instruction at mepc was executed
+  # exactly once rather than skipped. The counter reaching 60 is that
+  # statement: mepc pointed at an `addi a5, a5, 1`, a `li` or the branch behind
+  # them, and resuming one instruction late would have lost an iteration or the
+  # branch that closes the loop.
+  TEST_CASE( 8, a5, 60, nop; )
+
+  #-------------------------------------------------------------
+  # No nesting, and no second entry. The handler disarmed the timer by moving
+  # mtimecmp out of reach, so `mtip` is low again; and even before that, entry
+  # cleared mstatus.MIE, so nothing could have re-entered while the handler ran.
+  #-------------------------------------------------------------
+
+  TEST_CASE( 9, a0, 0, csrr a0, mip; )
+
+  TEST_CASE( 10, a4, 1, \
+    nop; nop; nop; nop; nop; nop; nop; nop; \
+    nop; nop; nop; nop; nop; nop; nop; nop; \
+    la a3, irq_count; lw a4, 0(a3); )
+
+  # Entry cleared mstatus.MIE and pushed the old value into MPIE, observed from
+  # INSIDE the handler rather than inferred: the handler recorded mstatus on
+  # entry. MIE (bit 3) clear, MPIE (bit 7) set.
+  TEST_CASE( 11, a4, 0, la a3, irq_mstatus; lw a4, 0(a3); andi a4, a4, 0x8; )
+  TEST_CASE( 12, a4, 0x80, la a3, irq_mstatus; lw a4, 0(a3); andi a4, a4, 0x80; )
+
+  # ...and mret restored MIE from MPIE, so the machine is armed for the next one
+  # rather than having quietly turned interrupts off for good.
+  TEST_CASE( 13, a1, 0x8, csrr a0, mstatus; andi a1, a0, 0x8; )
+
+  #-------------------------------------------------------------
+  # It is repeatable. A core that takes exactly one interrupt per reset would
+  # pass everything above.
+  #-------------------------------------------------------------
+
+  RVTEST_ARM_TIMER( 40 )
+
+  .option push
+  .option norvc
+  li    a5, 0
+1:
+  addi  a5, a5, 1
+  li    a6, 60
+  blt   a5, a6, 1b
+  .option pop
+
+  TEST_CASE( 14, a4, 2, la a3, irq_count; lw a4, 0(a3); )
+  TEST_CASE( 15, a4, 0x80000007, la a3, irq_cause; lw a4, 0(a3); )
+
+  #-------------------------------------------------------------
+  # MTIP IS A LEVEL. The spec says the interrupt remains posted until mtimecmp
+  # becomes greater than mtime, and that taking the trap does not clear it. So
+  # a handler that returns without moving mtimecmp is re-entered immediately --
+  # before the instruction at mepc has run.
+  #
+  # This is the single easiest thing to get wrong: a core that cleared the
+  # pending bit on entry, or that latched an edge, passes every case above and
+  # fails here. `irq_limit` is what stops the correct behaviour being a
+  # livelock: the sticky handler disarms once the count reaches it.
+  #-------------------------------------------------------------
+
+  la    a3, irq_count
+  sw    x0, 0(a3)
+  la    a3, irq_limit
+  li    a4, 3
+  sw    a4, 0(a3)
+
+  RVTEST_INSTALL_STICKY_TIMER_HANDLER
+  RVTEST_ARM_TIMER( 20 )
+
+  .option push
+  .option norvc
+  li    a5, 0
+1:
+  addi  a5, a5, 1
+  li    a6, 60
+  blt   a5, a6, 1b
+  .option pop
+
+  # Three entries from ONE arming. The handler moved mtimecmp only on the last.
+  TEST_CASE( 16, a4, 3, la a3, irq_count; lw a4, 0(a3); )
+
+  # ...and the interrupted code still finished, so the re-entries did not eat
+  # the instruction at mepc.
+  TEST_CASE( 17, a5, 60, nop; )
+
+  RVTEST_INSTALL_TIMER_HANDLER
+
+  #-------------------------------------------------------------
+  # The torn 64-bit write, and its demonstrated red direction.
+  #
+  # A 32-bit store touches one half of mtimecmp, so an update is a sequence and
+  # the ORDER decides whether the pair is ever transiently smaller than the
+  # lesser of the old and new values. The spec's own sample code writes the LOW
+  # half all-ones, then the high half, then the low half.
+  #
+  # Set up so the naive order is genuinely dangerous. mtime is parked at
+  # 0x1_0000_0050, mtimecmp is {2, 0x10}, and the target is {1, 0xfffffff0}:
+  #
+  #   high half first  ->  {1, 0x10}, which mtime is past. FIRES.
+  #   spec's order     ->  {2, all ones}, {1, all ones}, {1, 0xfffffff0}.
+  #                        Every intermediate is out of reach.
+  #
+  # Test 18 fires it the wrong way ON PURPOSE, because a sequence whose failure
+  # path has never run is not a check. Test 20 then does it the spec's way over
+  # the same values and asserts nothing fires.
+  #-------------------------------------------------------------
+
+  la    a3, irq_count
+  sw    x0, 0(a3)
+
+  li    t0, MTIMER_BASE
+  li    t1, 2
+  sw    t1, MTIMECMPH_OFFSET(t0)    # mtimecmp = {2, 0x10}
+  li    t1, 0x10
+  sw    t1, MTIMECMP_OFFSET(t0)
+  li    t1, 1
+  sw    t1, 4(t0)                   # mtime = {1, 0x50}
+  li    t1, 0x50
+  sw    t1, 0(t0)
+
+  # The naive order: high half first. The pair passes through {1, 0x10}.
+  li    t1, 1
+  sw    t1, MTIMECMPH_OFFSET(t0)
+  nop
+  nop
+  nop
+  nop
+  li    t1, 0xfffffff0
+  sw    t1, MTIMECMP_OFFSET(t0)
+
+  TEST_CASE( 18, a4, 1, \
+    nop; nop; nop; nop; \
+    la a3, irq_count; lw a4, 0(a3); )
+
+  # The handler disarmed and recorded the cause, so test 18 counted a real
+  # timer interrupt rather than any other trap.
+  TEST_CASE( 19, a4, 0x80000007, la a3, irq_cause; lw a4, 0(a3); )
+
+  # Now the same update, the spec's way, from the same starting point.
+  la    a3, irq_count
+  sw    x0, 0(a3)
+
+  li    t0, MTIMER_BASE
+  li    t1, 2
+  sw    t1, MTIMECMPH_OFFSET(t0)
+  li    t1, 0x10
+  sw    t1, MTIMECMP_OFFSET(t0)
+  li    t1, 1
+  sw    t1, 4(t0)
+  li    t1, 0x50
+  sw    t1, 0(t0)
+
+  li    t1, -1
+  sw    t1, MTIMECMP_OFFSET(t0)     # low = all ones: no smaller than the old
+  li    t1, 1
+  sw    t1, MTIMECMPH_OFFSET(t0)    # high = new: no smaller than the new
+  nop
+  nop
+  nop
+  nop
+  li    t1, 0xfffffff0
+  sw    t1, MTIMECMP_OFFSET(t0)     # low = new
+
+  TEST_CASE( 20, a4, 0, \
+    nop; nop; nop; nop; \
+    la a3, irq_count; lw a4, 0(a3); )
+
+  # ...and the pair really is out of reach afterwards, so test 20 passed
+  # because the sequence was safe and not because the timer had stopped.
+  TEST_CASE( 21, a0, 0, csrr a0, mip; )
+
+  #-------------------------------------------------------------
+  # One more end-to-end entry, so the sequences above are shown to leave the
+  # timer usable rather than merely quiet. RVTEST_ARM_TIMER writes a zero high
+  # half, so mtime's high half has to come back to zero first.
+  #-------------------------------------------------------------
+
+  li    t0, MTIMER_BASE
+  sw    x0, 4(t0)
+  sw    x0, 0(t0)
+
+  RVTEST_ARM_TIMER( 40 )
+
+  .option push
+  .option norvc
+  li    a5, 0
+1:
+  addi  a5, a5, 1
+  li    a6, 60
+  blt   a5, a6, 1b
+  .option pop
+
+  TEST_CASE( 22, a4, 1, la a3, irq_count; lw a4, 0(a3); )
+
+  TEST_PASSFAIL
+
+  RVTEST_TIMER_HANDLER
+  RVTEST_STICKY_TIMER_HANDLER
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+  RVTEST_TIMER_DATA
+
+RVTEST_DATA_END

--- a/test/asm/mtimermask.S
+++ b/test/asm/mtimermask.S
@@ -1,0 +1,147 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# mtimermask.S
+#-----------------------------------------------------------------------------
+#
+# The two masks, and the two stalls an interrupt has to wait out.
+#
+# The masks are checked SEPARATELY -- mstatus.MIE clear with mie.MTIE set, then
+# the other way round -- because a core that ANDed only one of them in would
+# pass a test that cleared both. Each case also asserts that mip.MTIP is HIGH
+# while nothing is taken: the source really is asserting and the mask really is
+# what is holding it off, rather than the timer having failed to fire at all.
+# Unmasking then takes the interrupt that was already pending, which is the
+# other half of the same claim.
+#
+# The two stall cases are the reason this design is cheap. `stall` sits ABOVE
+# the trap arm in rtl/decoder.v's next_pc chain, so a divide in flight and a
+# serializing CSR instruction each hold the interrupt off with no logic of
+# their own. What that buys is asserted here from the program's side: the
+# divides produce the right answers and the CSR reads see the right values,
+# with an interrupt landing in the middle of both.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  RVTEST_INSTALL_TIMER_HANDLER
+
+  #-------------------------------------------------------------
+  # mstatus.MIE clear, mie.MTIE set. Nothing is taken; the line is asserting.
+  #-------------------------------------------------------------
+
+  # mtimecmp resets to zero, so mtip is asserted before this point; both
+  # enables reset to zero, which is what makes that harmless.
+  RVTEST_DISARM_TIMER
+  RVTEST_ENABLE_MTIE
+  RVTEST_DISABLE_MIE
+  RVTEST_ARM_TIMER( 20 )
+
+  TEST_CASE( 2, a4, 0, \
+    nop; nop; nop; nop; nop; nop; nop; nop; \
+    nop; nop; nop; nop; nop; nop; nop; nop; \
+    nop; nop; nop; nop; nop; nop; nop; nop; \
+    la a3, irq_count; lw a4, 0(a3); )
+
+  # The source IS asserting, so test 2 passed because MIE masked it and not
+  # because the timer never fired.
+  TEST_CASE( 3, a0, 0x80, csrr a0, mip; )
+
+  # Unmasking takes the interrupt that was already pending.
+  RVTEST_ENABLE_MIE
+
+  TEST_CASE( 4, a4, 1, \
+    nop; nop; nop; nop; \
+    la a3, irq_count; lw a4, 0(a3); )
+  TEST_CASE( 5, a4, 0x80000007, la a3, irq_cause; lw a4, 0(a3); )
+
+  #-------------------------------------------------------------
+  # The other way round: mstatus.MIE set, mie.MTIE clear.
+  #-------------------------------------------------------------
+
+  RVTEST_DISABLE_MTIE
+  RVTEST_ARM_TIMER( 20 )
+
+  TEST_CASE( 6, a4, 1, \
+    nop; nop; nop; nop; nop; nop; nop; nop; \
+    nop; nop; nop; nop; nop; nop; nop; nop; \
+    nop; nop; nop; nop; nop; nop; nop; nop; \
+    la a3, irq_count; lw a4, 0(a3); )
+
+  TEST_CASE( 7, a0, 0x80, csrr a0, mip; )
+  TEST_CASE( 8, a0, 0,    csrr a0, mie; )
+
+  RVTEST_ENABLE_MTIE
+
+  TEST_CASE( 9, a4, 2, \
+    nop; nop; nop; nop; \
+    la a3, irq_count; lw a4, 0(a3); )
+
+  #-------------------------------------------------------------
+  # Arrival during a divide. The divider holds `decoder_out` for its whole run,
+  # and that is a stall, so the interrupt cannot be taken until the division
+  # has retired. Four back-to-back divides span far more than the arming delay,
+  # so the interrupt lands inside one of them.
+  #-------------------------------------------------------------
+
+  RVTEST_ARM_TIMER( 40 )
+
+  li    a0, 1000
+  li    a1, 7
+  div   a2, a0, a1
+  rem   a3, a0, a1
+  li    a4, -1000
+  div   a5, a4, a1
+  rem   a6, a4, a1
+
+  TEST_CASE( 10, a2, 142,  nop; )
+  TEST_CASE( 11, a3, 6,    nop; )
+  TEST_CASE( 12, a5, -142, nop; )
+  TEST_CASE( 13, a6, -6,   nop; )
+
+  TEST_CASE( 14, a4, 3, la a3, irq_count; lw a4, 0(a3); )
+
+  #-------------------------------------------------------------
+  # Arrival during serialization. A CSR instruction is held in decode until
+  # execute, access and writeback are empty; the interrupt waits that out for
+  # the same reason it waits out a divide, so a one-cycle architectural update
+  # can never be interleaved with an entry.
+  #-------------------------------------------------------------
+
+  li    a0, 0x5a5a5a5a
+  csrw  mscratch, a0
+
+  RVTEST_ARM_TIMER( 30 )
+
+  csrr  a1, mscratch
+  csrr  a2, mscratch
+  csrr  a3, mscratch
+  csrr  a5, mscratch
+  csrr  a6, mscratch
+  csrr  a7, mscratch
+
+  TEST_CASE( 15, a1, 0x5a5a5a5a, nop; )
+  TEST_CASE( 16, a7, 0x5a5a5a5a, nop; )
+  TEST_CASE( 17, a4, 4, la a3, irq_count; lw a4, 0(a3); )
+
+  # mscratch survived the entry: the handler does not touch it, and an
+  # interrupt taken mid-serialization must not have let a CSR write through.
+  TEST_CASE( 18, a0, 0x5a5a5a5a, csrr a0, mscratch; )
+
+  TEST_PASSFAIL
+
+  RVTEST_TIMER_HANDLER
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+  RVTEST_TIMER_DATA
+
+RVTEST_DATA_END

--- a/test/asm/riscv_test.h
+++ b/test/asm/riscv_test.h
@@ -127,4 +127,153 @@ trap_handler:                                                                \
         la      t0, trap_handler;                                           \
         csrw    mtvec, t0;
 
+// The machine timer (rtl/timer.v), at the same base in test/testbench.v and in
+// rtl/littlesoc.v. Four words: mtime, mtimeh, mtimecmp, mtimecmph.
+#define MTIMER_BASE      0x00020000
+#define MTIMECMP_OFFSET  8
+#define MTIMECMPH_OFFSET 12
+
+// Constraint 1 does NOT apply to the handler below and its opposite does: an
+// interrupt is taken BETWEEN instructions, so `mepc` holds an instruction that
+// has not run and the handler must resume AT it, not past it. Advancing mepc
+// here would skip a real instruction, which is the mistake this macro exists to
+// stop each test making on its own.
+//
+// It clobbers t0 and t1, and it disarms the timer before returning: `mtip` is a
+// level, so a handler that returns without moving `mtimecmp` is re-entered
+// immediately and forever.
+#define RVTEST_TIMER_HANDLER                                                 \
+        .align  2;                                                          \
+timer_handler:                                                               \
+        .option push;                                                       \
+        .option norvc;                                                      \
+        la      t0, irq_count;                                              \
+        lw      t1, 0(t0);                                                  \
+        addi    t1, t1, 1;                                                  \
+        sw      t1, 0(t0);                                                  \
+        csrr    t1, mcause;                                                 \
+        la      t0, irq_cause;                                              \
+        sw      t1, 0(t0);                                                  \
+        csrr    t1, mepc;                                                   \
+        la      t0, irq_epc;                                                \
+        sw      t1, 0(t0);                                                  \
+        csrr    t1, mstatus;                                                \
+        la      t0, irq_mstatus;                                            \
+        sw      t1, 0(t0);                                                  \
+        li      t0, MTIMER_BASE;                                            \
+        li      t1, -1;                                                     \
+        sw      t1, MTIMECMP_OFFSET(t0);                                    \
+        sw      t1, MTIMECMPH_OFFSET(t0);                                   \
+        mret;                                                               \
+timer_handler_end:                                                           \
+        .option pop;
+
+// The same, minus the disarm, until `irq_count` reaches `irq_limit`. MTIP is a
+// LEVEL: the spec says the interrupt remains posted until mtimecmp becomes
+// greater than mtime, and taking the trap does not clear it. So a handler that
+// returns without moving mtimecmp is re-entered on the first cycle after `mret`
+// that would otherwise have issued -- before the instruction at mepc runs. The
+// limit is what stops that being a livelock in a test.
+//
+// Clobbers t0 and t1.
+#define RVTEST_STICKY_TIMER_HANDLER                                          \
+        .align  2;                                                          \
+sticky_timer_handler:                                                        \
+        .option push;                                                       \
+        .option norvc;                                                      \
+        la      t0, irq_count;                                              \
+        lw      t1, 0(t0);                                                  \
+        addi    t1, t1, 1;                                                  \
+        sw      t1, 0(t0);                                                  \
+        la      t0, irq_limit;                                              \
+        lw      t0, 0(t0);                                                  \
+        blt     t1, t0, 1f;                                                 \
+        li      t0, MTIMER_BASE;                                            \
+        li      t1, -1;                                                     \
+        sw      t1, MTIMECMP_OFFSET(t0);                                    \
+        sw      t1, MTIMECMPH_OFFSET(t0);                                   \
+1:      mret;                                                               \
+        .option pop;
+
+// Invoke after RVTEST_DATA_BEGIN, like RVTEST_TRAP_DATA, so it lands in RAM.
+#define RVTEST_TIMER_DATA                                                    \
+        .align  2;                                                          \
+        .global irq_count;                                                  \
+irq_count:                                                                   \
+        .word   0;                                                          \
+        .global irq_cause;                                                  \
+irq_cause:                                                                   \
+        .word   0;                                                          \
+        .global irq_epc;                                                    \
+irq_epc:                                                                     \
+        .word   0;                                                          \
+        .global irq_mstatus;                                                \
+irq_mstatus:                                                                 \
+        .word   0;                                                          \
+        .global irq_limit;                                                  \
+irq_limit:                                                                   \
+        .word   0;
+
+#define RVTEST_INSTALL_TIMER_HANDLER                                         \
+        la      t0, timer_handler;                                          \
+        csrw    mtvec, t0;
+
+#define RVTEST_INSTALL_STICKY_TIMER_HANDLER                                  \
+        la      t0, sticky_timer_handler;                                   \
+        csrw    mtvec, t0;
+
+// Arm the timer to assert `delay` ticks from now, in the order the privileged
+// spec's own sample code uses for RV32:
+//
+//     low half = all ones     -- no smaller than the OLD value
+//     high half = new high    -- no smaller than the NEW value
+//     low half = new low      -- the new value
+//
+// A 32-bit store touches one half, so the pair is briefly a mix of old and new.
+// This order makes every intermediate at least as large as the smaller of the
+// two, which is what stops a spurious interrupt being manufactured in the
+// middle of the update. Writing the high half first does NOT: with the old low
+// half small, the pair passes through {new high, old low}, and mtime may
+// already be past it. test/asm/mtimer.S fires an interrupt that way on purpose.
+//
+// mtime's high half is zero for the whole of a program here unless the program
+// writes it, so the arithmetic can be 32-bit. Clobbers t0, t1 and t2.
+#define RVTEST_ARM_TIMER(delay)                                              \
+        li      t0, MTIMER_BASE;                                            \
+        lw      t1, 0(t0);                                                  \
+        addi    t1, t1, delay;                                              \
+        li      t2, -1;                                                     \
+        sw      t2, MTIMECMP_OFFSET(t0);                                    \
+        sw      x0, MTIMECMPH_OFFSET(t0);                                   \
+        sw      t1, MTIMECMP_OFFSET(t0);
+
+// mtimecmp resets to zero, so mtip is asserted out of reset -- harmless while
+// both enables are clear, and the first thing any boot path has to undo.
+// The low half first, per the sequence below; the third store would write the
+// low half a second time with the same value, so it is left out.
+// Clobbers t0 and t1.
+#define RVTEST_DISARM_TIMER                                                  \
+        li      t0, MTIMER_BASE;                                            \
+        li      t1, -1;                                                     \
+        sw      t1, MTIMECMP_OFFSET(t0);                                    \
+        sw      t1, MTIMECMPH_OFFSET(t0);
+
+// MTIE is bit 7 of mie; MIE is bit 3 of mstatus. Separately, because a test
+// that masks one of them has to leave the other on.
+#define RVTEST_ENABLE_MTIE                                                   \
+        li      t0, 0x80;                                                   \
+        csrs    mie, t0;
+
+#define RVTEST_DISABLE_MTIE                                                  \
+        li      t0, 0x80;                                                   \
+        csrc    mie, t0;
+
+#define RVTEST_ENABLE_MIE                                                    \
+        li      t0, 0x8;                                                    \
+        csrs    mstatus, t0;
+
+#define RVTEST_DISABLE_MIE                                                   \
+        li      t0, 0x8;                                                    \
+        csrc    mstatus, t0;
+
 #endif

--- a/test/csr_tb.v
+++ b/test/csr_tb.v
@@ -29,6 +29,9 @@ module csr_tb;
   logic        trap_entry, mret_entry;
   logic [31:0] trap_cause, trap_epc;
   logic [31:0] mtvec_value, mepc_value;
+  // The platform's timer line, and the one bit rtl/decoder.v reads back.
+  logic        irq_timer;
+  logic        interrupt_pending;
  `ifdef RISCV_FORMAL
   rvfi_csr64 rvfi_mcycle, rvfi_minstret;
   rvfi_csr32 rvfi_mscratch;
@@ -48,8 +51,10 @@ module csr_tb;
     .trap_cause(trap_cause),
     .trap_epc(trap_epc),
     .mret_entry(mret_entry),
+    .irq_timer(irq_timer),
     .mtvec_value(mtvec_value),
-    .mepc_value(mepc_value)
+    .mepc_value(mepc_value),
+    .interrupt_pending(interrupt_pending)
    `ifdef RISCV_FORMAL
     ,
     .rvfi_mcycle(rvfi_mcycle),
@@ -140,6 +145,7 @@ module csr_tb;
     mret_entry = 1'b0;
     trap_cause = 32'b0;
     trap_epc = 32'b0;
+    irq_timer = 1'b0;
     reset = 1'b1;
     repeat (2) @(posedge clk);
     #1;
@@ -152,8 +158,8 @@ module csr_tb;
     check_read("mstatus resets to MPP=M", 12'h300, 32'h0000_1800);
 
     check_read("misa", 12'h301, 32'h4000_1104);
-    check_read("mie reads 0", 12'h304, 32'h0);
-    check_read("mip reads 0", 12'h344, 32'h0);
+    check_read("mie resets to 0", 12'h304, 32'h0);
+    check_read("mip reads 0 with no source asserting", 12'h344, 32'h0);
     check_read("mtval reads 0", 12'h343, 32'h0);
     check_read("mvendorid", 12'hF11, 32'h0);
     check_read("marchid", 12'hF12, 32'h0);
@@ -221,10 +227,8 @@ module csr_tb;
     // truth about what landed.
     poke(12'h301, 32'hffff_ffff);
     check_read("misa ignores a write", 12'h301, 32'h4000_1104);
-    poke(12'h304, 32'hffff_ffff);
-    check_read("mie ignores a write", 12'h304, 32'h0);
     poke(12'h344, 32'hffff_ffff);
-    check_read("mip ignores a write", 12'h344, 32'h0);
+    check_read("mip ignores a write -- MTIP is the platform's line", 12'h344, 32'h0);
     poke(12'h343, 32'hffff_ffff);
     check_read("mtval ignores a write", 12'h343, 32'h0);
     poke(12'hF14, 32'hffff_ffff);
@@ -326,6 +330,66 @@ module csr_tb;
     check_read("mepc preserves bit 1 on a 2-aligned faulting pc", 12'h341, 32'h0000_0146);
     take_trap(32'd4, 32'h0000_0147);
     check_read("...and still masks bit 0", 12'h341, 32'h0000_0146);
+
+    //-----------------------------------------------------------------------
+    // mie, mip and the interrupt decision. No riscv-formal check at the pin
+    // names any of these, so this bench and test/asm/mtimer*.S are the whole
+    // oracle for them.
+    //-----------------------------------------------------------------------
+
+    // MTIE is the only writable bit. MSIE and MEIE name sources this platform
+    // does not have, and a WARL field with no source behind it reads zero
+    // however it was written -- so writing all ones is the vector that
+    // separates "one writable bit" from "a writable register".
+    poke(12'h304, 32'hffff_ffff);
+    check_read("mie keeps only MTIE", 12'h304, 32'h0000_0080);
+    poke(12'h304, 32'h0000_0000);
+    check_read("...and MTIE clears again", 12'h304, 32'h0);
+
+    // mip is read-only and reports the line. Software lowers MTIP by moving
+    // mtimecmp, which is a store to rtl/timer.v and not a CSR write at all.
+    irq_timer = 1'b1;
+    #1;
+    check_read("mip.MTIP follows the platform line", 12'h344, 32'h0000_0080);
+    poke(12'h344, 32'h0000_0000);
+    check_read("...and a write cannot clear it", 12'h344, 32'h0000_0080);
+
+    // The three-term gate, one term at a time. Each of these has been a real
+    // bug in somebody's core: an interrupt that fires with MIE clear, one that
+    // ignores its enable bit, and one that fires with no source at all.
+    poke(12'h300, 32'h0000_0000);   // mstatus.MIE = 0
+    poke(12'h304, 32'h0000_0080);   // mie.MTIE = 1
+    #1;
+    check_bit("MTIE and a source are not enough with mstatus.MIE clear",
+              interrupt_pending, 1'b0);
+    poke(12'h300, 32'h0000_0008);   // mstatus.MIE = 1
+    poke(12'h304, 32'h0000_0000);   // mie.MTIE = 0
+    #1;
+    check_bit("...nor MIE and a source with MTIE clear", interrupt_pending, 1'b0);
+    poke(12'h304, 32'h0000_0080);
+    irq_timer = 1'b0;
+    #1;
+    check_bit("...nor both enables with no source", interrupt_pending, 1'b0);
+    irq_timer = 1'b1;
+    #1;
+    check_bit("all three together arm it", interrupt_pending, 1'b1);
+
+    // This is what bounds interrupt entry: taking one clears MIE on the same
+    // edge, so the pending bit is already down on the next cycle and nothing
+    // re-arms until `mret`. Delete the `mstatus_mie <= 1'b0` in rtl/csrs.v's
+    // trap block and the core takes an interrupt every cycle forever, with
+    // this vector the only thing that says so.
+    take_trap(32'h8000_0007, 32'h0000_0400);
+    check_bit("entry disarms it, so there is no second entry", interrupt_pending, 1'b0);
+    check_read("...recording the interrupt cause", 12'h342, 32'h8000_0007);
+    check_read("...and mepc, which points AT the un-executed instruction",
+               12'h341, 32'h0000_0400);
+    check_read("...having pushed MIE into MPIE", 12'h300, 32'h0000_1880);
+
+    take_mret();
+    #1;
+    check_bit("mret pops MIE back, so a still-asserting line re-arms",
+              interrupt_pending, 1'b1);
 
     if (errors != 0) begin
       $display("FAILED: %0d mismatches", errors);

--- a/test/decoder_tb.v
+++ b/test/decoder_tb.v
@@ -35,6 +35,9 @@ module decoder_tb;
   logic [31:0] csr_wdata;
   logic [31:0] mtvec = 32'h0000_0100;
   logic [31:0] mepc  = 32'h0000_0244;
+  // rtl/csrs.v has already ANDed the source, mie and mstatus.MIE together, so
+  // driving this directly is driving the whole interrupt decision.
+  logic interrupt_pending = 1'b0;
   logic trap_entry, mret_entry;
   logic [31:0] trap_cause, trap_epc;
 
@@ -55,6 +58,7 @@ module decoder_tb;
     .csr_implemented(csr_implemented),
     .mtvec(mtvec),
     .mepc(mepc),
+    .interrupt_pending(interrupt_pending),
     .pc(pc),
     .next_pc(next_pc),
     .rs1(rs1),
@@ -115,6 +119,11 @@ module decoder_tb;
   // `stall` and not there would leave the cycles it costs unexplained. This says
   // so in a gate that runs on every change, rather than the next time somebody
   // asks for the table.
+  //
+  // `interrupt_pending` is deliberately NOT one of them, and this is what says
+  // so: an interrupt entry happens ON an issuing cycle and costs no stalled
+  // cycle to explain. Put it in `stall` and the pc would hold instead of
+  // vectoring to mtvec, and this check goes red.
   //
   // On both clock edges, not just the rising one. Every vector here presents its
   // instruction just after a rising edge, so the falling edge is where it is
@@ -455,6 +464,113 @@ module decoder_tb;
     #1;
     check_bit("a plain fence does not serialize", dut.serialize, 1'b0);
     executor_out.valid = 1'b0;
+
+    //-----------------------------------------------------------------------
+    // The machine timer interrupt. It is asynchronous and this core commits
+    // every trap in decode, which only works because the interrupt is taken on
+    // a cycle that would otherwise have ISSUED: the instruction it displaces
+    // has not issued, so there is nothing downstream to take back.
+    //-----------------------------------------------------------------------
+
+    in.pc = 32'h0000_0300;
+    present_and_fetch(32'h00100093);   // addi x1, x0, 1 -- a harmless victim
+    check_bit("without an interrupt the instruction just issues", trap_entry, 1'b0);
+
+    interrupt_pending = 1'b1;
+    #1;
+    check_bit("an armed interrupt is taken on an issuing cycle", trap_entry, 1'b1);
+    check_hex("...with cause interrupt/7", trap_cause, 32'h8000_0007);
+    check_hex("...and mepc pointing AT the instruction, not past it",
+              trap_epc, 32'h0000_0300);
+    check_hex("...vectoring to mtvec", next_pc, 32'h0000_0100);
+    check_bit("...counting nothing in minstret", instret, 1'b0);
+    check_bit("...committing no CSR write", csr_wen, 1'b0);
+    check_bit("...and no CSR read", csr_ren, 1'b0);
+    check_bit("...and it is not an mret", mret_entry, 1'b0);
+    check_bit("...and it is not itself a stall", dut.stall, 1'b0);
+    @(posedge clk);
+    #1;
+    check_hex("...so the next fetch is the handler", pc, 32'h0000_0100);
+    check_bit("...and decoder_out is a bubble: the victim never issued",
+              out.valid, 1'b0);
+    interrupt_pending = 1'b0;
+
+    // The other direction. Without this the vectors above pass on a decoder
+    // that traps unconditionally.
+    in.pc = 32'h0000_0400;
+    present_and_fetch(32'h00100093);
+    check_bit("a disarmed interrupt takes nothing", trap_entry, 1'b0);
+    check_hex("...and leaves trap_cause at zero", trap_cause, 32'b0);
+    @(posedge clk);
+    #1;
+    check_bit("...and the instruction issues normally", out.valid, 1'b1);
+
+    // `stall` outranks the trap arm of the next_pc chain, so every reason the
+    // core already has to wait holds the interrupt off too -- no new logic, and
+    // no way for an interrupt to cut into a divide or a serialization.
+    in.pc = 32'h0000_0500;
+    present_and_fetch(32'h00100093);
+    interrupt_pending = 1'b1;
+    divider_stall = 1'b1;
+    #1;
+    check_bit("a divide holds the interrupt off", trap_entry, 1'b0);
+    check_hex("...and the pc with it", next_pc, pc);
+    divider_stall = 1'b0;
+    accessor_stall = 1'b1;
+    #1;
+    check_bit("so does a load turnaround", trap_entry, 1'b0);
+    accessor_stall = 1'b0;
+    fetch_stall = 1'b1;
+    #1;
+    check_bit("so does a stolen fetch window", trap_entry, 1'b0);
+    fetch_stall = 1'b0;
+    #1;
+    check_bit("and the interrupt is taken the moment they clear", trap_entry, 1'b1);
+    @(posedge clk);
+    #1;
+    interrupt_pending = 1'b0;
+
+    // Serialization is the one that matters most: an `mret` interrupted
+    // half-way would pop mstatus and then push it again. It cannot happen,
+    // because `mret` is still waiting for the pipeline to empty and waiting is
+    // a stall.
+    in.pc = 32'h0000_0540;
+    executor_out.valid = 1'b1;
+    executor_out.rd = 5'd0;
+    present_and_fetch(32'h30200073);   // mret
+    interrupt_pending = 1'b1;
+    #1;
+    check_bit("a serializing mret holds the interrupt off", trap_entry, 1'b0);
+    check_bit("...and does not commit either", mret_entry, 1'b0);
+    executor_out.valid = 1'b0;
+    #1;
+    check_bit("once the pipe is empty the interrupt is taken", trap_entry, 1'b1);
+    check_bit("...and the mret it displaced still does not commit", mret_entry, 1'b0);
+    check_hex("...so mepc is the mret's own address, and it runs again",
+              trap_epc, 32'h0000_0540);
+    @(posedge clk);
+    #1;
+    interrupt_pending = 1'b0;
+
+    // An instruction that would fault AND an armed interrupt. The interrupt
+    // wins because the instruction does not execute; it faults instead when it
+    // re-executes after the handler returns.
+    in.pc = 32'h0000_0600;
+    reg_rs1 = 32'h0001_0001;
+    present_and_fetch(32'h00452583);   // the misaligned lw
+    check_hex("on its own it is a load-misaligned fault", trap_cause, 32'd4);
+    interrupt_pending = 1'b1;
+    #1;
+    check_hex("an interrupt outranks the instruction's own fault",
+              trap_cause, 32'h8000_0007);
+    check_bit("...and it is still one trap entry, not two", trap_entry, 1'b1);
+    check_hex("...at the same mepc either way", trap_epc, 32'h0000_0600);
+    @(posedge clk);
+    #1;
+    check_bit("...publishing nothing, where the fault would have retired",
+              out.valid, 1'b0);
+    interrupt_pending = 1'b0;
+    reg_rs1 = 32'b0;
 
     if (errors != 0) begin
       $display("FAILED: %0d mismatches", errors);

--- a/test/probe_gates.sh
+++ b/test/probe_gates.sh
@@ -27,7 +27,7 @@ REPO=$(cd "$HERE/.." && pwd)
 # Pinned as a literal: a probe that is deleted, or that stops being reached by
 # an early `return`, would otherwise cut this file's coverage while it kept
 # printing a green summary.
-PROBES_EXPECTED=152
+PROBES_EXPECTED=155
 
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/littlecpu-probe.XXXXXX") || {
   echo "error: could not create a temporary directory under ${TMPDIR:-/tmp}." >&2

--- a/test/probe_gates.sh
+++ b/test/probe_gates.sh
@@ -27,7 +27,7 @@ REPO=$(cd "$HERE/.." && pwd)
 # Pinned as a literal: a probe that is deleted, or that stops being reached by
 # an early `return`, would otherwise cut this file's coverage while it kept
 # printing a green summary.
-PROBES_EXPECTED=145
+PROBES_EXPECTED=152
 
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/littlecpu-probe.XXXXXX") || {
   echo "error: could not create a temporary directory under ${TMPDIR:-/tmp}." >&2
@@ -1126,6 +1126,77 @@ probe "over budget names the count and the budget" 1 \
 d=$(fr_fixture); sed -i.bak '/ICESTORM_LC:/d' "$d/fit.log"
 probe "no utilisation table is a failure, not a 0% fit" 1 \
   "printed no utilisation table" "$FR $d/fit.log --max-lc 4100"
+
+begin_group "formal/check-interrupt-tie-off.py"
+
+IT="python3 $REPO/formal/check-interrupt-tie-off.py"
+
+# The riscv-formal stand-in carries only what the upstream half reads: two
+# files that mention rvfi_intr and one that does not, so the control is
+# non-empty in both directions.
+it_fixture() {
+  local d; d=$(new_case)
+  mkdir -p "$d/formal" "$d/rf/checks"
+  for f in wrapper.v complete.sv cover.sv dmemcheck.sv imemcheck.sv; do
+    cp "$REPO/formal/$f" "$d/formal/$f"
+  done
+  printf 'wire intr = rvfi_intr[0];\n' > "$d/rf/checks/rvfi_pc_fwd_check.sv"
+  printf 'wire intr = rvfi_intr[0];\n' > "$d/rf/checks/rvfi_insn_check.sv"
+  printf 'assert (rvfi_valid);\n'      > "$d/rf/checks/rvfi_reg_check.sv"
+  {
+    printf 'HARNESS wrapper.v\nHARNESS complete.sv\nHARNESS cover.sv\n'
+    printf 'HARNESS dmemcheck.sv\nHARNESS imemcheck.sv\n'
+    printf 'UPSTREAM checks/rvfi_pc_fwd_check.sv\n'
+    printf 'UPSTREAM checks/rvfi_insn_check.sv\n'
+  } > "$d/BASELINE"
+  printf '%s' "$d"
+}
+
+its() { printf "%s %s/formal %s/BASELINE %s/rf" "$IT" "$1" "$1" "$1"; }
+
+d=$(it_fixture)
+probe "control: the shipping harnesses tie off, both directions" 0 \
+  "INTERRUPT TIE-OFF: PASS" "$(its "$d")"
+
+probe "wrong argument count is exit 2" 2 "check-interrupt-tie-off.py" \
+  "$IT $d/formal"
+
+# The failure that matters most: a harness the baseline claims is tied off and
+# is not. Its checks would be running against a machine with interrupts, at
+# depths derived without them.
+d=$(it_fixture); sed -i.bak "/\.irq_timer(1'b0),/d" "$d/formal/complete.sv"
+probe "a declared harness that does not tie the input off is red" 1 \
+  "does not connect .irq_timer" "$(its "$d")"
+
+d=$(it_fixture); sed -i.bak '/^HARNESS cover.sv$/d' "$d/BASELINE"
+probe "a harness with no line in the baseline is red" 1 \
+  "does not name it" "$(its "$d")"
+
+d=$(it_fixture); rm "$d/formal/cover.sv"
+probe "a line with no harness behind it is red too" 1 \
+  "which does not instantiate littlecpu" "$(its "$d")"
+
+# The re-derivation from the pin, in both directions. This is what a baseline
+# alone cannot do: a stale tie-off covers less and less while staying green.
+d=$(it_fixture); printf 'if (!rvfi_intr[0]) assert(0);\n' > "$d/rf/checks/rvfi_unique_check.sv"
+probe "a pin that makes another check read rvfi_intr is red" 1 \
+  "may now have something to say" "$(its "$d")"
+
+d=$(it_fixture); printf 'nothing to see here\n' > "$d/rf/checks/rvfi_insn_check.sv"
+probe "a baselined upstream file that stopped mentioning it is red" 1 \
+  "was not re-derived" "$(its "$d")"
+
+d=$(it_fixture); printf 'assert (csr_mstatus_wdata == 0);\n' >> "$d/rf/checks/rvfi_reg_check.sv"
+probe "a pin that models an interrupt CSR makes the tie-off an argument again" 1 \
+  "now has a model of interrupt state" "$(its "$d")"
+
+d=$(it_fixture); printf 'HARNESS\n' >> "$d/BASELINE"
+probe "a malformed baseline line is named rather than skipped" 1 \
+  "expected \`HARNESS <path>\`" "$(its "$d")"
+
+d=$(it_fixture); rm -rf "$d/rf/checks"
+probe "an unreadable clone makes the re-derivation impossible, and fatal" 1 \
+  "is not a directory" "$(its "$d")"
 
 echo
 if [ "$probes" -ne "$PROBES_EXPECTED" ]; then

--- a/test/testbench.v
+++ b/test/testbench.v
@@ -23,10 +23,12 @@ module testbench(
   logic        mem_ren;
   logic [31:0] mem_rdata;
   logic        fetch_stall;
-  // Both memories answer zero outside their own range, so the buses join with
-  // an OR. Same wiring as rtl/littlesoc.v, so the legs cannot drift apart.
-  logic [31:0] imem_mem_rdata, dmem_mem_rdata;
-  assign mem_rdata = imem_mem_rdata | dmem_mem_rdata;
+  logic        irq_timer;
+  // All three memories answer zero outside their own range, so the buses join
+  // with an OR. Same wiring, same timer base as rtl/littlesoc.v, so the legs
+  // cannot drift apart and a `.S` program that arms the timer runs on both.
+  logic [31:0] imem_mem_rdata, dmem_mem_rdata, timer_mem_rdata;
+  assign mem_rdata = imem_mem_rdata | dmem_mem_rdata | timer_mem_rdata;
   logic        trap;
  `ifdef RISCV_FORMAL
   logic        rvfi_valid;
@@ -79,6 +81,16 @@ module testbench(
     .fetch_stall(fetch_stall)
   );
 
+  timer #(.BASE(32'h0002_0000)) mtimer (
+    .clk(clk),
+    .reset(reset),
+    .mem_addr(mem_addr),
+    .mem_wdata(mem_wdata),
+    .mem_wstrb(mem_wstrb),
+    .mem_rdata(timer_mem_rdata),
+    .mtip(irq_timer)
+  );
+
   littlecpu uut (
     .clk(clk),
     .reset(reset),
@@ -93,6 +105,7 @@ module testbench(
     .mem_ren(mem_ren),
     .mem_rdata(mem_rdata),
     .fetch_stall(fetch_stall),
+    .irq_timer(irq_timer),
     .trap(trap)
    `ifdef RISCV_FORMAL
     , .rvfi_valid(rvfi_valid),

--- a/test/timer_tb.v
+++ b/test/timer_tb.v
@@ -1,0 +1,312 @@
+`timescale 1 ns / 1 ps
+`default_nettype none
+
+// rtl/timer.v's bus port, driven directly.
+//
+// Nothing else checks this module. It is outside the core, so `make fit` does
+// not see it and no riscv-formal check instantiates it -- the generated checks
+// tie the core's `irq_timer` off. The `.S` programs exercise it through real
+// loads and stores, but only along the paths a working program takes; the
+// awkward cases are here: an out-of-range access, a byte-granular write, a
+// write racing the free-running increment, and the torn 64-bit `mtimecmp`
+// update, which is the one sequence software has to get right and the one this
+// module has to make safe.
+module timer_tb;
+  logic clk = 0;
+  always #5 clk = ~clk;
+
+  logic reset;
+  logic [31:0] mem_addr, mem_wdata;
+  logic [3:0]  mem_wstrb;
+  logic [31:0] mem_rdata;
+  logic        mtip;
+
+  localparam logic [31:0] BASE = 32'h0002_0000;
+  localparam logic [31:0] MTIME_LO    = BASE + 32'd0;
+  localparam logic [31:0] MTIME_HI    = BASE + 32'd4;
+  localparam logic [31:0] MTIMECMP_LO = BASE + 32'd8;
+  localparam logic [31:0] MTIMECMP_HI = BASE + 32'd12;
+
+  timer #(.BASE(BASE)) dut (
+    .clk(clk),
+    .reset(reset),
+    .mem_addr(mem_addr),
+    .mem_wdata(mem_wdata),
+    .mem_wstrb(mem_wstrb),
+    .mem_rdata(mem_rdata),
+    .mtip(mtip)
+  );
+
+  int errors = 0;
+
+  task automatic check_hex(input string what, input logic [31:0] got, input logic [31:0] expected);
+    begin
+      if (got !== expected) begin
+        $display("MISMATCH %s: got=%08x expected=%08x", what, got, expected);
+        errors++;
+      end
+    end
+  endtask
+
+  task automatic check_bit(input string what, input logic got, input logic expected);
+    begin
+      if (got !== expected) begin
+        $display("MISMATCH %s: got=%b expected=%b", what, got, expected);
+        errors++;
+      end
+    end
+  endtask
+
+  // The bus is idle unless a task is driving it, so nothing here accidentally
+  // holds a write strobe over an edge it did not mean to.
+  task automatic idle();
+    begin
+      mem_addr  = 32'h0;
+      mem_wstrb = 4'b0000;
+      mem_wdata = 32'h0;
+      @(posedge clk);
+      #1;
+    end
+  endtask
+
+  task automatic store(input logic [31:0] a, input logic [31:0] d, input logic [3:0] strb);
+    begin
+      mem_addr  = a;
+      mem_wdata = d;
+      mem_wstrb = strb;
+      @(posedge clk);
+      #1;
+      mem_wstrb = 4'b0000;
+    end
+  endtask
+
+  // The read port is registered, so the answer belongs to the address that was
+  // presented across the previous edge -- the same one-cycle turnaround
+  // rtl/accessor.v gives every load.
+  task automatic load(input logic [31:0] a);
+    begin
+      mem_addr  = a;
+      mem_wstrb = 4'b0000;
+      @(posedge clk);
+      #1;
+    end
+  endtask
+
+  logic [31:0] first_read;
+
+  initial begin
+    reset     = 1'b1;
+    mem_addr  = 32'h0;
+    mem_wdata = 32'h0;
+    mem_wstrb = 4'b0000;
+    repeat (2) @(posedge clk);
+    #1;
+    reset = 1'b0;
+
+    // Every register here resets to zero, so mtime >= mtimecmp holds from the
+    // first cycle and mtip is asserted out of reset. Nothing is taken, because
+    // mstatus.MIE and mie.MTIE reset to zero too; software sets mtimecmp before
+    // it enables either. Asserted rather than left implicit, because it is the
+    // one thing about this module a reader would guess wrong.
+    load(MTIMECMP_LO);
+    check_hex("mtimecmp resets to zero (low)", mem_rdata, 32'h0);
+    load(MTIMECMP_HI);
+    check_hex("...and high", mem_rdata, 32'h0);
+    check_bit("...so mtip is asserted out of reset, which the enables make harmless",
+              mtip, 1'b1);
+
+    load(MTIME_HI);
+    check_hex("mtimeh starts at zero", mem_rdata, 32'h0);
+
+    // Disarming is a store, and it is what a boot path does before enabling
+    // anything.
+    store(MTIMECMP_HI, 32'hffff_ffff, 4'b1111);
+    store(MTIMECMP_LO, 32'hffff_ffff, 4'b1111);
+    idle();
+    check_bit("moving mtimecmp out of reach disarms it", mtip, 1'b0);
+
+    load(MTIME_LO);
+    first_read = mem_rdata;
+    load(MTIME_LO);
+    check_hex("mtime advances one per cycle", mem_rdata, first_read + 32'd1);
+
+    // Out of range in both directions, and the word just past the end, which is
+    // the one an index built from truncated address bits would alias onto
+    // mtime.
+    load(BASE - 32'd4);
+    check_hex("below the range reads zero", mem_rdata, 32'h0);
+    load(BASE + 32'd16);
+    check_hex("just past the range reads zero, not mtime", mem_rdata, 32'h0);
+    load(32'h0001_0000);
+    check_hex("the data RAM's base reads zero here", mem_rdata, 32'h0);
+
+    // A store outside the range must not land either.
+    store(BASE + 32'd16, 32'hdead_beef, 4'b1111);
+    load(MTIME_HI);
+    check_hex("an out-of-range store lands nowhere", mem_rdata, 32'h0);
+
+    //-----------------------------------------------------------------------
+    // mtip is `mtime >= mtimecmp`, a level rather than a pulse. Both sides come
+    // out of flip-flops, so every check below spends one idle cycle first --
+    // the write lands on one edge and the comparison of what landed on the
+    // next.
+    //-----------------------------------------------------------------------
+
+    store(MTIMECMP_HI, 32'h0000_0000, 4'b1111);
+    store(MTIMECMP_LO, 32'h0000_0200, 4'b1111);
+    store(MTIME_HI, 32'h0000_0000, 4'b1111);
+    // One short, with the increment suppressed by this very write, so the next
+    // cycle lands mtime exactly ON mtimecmp.
+    store(MTIME_LO, 32'h0000_01ff, 4'b1111);
+    check_bit("mtime below mtimecmp raises nothing", mtip, 1'b0);
+    idle();
+    check_bit("mtime EQUAL to mtimecmp is pending -- the compare is >=, not >",
+              mtip, 1'b1);
+
+    idle();
+    check_bit("...and it stays high, because it is a level and not a pulse",
+              mtip, 1'b1);
+    idle();
+    check_bit("...still", mtip, 1'b1);
+
+    // The only way software lowers it.
+    store(MTIMECMP_LO, 32'hffff_ffff, 4'b1111);
+    idle();
+    check_bit("moving mtimecmp forward is what clears it", mtip, 1'b0);
+
+    // mtime = 0x1_0000_0000 against mtimecmp = 0x0_ffff_ffff. Pending over 64
+    // bits; a comparison that looked at the low halves alone would read
+    // 0x0000_0000 >= 0xffff_ffff and say no.
+    store(MTIME_HI, 32'h0000_0001, 4'b1111);
+    store(MTIME_LO, 32'h0000_0000, 4'b1111);
+    idle();
+    check_bit("the compare is over all 64 bits, not the low half", mtip, 1'b1);
+
+    //-----------------------------------------------------------------------
+    // The torn 64-bit write, and the red direction that makes it a check.
+    //
+    // A 32-bit store touches one half, so an update to mtimecmp is a sequence.
+    // The privileged spec's own sample code for RV32 writes the LOW half all
+    // ones, then the high half, then the low half -- every intermediate is then
+    // at least as large as the smaller of the old and new values, so nothing
+    // fires on the way through.
+    //
+    // The vectors below use a case where the naive order is genuinely unsafe:
+    // mtime = 0x1_0000_0050, mtimecmp = {2, 0x10}, target {1, 0xffff_fff0}.
+    // Writing the high half first passes through {1, 0x10}, which mtime is
+    // past.
+    //-----------------------------------------------------------------------
+
+    store(MTIMECMP_HI, 32'h0000_0002, 4'b1111);
+    store(MTIMECMP_LO, 32'h0000_0010, 4'b1111);
+    store(MTIME_HI, 32'h0000_0001, 4'b1111);
+    store(MTIME_LO, 32'h0000_0050, 4'b1111);
+    idle();
+    check_bit("mtime under mtimecmp over 64 bits raises nothing", mtip, 1'b0);
+
+    // The wrong way, on purpose. A sequence whose failure path has never run is
+    // not a check, and this is that failure path.
+    store(MTIMECMP_HI, 32'h0000_0001, 4'b1111);
+    idle();
+    check_bit("high half first passes through a reachable pair, and it FIRES",
+              mtip, 1'b1);
+    store(MTIMECMP_LO, 32'hffff_fff0, 4'b1111);
+    idle();
+    // The end state is safe, which is what makes the transient the only thing
+    // that was wrong.
+    check_bit("...even though the end state it reaches is out of reach again",
+              mtip, 1'b0);
+
+    // The spec's way, over the same values.
+    store(MTIMECMP_HI, 32'h0000_0002, 4'b1111);
+    store(MTIMECMP_LO, 32'h0000_0010, 4'b1111);
+    store(MTIME_HI, 32'h0000_0001, 4'b1111);
+    store(MTIME_LO, 32'h0000_0050, 4'b1111);
+    idle();
+    check_bit("back to the starting point", mtip, 1'b0);
+
+    store(MTIMECMP_LO, 32'hffff_ffff, 4'b1111);
+    idle();
+    check_bit("step 1: the low half all ones, no smaller than the old value",
+              mtip, 1'b0);
+    store(MTIMECMP_HI, 32'h0000_0001, 4'b1111);
+    idle();
+    check_bit("step 2: the new high half, no smaller than the new value",
+              mtip, 1'b0);
+    store(MTIMECMP_LO, 32'hffff_fff0, 4'b1111);
+    idle();
+    check_bit("step 3: the new low half, and nothing fired on the way",
+              mtip, 1'b0);
+
+    //-----------------------------------------------------------------------
+    // mtime wraps on overflow, which the spec states normatively rather than
+    // leaving undefined.
+    //-----------------------------------------------------------------------
+
+    store(MTIME_HI, 32'hffff_ffff, 4'b1111);
+    store(MTIME_LO, 32'hffff_ffff, 4'b1111);
+    idle();
+    load(MTIME_LO);
+    check_hex("mtime wraps past all ones rather than saturating there",
+              mem_rdata, 32'h0000_0000);
+    load(MTIME_HI);
+    check_hex("...both halves, so it is one 64-bit counter", mem_rdata, 32'h0000_0000);
+
+    //-----------------------------------------------------------------------
+    // Byte strobes. `sb` to one byte of mtimecmp must not disturb the other
+    // three, or the sequence above stops being safe.
+    //-----------------------------------------------------------------------
+
+    store(MTIMECMP_LO, 32'h1122_3344, 4'b1111);
+    store(MTIMECMP_LO, 32'h0000_00ff, 4'b0001);
+    load(MTIMECMP_LO);
+    check_hex("a byte store writes one byte", mem_rdata, 32'h1122_33ff);
+    store(MTIMECMP_LO, 32'hee00_0000, 4'b1000);
+    load(MTIMECMP_LO);
+    check_hex("...at the top too", mem_rdata, 32'hee22_33ff);
+    store(MTIMECMP_HI, 32'h0000_5566, 4'b0011);
+    load(MTIMECMP_HI);
+    check_hex("...and into the high word", mem_rdata, 32'h0000_5566);
+
+    //-----------------------------------------------------------------------
+    // A write to either half of mtime beats that cycle's increment, for the
+    // whole 64-bit register. Suppressing per half instead differs only at the
+    // carry boundary, where the carry would land in the high half while the
+    // write replaced the low one -- so a `sw` of zero to mtime would advance
+    // mtimeh. Nothing else in the tree reaches that cycle.
+    //-----------------------------------------------------------------------
+
+    store(MTIME_HI, 32'h0000_0000, 4'b1111);
+    store(MTIME_LO, 32'h0000_0040, 4'b1111);
+    load(MTIME_LO);
+    check_hex("a write to mtime beats that cycle's increment", mem_rdata, 32'h0000_0040);
+
+    // Every `load` costs a cycle, and mtime is running, so the expectations
+    // below count them: the read port answers with the value the counter held
+    // during the cycle the address was presented.
+    store(MTIME_LO, 32'hffff_ffff, 4'b1111);
+    idle();
+    load(MTIME_LO);
+    check_hex("mtime wraps its low half", mem_rdata, 32'h0000_0000);
+    load(MTIME_HI);
+    check_hex("...and the carry reaches mtimeh", mem_rdata, 32'h0000_0001);
+
+    store(MTIME_HI, 32'h0000_0000, 4'b1111);
+    store(MTIME_LO, 32'hffff_ffff, 4'b1111);
+    store(MTIME_LO, 32'h0000_0000, 4'b1111);
+    load(MTIME_HI);
+    check_hex("a write at the carry boundary discards the carry too", mem_rdata, 32'h0000_0000);
+    load(MTIME_LO);
+    // Plus the one cycle the mtimeh read above took.
+    check_hex("...and the low half restarts from what was written",
+              mem_rdata, 32'h0000_0001);
+
+    if (errors != 0) begin
+      $display("FAILED: %0d mismatches", errors);
+      $fatal(1);
+    end else begin
+      $display("PASSED: machine timer (map, level compare, torn write, byte strobes, counter)");
+      $finish;
+    end
+  end
+endmodule


### PR DESCRIPTION
Closes JEF-777.

`mie` and `mip` were read-only zero — not "interrupts disabled" but **absent**, so this core could only ever run one polled loop. This adds the machine timer interrupt.

## The premise held, and it is what makes this cheap

`rtl/decoder.v`'s `next_pc` chain is `reset > stall > trap > mret > jalr > jal > branch > sequential`, and `trap_entry` is `issuing && trap`. Verified before writing anything: nothing else consumes `trap_pending` in a way that breaks the argument.

So an interrupt ORed into the trap arm as a **registered** level is taken only on a cycle that would otherwise have issued. The instruction it displaces has not issued — `mepc` is its own address and it re-executes after `mret`. **No wrong-path state; nothing is un-committed.** And because `stall` outranks the trap arm, the interrupt waits out a divide, a load turnaround, a hazard, the operand-fetch cycle, a stolen fetch window and a serialization with no logic of its own.

One place it is not simply "the trap arm with another input": an exception rides out on its own instruction (`out.valid` high, flags cleared), an interrupt takes the **bubble** arm because its instruction did not issue. `issuing` now guards the last two arms of the publish block rather than the last one.

## Scope

`mtime`/`mtimecmp` as four words at `0x0002_0000` in `rtl/timer.v`, wired identically into `rtl/littlesoc.v` and `test/testbench.v`. `mie.MTIE` writable; `mip.MTIP` the platform line; `mcause = 0x8000_0007`. `mip.MSIP`/`MEIP` stay read-only zero — conformant WARL with neither source present. No controller, no vectored `mtvec`.

## Measurements

| | |
|---|---|
| **worst-case latency** | **33 cycles = 2.75 µs @ 12 MHz** — swept the arming delay 1→80 against divides/loads/CSR reads/`fence.i`, reading `interrupt_pending` and `trap_entry` out of the elaborated design each cycle. Flat 0–33, max exactly 33 = the 32-cycle divide plus the operand-fetch cycle. (Ticket expected ~40.) |
| **`make soc-timing`, 4 seeds** | 75.36 / 78.22 / 79.02 / 79.26 ns → **worst 12.62 MHz against the 12.0 MHz requirement.** Holds at every placement. |
| **`make fit`** | 3974 cells vs **3880 for `origin/main` on the same local toolchain** = +94, outside the ±50 band. Ratchet 4100 holds. Split measured by tying the decoder's input off: **the decode-side interrupt path is 23 cells**; the rest is `mie`/`mip` becoming live in a 20-entry CSR read mux. |
| **`make cycles`** | **no seventh stall reason.** `unattributed` = 0 suite-wide; the six-reason identity in `test/decoder_tb.v` is unchanged, and asserts the interrupt is *not* in `stall`. |

## The proof

riscv-formal ships **no model of an interrupt** at the pin: it carries `rvfi_intr`, four checks read it, and all they do is *suppress* pc-continuity. No `rvfi_*_check.sv` names `mie`, `mip` or `mstatus`.

- **Tied off in all five harnesses**, declared in `formal/INTERRUPT_TIE_OFF` and enforced by `formal/check-interrupt-tie-off.py`: harness set both ways, a required `.irq_timer(1'b0)` on each, upstream `rvfi_intr` file set both ways, and a re-derivation that no check models an interrupt CSR. A prerequisite of `make -C formal check`; **10 new probes in `test/probe_gates.sh`** force every failure path (142 → 152).
- **F and G re-measured under the tie-off, and the flip points reproduce exactly** — `hang` red at 6 / PASS at 7, `liveness` red at gap 5 / PASS at gap 6 at trig 10 *and* trig 15. So F=6, G=6, **no `[depth]` line moves**.
- **`components_traps` 25 → 34 assertions**, counted off `model/design_smt2.smt2` — the model the proof ran on — not inferred from the word PASS. PASS by k-induction. It says: entry commits nothing (`!instret && !csr_wen && !csr_ren && !mret_entry`, and `!decoder_out.valid` the cycle after); `mepc` is the un-issued pc and `mcause` is interrupt/7; no arming without each of the three enable terms read the way software reads them; and entry disarms, so there is no second one.

**One deviation, stated rather than papered over.** A literal "irq held ⇒ entry within N" is *not* proved. In `formal/traps.sv` the three stall inputs and `executor_out` are free, so an environment holding any of them starves any bound; stating it would have meant four new assumptions to discharge. The bound is instead a composition — *entry disarms until `mret`* (proved here) + *armed and unstalled ⇒ entry this cycle* (proved in `components_decoder`) — plus the measured 33.

**All gates green:** 85/85 generated checks with both set equalities both ways; `complete`, `complete_cover`, `dmemcheck`, `imemcheck`, `nonperturbation`, all four component proofs; `make test` 61/61; `test-units` 8/8; `probe-gates` 152/152; `monitor-check`; `waves`; svlint clean both passes.

## Three corrections from reading the privileged spec directly

1. **The brief's `mtimecmp` write order was backwards, and I had built it.** The spec's own RV32 sample is **low all-ones → high → low**, not high-first. Mine parked the *high* half, which only works because `mtime` is small; the spec's order is safe unconditionally. Fixed in `RVTEST_ARM_TIMER`, the handlers and both benches — and **both `test/timer_tb.v` and `test/asm/mtimer.S` now fire a spurious interrupt the naive way on purpose** before doing it correctly over the same values, because a sequence whose failure path has never run is not a check.
2. **MTIP is a level.** Posted until `mtimecmp > mtime`; taking the trap does not clear it. `mtimer.S` now takes **three entries from one arming** through a sticky handler with a limit in RAM. This is the easiest thing here to get wrong and nothing else caught it.
3. **`mtime` ticks once per clock cycle = 83.33 ns @ 12 MHz**, written down in `rtl/timer.v` and `CLAUDE.md` because the spec requires the platform to publish the period and firmware cannot derive it. Also added: 64-bit wrap, asserted since the spec makes it normative rather than undefined.

## Sail co-simulation: the spec permits both machines

`mtimer.S`/`mtimermask.S` baselined `INCONCLUSIVE SAIL-LIMIT`, with the reasoning at the entry. **This is not work left undone.** Everything that differs is platform-defined: the address map; the tick period (required only to be *constant* and published — this ticks per cycle, the model per two instructions, `instructions_per_tick: 2`); and how promptly MTIP follows the comparison ("eventually, but not necessarily immediately", with the spec itself warning software about the resulting spurious interrupt).

A `NONCOMPARABLE_CSRS`-style value exemption was considered first and **cannot** close it, for a structural reason: with different tick periods the interrupt lands between a *different pair of instructions*, so what differs is the **position** of the change in the sequence — exactly what that mechanism goes on comparing. Configuration does not reach it either: `platform.clint` has only `base`/`size`/`supported`.

## Notes

- `rvfi_intr` is now **driven** and is not optional: both sim legs' monitor checks pc continuity and stops only for a retire carrying it, so an undriven bit makes every interrupt a monitor error.
- `mtimecmp` **resets to zero**, so `mtip` is asserted out of reset — harmless because both enables also reset to zero. Forced, too: the cxxrtl runner deasserts reset before the first rising edge, so a non-zero reset value would be invisible on the primary simulator and present on the board.
- **ADR-0082**, confirmed free by `git ls-tree origin/main docs/adr/` (main holds 0080) and `gh pr list` (#138 holds 0081), not by taking the reserved number on trust.
- Rebased onto `31c4fff` (ADR-0080 / #137). **Expect a conflict with #138** in `test/OBSERVED_FLOOR` (two added lines), `CLAUDE.md` and `docs/adr/README.md`; happy to rebase again after it merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
