### PR TITLE
The memory map has one source, and every restatement is checked (JEF-788)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -399,8 +399,17 @@ pin-bump-test:
 tool-cache-test:
 	@./test/tool_cache_test.sh '$(SAIL_RISCV_DIR)' '$(SVLINT_DIR)'
 
+# Compares every file that describes the memory map against the RTL that
+# implements it. Hangs off `test` like the other bash checks -- grep and sed, no
+# cross compiler, no simulator, no yosys -- and it has to run BEFORE the suite is
+# graded, because what it catches is the suite grading a machine that is not the
+# one that places on the part.
+.PHONY: memmap-test
+memmap-test:
+	@./test/memmap_test.sh
+
 .PHONY: test
-test: sim test-units probe-gates pin-bump-test tool-cache-test
+test: sim test-units probe-gates pin-bump-test tool-cache-test memmap-test
 	@./test/run_tests.sh ./sim test/asm test/EXPECTED_FAIL test/OBSERVED_FLOOR
 
 # The same suite `make test` runs, with the runner charging every cycle to the
@@ -490,6 +499,10 @@ fit: fit.json
 # shape this board can boot a program with globals from, so it is the default:
 # an image shape nothing builds is one nobody notices breaking.
 SOC_PROG      ?= datainit.c
+# soc/rom_banks.py rejects an image that overruns the ROM, so this has to be
+# rtl/littlesoc.v's `ROM_WORDS` and not merely near it: too small rejects a
+# program that fits, too large splits one that does not into banks the
+# bitstream then truncates. test/memmap_test.sh compares them.
 SOC_ROM_WORDS := 2048
 # Exact rather than budgeted the way FIT_MAX_LC is, because both are properties
 # of the RTL rather than of placement: 2 SPRAM for the 64 KB data RAM, and 16

--- a/docs/adr/0085-the-memory-map-has-one-source-and-every-restatement-is-checked.md
+++ b/docs/adr/0085-the-memory-map-has-one-source-and-every-restatement-is-checked.md
@@ -1,0 +1,129 @@
+# ADR-0085: The memory map has one source, and every restatement is checked
+
+**Status:** Accepted · 2026-08-08 · *Closes the defect class
+[ADR-0084](0084-dhrystone-is-the-comparable-number-and-the-raw-share-does-not-transfer.md) found in
+`test/testbench.v` and
+[ADR-0081](0081-the-data-image-lives-in-rom-and-crt0-copies-it.md) found in `test/OBSERVED_FLOOR`.
+No `rtl/` behaviour changes: the parameters removed from `rtl/littlesoc.v` resolved to the values
+they still resolve to, and `make soc-timing`'s SPRAM and block-RAM census is the evidence.*
+
+## Context
+
+`test/testbench.v` is what every program in `test/asm` runs against. `rtl/littlesoc.v` is what
+places on the part. Where the two describe the same thing differently, **the suite is grading a
+machine that does not exist**, and nothing compared them.
+
+That is not hypothetical. It bit three times in one day:
+
+- **The data RAM.** The harness modelled 1024 words (4 KB) against the SoC's 16384 (64 KB) —
+  sixteen times smaller. It was invisible for the project's whole life because every `.S` program
+  fits under 4 KB, and it surfaced only when Dhrystone needed more.
+- **`test/OBSERVED_FLOOR`** had no notion of C programs, so the first one went red on CI for a
+  reason unrelated to the defect the floor exists to catch.
+- **`.github/workflows/ci.yml`** carried a hand-copied RTL file list claiming it "cannot diverge".
+  It had.
+
+One shape each time: **a second description of the design, maintained by hand, with nothing
+checking it against the first.** A comment asking two files to agree is the weakest instrument
+available, and it is exactly what produced all three.
+
+## What the audit found
+
+Every place the two files describe the same thing, and every third-party copy of the same map:
+
+| # | Fact | What was found | Class |
+|---|---|---|---|
+| 1 | RAM base `0x0001_0000` | Agreed, stated twice | Should be impossible |
+| 2 | RAM size 16384 words | Agreed, stated twice — **this is the axis that already failed** | Should be impossible |
+| 3 | Timer base `0x0002_0000` | Agreed, stated twice | Should be impossible |
+| 4 | ROM size | 2048 on the part, 4096 simulated | Deliberate |
+| 5 | `ram` in `sections.lds` / `boot.lds` | **4 KB, against both machines' 64 KB** | Defect |
+| 6 | `rom` in the three linker scripts | Matched by hand | Needs a check |
+| 7 | `kRamBase` in `cxxrtl.cc` / `cosim.cc` | Agreed, C++ cannot read a parameter | Needs a check |
+| 8 | `MTIMER_BASE` in `riscv_test.h` | Agreed, assembly cannot read a parameter | Needs a check |
+| 9 | `SOC_ROM_WORDS` in the Makefile | Agreed, hand-copied from `rtl/littlesoc.v` | Needs a check |
+| 10 | RAM top against timer base | Abut, by two comments that had to agree | Needs a check |
+| 11 | Reset: POR counter vs. driven input | Real, and correct | Deliberate |
+| 12 | LEDs, `btn_n`, the image loader | Present in one, absent in the other | Deliberate |
+| 13 | `TEXT_BYTES` in `formal/arbiter.v` | Says outright that the size does not matter | Deliberate |
+
+Item 5 is the finding worth naming. **It is the same defect ADR-0084 fixed, one file over.** The
+harness's 4 KB was corrected and the linker scripts' 4 KB was left, so the suite went on linking
+every program against a RAM sixteen times smaller than either machine — and `sections.lds`'s
+comment still claimed the harness was "sized to match". `test/bench/bench.lds`, written later,
+already said 64 KB and Dhrystone already ran with its stack top at the top of it, which is what
+shows the number was stale rather than a budget.
+
+## Decision
+
+**Order of preference: share a source, then check, then comment.**
+
+### 1. The shared numbers are shared, not stated twice
+
+`rtl/memory.v` already carried the base and the size as its parameter defaults, and `rtl/timer.v`
+already carried its base. `rtl/littlesoc.v` and `test/testbench.v` were both merely *re-stating*
+those defaults. **Both files now instantiate `memory` and `timer` with no parameter overrides at
+all**, so there is exactly one statement of each number — in the module that implements it — and
+the two integrators have nothing left to disagree about.
+
+This costs no new file, no include-path plumbing and no macro: it is a deletion. A shared header
+was considered and rejected as strictly worse, because it would have been a *fourth* copy sitting
+alongside the module defaults rather than replacing them, and because yosys resolves `` `include ``
+relative to the including file while iverilog is configured with `-I./rtl/`, so the two frontends
+need different spellings of the same path.
+
+The ROM stays written down in both files, because it is the one size that deliberately differs:
+simulation has no block RAM to run out of, and `test/asm/rvc.S`'s page-boundary-straddle case pads
+past 8 KB on purpose. It is now the **only** parameter override in either file, which is what makes
+the deliberate difference the visible one.
+
+### 2. The linker scripts describe the machine
+
+`sections.lds` and `boot.lds` give `ram` 64 KB, which is what both machines have. The only
+behavioural consequence is that `boot.lds`'s `__stack_top` — `ORIGIN(ram) + LENGTH(ram)` — moves
+from `0x0001_1000` to `0x0002_0000`, the same value `bench.lds` has always given Dhrystone. Retire
+counts are unchanged across the suite.
+
+### 3. Everything that cannot share a parameter is compared
+
+`test/memmap_test.sh` reads `rtl/memory.v` and `rtl/timer.v` as the source and fails when any
+restatement disagrees. It runs from `make test`, needs only grep and sed, and covers items 5–10
+above plus the two properties that keep the sharing honest:
+
+- **neither integrator overrides `memory` or `timer`** — an override reappearing is the whole
+  defect coming back;
+- **neither integrator has *stopped* instantiating them** — otherwise the first check passes by
+  silence.
+
+It also asserts the simulated ROM is never *smaller* than the part's, which is the direction of
+item 4 that would be a defect rather than a convenience.
+
+Seventeen probes in `test/probe_gates.sh` force each comparison red, including the original
+defect re-entered as `memory #(.RAM_WORDS(1024))`. The fixture is a copy of the shipping files
+rather than a stub tree, so the control is the real repository and every red probe is one edit away
+from it.
+
+## Consequences
+
+- A future change to the data RAM's size or base is made in `rtl/memory.v` and is inherited by the
+  simulated machine with nothing to keep in step. The same for the timer's base in `rtl/timer.v`.
+- Changing the ROM size on the part is still a change in three files — `rtl/littlesoc.v`, the
+  Makefile's `SOC_ROM_WORDS` and `test/bench/bench.lds` — but the check now names all three the
+  moment they disagree, instead of `soc/rom_banks.py` rejecting a program that fits.
+- What this does **not** cover: `test/mem_tb.v`, `test/imem_tb.v` and `test/monitor_tb.v` pick
+  small sizes of their own on purpose, because a unit bench that walked a 16384-word array would
+  spend the suite's whole runtime proving the same boundary. They are benches of the modules, not
+  descriptions of the platform, and are deliberately outside the comparison.
+- The reset difference (item 11) is not closed and should not be: the SoC has to make its own reset
+  because the FPGA comes out of configuration without one, and the harness is driven by its runner.
+  It is already load-bearing elsewhere — every reset value in `rtl/timer.v` is zero partly because
+  the cxxrtl runner never clocks an edge under reset, so a non-zero one would be invisible on the
+  primary simulator and present on the board.
+
+### Rejected: generate the linker scripts from the RTL
+
+It would close items 5 and 6 by construction rather than by comparison, and it is the right answer
+if the map ever grows a third region. Today it buys one file's worth of agreement for a code
+generator, a build step and a generated-but-tracked artifact of exactly the kind
+`test/monitor.v` already shows to be a standing cost. The comparison is a tenth of the machinery
+and fails just as loudly.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -86,6 +86,7 @@ and what it costs. Reversing one is fine — write a new ADR that supersedes it.
 | [0082](0082-the-machine-timer-interrupt-is-taken-at-a-decode-boundary.md) | The machine timer interrupt is taken at a decode boundary | Accepted · amends `CLAUDE.md`'s "no interrupts"; restricts the generated checks per 0010 and mechanises it per 0014; defers co-simulation per 0032 |
 | [0083](0083-the-forwarding-network-is-priced-and-declined-on-the-margin.md) | The forwarding network is priced, and declined on the margin | Accepted · prices 0004's stall-only interlock; replaces 0042's 44/52 as the evidence `CLAUDE.md` cites; graded against 0066 by 0076's ceiling method; its 29.3% qualified by 0084 |
 | [0084](0084-dhrystone-is-the-comparable-number-and-the-raw-share-does-not-transfer.md) | Dhrystone is the number this core can be quoted by, and the suite's RAW share does not transfer | Accepted · runs on 0081's `.data` image; re-reads 0070's accounting on compiled code and qualifies 0083's 29.3%; enlarges 0074's prize without reopening it |
+| [0085](0085-the-memory-map-has-one-source-and-every-restatement-is-checked.md) | The memory map has one source, and every restatement is checked | Accepted · closes the defect class 0084 and 0081 each found once; makes 0008's map a shared default rather than two copies; leaves 0054's ROM ceiling and 0044's boot path where they are |
 
 0001–0007 came from the design brief
 ([`docs/ideas/finish-the-rewrite.md`](../ideas/finish-the-rewrite.md)). 0008–0011 came out of

--- a/rtl/littlesoc.v
+++ b/rtl/littlesoc.v
@@ -88,8 +88,12 @@ module littlesoc (
     .fetch_stall(fetch_stall)
   );
 
-  // 16384 words = 64 KB = two `SB_SPRAM256KA` of the part's four.
-  memory #(.BASE(32'h0001_0000), .RAM_WORDS(16384)) dmem (
+  // Base and size are rtl/memory.v's own defaults -- 64 KB at 0x0001_0000, two
+  // `SB_SPRAM256KA` of the part's four -- and test/testbench.v takes the same
+  // ones rather than restating them, so the simulated machine and this one
+  // cannot describe different memories. `make soc-timing`'s SPRAM census is the
+  // second half of that: the count only comes out at 2 for this size.
+  memory dmem (
     .clk(clk),
     .mem_addr(mem_addr),
     .mem_wdata(mem_wdata),
@@ -97,10 +101,10 @@ module littlesoc (
     .mem_rdata(dmem_mem_rdata)
   );
 
-  // The machine timer, just above the data RAM. This is the only interrupt
-  // source on this platform, so `mip.MSIP` and `mip.MEIP` stay read-only zero
-  // in rtl/csrs.v.
-  timer #(.BASE(32'h0002_0000)) mtimer (
+  // The machine timer, at rtl/timer.v's default base, which is the first word
+  // past the data RAM above. This is the only interrupt source on this
+  // platform, so `mip.MSIP` and `mip.MEIP` stay read-only zero in rtl/csrs.v.
+  timer mtimer (
     .clk(clk),
     .reset(reset),
     .mem_addr(mem_addr),

--- a/test/asm/boot.lds
+++ b/test/asm/boot.lds
@@ -13,9 +13,12 @@
  * __data_start before main, and zeroes .bss after it.
  *
  * The memory map is sections.lds' -- same Harvard split, same reason `ram` sits
- * past `rom`'s ceiling to keep GNU ld's single flat address space happy. The
- * two files have to agree about it; test/testbench.v's RAM_BASE and
- * test/cxxrtl.cc's kRamBase are the third and fourth copies.
+ * past `rom`'s ceiling to keep GNU ld's single flat address space happy, and
+ * the same two region sizes. Several files state parts of that map in their own
+ * syntax and cannot include one another: test/cxxrtl.cc and test/cosim.cc each
+ * carry `ram`'s ORIGIN as `kRamBase`, and test/asm/riscv_test.h carries the
+ * timer's base. test/memmap_test.sh compares all of them against the RTL and is
+ * what makes this comment a check rather than a request.
  *
  * `.tohost` is the one output section that stays loadable at its own address in
  * `ram`. It is an IO window, not program data: the runners watch the first word
@@ -29,7 +32,7 @@
  */
 MEMORY {
     rom(rx)  : ORIGIN = 0x00000000, LENGTH = 16K
-    ram(!rx) : ORIGIN = 0x00010000, LENGTH = 4K
+    ram(!rx) : ORIGIN = 0x00010000, LENGTH = 64K
 }
 
 SECTIONS {

--- a/test/asm/riscv_test.h
+++ b/test/asm/riscv_test.h
@@ -127,8 +127,9 @@ trap_handler:                                                                \
         la      t0, trap_handler;                                           \
         csrw    mtvec, t0;
 
-// The machine timer (rtl/timer.v), at the same base in test/testbench.v and in
-// rtl/littlesoc.v. Four words: mtime, mtimeh, mtimecmp, mtimecmph.
+// The machine timer, four words: mtime, mtimeh, mtimecmp, mtimecmph. Assembly
+// cannot read rtl/timer.v's `BASE`, so this is a copy of it and
+// test/memmap_test.sh compares the two.
 #define MTIMER_BASE      0x00020000
 #define MTIMECMP_OFFSET  8
 #define MTIMECMPH_OFFSET 12

--- a/test/asm/sections.lds
+++ b/test/asm/sections.lds
@@ -9,16 +9,22 @@
  * GNU ld's MEMORY command still models one flat linker address space (it
  * rejects two regions whose byte ranges overlap, even when the hardware
  * backing them is Harvard), so `ram` is placed well past `rom`'s ceiling
- * purely to keep the linker happy. `rom` and `ram` are sized generously
- * above the largest measured `.text`/`.data` in this suite so headroom, not
- * link-map tightness, is the constraint. `rom` grew from 8K to 16K when
- * test/asm/rvc.S (riscv-tests' rv32uc/rvc.S) landed --
- * its page-boundary-straddle case alone pads past 8K (`.align 12` then
- * `.skip 4094`) before the rest of the suite's ~1.5K text even starts.
- * test/testbench.v's simulation ROM/RAM arrays are sized to match (see the
- * comment there); the cxxrtl runner subtracts `ram`'s ORIGIN back out when
- * it pokes RAM contents via debug_items, and the iverilog leg's live bus
- * decode does the same at runtime.
+ * purely to keep the linker happy.
+ *
+ * BOTH REGIONS ARE THE SIMULATED MACHINE'S, not headroom picked by hand, and
+ * test/memmap_test.sh fails if they stop being: `ram` is rtl/memory.v's 64 KB
+ * at its base, and `rom` is test/testbench.v's 16 KB. That ROM is larger than
+ * the SoC's 8 KB on purpose -- test/asm/rvc.S's page-boundary-straddle case
+ * alone pads past 8K (`.align 12` then `.skip 4094`) before the rest of the
+ * suite's ~1.5K text starts -- so an `.S` program's fit on the part is decided
+ * by soc/rom_banks.py instead, when `make soc-timing` builds its image.
+ *
+ * Do not shrink either region back to "enough for this suite". `ram` said 4 KB
+ * while both machines had 64 KB, and every program fit, so nothing said so.
+ *
+ * The cxxrtl runner subtracts `ram`'s ORIGIN back out when it pokes RAM
+ * contents via debug_items, and the iverilog leg's live bus decode does the
+ * same at runtime.
  *
  * This is the script for the assembly programs, and their `.data` reaches RAM
  * only because a harness put it there. The C programs use test/asm/boot.lds,
@@ -28,7 +34,7 @@
  */
 MEMORY {
     rom(rx)  : ORIGIN = 0x00000000, LENGTH = 16K
-    ram(!rx) : ORIGIN = 0x00010000, LENGTH = 4K
+    ram(!rx) : ORIGIN = 0x00010000, LENGTH = 64K
 }
 
 SECTIONS {

--- a/test/cosim.cc
+++ b/test/cosim.cc
@@ -57,7 +57,8 @@
 
 namespace {
 
-// Kept in sync with test/cxxrtl.cc, test/testbench.v and test/asm/sections.lds.
+// A copy of rtl/memory.v's `BASE`, as in test/cxxrtl.cc; C++ cannot read the
+// RTL's parameter. test/memmap_test.sh compares both against it.
 constexpr uint32_t kRamBase = 0x00010000;
 
 using HexImage = std::map<uint32_t, uint32_t>;

--- a/test/cxxrtl.cc
+++ b/test/cxxrtl.cc
@@ -61,8 +61,9 @@ namespace {
 
 // test/asm/sections.lds' `ram` region starts here; the cxxrtl runner
 // subtracts it back out of the `--ram` image's word addresses so they land
-// at the right index in test/testbench.v's `memory` array. Keep in sync
-// with sections.lds and test/testbench.v's RAM_BASE.
+// at the right index in test/testbench.v's `memory` array. C++ cannot read the
+// RTL's parameter, so this is a copy of rtl/memory.v's `BASE` and
+// test/memmap_test.sh is what compares the two.
 constexpr uint32_t kRamBase = 0x00010000;
 
 // A parsed `objcopy -O verilog --verilog-data-width=4` image: word address

--- a/test/memmap_test.sh
+++ b/test/memmap_test.sh
@@ -1,0 +1,291 @@
+#!/bin/bash
+# Asserts that every file describing this machine's memory map describes the
+# same one.
+#
+# Usage: memmap_test.sh [repo-root]     # defaults to this script's parent
+#
+# WHY THIS EXISTS. test/testbench.v is what every program in the suite runs
+# against and rtl/littlesoc.v is what places on the part, and for the project's
+# whole life nothing compared them. The harness modelled a 4 KB data RAM against
+# the SoC's 64 KB -- sixteen times smaller -- and no program was large enough to
+# notice, so the suite was grading a machine that did not exist. Two more copies
+# of the same map went stale the same way in the same day.
+#
+# The map itself is no longer stated twice: rtl/memory.v and rtl/timer.v carry
+# the base and the size as their own parameter defaults, and rtl/littlesoc.v and
+# test/testbench.v both instantiate them without overriding anything, so the two
+# integrators have nothing to disagree about. THE FIRST CHECK BELOW IS WHAT KEEPS
+# THAT TRUE -- an override reappearing in either file is the whole defect coming
+# back, and it would otherwise be invisible.
+#
+# The rest cannot share a parameter, because they are C++, linker scripts,
+# assembly and make. For those a comparison is the only instrument left.
+#
+# Hermetic: grep, sed and shell arithmetic. No toolchain, no simulator, no
+# yosys, so this runs inside `make test` anywhere.
+set -euo pipefail
+
+HERE=$(cd "$(dirname "$0")" && pwd)
+REPO=${1:-$(cd "$HERE/.." && pwd)}
+
+if [ ! -d "$REPO" ]; then
+  echo "error: '$REPO' is not a directory, so there is nothing to compare." >&2
+  exit 1
+fi
+
+rc=0
+
+fail() {
+  echo "error: $*" >&2
+  rc=1
+}
+
+# Reads one file, or stops. A check that silently skips a missing file is a
+# check that deletes itself the day the file is renamed.
+need() {
+  local path=$1
+  if [ ! -f "$REPO/$path" ]; then
+    echo "error: $path is missing, so its copy of the memory map cannot be" >&2
+    echo "compared. If it moved, move this check with it." >&2
+    exit 1
+  fi
+}
+
+for f in rtl/memory.v rtl/timer.v rtl/imemory.v rtl/littlesoc.v test/testbench.v \
+         test/cxxrtl.cc test/cosim.cc test/asm/riscv_test.h test/asm/sections.lds \
+         test/asm/boot.lds test/bench/bench.lds Makefile; do
+  need "$f"
+done
+
+# A declaration this cannot read is fatal rather than empty: comparing against
+# an empty string is how a check goes on reporting green over a file it has
+# stopped understanding.
+no_param() {  # $1 = file, $2 = parameter name
+  echo "error: no \`$2\` parameter default found in $1. This check reads the" >&2
+  echo "RTL as the source of the map; if the declaration was respelled, teach" >&2
+  echo "this script the new spelling rather than dropping the comparison." >&2
+  exit 1
+}
+
+# `32'h0001_0000` -> 65536. The underscores are the readable spelling in the
+# RTL and mean nothing to arithmetic.
+hex_param() {  # $1 = file, $2 = parameter name
+  local raw
+  raw=$(sed -nE "s/.*parameter[[:space:]]+logic[[:space:]]*\[31:0\][[:space:]]*$2[[:space:]]*=[[:space:]]*32'h([0-9a-fA-F_]*).*/\1/p" \
+          "$REPO/$1" | head -1 | tr -d _)
+  [ -n "$raw" ] || no_param "$1" "$2"
+  echo $((16#$raw))
+}
+
+int_param() {  # $1 = file, $2 = parameter name
+  local raw
+  raw=$(sed -nE "s/.*parameter[[:space:]]+integer[[:space:]]+$2[[:space:]]*=[[:space:]]*([0-9]+).*/\1/p" \
+          "$REPO/$1" | head -1)
+  [ -n "$raw" ] || no_param "$1" "$2"
+  echo "$raw"
+}
+
+# ---- the source of the map ------------------------------------------------
+
+RAM_BASE=$(hex_param rtl/memory.v BASE)
+RAM_WORDS=$(int_param rtl/memory.v RAM_WORDS)
+TIMER_BASE=$(hex_param rtl/timer.v BASE)
+RAM_BYTES=$((RAM_WORDS * 4))
+RAM_TOP=$((RAM_BASE + RAM_BYTES))
+
+hexfmt() { printf '0x%08x' "$1"; }
+
+# ---- 1. neither integrator restates it ------------------------------------
+#
+# The shared default is only shared while both files stay silent. `imemory` is
+# excluded from the `memory` pattern by the leading boundary: it is a different
+# module with a size of its own.
+
+for f in rtl/littlesoc.v test/testbench.v; do
+  for m in memory timer; do
+    if ! grep -qE "(^|[^[:alnum:]_])$m[[:space:]]*(#\(|[a-z_]+[[:space:]]*\()" "$REPO/$f"; then
+      fail "$f does not instantiate \`$m\` at all. The comparison below would
+pass vacuously, so a deleted memory is red here rather than silent."
+    fi
+    if grep -qE "(^|[^[:alnum:]_])$m[[:space:]]*#\(" "$REPO/$f"; then
+      fail "$f overrides \`$m\`'s parameters. The data RAM's base and size and
+the timer's base are rtl/$m.v's defaults precisely so that rtl/littlesoc.v and
+test/testbench.v cannot describe different machines -- the harness once modelled
+a RAM sixteen times smaller than the SoC's and every program still fit. If this
+override is deliberate, it needs a reason recorded in an ADR first."
+    fi
+  done
+done
+
+# ---- 2. the regions abut ---------------------------------------------------
+
+if [ "$RAM_TOP" -ne "$TIMER_BASE" ]; then
+  fail "the data RAM ends at $(hexfmt $RAM_TOP) and the timer starts at
+$(hexfmt "$TIMER_BASE"). rtl/littlesoc.v and test/testbench.v both join the three
+read buses with an OR rather than a mux, which is only sound while the ranges do
+not overlap; a gap is merely wasted map, but an overlap ORs two live answers
+together and neither simulator would report it."
+fi
+
+# ---- 3. the linker scripts -------------------------------------------------
+#
+# `LENGTH = 64K` -> bytes. ld also accepts M and a bare count.
+
+lds_field() {  # $1 = file, $2 = region, $3 = ORIGIN|LENGTH
+  sed -nE "s/^[[:space:]]*$2[[:space:]]*\([^)]*\)[[:space:]]*:.*$3[[:space:]]*=[[:space:]]*([0-9A-Za-zx_]*).*/\1/p" \
+    "$REPO/$1" | head -1
+}
+
+# A size bash cannot read must stop the run. Left to arithmetic expansion, a
+# non-numeric literal is treated as a VARIABLE NAME and quietly becomes 0, which
+# compares unequal and reports a drift that is really a parse failure. So the
+# digits are checked before any arithmetic sees them.
+as_bytes() {  # $1 = an ld size literal
+  local v=$1 mult=1 digits
+  case "$v" in
+    *K|*k)   digits=${v%[Kk]}; mult=1024 ;;
+    *M|*m)   digits=${v%[Mm]}; mult=$((1024 * 1024)) ;;
+    0x*|0X*) digits=${v#0[xX]}
+             case "$digits" in
+               ""|*[!0-9a-fA-F]*) digits="" ;;
+               *) echo $((16#$digits)); return ;;
+             esac ;;
+    *)       digits=$v ;;
+  esac
+  case "$digits" in
+    ""|*[!0-9]*)
+      echo "error: '$v' is not a size this check can read. Teach it the" >&2
+      echo "spelling rather than letting an unparsed region compare as zero." >&2
+      exit 1 ;;
+  esac
+  echo $((digits * mult))
+}
+
+check_lds_ram() {  # $1 = file
+  local origin length
+  origin=$(lds_field "$1" ram ORIGIN)
+  length=$(lds_field "$1" ram LENGTH)
+  if [ -z "$origin" ] || [ -z "$length" ]; then
+    fail "$1 declares no \`ram\` MEMORY region this check can read."
+    return
+  fi
+  origin=$(as_bytes "$origin"); length=$(as_bytes "$length")
+  if [ "$origin" -ne "$RAM_BASE" ]; then
+    fail "$1 puts \`ram\` at $(hexfmt "$origin"), but rtl/memory.v's BASE is
+$(hexfmt "$RAM_BASE"). Every program's \`.data\` would link to an address the
+hardware does not decode."
+  fi
+  if [ "$length" -ne "$RAM_BYTES" ]; then
+    fail "$1 gives \`ram\` $length bytes against the $RAM_BYTES bytes
+rtl/memory.v actually has. Too small silently wastes most of the machine and is
+how a 4 KB harness went unnoticed against a 64 KB SoC; too large links programs
+that run off the end of it."
+  fi
+}
+
+check_lds_rom() {  # $1 = file, $2 = expected words, $3 = whose
+  local length
+  length=$(lds_field "$1" rom LENGTH)
+  if [ -z "$length" ]; then
+    fail "$1 declares no \`rom\` MEMORY region this check can read."
+    return
+  fi
+  length=$(as_bytes "$length")
+  if [ "$length" -ne $(( $2 * 4 )) ]; then
+    fail "$1 gives \`rom\` $length bytes against $3's $(( $2 * 4 )). A link that
+succeeds here has to be one that machine can hold."
+  fi
+}
+
+SOC_ROM_WORDS_RTL=$(sed -nE "s/.*\.ROM_WORDS\(([0-9]+)\).*/\1/p" "$REPO/rtl/littlesoc.v" | head -1)
+TB_ROM_WORDS=$(sed -nE "s/.*localparam[[:space:]]+int[[:space:]]+ROM_WORDS[[:space:]]*=[[:space:]]*([0-9]+).*/\1/p" \
+                 "$REPO/test/testbench.v" | head -1)
+
+for pair in "rtl/littlesoc.v:$SOC_ROM_WORDS_RTL" "test/testbench.v:$TB_ROM_WORDS"; do
+  if [ -z "${pair#*:}" ]; then
+    echo "error: ${pair%%:*} names no ROM_WORDS. The ROM is the one size the" >&2
+    echo "two machines differ on deliberately, so it is the one that must stay" >&2
+    echo "written down in both." >&2
+    exit 1
+  fi
+done
+
+check_lds_ram test/asm/sections.lds
+check_lds_ram test/asm/boot.lds
+check_lds_ram test/bench/bench.lds
+
+# The suite's two scripts link against the SIMULATED ROM, which is larger than
+# the part's on purpose. bench.lds links against the part's, because the point of
+# building a benchmark is to find out whether it fits.
+check_lds_rom test/asm/sections.lds "$TB_ROM_WORDS" "test/testbench.v"
+check_lds_rom test/asm/boot.lds     "$TB_ROM_WORDS" "test/testbench.v"
+check_lds_rom test/bench/bench.lds  "$SOC_ROM_WORDS_RTL" "rtl/littlesoc.v"
+
+# ---- 4. the runners --------------------------------------------------------
+
+check_ram_base_cc() {  # $1 = file
+  local raw
+  raw=$(sed -nE "s/.*constexpr[[:space:]]+uint32_t[[:space:]]+kRamBase[[:space:]]*=[[:space:]]*0[xX]([0-9a-fA-F]*).*/\1/p" \
+          "$REPO/$1" | head -1)
+  if [ -z "$raw" ]; then
+    fail "$1 declares no \`kRamBase\`, so nothing says where it thinks RAM is."
+    return
+  fi
+  if [ $((16#$raw)) -ne "$RAM_BASE" ]; then
+    fail "$1's kRamBase is $(hexfmt $((16#$raw))) against rtl/memory.v's
+$(hexfmt "$RAM_BASE"). This runner subtracts it from every word of the RAM image
+before poking it in, so the whole image would land at the wrong offset."
+  fi
+}
+
+check_ram_base_cc test/cxxrtl.cc
+check_ram_base_cc test/cosim.cc
+
+# ---- 5. the assembly header ------------------------------------------------
+
+MTIMER_RAW=$(sed -nE "s/^#define[[:space:]]+MTIMER_BASE[[:space:]]+0[xX]([0-9a-fA-F]*).*/\1/p" \
+               "$REPO/test/asm/riscv_test.h" | head -1)
+if [ -z "$MTIMER_RAW" ]; then
+  fail "test/asm/riscv_test.h defines no MTIMER_BASE, so the programs that arm
+the timer have no address to arm it at."
+elif [ $((16#$MTIMER_RAW)) -ne "$TIMER_BASE" ]; then
+  fail "test/asm/riscv_test.h's MTIMER_BASE is $(hexfmt $((16#$MTIMER_RAW)))
+against rtl/timer.v's $(hexfmt "$TIMER_BASE"). A store to the wrong address is
+dropped by every memory on the bus, so mtimer.S would wait for an interrupt that
+is never armed rather than fail."
+fi
+
+# ---- 6. the SoC ROM image --------------------------------------------------
+
+MK_ROM_WORDS=$(sed -nE 's/^SOC_ROM_WORDS[[:space:]]*:=[[:space:]]*([0-9]+).*/\1/p' \
+                 "$REPO/Makefile" | head -1)
+if [ -z "$MK_ROM_WORDS" ]; then
+  fail "the Makefile sets no SOC_ROM_WORDS, so soc/rom_banks.py has no ceiling
+to reject an oversized image against."
+elif [ "$MK_ROM_WORDS" -ne "$SOC_ROM_WORDS_RTL" ]; then
+  fail "the Makefile builds the SoC ROM image for $MK_ROM_WORDS words and
+rtl/littlesoc.v instantiates $SOC_ROM_WORDS_RTL. soc/rom_banks.py grades the
+image against the Makefile's number, so the two disagreeing means it either
+rejects a program that fits or splits one that does not into banks the bitstream
+then truncates."
+fi
+
+# ---- 7. the one deliberate difference --------------------------------------
+
+if [ "$TB_ROM_WORDS" -lt "$SOC_ROM_WORDS_RTL" ]; then
+  fail "test/testbench.v simulates $TB_ROM_WORDS words of ROM against
+rtl/littlesoc.v's $SOC_ROM_WORDS_RTL. The harness is allowed to be larger --
+simulation has no block RAM to run out of, and rvc.S needs it -- but never
+smaller, or a program the part can hold would fail in simulation."
+fi
+
+if [ "$rc" -ne 0 ]; then
+  echo >&2
+  echo "The memory map is described in more than one place and they have" >&2
+  echo "drifted. test/testbench.v is what the suite grades against and" >&2
+  echo "rtl/littlesoc.v is what places on the part; where they disagree, the" >&2
+  echo "suite is testing a machine that does not exist." >&2
+  exit 1
+fi
+
+echo "Memory map agreed on: ram $(hexfmt "$RAM_BASE")+${RAM_BYTES}B, timer $(hexfmt "$TIMER_BASE"), rom ${SOC_ROM_WORDS_RTL} words on the part / ${TB_ROM_WORDS} simulated"

--- a/test/probe_gates.sh
+++ b/test/probe_gates.sh
@@ -27,7 +27,7 @@ REPO=$(cd "$HERE/.." && pwd)
 # Pinned as a literal: a probe that is deleted, or that stops being reached by
 # an early `return`, would otherwise cut this file's coverage while it kept
 # printing a green summary.
-PROBES_EXPECTED=155
+PROBES_EXPECTED=173
 
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/littlecpu-probe.XXXXXX") || {
   echo "error: could not create a temporary directory under ${TMPDIR:-/tmp}." >&2
@@ -1091,6 +1091,107 @@ probe "an svlint install inside the checkout is red on its own" 1 \
 probe "a relative install directory is red before it is compared" 1 \
   "names a relative tool install directory" \
   "XDG_CACHE_HOME=$tmp/cache $TCT tools/sail tools/svlint"
+
+begin_group "test/memmap_test.sh"
+
+# The fixture is a COPY OF THE SHIPPING FILES, not a stub tree, so the control
+# below is the real repo and every red probe is one edit away from it. A
+# hand-written fixture would drift from the map it is supposed to be checking,
+# which is the defect this whole check exists for.
+MM="$HERE/memmap_test.sh"
+
+mm_fixture() {
+  local d; d=$(new_case)
+  mkdir -p "$d/rtl" "$d/test/asm" "$d/test/bench"
+  cp "$REPO"/rtl/memory.v "$REPO"/rtl/timer.v "$REPO"/rtl/imemory.v \
+     "$REPO"/rtl/littlesoc.v "$d/rtl/"
+  cp "$REPO"/test/testbench.v "$REPO"/test/cxxrtl.cc "$REPO"/test/cosim.cc "$d/test/"
+  cp "$REPO"/test/asm/riscv_test.h "$REPO"/test/asm/sections.lds \
+     "$REPO"/test/asm/boot.lds "$d/test/asm/"
+  cp "$REPO"/test/bench/bench.lds "$d/test/bench/"
+  cp "$REPO"/Makefile "$d/"
+  printf '%s' "$d"
+}
+
+d=$(mm_fixture)
+probe "control: the shipping files describe one machine" 0 \
+  "Memory map agreed on:" "$MM $d"
+
+probe "a repo root that does not exist is red before anything is parsed" 1 \
+  "is not a directory" "$MM $d/nowhere"
+
+# THE ONE THAT MATTERS: the original defect, re-entered. The harness modelled a
+# RAM sixteen times smaller than the SoC's and every program still fit.
+d=$(mm_fixture); sed -i.bak 's/^  memory dmem (/  memory #(.RAM_WORDS(1024)) dmem (/' "$d/test/testbench.v"
+probe "the harness sizing its own RAM again is red" 1 \
+  "overrides \`memory\`'s parameters" "$MM $d"
+
+d=$(mm_fixture); sed -i.bak "s/^  timer mtimer (/  timer #(.BASE(32'h0003_0000)) mtimer (/" "$d/rtl/littlesoc.v"
+probe "the SoC restating the timer base is red too" 1 \
+  "rtl/littlesoc.v overrides \`timer\`'s parameters" "$MM $d"
+
+# Without this the check above passes vacuously on a file that lost its memory.
+d=$(mm_fixture); sed -i.bak 's/^  memory dmem (/  nomemory dmem (/' "$d/test/testbench.v"
+probe "a harness with no data RAM at all does not pass by silence" 1 \
+  "does not instantiate \`memory\` at all" "$MM $d"
+
+d=$(mm_fixture); sed -i.bak 's/LENGTH = 64K/LENGTH = 4K/' "$d/test/asm/sections.lds"
+probe "a linker script back on the old 4 KB ram is red" 1 \
+  "gives \`ram\` 4096 bytes" "$MM $d"
+
+d=$(mm_fixture); sed -i.bak 's/ORIGIN = 0x00010000/ORIGIN = 0x00020000/' "$d/test/asm/boot.lds"
+probe "a linker script that moves ram off the decoded base is red" 1 \
+  "puts \`ram\` at 0x00020000" "$MM $d"
+
+d=$(mm_fixture); sed -i.bak 's/LENGTH = 16K/LENGTH = 8K/' "$d/test/asm/boot.lds"
+probe "a suite script linking against a rom the harness has not got" 1 \
+  "gives \`rom\` 8192 bytes" "$MM $d"
+
+d=$(mm_fixture); sed -i.bak 's/LENGTH = 8K/LENGTH = 32K/' "$d/test/bench/bench.lds"
+probe "the benchmark script must keep linking against the part's rom" 1 \
+  "test/bench/bench.lds gives \`rom\` 32768 bytes" "$MM $d"
+
+d=$(mm_fixture); sed -i.bak 's/kRamBase = 0x00010000/kRamBase = 0x00011000/' "$d/test/cxxrtl.cc"
+probe "the cxxrtl runner's kRamBase drifting is red" 1 \
+  "test/cxxrtl.cc's kRamBase is 0x00011000" "$MM $d"
+
+d=$(mm_fixture); sed -i.bak 's/kRamBase = 0x00010000/kRamBase = 0x00011000/' "$d/test/cosim.cc"
+probe "the co-sim runner's kRamBase drifting is red on its own" 1 \
+  "test/cosim.cc's kRamBase is 0x00011000" "$MM $d"
+
+d=$(mm_fixture); sed -i.bak 's/MTIMER_BASE      0x00020000/MTIMER_BASE      0x00030000/' "$d/test/asm/riscv_test.h"
+probe "the timer address the programs arm is checked against the timer" 1 \
+  "MTIMER_BASE is 0x00030000" "$MM $d"
+
+# A store to an unmapped address is dropped by every memory on this bus, so the
+# programs would wait forever rather than fail.
+d=$(mm_fixture); sed -i.bak "s/BASE = 32'h0002_0000/BASE = 32'h0004_0000/" "$d/rtl/timer.v"
+probe "a gap opening between the data RAM and the timer is red" 1 \
+  "the data RAM ends at 0x00020000 and the timer starts at" "$MM $d"
+
+d=$(mm_fixture); sed -i.bak 's/^SOC_ROM_WORDS := 2048/SOC_ROM_WORDS := 4096/' "$d/Makefile"
+probe "the ROM image built to a different size than the ROM is red" 1 \
+  "builds the SoC ROM image for 4096 words" "$MM $d"
+
+d=$(mm_fixture); sed -i.bak 's/localparam int ROM_WORDS = 4096;/localparam int ROM_WORDS = 1024;/' "$d/test/testbench.v"
+probe "a simulated ROM smaller than the part's is red" 1 \
+  "The harness is allowed to be larger" "$MM $d"
+
+# The parse is load-bearing: a respelled declaration must stop the run rather
+# than compare against an empty string.
+d=$(mm_fixture); sed -i.bak "s/parameter logic \[31:0\] BASE/parameter logic [31:0] RAM_ORIGIN/" "$d/rtl/memory.v"
+probe "a respelled parameter stops rather than comparing nothing" 1 \
+  "no \`BASE\` parameter default found in rtl/memory.v" "$MM $d"
+
+d=$(mm_fixture); rm "$d/test/cosim.cc"
+probe "a file that moved away takes the check with it, loudly" 1 \
+  "test/cosim.cc is missing" "$MM $d"
+
+# Bash arithmetic reads a bare word as a variable name, so an unparsed size
+# would otherwise compare as zero and report drift that is really a parse bug.
+d=$(mm_fixture); sed -i.bak 's/LENGTH = 64K/LENGTH = LOTS/' "$d/test/asm/sections.lds"
+probe "a size the parser cannot read stops rather than comparing as zero" 1 \
+  "is not a size this check can read" "$MM $d"
 
 begin_group "soc/fit_report.py"
 

--- a/test/sail/rv32imc_zicsr.json
+++ b/test/sail/rv32imc_zicsr.json
@@ -188,7 +188,7 @@
     // harness never does (no --device-tree-blob, no --print-device-tree).
     "dtb_address": { "len": 64, "value": "0x1000" },
 
-    // test/asm/sections.lds: rom at 0x0 (16K) + ram at 0x10000 (4K), rounded
+    // test/asm/sections.lds: rom at 0x0 (16K) + ram at 0x10000 (64K), rounded
     // up to a flat 1MB so the linker script can grow without this file having
     // to. The model's default RV32 map puts MainMemory at
     // 0x8000_0000, where nothing this suite builds is executable or loadable.

--- a/test/testbench.v
+++ b/test/testbench.v
@@ -5,16 +5,15 @@ module testbench(
 	input reset
 `endif
 );
-  // RAM_BASE is non-zero so a wild store through a zero pointer lands outside
-  // the mapped region rather than on real test data. ROM_WORDS exceeds the
-  // shipping SoC's 2048 because simulation has no block RAM to run out of and
-  // rvc.S needs more than 30 EBRs allow. RAM_WORDS is the SoC's exactly -- 64 KB
-  // ending one word below the timer at 0x0002_0000 -- so a program that fits
-  // the simulated RAM fits the hardware's; test/asm/sections.lds and
-  // test/asm/boot.lds ask for far less than that and are unaffected.
-  localparam logic [31:0] RAM_BASE  = 32'h0001_0000;
-  localparam int          ROM_WORDS = 4096;
-  localparam int          RAM_WORDS = 16384;
+  // ROM_WORDS is the ONLY thing this harness sizes differently from
+  // rtl/littlesoc.v, and it is deliberate: simulation has no block RAM to run
+  // out of, and rvc.S pads past what the part's 30 EBRs allow. The data RAM and
+  // the timer take rtl/memory.v's and rtl/timer.v's own parameter defaults --
+  // the same ones rtl/littlesoc.v takes -- so neither file states the map and
+  // neither can drift from the other. This harness once modelled a RAM sixteen
+  // times smaller than the SoC's, and every program fit, so nothing said so.
+  // test/memmap_test.sh is what keeps an override from reappearing here.
+  localparam int ROM_WORDS = 4096;
   logic [31:0] imem_addr;
   logic [31:0] imem_data;
   logic [31:0] imem_addr2;
@@ -28,8 +27,7 @@ module testbench(
   logic        fetch_stall;
   logic        irq_timer;
   // All three memories answer zero outside their own range, so the buses join
-  // with an OR. Same wiring, same timer base as rtl/littlesoc.v, so the legs
-  // cannot drift apart and a `.S` program that arms the timer runs on both.
+  // with an OR, exactly as rtl/littlesoc.v joins them.
   logic [31:0] imem_mem_rdata, dmem_mem_rdata, timer_mem_rdata;
   assign mem_rdata = imem_mem_rdata | dmem_mem_rdata | timer_mem_rdata;
   logic        trap;
@@ -61,7 +59,7 @@ module testbench(
   logic reset = 1;
   always #5 clk = ~clk;
  `endif
-  memory #(.BASE(RAM_BASE), .RAM_WORDS(RAM_WORDS)) dmem (
+  memory dmem (
     .clk(clk),
     .mem_addr(mem_addr),
     .mem_wdata(mem_wdata),
@@ -84,7 +82,7 @@ module testbench(
     .fetch_stall(fetch_stall)
   );
 
-  timer #(.BASE(32'h0002_0000)) mtimer (
+  timer mtimer (
     .clk(clk),
     .reset(reset),
     .mem_addr(mem_addr),


### PR DESCRIPTION
Closes JEF-788.

`test/testbench.v` is what every program runs against; `rtl/littlesoc.v` is what places on the part. Where they disagree the suite grades a machine that does not exist, and nothing compared them.

## The enumeration

Every place the two files, or a copy of their map, describe the same thing.

| # | Fact | Found | Class | Disposition |
|---|---|---|---|---|
| 1 | RAM base `0x0001_0000` | agreed, stated twice | 3 impossible | **shared** |
| 2 | RAM size 16384 words | agreed, stated twice — *the axis that already failed* | 3 impossible | **shared** |
| 3 | Timer base `0x0002_0000` | agreed, stated twice | 3 impossible | **shared** |
| 4 | ROM size | 2048 on the part, 4096 simulated | 2 deliberate | kept in both + checked `sim >= part` |
| 5 | `ram` in `sections.lds`/`boot.lds` | **4 KB against both machines' 64 KB** | **1 defect** | **fixed** |
| 6 | `rom` in the three linker scripts | matched by hand | 2 deliberate | checked |
| 7 | `kRamBase` in `cxxrtl.cc`/`cosim.cc` | agreed; C++ cannot read a parameter | 2 deliberate | checked |
| 8 | `MTIMER_BASE` in `riscv_test.h` | agreed; assembly cannot read a parameter | 2 deliberate | checked |
| 9 | `SOC_ROM_WORDS` in the Makefile | hand-copied from `littlesoc.v` | 2 deliberate | checked |
| 10 | RAM top vs. timer base | abut, by two comments that had to agree | 2 deliberate | checked |
| 11 | Reset: POR counter vs. driven input | real, and correct | 2 deliberate | commented |
| 12 | LEDs, `btn_n`, the image loader | in one, absent in the other | 2 deliberate | left alone |
| 13 | `TEXT_BYTES` in `formal/arbiter.v` | says outright the size does not matter | 2 deliberate | left alone |

## Shared, not checked (items 1–3)

`rtl/memory.v` and `rtl/timer.v` **already** carried the base, the size and the timer base as parameter defaults; both integrators were merely re-stating them. Both now instantiate `memory` and `timer` **with no overrides at all**, so there is exactly one statement of each number — in the module that implements it.

This is a deletion, not a new file. A shared header was rejected: it would be a *fourth* copy sitting beside the defaults rather than replacing them, and yosys resolves `` `include `` relative to the including file while iverilog is configured with `-I./rtl/`, so the two frontends need different spellings. The ROM stays written down in both files because it is the one size that deliberately differs — and it is now the **only** parameter override in either file, which makes the deliberate difference the visible one.

## The case-1 defect (item 5)

`sections.lds` and `boot.lds` gave `ram` 4 KB while both machines had 64 KB — **the same stale number ADR-0084 fixed, one file over**, so every program linked against a RAM sixteen times smaller than either machine. `sections.lds`'s comment still claimed the harness was "sized to match". `test/bench/bench.lds` already said 64 KB and Dhrystone already ran with its stack top at the top of it, which is what shows this was stale rather than a budget.

Only `boot.lds`'s `__stack_top` moves, `0x00011000` → `0x00020000`. Retire counts are unchanged across the suite.

## Checked, because it cannot be shared

`test/memmap_test.sh` reads the RTL as the source and compares the three linker scripts, both runners' `kRamBase`, `MTIMER_BASE` and `SOC_ROM_WORDS` against it — plus the RAM/timer abutment, `sim ROM >= part ROM`, and the two properties that keep the sharing honest: **neither file overrides those parameters**, and **neither has stopped instantiating them**, so the first check cannot pass by silence. Hermetic (grep + sed); runs from `make test`.

18 probes force each comparison red, including the original defect re-entered as `memory #(.RAM_WORDS(1024))`. The fixture is a copy of the shipping files, so the control is the real repository. `PROBES_EXPECTED` 155 → 173 in the same commit.

## Gates

| Gate | Result |
|---|---|
| `make test` | **62/62**, both baselines matched |
| `make test-units` | pass |
| `make probe-gates` | **173** comparisons, every failure path executed |
| `make cycles` | 32624 cycles, CPI 2.08, `unattributed` 0 |
| `make cosim-suite` | 60/62 AGREE, matches `COSIM_EXPECTED_FAIL` |
| `make -C formal check` | **85/85**, matches `EXPECTED_FAIL` and `EXPECTED_CHECKS` |
| `make fit` | 3958 of 4100 |
| `make soc-timing` | **12.20 MHz** against the 12.0 floor |
| SPRAM / EBR census | **2 and 20, exactly as declared** |
| `make monitor-check` | clean |

The census is the load-bearing one: it comes out at 2 SPRAM and 20 EBR only for this geometry, so it is independent evidence that the removed parameters resolve to what they resolved to before. **No `rtl/` behaviour change.**

## Decisions I made without asking

- **ADR-0085** is the number. Confirmed by `ls docs/adr/` (highest is 0084) and `gh pr list --state open` (empty, so nothing in flight reserves one). 0072, 0073 and 0077 left as the pre-existing gaps.
- **Linker `ram` widened to 64 KB** rather than gating `<=` and leaving 4 KB. The region should describe the machine; `bench.lds` already proved the resulting stack top works.
- **Unit benches deliberately excluded** from the comparison. `mem_tb.v`, `imem_tb.v` and `monitor_tb.v` pick small sizes on purpose — they are benches of the modules, not descriptions of the platform.

## Nothing here needs an SoC change

Every disagreement was closable from the harness, the scripts or a redundant override. Item 11 (reset) is the one that cannot be closed and should not be: the FPGA comes out of configuration without a reset, so the SoC must make its own. It is already load-bearing — every reset value in `rtl/timer.v` is zero partly because the cxxrtl runner never clocks an edge under reset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
