### PR TITLE
Both cores in one harness: the 3x gap is 1.6x, and it is the fetch loop (JEF-789)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,18 @@ soc.icetime.log
 # artifacts of whichever SOC_PROG was last built, not source.
 soc/rom_even.hex
 soc/rom_odd.hex
+# `make compare-timing`: two netlists, two placements, the logs and the icetime
+# reports. Same rule as the soc.* files above -- the reports ARE the measurement
+# and are kept on disk to read, and never committed, because a checked-in timing
+# report is a number that stops tracking the RTL.
+compare.*.json
+compare.*.asc
+compare.*.log
+compare.*.rpt
+compare.vvp
+soc/compare/rom_even.hex
+soc/compare/rom_odd.hex
+soc/compare/rom_flat.hex
 formal/riscv-formal
 formal/riscv-formal.tmp
 formal/complete

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,6 +217,16 @@ and times.
   ROM (ADR-0084). Dhrystone is string-dominated and the optimiser can delete part of the work, so
   **the flags, the compiler and the string library travel with the number** — the program prints all
   three and will not compile without them. It is not a gate and adds no ratchet.
+- **The only cross-core comparison that means anything is one harness**, and `soc/compare/` is it:
+  same part, memories, program, toolchain and seeds, this core against the VexRiscv Verilog in the
+  pinned riscv-formal clone. Measured that way the gap is **1.6×, not the 3× two separately-published
+  numbers suggested**, both critical paths are the fetch loop, and their 92 MHz does not reproduce
+  here (ADR-0086). Neither side is a shipped design — theirs is RV32IC with a branch predictor and no
+  privileged architecture, ours has no timer in the harness and 4 KB of ROM — so quote it with what
+  it is. **A harness whose outputs do not depend on the datapath measures nothing**: an all-NOP ROM
+  placed 449 cells of a 1711-cell core and reported a critical path, so
+  `soc/compare/placed_vs_synth.py` grades the placed count against the core's own synthesis and
+  `make compare-smoke` requires both cores to publish the same values.
 - **Read logic levels apart**: a LUT level costs ~3.3 ns (delay plus interconnect), a carry hop
   ~0.34 ns and no interconnect. A change that trades a carry hop for a LUT level gets shallower by
   icetime's count and slower in nanoseconds. The SoC is routing-dominated; wide flat muxes route
@@ -270,6 +280,12 @@ make monitor-check  # regenerate test/monitor.v at the pin and diff
 make fit            # the core's area number; ratchet on FIT_MAX_LC
 make soc-timing     # the SoC place-and-time flow; requirement on SOC_MIN_MHZ.
                     # SOC_SEED picks a placement; soc/timing_sweep.sh runs four
+make compare-timing # this core and VexRiscv in ONE hx8k harness; COMPARE_CORE
+                    # picks the side, soc/compare/sweep.sh runs both over seeds.
+                    # A measurement, not a gate -- but the placed-vs-synthesised
+                    # check inside it is graded
+make compare-smoke  # both harnesses run the one image in iverilog and must
+                    # publish the same values; says the netlist RUNS
 
 make -C formal check                # the generated riscv-formal checks; always a fresh run.
                                     # interrupt-tie-off is a prerequisite

--- a/Makefile
+++ b/Makefile
@@ -408,8 +408,17 @@ tool-cache-test:
 memmap-test:
 	@./test/memmap_test.sh
 
+# The cross-core comparison harness states its geometry in six places and this
+# is what says they agree. Hangs off `test` like the other bash checks -- grep
+# and sed only -- because the harness itself needs yosys, nextpnr and the pinned
+# clone, so nothing else on this machine would notice it rotting.
+.PHONY: compare-geometry-test
+compare-geometry-test:
+	@./soc/compare/geometry_test.sh
+
 .PHONY: test
-test: sim test-units probe-gates pin-bump-test tool-cache-test memmap-test
+test: sim test-units probe-gates pin-bump-test tool-cache-test memmap-test \
+      compare-geometry-test
 	@./test/run_tests.sh ./sim test/asm test/EXPECTED_FAIL test/OBSERVED_FLOOR
 
 # The same suite `make test` runs, with the runner charging every cycle to the
@@ -624,10 +633,174 @@ soc-timing: soc.asc
 	@# second one was the one holding the gate.
 	@python3 soc/timing_split.py soc.timing.rpt --min-mhz $(SOC_MIN_MHZ)
 
+# ---- the cross-core comparison harness -------------------------------------
+#
+# Places THIS core and VexRiscv in one harness -- one geometry, one program, one
+# part, one toolchain, the same seeds -- so the two Fmax figures are one
+# experiment instead of two. Nothing here is a gate on the shipping design and
+# nothing here touches rtl/: `make soc-timing` remains the SoC's measurement and
+# this target's numbers are not comparable to it.
+#
+# `COMPARE_CORE=littlecpu` (default) or `vexriscv`; `COMPARE_SEED=<n>` picks a
+# placement. soc/compare/sweep.sh runs both cores over four seeds each, which is
+# what a distribution needs.
+COMPARE_CORE  ?= littlecpu
+COMPARE_SEED  ?=
+# 4 KB of ROM (8 SB_RAM40_4K) and 2 KB of data RAM (4 more). Shrunk from the
+# shipping 8 KB / 64 KB so both designs fit one hx8k: VexRiscv takes 18 of the
+# part's 32 block RAMs before either memory -- 4 for a register file the same
+# size as this core's, 14 for a 1024-entry branch predictor -- and 30 is what
+# its side of the harness then comes to. soc/compare/bench.lds states the same
+# two sizes in its own syntax and soc/compare/geometry_test.sh compares them.
+COMPARE_ROM_WORDS := 1024
+COMPARE_RAM_WORDS := 512
+# The placed design must be at least this fraction of what the core synthesises
+# to alone. soc/compare/placed_vs_synth.py carries why, and it is the check that
+# stops this flow reporting a number for a core yosys folded away.
+COMPARE_MIN_RATIO := 0.8
+
+ifeq ($(COMPARE_CORE),vexriscv)
+COMPARE_TOP  := bench_vexriscv
+COMPARE_SRCS := soc/compare/bench_vexriscv.v rtl/memory.v
+# Read as plain Verilog, out of the SHA-pinned clone, and never copied into this
+# repo. Its RVFI outputs are left unconnected in the harness, where synthesis
+# prunes them; on the standalone run below they are the top's own ports, and
+# there `delete -port` -- formal/check-nonperturbation.py's technique -- is what
+# stops 556 SB_IO no ice40 package can place.
+COMPARE_READ := read_verilog $(RISCV_FORMAL_DIR)/cores/VexRiscv/VexRiscv.v; \
+                read_verilog -sv $(COMPARE_SRCS)
+COMPARE_CORE_READ := read_verilog $(RISCV_FORMAL_DIR)/cores/VexRiscv/VexRiscv.v; \
+                     hierarchy -top VexRiscv; delete -port VexRiscv/rvfi_*
+COMPARE_CORE_TOP  := VexRiscv
+COMPARE_DEPS      := $(COMPARE_SRCS) | $(RISCV_FORMAL_DIR)
+COMPARE_CORE_DEPS := | $(RISCV_FORMAL_DIR)
+else
+COMPARE_TOP  := bench_littlecpu
+# FIT_SRCS is already this repo's list of "the core and nothing else", which is
+# exactly what the standalone reference synthesis wants. A second copy of it
+# here would be the stale-list defect SIM_RTL_SRCS's comment describes.
+COMPARE_SRCS := $(FIT_SRCS) rtl/imemory.v rtl/memory.v \
+                soc/compare/bench_littlecpu.v
+COMPARE_READ := read_verilog -sv $(COMPARE_SRCS)
+COMPARE_CORE_READ := read_verilog -sv $(FIT_SRCS); \
+                     hierarchy -top littlecpu; delete -port littlecpu/rvfi_*
+COMPARE_CORE_TOP  := littlecpu
+COMPARE_DEPS      := $(COMPARE_SRCS)
+COMPARE_CORE_DEPS := $(FIT_SRCS)
+endif
+
+# PHONY for the same reason `soc-rom` is: the image depends on nothing make can
+# see a change to, and a stale ROM would make the measurement describe a
+# program nobody asked for. Both images come out of one objcopy run, so the two
+# harnesses cannot come to be running different code.
+.PHONY: compare-rom
+compare-rom: compare-geometry-test
+	@set -e; \
+	for candidate in riscv64-elf-gcc riscv64-unknown-elf-gcc; do \
+	  if command -v $$candidate >/dev/null 2>&1; then CC=$$candidate; break; fi; \
+	done; \
+	if [ -z "$$CC" ]; then \
+	  echo "error: no RISC-V cross compiler found; see \`make setup\`." >&2; exit 1; \
+	fi; \
+	OBJCOPY=$${CC%gcc}objcopy; \
+	command -v $$OBJCOPY >/dev/null 2>&1 || { \
+	  echo "error: $$OBJCOPY not found (half-installed toolchain)." >&2; exit 1; }; \
+	tmp=$$(mktemp -d "$${TMPDIR:-/tmp}/compare-rom.XXXXXX"); \
+	test -n "$$tmp" -a -d "$$tmp"; \
+	trap 'rm -rf "$$tmp"' EXIT; \
+	$$CC -march=rv32i -mabi=ilp32 -nostdlib -T soc/compare/bench.lds \
+	  -o "$$tmp/bench.elf" soc/compare/bench.S; \
+	$$OBJCOPY -O verilog --verilog-data-width=4 -j .text "$$tmp/bench.elf" "$$tmp/bench.hex"; \
+	python3 soc/rom_banks.py "$$tmp/bench.hex" \
+	  soc/compare/rom_even.hex soc/compare/rom_odd.hex --rom-words $(COMPARE_ROM_WORDS); \
+	python3 soc/compare/rom_flat.py "$$tmp/bench.hex" \
+	  soc/compare/rom_flat.hex --rom-words $(COMPARE_ROM_WORDS)
+
+# The core on its own, with no harness to fold against. This is the reference
+# soc/compare/placed_vs_synth.py grades the placement against; it never places
+# (both cores present far more SB_IO than any package has) and is not meant to.
+compare.$(COMPARE_CORE).core.log: $(COMPARE_CORE_DEPS)
+	@echo 'yosys: synthesising $(COMPARE_CORE_TOP) alone for hx8k (log: $@)'
+	@yosys -p '$(COMPARE_CORE_READ); synth_ice40 -top $(COMPARE_CORE_TOP); stat' \
+	  > $@ 2>&1 || { tail -40 $@; exit 1; }
+
+# `compare-rom` FIRST. COMPARE_DEPS ends with an order-only `| $(RISCV_FORMAL_DIR)`
+# for VexRiscv, and everything after a `|` is order-only -- so written the other
+# way round the phony stopped forcing a rebuild, `--seed` reached nextpnr on a
+# netlist make never regenerated, and four "placements" of that core reported
+# one number to the millisecond.
+compare.$(COMPARE_CORE).json: compare-rom $(COMPARE_DEPS)
+	@echo 'yosys: synthesising $(COMPARE_TOP) for hx8k (log: compare.$(COMPARE_CORE).synth.log)'
+	@# No `-dsp`: hx8k has no SB_MAC16, so this core's multiplier is soft logic
+	@# here and `make fit`'s DSP-mapped number does not transfer.
+	@# chparam BEFORE hierarchy, so the harness's geometry has one source -- the
+	@# variables above -- rather than a second copy in each .v file's defaults.
+	@yosys -p '$(COMPARE_READ); \
+	  chparam -set ROM_WORDS $(COMPARE_ROM_WORDS) -set RAM_WORDS $(COMPARE_RAM_WORDS) $(COMPARE_TOP); \
+	  hierarchy -top $(COMPARE_TOP); \
+	  synth_ice40 -top $(COMPARE_TOP) -json $@; stat' \
+	  > compare.$(COMPARE_CORE).synth.log 2>&1 \
+	  || { tail -40 compare.$(COMPARE_CORE).synth.log; exit 1; }
+
+# nextpnr's own status is not the signal, for the reason `soc.asc` records: it
+# grades its own default clock with its own estimator, and what is graded here
+# is icetime's report of the .asc it wrote.
+compare.$(COMPARE_CORE).asc: compare.$(COMPARE_CORE).json soc/compare/bench_hx8k.pcf
+	@echo 'nextpnr: placing $(COMPARE_TOP) on hx8k/ct256 (log: compare.$(COMPARE_CORE).pnr.log)'
+	@nextpnr-ice40 --hx8k --package ct256 --json $< --pcf soc/compare/bench_hx8k.pcf \
+	  $(if $(COMPARE_SEED),--seed '$(COMPARE_SEED)') --asc $@ \
+	  > compare.$(COMPARE_CORE).pnr.log 2>&1 || true
+	@test -s $@ || { \
+	  echo '*** make compare-timing: nextpnr produced no bitstream, so NOTHING'; \
+	  echo '*** was measured. That is a failed placement, not a fast design.'; \
+	  tail -30 compare.$(COMPARE_CORE).pnr.log; \
+	  rm -f $@; \
+	  exit 1; \
+	}
+
+# Both harnesses in one simulation, running the one image, required to publish
+# the same values. soc/compare/placed_vs_synth.py says the core is still in the
+# netlist; this says the netlist runs. Not a prerequisite of `compare-timing`:
+# it needs iverilog and the cross compiler, and a timing measurement of a design
+# that does not execute is a defect this catches rather than one it prevents.
+COMPARE_SMOKE_SRCS := $(SIM_RTL_SRCS) soc/compare/bench_littlecpu.v \
+                      soc/compare/bench_vexriscv.v soc/compare/bench_tb.v
+
+compare.vvp: $(COMPARE_SMOKE_SRCS) compare-rom | $(RISCV_FORMAL_DIR)
+	iverilog -I./rtl/ -g2012 -o $@ $(RISCV_FORMAL_DIR)/cores/VexRiscv/VexRiscv.v \
+	  $(COMPARE_SMOKE_SRCS)
+
+.PHONY: compare-smoke
+compare-smoke: compare.vvp
+	@vvp $<
+
+.PHONY: compare-timing
+compare-timing: compare.$(COMPARE_CORE).asc compare.$(COMPARE_CORE).core.log
+	@sed -n '/^Info: Device utilisation:/,/^$$/s/^Info: //p' compare.$(COMPARE_CORE).pnr.log
+	@echo
+	@echo '== is the core still there? =='
+	@python3 soc/compare/placed_vs_synth.py compare.$(COMPARE_CORE).pnr.log \
+	  compare.$(COMPARE_CORE).core.log $(COMPARE_CORE) --min-ratio $(COMPARE_MIN_RATIO)
+	@echo
+	@echo '== icetime: the critical path, and the LOGIC/ROUTING SPLIT =='
+	@icetime -d hx8k -P ct256 -p soc/compare/bench_hx8k.pcf -t \
+	  -r compare.$(COMPARE_CORE).timing.rpt compare.$(COMPARE_CORE).asc \
+	  > compare.$(COMPARE_CORE).icetime.log 2>&1 \
+	  || { cat compare.$(COMPARE_CORE).icetime.log; exit 1; }
+	@echo
+	@echo 'THIS IS NOT `make soc-timing`, AND NOT A LIKE-FOR-LIKE COMPARISON.'
+	@echo 'Different part, smaller memories, no timer, and the two cores'
+	@echo 'implement different ISAs: RV32IMC+Zicsr with traps here, RV32IC with'
+	@echo 'no CSR file and no traps there. Read ADR-0086 before quoting any of'
+	@echo 'it. One placement is a sample: soc/compare/sweep.sh runs four each.'
+	@python3 soc/timing_split.py compare.$(COMPARE_CORE).timing.rpt
+
 clean:
 	rm -f fit.json fit.log fit.synth.log
 	rm -f soc.json soc.asc soc.synth.log soc.pnr.log soc.timing.rpt
 	rm -f soc/rom_even.hex soc/rom_odd.hex
+	rm -f compare.*.json compare.*.asc compare.*.log compare.*.rpt compare.vvp
+	rm -f soc/compare/rom_even.hex soc/compare/rom_odd.hex soc/compare/rom_flat.hex
 	rm -f waves.vcd
 	rm -rf sim sim.dSYM
 	rm -rf cosim cosim.dSYM

--- a/docs/adr/0086-both-cores-in-one-harness-and-the-gap-is-the-fetch-loop.md
+++ b/docs/adr/0086-both-cores-in-one-harness-and-the-gap-is-the-fetch-loop.md
@@ -1,0 +1,229 @@
+# 0086 — Both cores in one harness, and the gap is the fetch loop
+
+Status: Accepted
+
+## Context
+
+[ADR-0080](0080-twenty-four-megahertz-is-not-reachable-on-the-up5k.md) placed this RTL on an hx8k at
+31.08 MHz over 22 logic levels, set it beside VexRiscv's published 63–92 MHz on the same fabric, and
+called the result "a real 3× gap on the same silicon". It also wrote down what that comparison was
+missing: *"Ours is now on their fabric, but theirs has never been placed on ours."* Their 92 MHz is
+their SoC, their memories, their floorplan, their seeds and their synthesis flags; ours is
+`make soc-timing`. Two experiments quoted as one.
+
+Nothing in the repository explained the gap either. ADR-0076 deleted the decode head whole and
+measured 3.3%, inside the churn band. ADR-0078 ceilinged the whole family of changes that take the
+pc off this cycle's decode at 16.32 MHz on up5k — real, and nowhere near 3×. Two cores with
+near-identical DMIPS/MHz (0.529 measured here against their published 0.52), both five-stage, both
+stall-only with no datapath bypass, and a factor of three nobody could point at.
+
+ADR-0080 recorded generating VexRiscv's Verilog as an open route needing a Scala toolchain. That
+turned out to be false: the generated Verilog is already in the tree. `formal/riscv-formal` is
+SHA-pinned and ships `cores/VexRiscv/VexRiscv.v`, 3810 lines, for that project's `FormalSimple`
+configuration. No sbt, no Scala, no vendoring.
+
+## Decision
+
+**Both cores are placed and timed in one harness, `soc/compare/`, and measured that way the gap is
+1.6×, not 3×.**
+
+Five placements a side, default seed plus 1–4, read on the worst of each:
+
+| ns, sorted | worst | spread |
+|---|---|---|
+| **this core** — 30.56 · 30.62 · 30.71 · 30.90 · **31.70** | **31.70 ns — 31.55 MHz** | 3.7% |
+| **VexRiscv** — 18.52 · 18.66 · 19.53 · 19.77 · **19.91** | **19.91 ns — 50.23 MHz** | 7.5% |
+
+**31.70 / 19.91 = 1.59×.** Best against best is 1.65×, so the answer does not turn on which end of
+the distribution is read; the two distributions do not come near overlapping either.
+
+It decomposes cleanly, and both terms are real:
+
+| worst placement of each | LUT levels | carry hops | ns per LUT level | logic / routing |
+|---|---|---|---|---|
+| this core | 22 | 2 | 1.43 | 8.86 ns / 22.87 ns (72.1% routing) |
+| VexRiscv | 17 | 0 | 1.17 | 6.51 ns / 13.42 ns (67.4% routing) |
+
+22/17 = 1.29 levels, 1.43/1.17 = 1.22 nanoseconds each, and 1.29 × 1.22 = 1.58 against the 1.59
+measured. **The path is a third longer and each level costs a fifth more.** VexRiscv's 17 levels are
+the same at all five placements; ours moves between 20 and 23.
+
+This also reproduces ADR-0080's hx8k figure — 31.08 MHz over 22 logic levels there, 31.55 MHz over
+22 here — on a smaller SoC, which is the check that this harness is measuring the thing that ADR
+measured.
+
+## The harness
+
+`make compare-timing COMPARE_CORE=littlecpu|vexriscv`, and `soc/compare/sweep.sh` for the
+distributions. One geometry, held by `soc/compare/geometry_test.sh` and checked on every
+`make test`:
+
+- **ice40 hx8k, ct256, three pads** — the clock and two LEDs, the iCE40-HX8K Breakout Board's own
+  assignments. hx8k because that is where both sides already had a number, and because it is the
+  only ice40 with enough logic to hold this core at all.
+- **4 KB of ROM in block RAM and 2 KB of data RAM**, both cores, `rtl/memory.v` instantiated by both
+  harnesses at the same base and the same depth.
+- **One program image**, `soc/compare/bench.S`, RV32I, built once and split into the two ROM shapes
+  each core's fetch wants.
+- **Same toolchain, same seeds**: Yosys 0.68+post (`c12172fb`), nextpnr-0.10-108-g68c1acd8, and
+  `icetime` read by `soc/timing_split.py` — the same instrument `make soc-timing` uses.
+
+VexRiscv is read out of the pinned clone and never copied into this repository. Its `rvfi_*` outputs
+are `delete -port`ed for the standalone reference synthesis, which is `formal/check-nonperturbation.py`'s
+technique; left connected they present 556 `SB_IO` and no ice40 package can place them.
+
+## The first attempt produced no number, and that is why there is now a gate
+
+The first version of this harness filled the ROM with NOPs. With no store ever executing every
+output of the design is provably constant, so yosys deleted the datapath: **449 placed logic cells
+against the 1711 the same core synthesises to on its own**, and a 33.69 ns critical path through the
+fragment that was left. `(* keep *)` on the instance held the cell and did not stop the folding
+inside it. Nothing in the flow said a word.
+
+So the flow now has `soc/compare/placed_vs_synth.py`: the placed `ICESTORM_LC` count against what the
+core synthesises to alone, with no harness to fold against, graded at 0.8×. Measured, both cores sit
+above 1.1×. The all-NOP case is 0.26×. It has five probes in `test/probe_gates.sh`, including that
+exact 449-against-1711, and `soc/compare/geometry_test.sh` has ten more.
+
+`soc/compare/bench_tb.v` is the second half. The gate says the core is in the netlist; it does not
+say the netlist runs, and the piece most likely not to is VexRiscv's bus adapter. So both harnesses
+run the one image in one iverilog simulation and are required to publish the **same sequence of
+values** to the same address. Two things this caught, both of which had produced a green run:
+
+- the program's mix was an `or`, which saturates the accumulator to all-ones, so every publication
+  was the same value and two stuck cores would have agreed;
+- every access was word-aligned, so deleting the shift from VexRiscv's byte strobe changed nothing.
+  The byte and halfword stores are at offsets 1 and 2 of their words now, and deleting that shift
+  fails the bench.
+
+A third defect was in the flow itself: `COMPARE_DEPS` ends in an order-only `|` for VexRiscv, and
+everything after a `|` is order-only, so the phony ROM rule stopped forcing a rebuild. `--seed`
+reached nextpnr on a netlist make never regenerated, and four "placements" reported one number to
+the millisecond. That is what a placement sweep looks like when it is not sweeping.
+
+## The two critical paths, side by side
+
+Both are the fetch loop. That is the finding, and it is not what a 3× gap suggests. The stations
+below are the nets `icetime` names along each path, with yosys's mangling stripped — the endpoints
+are real cell pins, the ones in between are derived names and read as ancestry rather than as
+signals.
+
+**This core, 31.70 ns, 22 LUT levels + 2 carry hops:**
+
+```
+ram_8_3 (SB_RAM40_4K) [clk] -> RDATA[14]   2.246 ns before the first LUT
+  -> riscv.accessor_out_valid, riscv.decoder.out    decode and the emptiness check
+  -> imem.fetch_stall, riscv.accessor.in_is_lw      two of the six stall reasons
+  -> imem.odd_first                                 which half of the fetch window
+  -> riscv.decoder.pc                               the pc adder, both carry hops
+  -> imem.rom_even.0.0_RADDR ...                    the ROM's address decode
+  -> imem.rom_even.0.1_RDATA[1]                     the ROM's read-data select register
+```
+
+**VexRiscv, 19.91 ns, 17 LUT levels, no carry hop:**
+
+```
+IBusSimplePlugin_injector_decodeInput_payload_rsp_inst   a REGISTER holding the instruction
+  -> _zz_decode_SRC2, execute_to_memory_MEMORY_STORE     decode and the hazard check
+  -> IBusSimplePlugin_decompressor_output_ready          the compressed decoder's handshake
+  -> IBusSimplePlugin_iBusRsp_stages_0_output_ready
+  -> IBusSimplePlugin_fetchPc_output_ready
+  -> IBusSimplePlugin_fetchPc_correctionReg              an ordinary flip-flop
+```
+
+Other placements of this core route the middle of that loop differently — one goes through
+`csrs.mcause` and `imem.in_range2` instead — but the two ends do not move, and neither does the
+count of levels between them.
+
+## What the difference actually is
+
+**Their fetch loop does not contain the instruction memory; ours contains it at both ends.** Ours
+starts at a block RAM's clock-to-output and spends **2.246 ns — 7% of the whole period — before the
+first LUT**, and ends inside the ROM's own address decode, because the fetch address is published a
+cycle early and a stalled cycle re-presents the same words. That is the no-wrong-path-state
+commitment, which is what keeps the BMC depths small and `pcloop`'s induction free of speculative
+state. Theirs starts and ends at ordinary flip-flops: the instruction is already registered when the
+loop begins, and the bus command leaves the cycle after the pc is written.
+
+**Their loop is a ready chain; ours is a decode-and-commit path.** Theirs is
+`decompressor_output_ready → iBusRsp_stages_0_output_ready → fetchPc_output_ready` — stage
+handshakes, one bit wide. Ours is `decoder.out`, the four-slot emptiness check
+(`accessor_out_valid`), two of the six stall reasons and then the pc adder. This core detects and
+commits every trap in decode, so `csrs.mcause` is in that neighbourhood too and turns up on the
+critical path of another placement; VexRiscv's configuration here has no CSR file and no traps at
+all, so it has nothing to put there.
+
+**They have a branch predictor and we forbid one.** 14 of their 18 block RAMs are
+`IBusSimplePlugin_predictor_history`, 1024 entries of 55 bits. Wrong-path state is exactly what this
+design commits not to have.
+
+**The rest is nanoseconds per logic level, and this harness cannot separate it from utilisation.**
+Ours places at 96% of the part, theirs at 31%. Congestion is pressure on the longer path and not on
+the shorter one. Controlling for it would need a bigger ice40 and there is not one.
+
+## Area, and the block RAM claim corrected
+
+| | placed `ICESTORM_LC` | core alone, `SB_LUT4` | placed / synthesised | block RAM in the harness |
+|---|---|---|---|---|
+| this core | 7400 / 7680 (96%) | 6611 | 1.12× | 16 — 4 register file, 8 ROM, 4 data RAM |
+| VexRiscv | 2379 / 7680 (31%) | 1711 | 1.39× | 30 — 4 register file, **14 branch predictor**, 8 ROM, 4 data RAM |
+
+**Their register file is the same 4 block RAMs ours is.** The 18 blocks VexRiscv synthesises to on
+its own are 4 for `RegFilePlugin_regFile` and 14 for the branch predictor's history table. That
+matters for anyone sizing a part: the ROM in this harness is 4 KB rather than the shipping 8 KB
+because a branch predictor had to fit beside it, not because of a register file.
+
+## What is different between the two designs, stated so nothing here is quoted as like-for-like
+
+**This is not a comparison of two shipped designs and must not be presented as one.**
+
+- **The ISAs differ, and not the way ADR-0080 recorded.** The generated core is **RV32IC** — the
+  compressed decoder is there, `IBusSimplePlugin_decompressor` and all — with **no M extension, no
+  CSR file, no traps and no interrupt**. Ours is RV32IMC_Zicsr_Zifencei with the full mandated M-mode
+  CSR set, five traps and a machine timer. ADR-0080's "every VexRiscv iCE40 number is RV32I" is
+  corrected for this artefact: C is on both sides, M and the privileged architecture are on ours
+  alone.
+- **This is not the 92 MHz configuration either.** That row is 1130 LC of "small, no datapath bypass,
+  no interrupt". This one is 1711 `SB_LUT4` with a compressed decoder and a 1024-entry branch
+  predictor. What it does share with that row is the stall-only interlock: `HazardSimplePlugin`'s
+  bypass conditions are constant-true here, so it stalls on every hazard, as this core does.
+- **The 92 MHz is not reproduced.** In this harness, on this toolchain, that core places at
+  50.23 MHz at its worst of five and 54.00 at its best. So a large part of the published 3× is not in the silicon at
+  all — it is the difference between their flow and this one, and this harness cannot say how much of
+  it is their floorplan, their memories, a PLL, `--freq`/`--opt-timing`, or a different
+  configuration. **It bounds our side, not theirs.**
+- **The harness is neither design's own SoC.** The shipping SoC is 8 KB of ROM and 64 KB of SPRAM on
+  an up5k; this is 4 KB and 2 KB of block RAM on an hx8k, because hx8k has no SPRAM and 32 block RAMs
+  to divide between two cores. `make soc-timing`'s number and this one are not comparable.
+- **`rtl/timer.v` is not in the harness.** With it this side is 7829 logic cells against the part's
+  7680 and does not place. `irq_timer` is driven from a free-running counter rather than tied off, so
+  the core's interrupt path is still real logic and the 324 cells left out are the peripheral's.
+- **No `-dsp`.** hx8k has no `SB_MAC16`, so this core's multiplier is soft logic here — 6611
+  `SB_LUT4` against the 3921 + 4 `SB_MAC16` it maps to on up5k. VexRiscv has no multiplier to map.
+- **The image is RV32I.** It has to be, to be one image. So this core's multiplier, divider,
+  compressed decoder and CSR instructions are in the placed netlist and never issued, which does not
+  move a static timing number.
+
+## Consequences
+
+- **The 3× is retired as a single number.** What is measured, one harness, five placements a side, is
+  1.6×. Anything past that is a flow difference this harness does not resolve, and a proposal that
+  starts from "they are three times faster" is starting from two experiments added together.
+- **The answer to "where is it" is the fetch loop, on both sides.** That agrees with ADR-0076, which
+  found no single input to `next_pc` worth more than 5% and all of them together worth 21%, and with
+  ADR-0078, which priced collecting that 21% at the no-wrong-path-state commitment. **This ADR
+  reopens neither.** It says the comparison points at the same place those two already measured, so
+  their ceilings are the numbers to beat, not this one.
+- **Two of ADR-0080's statements are corrected**, both about the artefact rather than about its
+  conclusions: the core is RV32IC, not RV32I, and its 18 block RAMs are mostly a branch predictor
+  rather than a register file. ADR-0080's own measurements are unchanged, and this harness reproduces
+  its 31.08 MHz over 22 levels to within the placement spread.
+- **`soc/compare/` is a measurement, not a gate.** Nothing in it grades the shipping design, nothing
+  in `rtl/` changed, and `SOC_MIN_MHZ` is untouched. The one graded thing is the placed-versus-
+  synthesised check, which grades the harness rather than the core, plus the geometry check that
+  hangs off `make test` because nothing else on a developer's machine would notice the harness
+  rotting.
+- **A harness that measures an optimised-away design is now a checked failure rather than a habit.**
+  Three separate defects in this one flow produced a green run and a number: the folded core, the
+  saturating program, and the sweep that never re-placed. The first two are checks now; the third is a
+  fixed prerequisite order with the reason written beside it.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -87,6 +87,7 @@ and what it costs. Reversing one is fine — write a new ADR that supersedes it.
 | [0083](0083-the-forwarding-network-is-priced-and-declined-on-the-margin.md) | The forwarding network is priced, and declined on the margin | Accepted · prices 0004's stall-only interlock; replaces 0042's 44/52 as the evidence `CLAUDE.md` cites; graded against 0066 by 0076's ceiling method; its 29.3% qualified by 0084 |
 | [0084](0084-dhrystone-is-the-comparable-number-and-the-raw-share-does-not-transfer.md) | Dhrystone is the number this core can be quoted by, and the suite's RAW share does not transfer | Accepted · runs on 0081's `.data` image; re-reads 0070's accounting on compiled code and qualifies 0083's 29.3%; enlarges 0074's prize without reopening it |
 | [0085](0085-the-memory-map-has-one-source-and-every-restatement-is-checked.md) | The memory map has one source, and every restatement is checked | Accepted · closes the defect class 0084 and 0081 each found once; makes 0008's map a shared default rather than two copies; leaves 0054's ROM ceiling and 0044's boot path where they are |
+| [0086](0086-both-cores-in-one-harness-and-the-gap-is-the-fetch-loop.md) | Both cores in one harness, and the gap is the fetch loop | Accepted · pays the comparison 0080 said was owed and corrects two of its statements about the artefact; points at the fetch loop 0076 and 0078 already measured, reopening neither |
 
 0001–0007 came from the design brief
 ([`docs/ideas/finish-the-rewrite.md`](../ideas/finish-the-rewrite.md)). 0008–0011 came out of

--- a/soc/compare/bench.S
+++ b/soc/compare/bench.S
@@ -1,0 +1,71 @@
+/*
+ * The one program both harnesses in this directory run.
+ *
+ * Its job is not to compute anything. Its job is to make the datapath
+ * OBSERVABLE, because the first version of this measurement filled the ROM with
+ * NOPs and yosys proved the outputs constant and folded the core away: 449
+ * placed logic cells against the 1711 the same core synthesises to on its own,
+ * and a critical path through the fragment that was left. soc/compare/placed_vs_synth.py
+ * is the check that now catches that; this file is what stops it triggering.
+ *
+ * So every result reaches a store, every store's data comes from a load and an
+ * ALU chain fed by an earlier store, and the loop never ends. Byte and halfword
+ * traffic is here because the two cores lane their accesses differently -- ours
+ * strobes bytes, VexRiscv replicates the store data across all four lanes and
+ * shifts the load result itself -- and a harness that only ever moved whole
+ * words would leave both spellings unexercised.
+ *
+ * RV32I ONLY. VexRiscv's checked-in configuration has no M extension and no
+ * compressed instructions, so anything else could not be one image. That means
+ * this core's multiplier, divider and compressed decoder are present in the
+ * placed netlist but never issued, which does not move a static timing number
+ * and is recorded with the result anyway.
+ */
+    .section .text.init
+    .globl _start
+_start:
+    li      t0, 0x00010000          /* soc/compare/bench.lds' ram ORIGIN */
+    li      s0, 0                   /* the value every iteration mixes into */
+
+outer:
+    li      t1, 0                   /* word index */
+    li      t2, 128                 /* half the 512-word RAM, so the byte and
+                                       halfword slots below stay clear of it */
+inner:
+    slli    t3, t1, 2
+    add     t3, t0, t3              /* &ram[i] */
+    xor     t4, t1, s0
+    slli    t5, t4, 3
+    add     t4, t4, t5
+    sw      t4, 0(t3)
+    lw      t6, 0(t3)               /* read back what was just written, so the
+                                       memory is in the dependence chain */
+    add     s0, s0, t6
+    sub     s0, s0, t1
+    srli    t5, s0, 7
+    xor     s0, s0, t5              /* xor rather than or: an `or` here fills s0
+                                       with ones and every publication below
+                                       comes out the same, which would let a
+                                       stuck core satisfy the bench's
+                                       cross-core comparison */
+    addi    t1, t1, 1
+    blt     t1, t2, inner
+
+    /* Deliberately NOT at offset 0 of their words. Every access this program
+       made before these was word-aligned, so VexRiscv's byte strobe -- the size
+       mask shifted by the low address bits -- came out the same whether the
+       shift was there or not, and deleting it did not fail this bench. Byte
+       lane 1 and halfword lane 1 are what make the shift observable. */
+    sb      s0, 513(t0)
+    lbu     a0, 513(t0)
+    sh      s0, 518(t0)
+    lhu     a1, 518(t0)
+    add     s0, s0, a0
+    add     s0, s0, a1
+
+    /* The harnesses' LEDs watch the data bus, so this store is what makes the
+       whole chain above reach a pin. */
+    sw      s0, 520(t0)
+    lw      a2, 520(t0)
+    add     s0, s0, a2
+    j       outer

--- a/soc/compare/bench.lds
+++ b/soc/compare/bench.lds
@@ -1,0 +1,30 @@
+/*
+ * The memory map both harnesses in this directory implement, and the only one.
+ * soc/compare/bench_littlecpu.v and soc/compare/bench_vexriscv.v are held to it
+ * by their ROM_WORDS and RAM_WORDS parameters and by rtl/memory.v's BASE, which
+ * both instantiate at its default.
+ *
+ * It is deliberately NOT the shipping map in test/asm/sections.lds. Both
+ * regions are shrunk so the two designs fit the same part: 4 KB of ROM is
+ * 8 SB_RAM40_4K and 2 KB of RAM is 4 more, which leaves room on an hx8k's 32
+ * blocks for a register file of either core's size. The distortion is the
+ * point of the harness rather than a shortcut -- one geometry, two cores.
+ *
+ * The program has no .data and no .bss, so there is no load-address trick here
+ * and no startup copy: everything it reads it stored itself. That keeps the
+ * image identical for both cores, neither of which then needs a runtime the
+ * other does not have.
+ */
+MEMORY {
+    rom(rx)  : ORIGIN = 0x00000000, LENGTH = 4K
+    ram(!rx) : ORIGIN = 0x00010000, LENGTH = 2K
+}
+
+SECTIONS {
+    .text : {
+        *(.text.init);
+        *(.text);
+        *(.text.*);
+        . = ALIGN(4);
+    } >rom
+}

--- a/soc/compare/bench_hx8k.pcf
+++ b/soc/compare/bench_hx8k.pcf
@@ -1,0 +1,21 @@
+# Pin constraints for both harnesses in this directory, on an ice40 hx8k in a
+# ct256 package -- the Lattice iCE40-HX8K Breakout Board's own assignments for
+# its 12 MHz oscillator and the first two of its eight LEDs.
+#
+# hx8k rather than the up5k this project ships on because that is where both
+# sides of the comparison already have a number: ADR-0080 measured this RTL at
+# 31.08 MHz on an hx8k, and every VexRiscv iCE40 figure their project publishes
+# is hx8k too. It is also the only ice40 with enough logic to hold this core at
+# all -- and it has no SPRAM, so the harness's data RAM is block RAM for both.
+#
+# THREE PADS, and both tops present exactly these three. rtl/littlesoc.v also
+# takes a reset button; there is none here because VexRiscv has no second input
+# to give one to, and an asymmetric pinout is a variable in a comparison whose
+# whole point is that nothing else varies. Three pads cannot move a fabric
+# critical path either way.
+#
+# No `-nowarn` flags: icetime's .pcf parser accepts exactly `set_io <name> <pin>`
+# and asserts out on anything longer. Every port here is constrained.
+set_io clk    J3
+set_io led0_n B5
+set_io led1_n B4

--- a/soc/compare/bench_littlecpu.v
+++ b/soc/compare/bench_littlecpu.v
@@ -1,0 +1,124 @@
+`timescale 1 ns / 1 ps
+`default_nettype none
+// This core, in the cross-core comparison harness. Its twin is
+// soc/compare/bench_vexriscv.v, and the two are held to one geometry: the same
+// ROM depth, the same data RAM module at the same base, the same three pads,
+// the same program image, the same part and the same seeds.
+//
+// It is NOT rtl/littlesoc.v and its number is not `make soc-timing`'s. Four
+// things differ, all of them so that both cores fit one part:
+//   - 4 KB of ROM instead of 8, and 2 KB of data RAM instead of 64;
+//   - the data RAM is block RAM, because the comparison runs on an hx8k, which
+//     has no SPRAM at all;
+//   - no rtl/timer.v, because with it this design is 7829 logic cells against
+//     the part's 7680 and does not place. `irq_timer` is driven from a counter
+//     instead of tied off, so the core's interrupt path is still real logic and
+//     the 324 cells left out are the peripheral's, not the core's;
+//   - no reset button, so the pinout is three pads rather than four.
+// Nothing about the core changes. rtl/ is untouched by this whole directory.
+module bench_littlecpu #(
+  parameter integer ROM_WORDS = 1024,
+  parameter integer RAM_WORDS = 512,
+  parameter INIT_EVEN = "soc/compare/rom_even.hex",
+  parameter INIT_ODD  = "soc/compare/rom_odd.hex"
+) (
+  input  logic clk,
+  output logic led0_n,
+  output logic led1_n
+);
+  // Power-on reset only. rtl/littlesoc.v also debounces a button; there is no
+  // button here because VexRiscv's harness would then need one too, and its
+  // core has no equivalent input to hang it off.
+  logic [3:0] por_count = 4'b0;
+  logic       por_done  = 1'b0;
+  logic       reset     = 1'b1;
+  always_ff @(posedge clk) begin
+    if (!por_done) begin
+      por_count <= por_count + 4'd1;
+      if (por_count == 4'hf) por_done <= 1'b1;
+    end
+    reset <= !por_done;
+  end
+
+  logic        trap;
+  logic [31:0] mem_addr, mem_wdata, mem_rdata;
+  logic [31:0] imem_mem_rdata, dmem_mem_rdata;
+  logic [3:0]  mem_wstrb;
+  logic        mem_ren, fetch_stall, irq_timer;
+
+  // Stands in for rtl/timer.v's `mtip` line, which there is no room on the part
+  // for. Tying it to zero instead would let yosys constant-fold `mip.MTIP`, the
+  // interrupt-taking condition and its arm of the trap cause -- real core logic,
+  // deleted from a measurement of the core. The program never sets `mie.MTIE`,
+  // so nothing is ever taken.
+  logic [15:0] irq_count = 16'b0;
+  always_ff @(posedge clk) irq_count <= irq_count + 16'd1;
+  assign irq_timer = irq_count[15];
+  logic [31:0] imem_addr, imem_addr2, imem_addr_next;
+  logic [31:0] imem_data, imem_data2;
+
+  littlecpu riscv (
+    .clk(clk),
+    .reset(reset),
+    .imem_addr(imem_addr),
+    .imem_data(imem_data),
+    .imem_addr2(imem_addr2),
+    .imem_data2(imem_data2),
+    .imem_addr_next(imem_addr_next),
+    .mem_addr(mem_addr),
+    .mem_wdata(mem_wdata),
+    .mem_wstrb(mem_wstrb),
+    .mem_ren(mem_ren),
+    .mem_rdata(mem_rdata),
+    .fetch_stall(fetch_stall),
+    .irq_timer(irq_timer),
+    .trap(trap)
+  );
+
+  imemory #(
+    .ROM_WORDS(ROM_WORDS),
+    .INIT_EVEN(INIT_EVEN),
+    .INIT_ODD(INIT_ODD)
+  ) imem (
+    .clk(clk),
+    .imem_addr_next(imem_addr_next),
+    .imem_data(imem_data),
+    .imem_data2(imem_data2),
+    .mem_addr(mem_addr),
+    .mem_wdata(mem_wdata),
+    .mem_wstrb(mem_wstrb),
+    .mem_ren(mem_ren),
+    .mem_rdata(imem_mem_rdata),
+    .fetch_stall(fetch_stall)
+  );
+
+  // The same module soc/compare/bench_vexriscv.v instantiates, at the same base
+  // and the same depth, so the data RAM is not a variable between the two.
+  memory #(.RAM_WORDS(RAM_WORDS)) dmem (
+    .clk(clk),
+    .mem_addr(mem_addr),
+    .mem_wdata(mem_wdata),
+    .mem_wstrb(mem_wstrb),
+    .mem_rdata(dmem_mem_rdata)
+  );
+
+  assign mem_rdata = imem_mem_rdata | dmem_mem_rdata;
+
+  // Both harnesses publish the same two bits of the data bus, so neither core
+  // is given an output the other does not have. `trap` is the one asymmetry and
+  // it is this core's: VexRiscv's configuration here implements no traps, so
+  // there is nothing on that side to fold it into.
+  logic store_bit, load_bit;
+  always_ff @(posedge clk) begin
+    if (reset) begin
+      store_bit <= 1'b0;
+      load_bit  <= 1'b0;
+    end else begin
+      if (|mem_wstrb) store_bit <= mem_wdata[0];
+      if (mem_ren)    load_bit  <= mem_rdata[0];
+      if (trap)       load_bit  <= 1'b1;
+    end
+  end
+  assign led0_n = !store_bit;
+  assign led1_n = !load_bit;
+endmodule

--- a/soc/compare/bench_tb.v
+++ b/soc/compare/bench_tb.v
@@ -1,0 +1,99 @@
+`timescale 1 ns / 1 ps
+`default_nettype none
+// Runs both harnesses on the same image and requires the two cores to write the
+// SAME sequence of values to the same address.
+//
+// The placement flow's own gate, soc/compare/placed_vs_synth.py, says the core
+// is still in the netlist. It does not say the netlist WORKS, and the part most
+// likely not to is soc/compare/bench_vexriscv.v's bus adapter: a store lane got
+// wrong, or a response presented a cycle early, leaves a core spinning in a
+// fault loop with every logic cell present and every timing number describing a
+// design that does not run. This is the check that could have failed.
+//
+// Word stores to soc/compare/bench.S's publication address are recorded from
+// each harness's data bus and compared element by element. The two cores retire
+// at different rates, so what is compared is the sequence, not the timing.
+module bench_tb;
+  localparam int      CYCLES  = 120000;
+  localparam int      WANT    = 6;
+  localparam bit [31:0] PUBLISH = 32'h0001_0208;  // ram base + 520
+
+  logic clk = 1'b0;
+  always #5 clk = ~clk;
+
+  logic ours_led0_n, ours_led1_n, vex_led0_n, vex_led1_n;
+
+  bench_littlecpu dut_ours (
+    .clk(clk), .led0_n(ours_led0_n), .led1_n(ours_led1_n)
+  );
+  bench_vexriscv dut_vex (
+    .clk(clk), .led0_n(vex_led0_n), .led1_n(vex_led1_n)
+  );
+
+  logic [31:0] ours_seen[0:63];
+  logic [31:0] vex_seen[0:63];
+  int          ours_n = 0, vex_n = 0;
+
+  always_ff @(posedge clk) begin
+    if (dut_ours.mem_wstrb == 4'b1111 && dut_ours.mem_addr == PUBLISH
+        && ours_n < 64) begin
+      ours_seen[ours_n] <= dut_ours.mem_wdata;
+      ours_n            <= ours_n + 1;
+    end
+    if (dut_vex.mem_wstrb == 4'b1111 && dut_vex.dbus_cmd_address == PUBLISH
+        && vex_n < 64) begin
+      vex_seen[vex_n] <= dut_vex.dbus_cmd_data;
+      vex_n           <= vex_n + 1;
+    end
+  end
+
+  int errors = 0;
+  int i;
+  initial begin
+    repeat (CYCLES) @(posedge clk);
+
+    if (ours_n < WANT) begin
+      $display("FAIL: littlecpu published %0d values in %0d cycles, wanted %0d.",
+               ours_n, CYCLES, WANT);
+      $display("      The core is not running soc/compare/bench.S.");
+      errors = errors + 1;
+    end
+    if (vex_n < WANT) begin
+      $display("FAIL: VexRiscv published %0d values in %0d cycles, wanted %0d.",
+               vex_n, CYCLES, WANT);
+      $display("      The bus adapter in soc/compare/bench_vexriscv.v is wrong,");
+      $display("      or the core is stuck.");
+      errors = errors + 1;
+    end
+
+    for (i = 0; i < WANT; i = i + 1) begin
+      if (i < ours_n && i < vex_n && ours_seen[i] !== vex_seen[i]) begin
+        $display("FAIL: publication %0d differs: littlecpu %08x, VexRiscv %08x.",
+                 i, ours_seen[i], vex_seen[i]);
+        $display("      One harness is not presenting the same machine to its core.");
+        errors = errors + 1;
+      end
+    end
+
+    // Agreement on a constant is agreement two stuck cores could reach. The
+    // program's mix was an `or` once, which saturates s0 to all-ones and made
+    // every publication identical; this is what caught it.
+    if (ours_n >= WANT && ours_seen[0] === ours_seen[WANT-1]) begin
+      $display("FAIL: all %0d publications are %08x. The program's value does not",
+               WANT, ours_seen[0]);
+      $display("      change, so this comparison cannot tell a running core from");
+      $display("      a stuck one.");
+      errors = errors + 1;
+    end
+
+    if (errors == 0) begin
+      $display("bench_tb: %0d published values, littlecpu and VexRiscv agree; first %08x, last matched %08x",
+               WANT, ours_seen[0], ours_seen[WANT-1]);
+      $display("PASS");
+    end else begin
+      $display("bench_tb: %0d error(s)", errors);
+      $fatal(1, "bench_tb failed");
+    end
+    $finish;
+  end
+endmodule

--- a/soc/compare/bench_vexriscv.v
+++ b/soc/compare/bench_vexriscv.v
@@ -1,0 +1,164 @@
+`timescale 1 ns / 1 ps
+`default_nettype none
+// VexRiscv in the same harness as soc/compare/bench_littlecpu.v: same ROM depth,
+// the same rtl/memory.v at the same base and depth, the same three pads, the
+// same program image, the same part and the same seeds.
+//
+// The core is not vendored. It is read straight out of the SHA-pinned
+// riscv-formal clone at formal/riscv-formal/cores/VexRiscv/VexRiscv.v, which is
+// the generated Verilog for that project's FormalSimple configuration, so no
+// Scala toolchain is involved and nothing here can drift from the pin.
+//
+// **That configuration is RV32I.** No M extension, no compressed instructions,
+// no CSR file, no traps and no interrupt. Roughly half of why it is a quarter of
+// this core's size. Any number taken from this file is a measurement of two
+// different ISAs and must be quoted as one.
+//
+// Its `rvfi_*` outputs are deleted in synthesis rather than tied off here --
+// `delete -port VexRiscv/rvfi_*`, the same technique formal/check-nonperturbation.py
+// uses on this core. Left connected they present 556 SB_IO and no ice40 package
+// can place them.
+//
+// ---- the bus ---------------------------------------------------------------
+//
+// Both sides are valid/ready with the command always accepted and the response
+// one cycle later, which is what the memories on the other harness already do.
+// `dBus_rsp_ready` is an INPUT and means "response valid" -- the name is the
+// generator's.
+//
+// Store data arrives replicated across all four byte lanes and the core shifts
+// load data itself (`writeBack_DBusSimplePlugin_rspShifted`), so the byte strobe
+// below is the size mask shifted by the low address bits and the read side hands
+// back the whole aligned word. Get that backwards and `sb` writes a word.
+module bench_vexriscv #(
+  parameter integer ROM_WORDS = 1024,
+  parameter integer RAM_WORDS = 512,
+  parameter INIT_ROM = "soc/compare/rom_flat.hex"
+) (
+  input  logic clk,
+  output logic led0_n,
+  output logic led1_n
+);
+  localparam int ROM_BITS = $clog2(ROM_WORDS);
+
+  logic [3:0] por_count = 4'b0;
+  logic       por_done  = 1'b0;
+  logic       reset     = 1'b1;
+  always_ff @(posedge clk) begin
+    if (!por_done) begin
+      por_count <= por_count + 4'd1;
+      if (por_count == 4'hf) por_done <= 1'b1;
+    end
+    reset <= !por_done;
+  end
+
+  logic        ibus_cmd_valid, ibus_rsp_valid;
+  logic [31:0] ibus_cmd_pc, ibus_rsp_inst;
+  logic        dbus_cmd_valid, dbus_cmd_wr, dbus_rsp_valid;
+  logic [31:0] dbus_cmd_address, dbus_cmd_data, dbus_rsp_data;
+  logic [1:0]  dbus_cmd_size;
+
+  VexRiscv riscv (
+    .clk(clk),
+    .reset(reset),
+    .iBus_cmd_valid(ibus_cmd_valid),
+    .iBus_cmd_ready(1'b1),
+    .iBus_cmd_payload_pc(ibus_cmd_pc),
+    .iBus_rsp_valid(ibus_rsp_valid),
+    .iBus_rsp_payload_error(1'b0),
+    .iBus_rsp_payload_inst(ibus_rsp_inst),
+    .dBus_cmd_valid(dbus_cmd_valid),
+    .dBus_cmd_ready(1'b1),
+    .dBus_cmd_payload_wr(dbus_cmd_wr),
+    .dBus_cmd_payload_address(dbus_cmd_address),
+    .dBus_cmd_payload_data(dbus_cmd_data),
+    .dBus_cmd_payload_size(dbus_cmd_size),
+    .dBus_rsp_ready(dbus_rsp_valid),
+    .dBus_rsp_error(1'b0),
+    .dBus_rsp_data(dbus_rsp_data),
+    .rvfi_valid(),
+    .rvfi_order(),
+    .rvfi_insn(),
+    .rvfi_trap(),
+    .rvfi_halt(),
+    .rvfi_intr(),
+    .rvfi_mode(),
+    .rvfi_ixl(),
+    .rvfi_rs1_addr(),
+    .rvfi_rs1_rdata(),
+    .rvfi_rs2_addr(),
+    .rvfi_rs2_rdata(),
+    .rvfi_rd_addr(),
+    .rvfi_rd_wdata(),
+    .rvfi_pc_rdata(),
+    .rvfi_pc_wdata(),
+    .rvfi_mem_addr(),
+    .rvfi_mem_rmask(),
+    .rvfi_mem_wmask(),
+    .rvfi_mem_rdata(),
+    .rvfi_mem_wdata()
+  );
+
+  // One word per cycle, where rtl/imemory.v serves two so a compressed
+  // instruction can straddle a word boundary. Same depth, same block count:
+  // 1024 words either way is 8 SB_RAM40_4K.
+  //
+  // The read is unconditional with the range test registered alongside it,
+  // which is rtl/imemory.v's shape and the one yosys turns into a block RAM's
+  // read port. Written as `inst <= in_range ? rom[i] : 0` it maps to logic.
+  logic [31:0] rom[0:ROM_WORDS-1];
+  generate if (INIT_ROM != "") begin : l_rom_init
+    initial $readmemh(INIT_ROM, rom);
+  end endgenerate
+
+  logic [29:0]        ibus_word;
+  logic [ROM_BITS-1:0] ibus_index;
+  logic [31:0]        rom_data;
+  logic               ibus_in_range;
+  assign ibus_word  = ibus_cmd_pc[31:2];
+  assign ibus_index = ibus_word[ROM_BITS-1:0];
+
+  always_ff @(posedge clk) begin
+    rom_data       <= rom[ibus_index];
+    ibus_in_range  <= ibus_word < 30'(ROM_WORDS);
+    ibus_rsp_valid <= !reset && ibus_cmd_valid;
+  end
+  // Out of range reads as zero, which is an illegal instruction, so a pc that
+  // runs off the end cannot wrap round onto real code. Same rule as rtl/imemory.v.
+  assign ibus_rsp_inst = ibus_in_range ? rom_data : 32'b0;
+
+  logic [3:0] size_mask, mem_wstrb;
+  always_comb begin
+    case (dbus_cmd_size)
+      2'b00:   size_mask = 4'b0001;
+      2'b01:   size_mask = 4'b0011;
+      default: size_mask = 4'b1111;
+    endcase
+  end
+  assign mem_wstrb = (dbus_cmd_valid && dbus_cmd_wr)
+                   ? (size_mask << dbus_cmd_address[1:0]) : 4'b0000;
+
+  memory #(.RAM_WORDS(RAM_WORDS)) dmem (
+    .clk(clk),
+    .mem_addr(dbus_cmd_address),
+    .mem_wdata(dbus_cmd_data),
+    .mem_wstrb(mem_wstrb),
+    .mem_rdata(dbus_rsp_data)
+  );
+
+  always_ff @(posedge clk) dbus_rsp_valid <= dbus_cmd_valid && !dbus_cmd_wr;
+
+  // The same two bits of the data bus soc/compare/bench_littlecpu.v publishes.
+  logic store_bit, load_bit;
+  always_ff @(posedge clk) begin
+    if (reset) begin
+      store_bit <= 1'b0;
+      load_bit  <= 1'b0;
+    end else begin
+      if (|mem_wstrb)   store_bit <= dbus_cmd_data[0];
+      if (dbus_rsp_valid) load_bit <= dbus_rsp_data[0];
+    end
+  end
+  assign led0_n = !store_bit;
+  assign led1_n = !load_bit;
+endmodule

--- a/soc/compare/geometry_test.sh
+++ b/soc/compare/geometry_test.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+# Asserts that every file describing the comparison harness's geometry describes
+# the same one.
+#
+# Usage: geometry_test.sh [repo-root]     # defaults to this script's grandparent
+#
+# The harness's whole claim is that both cores were measured in ONE geometry. Six
+# files state part of it -- the Makefile's variables, both harness tops' parameter
+# defaults, the linker script's two regions and the program's RAM base -- and
+# nothing but this compares them. A ROM that is 1024 words in the Makefile and
+# 2048 in the RTL still synthesises, still places and still reports a critical
+# path; it just reports it for a design the other core was not measured against.
+#
+# The Makefile's numbers reach synthesis through `chparam`, so they are what the
+# placed netlist is built from. The tops' defaults are what iverilog uses in
+# soc/compare/bench_tb.v, which has no chparam -- so a divergence would leave the
+# simulation that says the harness works and the placement that says how fast it
+# is describing different machines.
+#
+# Hermetic: grep, sed and shell arithmetic. No toolchain, no simulator, no yosys.
+set -euo pipefail
+
+HERE=$(cd "$(dirname "$0")" && pwd)
+REPO=${1:-$(cd "$HERE/../.." && pwd)}
+
+if [ ! -d "$REPO" ]; then
+  echo "error: '$REPO' is not a directory, so there is nothing to compare." >&2
+  exit 1
+fi
+
+rc=0
+
+fail() {
+  echo "error: $*" >&2
+  rc=1
+}
+
+for f in Makefile soc/compare/bench_littlecpu.v soc/compare/bench_vexriscv.v \
+         soc/compare/bench.lds soc/compare/bench.S rtl/memory.v; do
+  if [ ! -f "$REPO/$f" ]; then
+    echo "error: $f is missing, so its copy of the harness geometry cannot be" >&2
+    echo "compared. If it moved, move this check with it." >&2
+    exit 1
+  fi
+done
+
+# A declaration this cannot read is fatal rather than empty: comparing against
+# an empty string is how a check goes on reporting green over a file it has
+# stopped understanding.
+read_or_die() {  # $1 = label, $2 = file, $3 = sed program
+  local value
+  value=$(sed -n "$3" "$REPO/$2" | head -1)
+  if [ -z "$value" ]; then
+    echo "error: no $1 found in $2. This check compares the harness's stated" >&2
+    echo "geometry; if the declaration was respelled, teach this script the new" >&2
+    echo "spelling rather than dropping the comparison." >&2
+    exit 1
+  fi
+  printf '%s' "$value"
+}
+
+mk_rom=$(read_or_die "COMPARE_ROM_WORDS" Makefile \
+  's/^COMPARE_ROM_WORDS *:= *\([0-9]*\).*/\1/p')
+mk_ram=$(read_or_die "COMPARE_RAM_WORDS" Makefile \
+  's/^COMPARE_RAM_WORDS *:= *\([0-9]*\).*/\1/p')
+
+for top in bench_littlecpu bench_vexriscv; do
+  v_rom=$(read_or_die "ROM_WORDS default" "soc/compare/$top.v" \
+    's/.*parameter integer ROM_WORDS *= *\([0-9]*\).*/\1/p')
+  v_ram=$(read_or_die "RAM_WORDS default" "soc/compare/$top.v" \
+    's/.*parameter integer RAM_WORDS *= *\([0-9]*\).*/\1/p')
+  [ "$v_rom" = "$mk_rom" ] || fail \
+    "soc/compare/$top.v has ROM_WORDS=$v_rom, the Makefile has COMPARE_ROM_WORDS=$mk_rom"
+  [ "$v_ram" = "$mk_ram" ] || fail \
+    "soc/compare/$top.v has RAM_WORDS=$v_ram, the Makefile has COMPARE_RAM_WORDS=$mk_ram"
+done
+
+# `LENGTH = 4K` -> bytes. Only K is accepted: a script that quietly read `4M` as
+# 4 would compare two numbers that agree and mean different sizes.
+lds_bytes() {  # $1 = region name
+  local raw
+  raw=$(read_or_die "$1 region" soc/compare/bench.lds \
+    "s/^ *$1(.*LENGTH *= *\([0-9]*\)K *\$/\1/p")
+  echo $((raw * 1024))
+}
+
+lds_rom=$(lds_bytes rom)
+lds_ram=$(lds_bytes ram)
+[ "$lds_rom" = "$((mk_rom * 4))" ] || fail \
+  "soc/compare/bench.lds' rom region is $lds_rom bytes, the harness ROM is $((mk_rom * 4))"
+[ "$lds_ram" = "$((mk_ram * 4))" ] || fail \
+  "soc/compare/bench.lds' ram region is $lds_ram bytes, the harness RAM is $((mk_ram * 4))"
+
+# The program reaches RAM through a literal, because it has no .data for the
+# linker to place there. rtl/memory.v's default base is what both harnesses
+# instantiate, so the literal has to be that number.
+prog_base=$(read_or_die "RAM base literal" soc/compare/bench.S \
+  's/.*li *t0, *\(0x[0-9a-fA-F]*\).*/\1/p')
+rtl_base=$(read_or_die "BASE parameter default" rtl/memory.v \
+  "s/.*BASE *= *32'h\([0-9a-fA-F_]*\).*/\1/p")
+rtl_base=0x${rtl_base//_/}
+if [ "$((prog_base))" != "$((rtl_base))" ]; then
+  fail "soc/compare/bench.S addresses RAM at $prog_base, rtl/memory.v's BASE is $rtl_base"
+fi
+
+# The linker script's ram ORIGIN is the same number a third time.
+lds_origin=$(read_or_die "ram ORIGIN" soc/compare/bench.lds \
+  's/^ *ram(.*ORIGIN *= *\(0x[0-9a-fA-F]*\).*/\1/p')
+if [ "$((lds_origin))" != "$((rtl_base))" ]; then
+  fail "soc/compare/bench.lds' ram ORIGIN is $lds_origin, rtl/memory.v's BASE is $rtl_base"
+fi
+
+if [ "$rc" -eq 0 ]; then
+  echo "soc/compare geometry: ${mk_rom}-word ROM, ${mk_ram}-word RAM at $rtl_base," \
+       "stated the same way in all six places"
+fi
+exit $rc

--- a/soc/compare/placed_vs_synth.py
+++ b/soc/compare/placed_vs_synth.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Check that the placed harness still contains the core it claims to measure.
+
+THIS IS THE GATE THAT MAKES THE COMPARISON MEAN ANYTHING. The first attempt at
+this measurement filled the ROM with NOPs. With no store ever executing, every
+output of the design is provably constant, so yosys deleted the datapath: 449
+placed logic cells against the 1711 the same core synthesises to on its own, and
+a critical path of 33.69 ns through the fragment that was left. `(* keep *)` on
+the instance held the cell and did not stop the folding inside it. Nothing in
+the flow said a word.
+
+So the placed cell count is compared against what the core synthesises to
+ON ITS OWN, with no harness around it to fold against. The harness adds
+memories and a few registers and takes nothing away, so the placed count is
+normally ABOVE the standalone one -- 1.13x for this core and 1.41x for VexRiscv
+as measured. The floor is a fraction rather than an equality because packing,
+`abc9` and the harness's own glue all move the number by more than a percent,
+and because nothing here needs to be precise: the defect it catches is a factor
+of four.
+
+Reads nextpnr's utilisation table for the placed count and yosys's cell census
+for the synthesised one, both of which the flow already writes. It does not
+re-run either tool, so `test/probe_gates.sh` can drive it against fixture logs.
+"""
+
+import argparse
+import re
+import sys
+
+# nextpnr's utilisation table: `Info: \t ICESTORM_LC:  7447/  7680    96%`
+PLACED = re.compile(r"ICESTORM_LC:\s*(\d+)\s*/\s*(\d+)")
+# yosys's `stat` census, the same line shape soc/cell_census.py matches.
+SYNTH = re.compile(r"^\s+(\d+)\s+SB_LUT4\s*$")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("pnr_log", help="nextpnr-ice40 log for the harness")
+    parser.add_argument("synth_log", help="yosys log for the core synthesised alone")
+    parser.add_argument("core", help="the core's name, printed with the verdict")
+    parser.add_argument(
+        "--min-ratio",
+        type=float,
+        required=True,
+        help="placed ICESTORM_LC / standalone SB_LUT4 must be at least this",
+    )
+    args = parser.parse_args()
+
+    placed = None
+    for line in open(args.pnr_log):
+        found = PLACED.search(line)
+        if found:
+            placed = int(found.group(1))
+    if placed is None:
+        sys.exit(
+            f"{args.pnr_log}: no ICESTORM_LC utilisation line. nextpnr did not "
+            f"finish placing, so there is no placed design to check."
+        )
+
+    # The LAST census, matching soc/cell_census.py: yosys prints one per pass
+    # and the final one is the whole-design total.
+    synthesised = None
+    for line in open(args.synth_log):
+        found = SYNTH.match(line)
+        if found:
+            synthesised = int(found.group(1))
+    if synthesised is None or synthesised == 0:
+        sys.exit(
+            f"{args.synth_log}: no SB_LUT4 count. Without the standalone number "
+            f"there is nothing to compare the placement against."
+        )
+
+    ratio = placed / synthesised
+    print(
+        f"{args.core}: {placed} placed ICESTORM_LC against {synthesised} SB_LUT4 "
+        f"synthesised alone -- {ratio:.2f}x"
+    )
+    if ratio < args.min_ratio:
+        sys.exit(
+            f"\n*** {args.core}: the placed design is {ratio:.2f}x the core's own\n"
+            f"*** synthesis, under the {args.min_ratio:.2f}x floor. Most of the core is\n"
+            f"*** not in what was placed, so the timing number describes a fragment.\n"
+            f"*** The usual cause is a harness whose outputs do not depend on the\n"
+            f"*** datapath -- an all-NOP ROM does exactly this. Fix the program or\n"
+            f"*** the harness; do not lower the floor."
+        )
+    print(f"RATCHET: {ratio:.2f}x against a {args.min_ratio:.2f}x floor -- OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/soc/compare/rom_flat.py
+++ b/soc/compare/rom_flat.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Write soc/compare/bench_vexriscv.v's single-bank ROM image.
+
+soc/rom_banks.py writes rtl/imemory.v's two interleaved banks from the same
+objcopy output; VexRiscv fetches one word at a time and wants one flat file.
+Both images are the same program, and both are produced from the one `objcopy
+-O verilog` file the Makefile builds once, so the two harnesses cannot come to
+be running different code.
+
+objcopy's format is parsed by importing soc/rom_banks.py rather than by reading
+it again here. A second parser of the same format is a second thing that can
+silently stop matching, and this one would be the copy nobody looks at.
+"""
+
+import argparse
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+# Otherwise the import drops a `soc/__pycache__` into a source directory, which
+# is untracked build detritus nothing else here produces.
+sys.dont_write_bytecode = True
+from rom_banks import parse_verilog_hex  # noqa: E402
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("image", help="objcopy -O verilog --verilog-data-width=4 output")
+    parser.add_argument("out", help="output path for the flat ROM image")
+    parser.add_argument(
+        "--rom-words",
+        type=int,
+        required=True,
+        help="total 32-bit words of ROM; must match the harness's ROM_WORDS",
+    )
+    args = parser.parse_args()
+
+    image = parse_verilog_hex(args.image)
+    if not image:
+        sys.exit(f"{args.image} contains no words; refusing to write an empty ROM")
+
+    top = max(image)
+    if top >= args.rom_words:
+        sys.exit(
+            f"{args.image} reaches word {top} (byte 0x{top * 4:08x}), which is past "
+            f"the {args.rom_words}-word ({args.rom_words * 4} byte) ROM. The harness's "
+            f"ROM is small so that both cores fit one hx8k; shrink the program rather "
+            f"than the ROM."
+        )
+
+    # Full depth, zero-padded: iverilog warns at run time about a short
+    # $readmemh, and a warning fails the build here.
+    words = [0] * args.rom_words
+    for addr, word in image.items():
+        words[addr] = word
+
+    with open(args.out, "w") as handle:
+        for word in words:
+            handle.write(f"{word:08x}\n")
+
+    print(
+        f"{args.image}: {len(image)} words -> {args.out} "
+        f"({args.rom_words * 4} byte ROM)"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/soc/compare/sweep.sh
+++ b/soc/compare/sweep.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+# Run `make compare-timing` for both cores at several placements each and print
+# the two distributions.
+#
+#   soc/compare/sweep.sh                        # both cores, default + seeds 1-3
+#   COMPARE_SEEDS='default 1 2 3 4 5' soc/compare/sweep.sh
+#   COMPARE_CORES=vexriscv soc/compare/sweep.sh # one side only
+#
+# One placement is a sample. `make soc-timing`'s spread on the up5k is 1-2% and
+# its edit churn 3.6%; nothing says the hx8k is tighter, so a claim about which
+# of two cores is faster needs a distribution on both sides and is read on the
+# worst placement of each.
+#
+# `make` is deliberately NOT in a pipeline, for the reason soc/timing_sweep.sh
+# records: the default shell is errexit without pipefail, so a graded command
+# piped into `grep` reports grep's status and a failed placement prints its row
+# and exits 0. The status handed back here is make's.
+set -eu
+
+cd "$(dirname "$0")/../.."
+
+seeds=${COMPARE_SEEDS:-"default 1 2 3"}
+cores=${COMPARE_CORES:-"littlecpu vexriscv"}
+
+for core in $cores; do
+  echo "== $core"
+  rows=""
+  for seed in $seeds; do
+    case $seed in
+      default) arg="" ;;
+      *)       arg=$seed ;;
+    esac
+    if ! out=$(make compare-timing COMPARE_CORE="$core" COMPARE_SEED="$arg" "$@" 2>&1); then
+      printf '%s\n' "$out" >&2
+      echo "*** soc/compare/sweep.sh: $core seed '$seed' failed; the sweep stops here." >&2
+      exit 1
+    fi
+    line=$(printf '%s\n' "$out" | grep '^critical path :') || {
+      echo "*** soc/compare/sweep.sh: $core seed '$seed' exited 0 with no critical" >&2
+      echo "*** path line, which soc/timing_split.py is supposed to make impossible." >&2
+      exit 1
+    }
+    levels=$(printf '%s\n' "$out" | grep '^  logic levels:' | sed 's/^  logic levels: //')
+    lc=$(printf '%s\n' "$out" | grep 'placed ICESTORM_LC against')
+    ns=$(printf '%s\n' "$line" | sed 's/^critical path : \([0-9.]*\) ns.*/\1/')
+    mhz=$(printf '%s\n' "$line" | sed 's/.*(\([0-9.]*\) MHz).*/\1/')
+    printf '  seed %-8s %8s ns  %6s MHz   %s\n' "$seed" "$ns" "$mhz" "$levels"
+    printf '           %s\n' "$lc"
+    rows="$rows$ns "
+  done
+  echo "  sorted: $(printf '%s\n' $rows | sort -n | tr '\n' ' ')"
+  echo
+done
+
+echo "Read the WORST placement of each. Neither core's number here is its own"
+echo "project's published figure, and the two ISAs are not the same -- ADR-0086."

--- a/test/probe_gates.sh
+++ b/test/probe_gates.sh
@@ -27,7 +27,7 @@ REPO=$(cd "$HERE/.." && pwd)
 # Pinned as a literal: a probe that is deleted, or that stops being reached by
 # an early `return`, would otherwise cut this file's coverage while it kept
 # printing a green summary.
-PROBES_EXPECTED=173
+PROBES_EXPECTED=188
 
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/littlecpu-probe.XXXXXX") || {
   echo "error: could not create a temporary directory under ${TMPDIR:-/tmp}." >&2
@@ -1298,6 +1298,112 @@ probe "a malformed baseline line is named rather than skipped" 1 \
 d=$(it_fixture); rm -rf "$d/rf/checks"
 probe "an unreadable clone makes the re-derivation impossible, and fatal" 1 \
   "is not a directory" "$(its "$d")"
+
+begin_group "soc/compare/placed_vs_synth.py"
+
+PS="python3 $REPO/soc/compare/placed_vs_synth.py"
+
+# The numbers are the ones this repo actually measured: 2379 placed logic cells
+# against 1711 synthesised, and the 449-against-1711 that the all-NOP ROM
+# produced and that nothing caught.
+ps_fixture() {
+  local d; d=$(new_case)
+  cat > "$d/pnr.log" <<'LOG'
+Info: Device utilisation:
+Info: 	         ICESTORM_LC:    2379/   7680    30%
+Info: 	        ICESTORM_RAM:      30/     32    93%
+LOG
+  cat > "$d/core.log" <<'LOG'
+     1709   SB_LUT4
+       18   SB_RAM40_4K
+     1711   SB_LUT4
+LOG
+  printf '%s' "$d"
+}
+
+d=$(ps_fixture)
+probe "control: a placement holding the whole core is green" 0 "RATCHET:" \
+  "$PS $d/pnr.log $d/core.log vexriscv --min-ratio 0.8"
+
+# THE ONE THAT MATTERS: the defect this gate was written for.
+d=$(ps_fixture); sed -i.bak 's/2379\/   7680    30%/ 449\/   7680     5%/' "$d/pnr.log"
+probe "a core yosys folded away is red, not a fast design" 1 \
+  "under the 0.80x floor" "$PS $d/pnr.log $d/core.log vexriscv --min-ratio 0.8"
+
+d=$(ps_fixture); sed -i.bak '/ICESTORM_LC/d' "$d/pnr.log"
+probe "no utilisation table means nothing was placed, not that nothing was lost" 1 \
+  "no ICESTORM_LC utilisation line" \
+  "$PS $d/pnr.log $d/core.log vexriscv --min-ratio 0.8"
+
+d=$(ps_fixture); sed -i.bak '/SB_LUT4/d' "$d/core.log"
+probe "no standalone count leaves nothing to compare against" 1 \
+  "no SB_LUT4 count" "$PS $d/pnr.log $d/core.log vexriscv --min-ratio 0.8"
+
+# Without this the ratio is a division by zero, which would raise rather than
+# report -- and a traceback is not a diagnostic.
+d=$(ps_fixture); sed -i.bak 's/^     1711   SB_LUT4/        0   SB_LUT4/' "$d/core.log"
+probe "a standalone synthesis of zero cells is named, not divided by" 1 \
+  "no SB_LUT4 count" "$PS $d/pnr.log $d/core.log vexriscv --min-ratio 0.8"
+
+begin_group "soc/compare/geometry_test.sh"
+
+# A COPY OF THE SHIPPING FILES for the same reason test/memmap_test.sh's fixture
+# is one: the control has to be the real harness, so every red probe below is
+# one edit away from what is actually measured.
+GT="$REPO/soc/compare/geometry_test.sh"
+
+gt_fixture() {
+  local d; d=$(new_case)
+  mkdir -p "$d/rtl" "$d/soc/compare"
+  cp "$REPO"/rtl/memory.v "$d/rtl/"
+  cp "$REPO"/soc/compare/bench_littlecpu.v "$REPO"/soc/compare/bench_vexriscv.v \
+     "$REPO"/soc/compare/bench.lds "$REPO"/soc/compare/bench.S "$d/soc/compare/"
+  cp "$REPO"/Makefile "$d/"
+  printf '%s' "$d"
+}
+
+d=$(gt_fixture)
+probe "control: the shipping harness states one geometry" 0 \
+  "stated the same way in all six places" "$GT $d"
+
+probe "a repo root that does not exist is red before anything is parsed" 1 \
+  "is not a directory" "$GT $d/nowhere"
+
+d=$(gt_fixture); sed -i.bak 's/parameter integer ROM_WORDS = 1024/parameter integer ROM_WORDS = 2048/' \
+  "$d/soc/compare/bench_vexriscv.v"
+probe "one core's ROM growing behind the other's is red" 1 \
+  "has ROM_WORDS=2048, the Makefile has COMPARE_ROM_WORDS=1024" "$GT $d"
+
+d=$(gt_fixture); sed -i.bak 's/parameter integer RAM_WORDS = 512/parameter integer RAM_WORDS = 256/' \
+  "$d/soc/compare/bench_littlecpu.v"
+probe "one core's data RAM shrinking behind the other's is red" 1 \
+  "has RAM_WORDS=256, the Makefile has COMPARE_RAM_WORDS=512" "$GT $d"
+
+d=$(gt_fixture); sed -i.bak 's/LENGTH = 4K/LENGTH = 8K/' "$d/soc/compare/bench.lds"
+probe "a linker script linking past the harness ROM is red" 1 \
+  "rom region is 8192 bytes, the harness ROM is 4096" "$GT $d"
+
+d=$(gt_fixture); sed -i.bak 's/LENGTH = 2K/LENGTH = 16K/' "$d/soc/compare/bench.lds"
+probe "a linker script promising RAM the harness does not have is red" 1 \
+  "ram region is 16384 bytes, the harness RAM is 2048" "$GT $d"
+
+d=$(gt_fixture); sed -i.bak 's/li      t0, 0x00010000/li      t0, 0x00020000/' \
+  "$d/soc/compare/bench.S"
+probe "the program addressing RAM somewhere the harness has none is red" 1 \
+  "addresses RAM at 0x00020000" "$GT $d"
+
+d=$(gt_fixture); sed -i.bak 's/ORIGIN = 0x00010000/ORIGIN = 0x00020000/' \
+  "$d/soc/compare/bench.lds"
+probe "the linker script's RAM origin drifting from the RTL's base is red" 1 \
+  "ram ORIGIN is 0x00020000" "$GT $d"
+
+d=$(gt_fixture); rm "$d/soc/compare/bench.lds"
+probe "a file that moved out from under the check is fatal, not skipped" 1 \
+  "is missing" "$GT $d"
+
+d=$(gt_fixture); sed -i.bak 's/^COMPARE_ROM_WORDS/COMPARE_ROMWORDS/' "$d/Makefile"
+probe "a declaration this cannot read stops rather than comparing empty strings" 1 \
+  "teach this script the new" "$GT $d"
 
 echo
 if [ "$probes" -ne "$PROBES_EXPECTED" ]; then


### PR DESCRIPTION
Closes JEF-789.

ADR-0080 put this core at 31.08 MHz on an hx8k, set it beside VexRiscv's published 92 MHz on the same fabric, called it "a real 3x gap on the same silicon" — and recorded that the comparison was still owed, because theirs had never been placed on our flow. `soc/compare/` pays it: one part, one memory geometry, one program image, one toolchain, five placements a side.

**No `rtl/` changes. `SOC_MIN_MHZ` untouched.** This measures; it does not modify either core.

## The answer

**1.59x, not 3x.** Worst placement of each, five seeds:

| ns, sorted | worst | spread |
|---|---|---|
| **this core** — 30.56 · 30.62 · 30.71 · 30.90 · **31.70** | **31.70 ns — 31.55 MHz** | 3.7% |
| **VexRiscv** — 18.52 · 18.66 · 19.53 · 19.77 · **19.91** | **19.91 ns — 50.23 MHz** | 7.5% |

Best against best is 1.65x, so it does not turn on which end is read; the distributions do not come near overlapping. **Their 92 MHz does not reproduce here at all** — 50.23 worst, 54.00 best — so a large part of the published 3x was never in the silicon. It is the difference between their flow and this one, and this harness cannot attribute it further. It bounds our side, not theirs.

## The two critical paths, LUT levels and carry hops apart

| worst placement | LUT levels | carry hops | ns per LUT level | logic / routing |
|---|---|---|---|---|
| this core | 22 | 2 | 1.43 | 8.86 ns / 22.87 ns (72.1% routing) |
| VexRiscv | 17 | 0 | 1.17 | 6.51 ns / 13.42 ns (67.4% routing) |

22/17 = 1.29 levels, 1.43/1.17 = 1.22 ns each, 1.29 × 1.22 = 1.58 against the 1.59 measured.

**Both paths are the fetch loop.** Ours:

```
ram_8_3 (SB_RAM40_4K) [clk] -> RDATA[14]   2.246 ns before the first LUT
  -> riscv.accessor_out_valid, riscv.decoder.out    decode and the emptiness check
  -> imem.fetch_stall, riscv.accessor.in_is_lw      two of the six stall reasons
  -> imem.odd_first                                 which half of the fetch window
  -> riscv.decoder.pc                               the pc adder, both carry hops
  -> imem.rom_even.0.0_RADDR ... 0.1_RDATA[1]       the ROM's address decode
```

Theirs:

```
IBusSimplePlugin_injector_decodeInput_payload_rsp_inst   a REGISTER holding the instruction
  -> _zz_decode_SRC2, execute_to_memory_MEMORY_STORE     decode and the hazard check
  -> IBusSimplePlugin_decompressor_output_ready          the compressed decoder's handshake
  -> IBusSimplePlugin_iBusRsp_stages_0_output_ready
  -> IBusSimplePlugin_fetchPc_output_ready
  -> IBusSimplePlugin_fetchPc_correctionReg              an ordinary flip-flop
```

**Their fetch loop does not contain the instruction memory; ours contains it at both ends.** We spend 2.246 ns — 7% of the whole period — on block-RAM clock-to-out before the first LUT, and end inside the ROM's own address decode, because the fetch address publishes a cycle early. That is the no-wrong-path-state commitment. Theirs is a one-bit ready chain between two ordinary flip-flops. They also have a 1024-entry branch predictor; we forbid one. The remaining 1.22x per level is not separable from utilisation here — we place at 96% of the part, they at 31%, and there is no bigger ice40.

This agrees with ADR-0076 and ADR-0078, which already measured that loop and priced it. **This reopens neither** — their ceilings remain the numbers to beat.

## Placed-versus-synthesised, both cores

| | placed `ICESTORM_LC` | core alone, `SB_LUT4` | ratio | block RAM |
|---|---|---|---|---|
| this core | 7400 / 7680 (96%) | 6611 | **1.12x** | 16 — 4 regfile, 8 ROM, 4 RAM |
| VexRiscv | 2379 / 7680 (31%) | 1711 | **1.39x** | 30 — 4 regfile, **14 branch predictor**, 8 ROM, 4 RAM |

The first attempt at this measurement filled the ROM with NOPs and yosys folded the core away: **449 placed cells against 1711 synthesised**, and a 33.69 ns critical path through the fragment. `soc/compare/placed_vs_synth.py` grades that ratio at 0.8x now, and the all-NOP case is 0.26x.

**Two of ADR-0080's statements about the artefact are corrected.** The generated core is **RV32IC**, not RV32I — the compressed decoder is there. And its 18 block RAMs are 14 of branch predictor plus a register file that is **the same 4 blocks ours is**; the ROM shrank for a predictor, not a register file.

## Every distortion the harness required

**This is not a like-for-like comparison of shipped designs and must not be quoted as one.**

- **Different ISAs.** Theirs: RV32IC, no M, no CSR file, no traps, no interrupt. Ours: RV32IMC_Zicsr_Zifencei, mandated M-mode CSR set, five traps, a machine timer. C is on both sides; the privileged architecture is ours alone.
- **Not their 92 MHz configuration either.** That row is 1130 LC of "small, no bypass, no interrupt"; this is 1711 `SB_LUT4` with a compressed decoder and a predictor. What it does share is the stall-only interlock — `HazardSimplePlugin`'s bypass conditions are constant-true, so it stalls on every hazard, as we do.
- **Neither design's own SoC.** 4 KB ROM and 2 KB data RAM in block RAM on an hx8k, against the shipping 8 KB + 64 KB SPRAM on up5k. hx8k has no SPRAM and 32 block RAMs to divide between two cores.
- **`rtl/timer.v` is out.** With it we are 7829 cells against the part's 7680 and do not place. `irq_timer` is driven from a counter rather than tied off, so the core's interrupt path is still real logic; the 324 cells left out are the peripheral's.
- **No `-dsp`** — hx8k has no `SB_MAC16`, so our multiplier is soft logic (6611 `SB_LUT4` against 3921 + 4 DSP on up5k). Theirs has no multiplier.
- **The image is RV32I**, so our M, C and CSR instructions are placed but never issued. Does not move a static timing number.
- **96% against 31% utilisation.** Congestion is pressure on the longer path and not on the shorter one, and this harness cannot control for it.

## What is graded, and its red direction

- `soc/compare/placed_vs_synth.py` — five probes, including the exact 449-against-1711.
- `soc/compare/geometry_test.sh` — ten probes; holds the harness's six restatements of its geometry together, and hangs off `make test` because nothing else on a developer's machine would notice the harness rotting.
- `PROBES_EXPECTED` 173 → **188**.
- `soc/compare/bench_tb.v` — both harnesses on the one image, required to publish the same value sequence. Demonstrated red by deleting the byte-lane shift from VexRiscv's store strobe.

Three defects in this flow each produced a green run and a number before being caught: the folded core, a program whose `or` saturated so every publication was identical, and a `|` in `COMPARE_DEPS` that made the ROM rule order-only so `--seed` never re-placed anything and four "placements" reported one number to the millisecond.

VexRiscv is read from `formal/riscv-formal/cores/VexRiscv/VexRiscv.v` in the SHA-pinned clone (`c992aa61fdfe0846c5ed90324c596202a1c69b76`) and **never copied into this repo**. No Scala, no sbt.

## Tested

- `make test` — 62/62, failure list matches `EXPECTED_FAIL`, 188 probes green.
- `make soc-timing` — 12.20 MHz against the 12.00 floor, unchanged.
- `make fit` — 3958 of 4100, unchanged.
- `make compare-smoke` — both cores publish six agreeing values; red-direction demonstrated.
- `soc/compare/sweep.sh` with five seeds a side, then reproduced after `make clean`.

Decisions taken without asking, recorded in ADR-0086: hx8k as the fabric (both sides already had a number there, and it is the only ice40 that holds this core); the geometry shrink; dropping the timer; and a three-pad pinout so neither core has an input the other lacks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
