### PR TITLE
Give pcloop's operand-fetch excuse an anti-vacuity cover (JEF-797)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,13 @@ jobs:
       - name: Decoder component proof
         run: make -C formal components_decoder
 
-      - name: Fetcher/decoder PC-loop proof
+      # This one make also runs formal/pcloop_cover.sby, which is a prerequisite
+      # of the target rather than a step of its own. That task is the proof's
+      # anti-vacuity control: the increment assertion is excused on an
+      # operand-fetch cycle, and an excuse widened until it covers every issuing
+      # cycle would leave the assertion asking nothing. Wiring it as a
+      # prerequisite is what stops the two from being run apart.
+      - name: Fetcher/decoder PC-loop proof (+ its anti-vacuity cover)
         run: make -C formal components_pcloop
 
       - name: Trap commit proof

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ formal/dmemcheck
 formal/imemcheck
 formal/components_*
 formal/components
+formal/pcloop_cover
 test/rtl.cc
 test/monitor.sim.v
 *.vvp

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -354,7 +354,8 @@ make -C formal check                # the generated riscv-formal checks; always 
 make -C formal check-baseline       # re-grade a finished run without re-running
 make -C formal components_decoder   # component proofs by k-induction (mode prove):
 make -C formal components_executor  #   read the sby summaries, not the job colour
-make -C formal components_pcloop
+make -C formal components_pcloop    #   pcloop runs pcloop_cover first, its anti-vacuity
+                                    #   control, as a prerequisite of the same target
 make -C formal components_traps     #   traps is the only proof over real mtvec/mepc/mcause/mstatus
 make -C formal complete             # depth-50 whole-ISA walk minus COMPLETE_EXCLUSIONS
 make -C formal complete_cover       # its anti-vacuity control

--- a/formal/Makefile
+++ b/formal/Makefile
@@ -79,6 +79,11 @@ dmemcheck: dmemcheck.sby dmemcheck.sv arbiter.v $(RTL_SOURCES) | $(RISCV_FORMAL_
 imemcheck: imemcheck.sby imemcheck.sv arbiter.v $(RTL_SOURCES) | $(RISCV_FORMAL_DIR)
 cover:     cover.sby     cover.sv     arbiter.v $(RTL_SOURCES) | $(RISCV_FORMAL_DIR)
 
+# The anti-vacuity control for components_pcloop, over the same pcloop.sv. No
+# riscv-formal clone: it instantiates two rtl/ modules and nothing else, the way
+# the components tasks do, so it runs in the same CI job they do.
+pcloop_cover: pcloop_cover.sby pcloop.sv ../rtl/fetcher.v ../rtl/decoder.v ../rtl/structs.v
+
 # complete-exclusions is a prerequisite rather than a companion target: the
 # exclusion set is what makes this check passable at all, and checking it costs
 # milliseconds and fails before sby starts.
@@ -128,7 +133,12 @@ components_executor: components.sby ../rtl/executor.v ../rtl/structs.v
 	sby -f $< executor
 # Discharges the standalone decoder task's `assume(in.pc == pc)`, which is
 # where that proof's content went.
-components_pcloop: components.sby ../rtl/fetcher.v ../rtl/decoder.v \
+#
+# pcloop_cover is a prerequisite rather than a companion target, the same way
+# complete-exclusions is of `complete`: it is what says this proof's increment
+# assertion is still reached, and a control that can be run separately from the
+# thing it controls eventually is not run at all.
+components_pcloop: components.sby pcloop_cover ../rtl/fetcher.v ../rtl/decoder.v \
                    ../rtl/structs.v pcloop.sv
 	rm -rf $@
 	sby -f $< pcloop
@@ -146,6 +156,7 @@ components_traps: components.sby ../rtl/fetcher.v ../rtl/decoder.v ../rtl/csrs.v
 # /bin/sh, make's default shell, passes through literally and deletes nothing.
 clean:
 	rm -rf checks complete complete_cover cover dmemcheck imemcheck components components_*
+	rm -rf pcloop_cover
 	rm -rf $(RISCV_FORMAL_DIR) $(RISCV_FORMAL_DIR).tmp
 
 .PHONY: all clean

--- a/formal/pcloop.sv
+++ b/formal/pcloop.sv
@@ -173,7 +173,10 @@ module pcloop (
   // the next instruction's pair; what has to match it is the pair the current
   // instruction decodes to. Register the guess on both sides and this is true on
   // nearly every issuing cycle, which would excuse the pc from advancing almost
-  // everywhere and leave the assertion below asking nothing.
+  // everywhere and leave the assertion below asking nothing. That warning is not
+  // left to this comment to enforce: the two cover goals further down have to
+  // reach that assertion, and the second of them is unreachable under exactly
+  // that edit.
   logic [4:0] f_prev_rs1, f_prev_rs2;
   logic       f_read_taken, f_operand_fetch;
   always_ff @(posedge clk) begin
@@ -188,6 +191,16 @@ module pcloop (
     end
   end
   assign f_operand_fetch = !f_read_taken || f_prev_rs1 != rs1 || f_prev_rs2 != rs2;
+
+  // The control for the paragraph above, run by formal/pcloop_cover.sby. A
+  // comment cannot stop the excuse from widening; the two cover goals near the
+  // increment assertion can, and this is what the second of them reads. It says
+  // the pair presented to the register file changed from the one presented
+  // before it -- which is what an excuse built from two registered copies of the
+  // guess would be, so that excuse and this signal cannot both be low on the
+  // same cycle.
+  logic f_pair_moved;
+  assign f_pair_moved = read_rs1 != f_prev_rs1 || read_rs2 != f_prev_rs2;
 
   // List every reason decode can stall. Miss one and the assertion below covers
   // a cycle where the pc is allowed to hold, then fails there instead of
@@ -216,7 +229,7 @@ module pcloop (
   // computed from values that had settled before it.
   logic [31:0] past_pc, prev_mtvec, prev_mepc;
   logic prev_reset, prev_may_stall, prev_hard_stall, prev_jump_branch, prev_uncompressed;
-  logic prev_trap_entry, prev_mret_entry, prev_fetch_stall;
+  logic prev_trap_entry, prev_mret_entry, prev_fetch_stall, prev_pair_moved;
   always_ff @(posedge clk) begin
     past_pc           <= pc;
     prev_reset        <= reset;
@@ -229,6 +242,7 @@ module pcloop (
     prev_mret_entry   <= mret_entry;
     prev_mtvec        <= mtvec;
     prev_mepc         <= mepc;
+    prev_pair_moved   <= f_pair_moved;
   end
 
   always_comb if (clocked && !reset) assert(fetcher_out.pc == pc);
@@ -245,12 +259,37 @@ module pcloop (
   // The increment goes through the real fetcher. rtl/decoder.v adds fetcher_pc,
   // not its own pc, and only the echo assertion above ties fetcher_pc back to
   // past_pc.
+  //
+  // The guard is a signal rather than written out twice because the two cover
+  // goals below have to sit on exactly it. A cover under a copy could be
+  // narrowed apart from the assertion and go on reporting that a cycle nobody
+  // checks any more is reachable.
+  logic f_increment_checked;
+  assign f_increment_checked =
+      clocked && !prev_reset && !prev_may_stall && !prev_jump_branch;
+
   always_ff @(posedge clk)
-    if (clocked && !prev_reset && !prev_may_stall && !prev_jump_branch)
+    if (f_increment_checked)
       assert(pc == past_pc + (prev_uncompressed ? 32'd4 : 32'd2));
 
   // pc_inc == (uncompressed ? 4 : 2) is not asserted here. It would just
   // restate rtl/decoder.v, whose own proof already pins both constants.
+
+  // Only cover mode looks at these; formal/pcloop_cover.sby is that run, and
+  // formal/Makefile makes it a prerequisite of the proof so neither can be run
+  // without the other.
+  //
+  // The first fails if any term of f_may_stall becomes universal -- an excuse
+  // that fires everywhere leaves the assertion above guarded by something
+  // always false and passing having asked nothing. The second fails if
+  // f_operand_fetch stops comparing what was presented against the pair the
+  // instruction decodes to, which is the one edit that would make the excuse
+  // near-universal without making it constant.
+  always_ff @(posedge clk)
+    if (f_increment_checked) begin
+      increment_reached: cover (1'b1);
+      increment_reached_on_moved_pair: cover (prev_pair_moved);
+    end
 
   always_ff @(posedge clk)
     if (clocked && prev_hard_stall && !prev_reset) assert(pc == past_pc);

--- a/formal/pcloop_cover.sby
+++ b/formal/pcloop_cover.sby
@@ -1,0 +1,57 @@
+# The anti-vacuity control for components.sby's `pcloop` task, and it reads the
+# SAME pcloop.sv.
+#
+# That task's increment assertion -- the pc steps by 4 or 2 -- is guarded by
+# `!f_may_stall`, and one term of that OR is `f_operand_fetch`, which excuses the
+# pc from advancing on a cycle the register file was asked for a pair the
+# instruction in decode does not read. The excuse is correct. What it cannot
+# defend itself against is a later edit that makes it fire everywhere: decode
+# presents a guess at the next instruction's pair on an issuing cycle, so an
+# f_operand_fetch built from two registered copies of that guess would be true on
+# nearly every issuing cycle, and the proof would stay green having stopped
+# asking.
+#
+# So this task takes the same harness and asks the opposite question. sby's
+# `mode cover` strips the assertions and keeps the assumes, so what runs here is:
+# find a trace that reaches the increment assertion's guard, and one that reaches
+# it on a cycle where the pair presented had moved. The second is unreachable if
+# the excuse ever stops comparing against the decoded pair, because such an
+# excuse IS the moved-pair term.
+#
+# It is a separate .sby rather than a task inside components.sby because that
+# file sets `all: mode prove`, and a cover task would have to override an option
+# every other task there wants. formal/Makefile makes this a prerequisite of
+# `components_pcloop`, which is what stops the control from rotting apart from
+# the proof it controls.
+#
+# ENGINE: smtbmc boolector, the same solver components.sby had to pick for
+# pcloop -- the default yices sat in that task's basecase for over fourteen
+# minutes on this tree.
+#
+# DEPTH 30 is a HEADROOM number rather than a measured floor. Measured, both
+# goals are reached at step 4 and the task returns in about a second. The bound
+# is left well clear of that because the cheap failure mode is a goal that
+# becomes reachable only slightly later after some future pipeline change, which
+# would read as "unreachable" -- i.e. as an excuse that had swallowed every
+# issuing cycle -- and send the next reader hunting the wrong thing.
+
+[options]
+mode cover
+depth 30
+
+[engines]
+smtbmc boolector
+
+[script]
+# Read WITHOUT -formal, for the reason components.sby's pcloop task states: with
+# it, rtl/decoder.v's own `assume(in.pc == pc)` compiles into the instance and
+# the harness assumes what it exists to check.
+read -sv structs.v fetcher.v decoder.v
+read -sv -formal structs.v pcloop.sv
+prep -top pcloop
+
+[files]
+../rtl/fetcher.v
+../rtl/decoder.v
+../rtl/structs.v
+pcloop.sv


### PR DESCRIPTION
Closes JEF-797.

`formal/pcloop.sv`'s increment assertion — the pc steps by 4 or 2 — is guarded by
`!f_may_stall`, and one term of that OR is `f_operand_fetch`, which excuses the pc from
advancing on a cycle the register file was asked for a pair the instruction in decode does
not read. **The excuse is correct and is untouched here.** The risk ADR-0089 created and
wrote down is that a later edit makes it universal: decode now presents a *guess* at the
next instruction's pair on an issuing cycle, so an `f_operand_fetch` built from two
registered copies of that guess would be true on nearly every issuing cycle and the proof
would stay green having stopped asking. A tripwire comment says exactly that, and a comment
is not a grader.

## What this adds

`formal/pcloop_cover.sby` — `mode cover`, `smtbmc boolector`, depth 30 — over the same
`pcloop.sv`, built on `complete_cover`'s precedent. Two goals, both sitting under the
increment assertion's own guard, so reaching one is reaching a cycle that assertion really
checked:

```systemverilog
  logic f_pair_moved;
  assign f_pair_moved = read_rs1 != f_prev_rs1 || read_rs2 != f_prev_rs2;
  ...
  logic f_increment_checked;
  assign f_increment_checked =
      clocked && !prev_reset && !prev_may_stall && !prev_jump_branch;

  always_ff @(posedge clk)
    if (f_increment_checked)
      assert(pc == past_pc + (prev_uncompressed ? 32'd4 : 32'd2));

  always_ff @(posedge clk)
    if (f_increment_checked) begin
      increment_reached: cover (1'b1);
      increment_reached_on_moved_pair: cover (prev_pair_moved);
    end
```

`increment_reached` fails if any term of `f_may_stall` becomes universal.
`increment_reached_on_moved_pair` is the discriminating one: an excuse built from two
registered copies of the guess **is** the moved-pair term, so that excuse and this goal
cannot both hold — and that mutation leaves the first goal reachable, which is why one goal
was not enough.

The assertion's guard becomes a named signal for the same reason the cover exists: a cover
under a second copy of it could be narrowed apart from the assertion and go on reporting a
cycle nobody checks any more. Nothing else about the assertion changed.

## Its red direction, demonstrated

Both mutations applied to the shipped `formal/pcloop.sv`, reverted after.

**1. `f_operand_fetch` widened so it excuses every issuing cycle** —
`assign f_operand_fetch = 1'b1;`

```
Unreached cover statement at pcloop: increment_reached
Unreached cover statement at pcloop: increment_reached_on_moved_pair
engine_0 (smtbmc boolector) returned FAIL
DONE (FAIL, rc=2)
```

**2. the guess registered on both sides of the comparison** — the tripwire's named edit,
`f_prev_rs1 != read_rs1 || f_prev_rs2 != read_rs2`

```
reached cover statement pcloop.increment_reached at pcloop.sv:290 step 4
Unreached cover statement at pcloop: increment_reached_on_moved_pair
engine_0 (smtbmc boolector) returned FAIL
DONE (FAIL, rc=2)
```

**3. it gates the proof's target, not only its own** — with mutation 1 in place,
`make -C formal components_pcloop` exits **2** (`make: *** [pcloop_cover] Error 2`).

Unmutated, both goals are reached at step 4 and the task returns in about a second.

## Where it runs

`pcloop_cover` is a **prerequisite of `components_pcloop`**, the way `complete-exclusions`
is of `complete` — not a companion target and not a CI step of its own, so the control
cannot be run apart from the thing it controls. The required `components` job's
"Fetcher/decoder PC-loop proof" step runs `make -C formal components_pcloop`, so it executes
there today with no new job or step. It needs no riscv-formal clone (two `rtl/` modules and
nothing else), which is what lets it live in that job.

## Checks

| gate | result |
|---|---|
| `make -C formal pcloop_cover` | PASS, both goals reached at step 4 |
| `make -C formal components_pcloop` | successful proof by k-induction (the cover statements are invisible to `mode prove`) |
| `make -C formal components_decoder` / `_executor` / `_traps` | successful proof by k-induction, all three |
| `make -C formal check` | **85 checks: 85 pass, 0 fail**; failure list matches `EXPECTED_FAIL` exactly, generated set matches `EXPECTED_CHECKS` exactly |
| `make -C formal nonperturbation` | green |
| `make test` | 62/62, `EXPECTED_FAIL` exact, suite shape matches `OBSERVED_FLOOR` (62 programs), **188 graded comparisons, every failure path executed** |

`make -C formal complete` does not run on this machine — the local Homebrew yosys rejects
abc's `-g AND -fast`, and it fails identically on unmodified `main`. It is covered on CI.

No depth moved and F and G are untouched: this adds no stall reason, lengthens no stage and
widens no scoreboard, and the generated checks do not read `pcloop.sv`.

## Decisions taken without asking

- **No probe in `test/probe_gates.sh`.** That script is a hermetic forcing of the shell and
  python graders; this control's grader is sby's own exit status, which is how every other
  `.sby` task is graded and which `complete_cover` has no probe for either. Its red
  direction is demonstrated by mutation above instead. `PROBES_EXPECTED` is unchanged and
  verified at 188 by the run, not assumed.
- **A separate `.sby` rather than a task in `components.sby`.** That file sets
  `all: mode prove`; a cover task would have to override an option every other task there
  wants. Same split, and the same reason, as `complete_cover` against `complete`.
- **No ADR.** Nothing here changes a decision — it mechanises a warning ADR-0089 already
  recorded.

## What it does not catch, stated plainly

`increment_reached_on_moved_pair` is unreachable under the *shipped* design's opposite too:
if the operand-fetch guess were ever reverted, decode would present the current
instruction's own pair, the pair could not move on an issuing cycle, and this goal would go
red. That is a feature — a control written for a hazard the guess created has to be
re-derived if the guess goes — but it is a red that means "re-read this", not "the pc is
wrong", and the `.sby` header says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJ77ZZJ6pDiL3vj3Qw9hKs
