### PR TITLE
Clock the reset edge in the cxxrtl runner (JEF-798)

### DIFF
--- a/test/cxxrtl.cc
+++ b/test/cxxrtl.cc
@@ -454,8 +454,6 @@ int main(int argc, char **argv) {
   top.step();
 
   for (long cycle = 0; cycle < args.cycles; ++cycle) {
-    if (cycle == 0)
-      top.p_reset.set(false);
     top.p_clk.set<bool>(false);
     top.step();
     // Sampled here, between the two edges, because these are combinational: with
@@ -485,6 +483,17 @@ int main(int argc, char **argv) {
     top.p_clk.set<bool>(true);
     top.step();
     sample(cycle * 2 + 1);
+
+    // Reset spans exactly one rising edge and is released after it, the shape
+    // test/testbench.v drives and rtl/littlesoc.v's power-on counter
+    // generalizes. Clearing the pin BEFORE the first edge instead runs no
+    // `if (reset)` in the design at all: the core starts from whatever its
+    // registers powered up with, a broken reset value is invisible here and red
+    // in every other leg, and only a stalled cycle re-reading the ROM hides it.
+    // Cycle 0 is that reset cycle and is counted like any other -- it is an edge
+    // the run took -- so `--stalls` charges it like any other stalled cycle.
+    if (cycle == 0)
+      top.p_reset.set(false);
 
     uint32_t errcode = monitor_errcode->curr[0] & 0xffff;
     if (errcode != 0) {


### PR DESCRIPTION
Closes JEF-798.

`test/cxxrtl.cc` set `p_reset`, called `step()` with the clock unchanged, and cleared the pin before the first rising edge. No `if (reset)` in the design ever ran under the primary test leg — the core started from whatever cxxrtl zero-initialised, and got away with it only because a stalled cycle re-presents the fetch address, so the first window is right by the time anything issues. ADR-0091 recorded the finding and left it alone deliberately; a fetch that holds its output register turns it into 62 programs trapping to zero.

Reset now spans exactly one rising edge and is released after it, which is the shape `test/testbench.v` drives (`repeat (1) @(posedge clk); reset <= 0;`) and `rtl/littlesoc.v`'s 16-cycle power-on counter generalizes.

## The gate can now fail

`rtl/decoder.v`'s `reset: next_pc = 32'b0` changed to `32'd8` — a real break of the reset path, and nothing else touched:

| runner | `make test` on the broken RTL |
|---|---|
| main's `test/cxxrtl.cc` | **62/62 PASS**, failure list matches `test/EXPECTED_FAIL` exactly |
| this branch | **red** — TRAP-TO-ZERO, FAIL 2, TIMEOUT and BELOW-FLOOR across the suite |

`make waves` (iverilog, which already clocked reset) went red on the same break with `FLOOR VIOLATION: writes=0 retires=194`, and the unit benches stayed green — so before this change the cxxrtl leg was the one that could not see it. The breakage was reverted; the diff is `test/cxxrtl.cc` only.

## Cycles

The reset cycle is cycle 0 of the run and is counted like any other, so `make cycles` moves +1 per program.

| | cycles | retires | CPI | operand | unattributed |
|---|---|---|---|---|---|
| `b2b7d81` | 29 454 | 15 654 | 1.88 | 1650 | 0 |
| this branch | **29 516** | 15 654 | **1.89** | **1712** | 0 |

Every one of the 62 programs moved by exactly +1 cycle, and every one of those cycles is charged to `operand` — `read_taken` is low under reset, so `operand_stall` is the first reason the decoder has true on that edge. No other column moved on any program, and `unattributed` is still 0.

## `test/OBSERVED_FLOOR` does not move, and that is the re-derivation

The ticket expected a shift there. It records **retires**, not cycles, and retires are unchanged at 15 654 — identical on every program in both columns, `.S` and `.c` alike. So the file is left exactly as it is: nothing in it was measured to move, and editing it would be a re-baseline of a measurement that did not change. The per-program cycle counts that did move are not recorded in any tracked file; `make cycles` is not a ratchet.

## Verification

| leg | verdict |
|---|---|
| `make test` | 62/62, failure list matches `test/EXPECTED_FAIL` exactly |
| `make test-units` | green, bench list checked both ways |
| `make probe-gates` | 188 graded comparisons, every failure path executed |
| `make waves` (iverilog) | RETIRES 79 SPEC-CHECKED 79 WRITES 20 |
| `make -C formal check` | 85 checks, 85 pass; matches `EXPECTED_FAIL` and `EXPECTED_CHECKS` |
| `components_decoder` / `_executor` / `_pcloop` / `_traps` | all PASS, successful proof by k-induction |
| `make cosim-suite` | 60/62, matches `test/COSIM_EXPECTED_FAIL` exactly |
| `make cycles` | 29 516, CPI 1.89, `unattributed` 0 |

`make cosim-suite` reads the core's real `regs_a` and is unchanged: `test/cosim.cc` compares the *sequence* of architectural register changes against sail, not the cycle they land on, and the register file has no reset, so an extra reset edge changes neither its contents nor the sequence.

`make -C formal complete` does not return a verdict on this machine — local Homebrew yosys rejects `abc -g AND -fast`, identically on unmodified main, recorded in ADR-0088, ADR-0090 and ADR-0091. Relying on CI's pinned OSS CAD Suite for it.

## One finding for follow-up, deliberately not fixed here

`test/cosim.cc` has the identical shape (`p_reset.set(true); step();` then clearing it before the first edge), and its comment claims to "seed the shadow from the post-reset state" — there is no post-reset state, for the same reason. It is out of this ticket's scope, co-simulation is not a required leg, and its baseline is unaffected either way, so it is reported rather than changed.

No ADR: ADR-0091 already records the finding, and the re-baseline turned up nothing that changes a decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJ77ZZJ6pDiL3vj3Qw9hKs
