### PR TITLE
Clock the reset edge in the co-simulation runner (JEF-799)

### DIFF
--- a/test/cosim.cc
+++ b/test/cosim.cc
@@ -254,9 +254,10 @@ int main(int argc, char **argv) {
 
   top.p_reset.set(true);
   top.step();
-  // The regfile has no reset, so its power-on contents are whatever cxxrtl
-  // zero-initialised them to. Seed the shadow from the post-reset state so
-  // the first printed change is a real one and not the initialisation.
+  // The regfile has no reset, so its contents here are whatever cxxrtl
+  // zero-initialised them to and the reset edge below leaves them alone. Seed
+  // the shadow from them so the first printed change is a real write and not
+  // the initialisation.
   std::memcpy(shadow, regs, sizeof(shadow));
 
   long change_index = 0;
@@ -264,12 +265,19 @@ int main(int argc, char **argv) {
   long verdict_cycle = 0;
 
   for (long cycle = 0; cycle < args.cycles; ++cycle) {
-    if (cycle == 0)
-      top.p_reset.set(false);
     top.p_clk.set<bool>(false);
     top.step();
     top.p_clk.set<bool>(true);
     top.step();
+
+    // Reset spans exactly one rising edge and is released after it, the shape
+    // test/testbench.v drives and rtl/littlesoc.v's power-on counter
+    // generalizes. Clearing the pin BEFORE the first edge instead runs no
+    // `if (reset)` in the design at all, and only a stalled cycle re-reading
+    // the ROM hides that -- so cycle 0 is the reset cycle and every printed
+    // cycle number counts it.
+    if (cycle == 0)
+      top.p_reset.set(false);
 
     // The two arrays are one architectural register file, written
     // from one address and one data word. Nothing else in this program would


### PR DESCRIPTION
Closes JEF-799.

`test/cosim.cc` carried the same shape `test/cxxrtl.cc` had until 9fbee42: it asserted `reset`, called `step()` with the clock unchanged, then cleared the pin **before** the first rising edge — so no `if (reset)` in the design ever ran under the co-simulation runner either. Reset now spans exactly one rising edge and is released after it, the shape `test/testbench.v` drives (`repeat (1) @(posedge clk); reset <= 0;`) and `rtl/littlesoc.v`'s power-on counter generalizes.

The comment beside the shadow seed said it seeded the shadow "from the post-reset state". There was no post-reset state, for exactly this reason. It now says what the sequence gives: the regfile has no reset, its contents at that point are cxxrtl's zero-initialisation, and the reset edge leaves them alone.

Runner-only. No RTL, no baseline file, no ADR — ADR-0091 already records the finding and this changes no decision.

## The reset edge is now taken — measured

Probing `mcycle` immediately after the first rising edge, same RTL, same program (`add.S`), the two runner shapes apart:

| shape | cycle 0 `reset` at the edge | `mcycle` after it |
|---|---|---|
| before | 0 (already released) | 1 |
| after | 1 | 0 |

The counter does not advance on cycle 0 any more, which is `rtl/csrs.v`'s reset arm running.

## The shadow seeding does not change — measured, not predicted

Instrumented the runner to print the seed and the register file immediately after the first rising edge, on `add.S`, `trap.S`, `datainit.c`, `mtimer.S` and `selfmod.S`: the seed is 32 zero words on every one, and is **bit-identical across the reset edge** on every one. The regfile has no reset, so the edge writes nothing — confirmed by reading it, not by the argument that predicts it.

## Register-change sequences, all 62 programs

Dumped the raw `CS` output for the whole suite before and after, using `test/cosim.py`'s own `assemble()` so the images are exactly what the runner is normally handed:

- **register sequences differ: none.** Change index, register writes and pc are identical on every program and every line.
- **cycle column differs on all 62, by exactly +1**, and the only distinct delta observed is `(1,)` — one reset edge per program and nothing else. `CS END`'s verdict cycle moves +1 with it. That matches what 9fbee42 measured on the other runner.

Only the cycle column is diagnostic here; `test/cosim.py` compares register-change *sequences*, which is why the graded result cannot move.

## Checks

| gate | result |
|---|---|
| `make cosim-suite` | **60/62 agreed**, divergence list matches `test/COSIM_EXPECTED_FAIL` exactly. The whole graded output is **byte-identical** to the pre-change run (`diff` empty), so the failure set is identical, not merely the same size: `mtimer.S` and `mtimermask.S`, both `INCONCLUSIVE SAIL-LIMIT`. |
| `make test` | 62/62, `test/EXPECTED_FAIL` exact |
| `make test-units` | 9/9 |
| `make probe-gates` | 188 graded comparisons, every failure path executed |

Sail was already unpacked at `~/.cache/little-cpu/sail` (pinned 0.13.1), so `cosim-suite` really ran.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
