### PR TITLE
Say why the abc engine cannot run locally, instead of a parse error (JEF-803)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -425,9 +425,17 @@ compare-geometry-test:
 window-test:
 	@./test/window_test.sh
 
+# Drives formal/check-abc-engine.sh both ways against a stub yosys and a stub
+# sby. Hangs off `test` like the other bash checks -- it is bash and two stubs,
+# so it runs anywhere -- and it has to, because the diagnostic it covers only
+# ever speaks on a machine that cannot run `make -C formal complete` at all.
+.PHONY: abc-engine-test
+abc-engine-test:
+	@./formal/test-abc-engine.sh
+
 .PHONY: test
 test: sim test-units probe-gates pin-bump-test tool-cache-test memmap-test \
-      compare-geometry-test window-test
+      compare-geometry-test window-test abc-engine-test
 	@./test/run_tests.sh ./sim test/asm test/EXPECTED_FAIL test/OBSERVED_FLOOR
 
 # The same suite `make test` runs, with the runner charging every cycle to the

--- a/formal/Makefile
+++ b/formal/Makefile
@@ -88,7 +88,20 @@ pcloop_cover: pcloop_cover.sby pcloop.sv ../rtl/fetcher.v ../rtl/decoder.v ../rt
 # complete-exclusions is a prerequisite rather than a companion target: the
 # exclusion set is what makes this check passable at all, and checking it costs
 # milliseconds and fails before sby starts.
-complete:  complete.sby  complete.sv  arbiter.v complete-exclusions $(RTL_SOURCES) | $(RISCV_FORMAL_DIR)
+#
+# abc-engine is a prerequisite for the second half of that reason only. It grades
+# nothing about the design; it turns one toolchain failure into a sentence.
+complete:  complete.sby  complete.sv  arbiter.v complete-exclusions abc-engine $(RTL_SOURCES) | $(RISCV_FORMAL_DIR)
+
+# This is the only target whose engine is `abc bmc3`, and where yosys and sby
+# were installed separately they can disagree about the call sby's AIG build
+# makes. That dies on a command syntax error in a pass nobody here wrote, which
+# reads like a broken branch and has been diagnosed as local more than once. The
+# script says what it is, and can only add a failure: it exits 0 unless this
+# yosys really refuses the call this sby is going to make.
+.PHONY: abc-engine
+abc-engine: check-abc-engine.sh
+	@./$<
 
 # The anti-vacuity control for the line above, over the same complete.sv: every
 # opcode class the exclusion set does not name must be reachable as a real

--- a/formal/check-abc-engine.sh
+++ b/formal/check-abc-engine.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# `complete` is the only target here whose engine is `abc bmc3`, and sby builds
+# that engine's AIG through a yosys script it writes itself. Where yosys and sby
+# were installed separately they can disagree about one line of that script --
+# an `abc` call carrying `-fast` -- and the target then dies on a command syntax
+# error inside a pass nobody in this repo wrote, which reads like a broken
+# branch. Run the same call first and name the toolchain instead.
+#
+# This can only ADD a failure. It exits 0 whenever it has no positive evidence,
+# so a working toolchain reaches sby exactly as before, and a toolchain that
+# defeats the probe still fails the way it does today.
+#
+# Usage: formal/check-abc-engine.sh
+set -euo pipefail
+
+yosys_bin=$(command -v "${YOSYS:-yosys}") || exit 0
+sby_bin=$(command -v sby) || exit 0
+
+# Read the call out of the sby that will run rather than hardcoding a copy of
+# it. A copy would go stale in the one direction that matters: refusing to start
+# on a yosys/sby pairing where the real invocation works. These are the two
+# directories sby's own launcher puts on sys.path.
+sby_dir=$(dirname "$sby_bin")
+abc_call=""
+for lib in "$sby_dir/share/python3" "$sby_dir/../share/yosys/python3"; do
+  [ -r "$lib/sby_core.py" ] || continue
+  abc_call=$(awk -F'"' '/print\("abc /{print $2; exit}' "$lib/sby_core.py")
+  break
+done
+[ -n "$abc_call" ] || exit 0
+
+probe=$("$yosys_bin" -qp "$abc_call" 2>&1) && exit 0
+
+# A yosys that fell over for some other reason -- a missing library, a suite
+# whose environment was not sourced -- is not evidence about the call, and
+# refusing to start on it would block a toolchain that works. Only yosys' own
+# words for a rejected argument list count.
+case "$probe" in
+  *"Command syntax error"*) ;;
+  *) exit 0 ;;
+esac
+
+version=$("$yosys_bin" -V 2>/dev/null | head -1)
+
+cat >&2 <<MSG
+error: the yosys and sby on this PATH cannot run \`make -C formal complete\`.
+
+It is the only target here whose engine is \`abc bmc3\`, and sby builds that
+engine's AIG with a yosys call this yosys rejects as a command syntax error:
+
+    $abc_call
+        asked for by $sby_bin
+        refused by   $yosys_bin
+        $version
+
+That is the toolchain, not this tree: the same call fails on unmodified main.
+The call is sby's own and is deliberately not adapted to whichever abc is on
+this machine -- doing that would grade something other than what CI grades.
+
+The check is NOT being skipped. It runs on CI in the formal job, on the YosysHQ
+OSS CAD Suite, where it passes: that suite ships yosys and sby together as a
+matching pair, which is what this PATH does not have. To run it here, put its
+bin directory ahead of both of the above.
+MSG
+exit 1

--- a/formal/test-abc-engine.sh
+++ b/formal/test-abc-engine.sh
@@ -1,0 +1,153 @@
+#!/bin/bash
+# Drives formal/check-abc-engine.sh against a stub yosys and a stub sby, and
+# pins both directions: it goes red naming the pinned toolchain on a yosys that
+# refuses sby's abc call, and it stays silently green on one that accepts it.
+#
+# The message is checked, not just the status. What this diagnostic is for is
+# the sentence it prints -- a bare exit 1 would be the raw parse error again,
+# with one more layer on top.
+#
+# It also pins that the call comes out of the sby that will run rather than out
+# of a hardcoded copy. A copy is wrong in the direction that costs: it would
+# refuse to start on a yosys/sby pairing where the real invocation works.
+#
+# Hermetic: no toolchain, no sby, no yosys, nothing but bash.
+#
+# Usage: formal/test-abc-engine.sh
+set -euo pipefail
+
+HERE=$(cd "$(dirname "$0")" && pwd)
+SCRIPT="$HERE/check-abc-engine.sh"
+
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/abc-engine.XXXXXX") || {
+  echo "error: could not create a temporary directory." >&2
+  exit 1
+}
+if [ -z "$tmp" ] || [ ! -d "$tmp" ]; then
+  echo "error: mktemp -d produced no usable directory." >&2
+  exit 1
+fi
+trap 'rm -rf "$tmp"' EXIT
+
+# The stub yosys accepts exactly the call in $STUB_ACCEPTS and answers anything
+# else the way a yosys that dropped a flag does, so a probe of the wrong string
+# is visible here rather than only on somebody's laptop.
+mkdir -p "$tmp/bin"
+cat > "$tmp/bin/yosys" <<'STUB'
+#!/bin/bash
+if [ "${1:-}" = "-V" ]; then
+  echo "Yosys 9.99 (stub)"
+  exit 0
+fi
+if [ "${1:-}" = "-qp" ] && [ "${2:-}" = "$STUB_ACCEPTS" ]; then
+  exit 0
+fi
+if [ -n "${STUB_OTHER_ERROR:-}" ]; then
+  echo "dyld: Library not loaded: libyosys.so" >&2
+  exit 1
+fi
+echo "ERROR: Command syntax error: Unknown option or option in arguments." >&2
+exit 1
+STUB
+chmod +x "$tmp/bin/yosys"
+
+# Only its path is read, so it never has to run.
+cat > "$tmp/bin/sby" <<'STUB'
+#!/bin/bash
+echo "stub sby: not meant to run" >&2
+exit 9
+STUB
+chmod +x "$tmp/bin/sby"
+
+# The layout sby's launcher searches, relative to the sby binary.
+mkdir -p "$tmp/share/yosys/python3"
+write_sby_core() {  # write_sby_core <abc call>
+  printf '                print("%s", file=f)\n' "$1" > \
+    "$tmp/share/yosys/python3/sby_core.py"
+}
+
+cases=0
+failed=0
+
+# check <label> <expected-exit> <expected-text> <shell-snippet>
+#
+# Both the status and a fragment of the output are pinned. A status alone would
+# be satisfied by a script that died on a typo before probing anything.
+check() {
+  local label=$1 want_exit=$2 want_text=$3 snippet=$4
+  cases=$((cases + 1))
+  local out rc why=""
+  set +e
+  out=$(eval "$snippet" 2>&1)
+  rc=$?
+  set -e
+  if [ "$rc" -ne "$want_exit" ]; then
+    why="exited $rc, expected $want_exit"
+  elif [ -n "$want_text" ] && ! grep -qF -- "$want_text" <<< "$out"; then
+    why="output does not contain $want_text"
+  elif [ -z "$want_text" ] && [ -n "$out" ]; then
+    why="expected no output, got some"
+  fi
+  if [ -z "$why" ]; then
+    printf '  ok   %s\n' "$label"
+  else
+    printf '  RED  %s\n     -> %s\n' "$label" "$why" >&2
+    printf '%s\n' "$out" | sed -e 's|^|        |' >&2
+    failed=1
+  fi
+}
+
+run() {  # run <accepted call> -- runs the script under test
+  env PATH="$tmp/bin:$PATH" STUB_ACCEPTS="$1" "$SCRIPT"
+}
+
+echo "== a yosys that refuses sby's abc call"
+write_sby_core "abc -g AND -fast"
+
+check "it fails" 1 "cannot run" \
+  'run "abc -g AND"'
+check "it names the toolchain to install" 1 "OSS CAD Suite" \
+  'run "abc -g AND"'
+check "it says the check is not skipped" 1 "The check is NOT being skipped." \
+  'run "abc -g AND"'
+check "it says CI still runs it" 1 "It runs on CI in the formal job" \
+  'run "abc -g AND"'
+check "it quotes the call that was refused" 1 "abc -g AND -fast" \
+  'run "abc -g AND"'
+check "it names the sby that asked for it" 1 "asked for by $tmp/bin/sby" \
+  'run "abc -g AND"'
+check "it names the yosys that refused it" 1 "refused by   $tmp/bin/yosys" \
+  'run "abc -g AND"'
+check "it quotes that yosys' version" 1 "Yosys 9.99 (stub)" \
+  'run "abc -g AND"'
+
+echo
+echo "== a yosys that accepts it"
+check "it is green and silent" 0 "" \
+  'run "abc -g AND -fast"'
+
+echo
+echo "== the call is read from sby, not hardcoded"
+write_sby_core "abc -g AND,NAND -quick"
+check "a different call is the one probed" 1 "abc -g AND,NAND -quick" \
+  'run "abc -g AND -fast"'
+check "a pairing that works is not blocked" 0 "" \
+  'run "abc -g AND,NAND -quick"'
+
+echo
+echo "== no evidence, no verdict"
+rm -f "$tmp/share/yosys/python3/sby_core.py"
+check "an sby whose source is unreadable is green" 0 "" \
+  'run "abc -g AND"'
+write_sby_core "abc -g AND -fast"
+check "no yosys at all is green" 0 "" \
+  'env PATH="$tmp/bin:$PATH" STUB_ACCEPTS= YOSYS=no-such-yosys "$SCRIPT"'
+check "a yosys that failed some other way is green" 0 "" \
+  'env PATH="$tmp/bin:$PATH" STUB_ACCEPTS= STUB_OTHER_ERROR=1 "$SCRIPT"'
+
+echo
+if [ "$failed" -ne 0 ]; then
+  echo "$cases checks, at least one RED." >&2
+  exit 1
+fi
+echo "$cases checks, all green."


### PR DESCRIPTION
Closes JEF-803.

`make -C formal complete` is the only target here whose engine is `abc bmc3`, and sby builds that engine's AIG through a yosys script it writes itself. Where yosys and sby were installed separately they can disagree about one line of it — an `abc` call carrying `-fast` — and the target dies on a command syntax error inside a pass nobody in this repo wrote, two hundred lines into sby's file copying. It fails identically on unmodified `main`, and four engineers in one session each diagnosed it as local and each wrote a paragraph about it.

## What changed

`formal/check-abc-engine.sh` runs that call first and names the toolchain. It is a prerequisite of `complete` for the same reason `complete-exclusions` is: it costs milliseconds and fails before sby starts.

Two properties make it safe to put in front of a required check:

- **It can only add a failure, never remove one.** It exits 0 whenever it has no positive evidence — no yosys, no sby, no readable `sby_core.py`, or a yosys that fell over for some other reason (a missing library, a suite whose environment was not sourced). On a working toolchain sby runs exactly as before. There is no path on which it makes the target exit 0 when the check did not run.
- **It reads the call out of the sby that will run**, rather than hardcoding a copy. A copy goes stale in the one direction that costs: refusing to start on a yosys/sby pairing where the real invocation works.

The flags are **not** adapted to a newer abc. The call is sby's own, and tuning it to whatever abc is on the local machine would grade something other than what CI grades. The message says that, and says the check is not being skipped.

`formal/test-abc-engine.sh` drives the diagnostic both ways against a stub yosys and a stub sby — 14 checks, status *and* message fragment pinned on each. It hangs off `make test` like the repo's other bash checks, and it has to: the diagnostic only ever speaks on a machine that cannot run the target at all, so nothing else here would notice it rotting.

## Both paths, on this machine

Before — `sby -f complete.sby`, which is what the target's recipe runs today:

```
SBY [complete] Copy '.../insn_xori.v' to '.../complete/src/insn_xori.v'.   (x200)
SBY [complete] aig: ERROR: Command syntax error: Unknown option or option in arguments.
SBY [complete] aig: > abc -g AND -fast
SBY [complete] aig: >            ^
SBY [complete] summary: engine_0 (abc bmc3) did not return a status
SBY [complete] DONE (ERROR, rc=16)
```

After — `make -C formal complete`, exit 2, sby never starts:

```
error: the yosys and sby on this PATH cannot run `make -C formal complete`.

It is the only target here whose engine is `abc bmc3`, and sby builds that
engine's AIG with a yosys call this yosys rejects as a command syntax error:

    abc -g AND -fast
        asked for by /usr/local/bin/sby
        refused by   /opt/homebrew/bin/yosys
        Yosys 0.68+post (git sha1 c12172fb..., Release, AppleClang clang++ 21.0.0)

That is the toolchain, not this tree: the same call fails on unmodified main.
The call is sby's own and is deliberately not adapted to whichever abc is on
this machine -- doing that would grade something other than what CI grades.

The check is NOT being skipped. It runs on CI in the formal job, on the YosysHQ
OSS CAD Suite, where it passes: that suite ships yosys and sby together as a
matching pair, which is what this PATH does not have. To run it here, put its
bin directory ahead of both of the above.
make: *** [abc-engine] Error 1
```

The local pair really is mismatched rather than merely new: an arm64 Homebrew `yosys 0.68` at `/opt/homebrew/bin`, and an unrelated sby at `/usr/local/bin` whose `sby_core.py` still emits `-fast`. That is why the message names both binaries — it is the fastest way to see which one to displace.

## Tests

- `formal/test-abc-engine.sh` — 14 checks, all green. Red direction demonstrated: replacing `check-abc-engine.sh` with a bare `exit 1` turns all 14 red, including the four that pin the sentences this ticket is about.
- `make test` — 62/62, failure list matches `test/EXPECTED_FAIL` exactly. Re-run after the simplification pass.
- `make probe-gates` — 188 graded comparisons, every failure path executed (unchanged; no baseline touched).
- `make -C formal complete` — the readable failure above, exit 2.

## The passing path

Nothing in `complete.sby` moved and no baseline was touched. The passing path is confirmed by the `formal` job on this PR: it installs the OSS CAD Suite and runs `make -C formal complete`, which now runs `abc-engine` first. A probe that misbehaved on that toolchain would turn the job red — a green `formal` job is the evidence that the passing path is untouched.

## Notes

- No ADR: this changes no decision.
- The message names "the YosysHQ OSS CAD Suite" without calling it pinned. `.github/actions/setup-oss-cad-suite` resolves the *latest* release on purpose ("Latest, not a pin" — only `formal/pin.mk`'s riscv-formal SHA is pinned), so calling the suite pinned in a diagnostic would send a reader looking for a version number that does not exist. CLAUDE.md's "Formal needs the pinned YosysHQ OSS CAD Suite" is the same wording and reads as pre-existing drift against that action; left alone as out of scope.
- Deriving the call from `sby_core.py` also means a future OSS CAD Suite whose yosys and sby both moved keeps working with no edit here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJ77ZZJ6pDiL3vj3Qw9hKs
