### PR TITLE
Put co-simulation in CI as a required check (JEF-800)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,88 @@ jobs:
             echo "wall time: ${elapsed}s"
           } >> "$GITHUB_STEP_SUMMARY"
 
+  # The only oracle here that reads the core's real register array instead of
+  # the core's own report of what it retired. Every other leg evaluates a spec
+  # model on rvfi_*, so a core that mis-reports a value and computes with that
+  # same mis-reported value satisfies all of them and this one alone objects.
+  #
+  # A job of its own, and not a step of `test`: it needs a network fetch none of
+  # the other jobs do, and a red result here has to read as "co-sim", not as a
+  # suite failure. Nothing on `make test`'s path reaches any of it.
+  cosim:
+    name: cosim
+    runs-on: little-cpu-runners
+    timeout-minutes: 15
+    steps:
+      - name: Record job start
+        run: echo "JOB_START=$(date +%s)" >> "$GITHUB_ENV"
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Verify the toolchain is present in the runner image
+        uses: ./.github/actions/verify-toolchain
+        with:
+          tools: riscv64-unknown-elf-gcc clang++
+
+      - name: Set up OSS CAD Suite
+        uses: ./.github/actions/setup-oss-cad-suite
+
+      # Read out of the Makefile rather than written here, so the key names the
+      # bytes the Makefile pins and cannot go on naming an older set.
+      - name: Resolve the Sail pin and the directory the fetch is cached in
+        id: pin
+        run: |
+          set -euo pipefail
+          make sail-pin > "$RUNNER_TEMP/sail-pin.txt"
+          cat "$RUNNER_TEMP/sail-pin.txt"
+          grep -E '^(key|path)=' "$RUNNER_TEMP/sail-pin.txt" >> "$GITHUB_OUTPUT"
+
+      # What is cached is the release tarball, not the unpacked tree, so the
+      # restored bytes still have to meet the Makefile's SHA-256 in the run that
+      # executes what comes out of them. A cache of the tree would put a binary
+      # on PATH that met no checksum here at all.
+      - name: Restore the pinned sail-riscv tarball
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ steps.pin.outputs.path }}
+          key: ${{ steps.pin.outputs.key }}
+
+      - name: make sail-setup
+        run: make sail-setup
+
+      - name: make cosim-suite
+        # Redirected rather than piped -- see the `fit` job for why. What is
+        # graded is test/run_cosim.sh's exit status: the divergence set against
+        # test/COSIM_EXPECTED_FAIL under set equality in both directions, so an
+        # unexpected agreement is as red as an unexpected divergence.
+        run: |
+          set +e
+          make cosim-suite > "$RUNNER_TEMP/cosim.txt" 2>&1
+          status=$?
+          set -e
+          cat "$RUNNER_TEMP/cosim.txt"
+          {
+            echo "### co-simulation vs test/COSIM_EXPECTED_FAIL"
+            echo '```'
+            cat "$RUNNER_TEMP/cosim.txt"
+            echo '```'
+            echo "Each program's real register file against RISC-V International's"
+            echo "executable specification. No rvfi_* signal is read on either"
+            echo "side. It covers the programs it is given and nothing else, and"
+            echo "the two baselined entries are the machine timer, which the"
+            echo "reference model cannot express."
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit "$status"
+
+      - name: Report job wall time
+        if: always()
+        run: |
+          elapsed=$(( $(date +%s) - JOB_START ))
+          {
+            echo "### cosim"
+            echo "wall time: ${elapsed}s"
+          } >> "$GITHUB_STEP_SUMMARY"
+
   # Every task in formal/components.sby needs a step here or it runs nowhere.
   # The standalone decoder proof assumes its pc input is what it last produced,
   # and components_pcloop is what discharges that, so the decoder task's result
@@ -115,7 +197,12 @@ jobs:
   components:
     name: components
     runs-on: little-cpu-runners
-    timeout-minutes: 5
+    # Four proofs in about four minutes, on a runner pool the whole workflow
+    # shares. At 5 the budget was under a minute of headroom and the job was
+    # killed after the fourth proof reported PASS, which reads as a failed gate
+    # rather than as a busy pool. Adding a tenth job to the workflow is what
+    # surfaced it.
+    timeout-minutes: 10
     steps:
       - name: Record job start
         run: echo "JOB_START=$(date +%s)" >> "$GITHUB_ENV"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,12 +194,16 @@ What a green result does and does not mean:
   `test/testbench.v` zeroes both ROM banks before poking its program for that reason, the way
   `soc/compare/rom_flat.py` zero-pads its image to full depth. A simulated memory defined only where
   a program was written is not a model of a block RAM, whose every word comes out of the bitstream.
-- **Sail co-simulation is deliberately not a leg and stays off CI's required checks** (ADR-0032).
-  `test/cosim.cc` reads the core's real `regs_a` and no `rvfi_*` signal — the property that lets it
-  catch architectural writes the self-reporting oracles structurally miss (measured: an extra
-  `regs[31] <=` write enabled only past the BMC bound, invisible to every riscv-formal check and
-  the whole `.S` suite, reported by co-sim in 0.6s). A change that needs its verdict carries
-  pre/post `make cosim-suite` output in the PR. Do not "align" it against `rvfi_valid`.
+- **Sail co-simulation is a required check on `main`, in a job of its own** (ADR-0032 as amended by
+  ADR-0095). `test/cosim.cc` reads the core's real `regs_a` and no `rvfi_*` signal — the property
+  that lets it catch architectural writes the self-reporting oracles structurally miss (measured: an
+  extra `regs[31] <=` write enabled only past the BMC bound, invisible to every riscv-formal check
+  and the whole `.S` suite, reported by co-sim in 0.6s). Do not "align" it against `rvfi_valid`.
+  Nothing on `make test`'s path reaches it, so a machine without Sail still runs the whole suite and
+  a divergence reads as co-sim. What it **cannot** cover is the interrupt path: `test/asm/mtimer.S`
+  and `test/asm/mtimermask.S` are baselined `INCONCLUSIVE SAIL-LIMIT` in
+  `test/COSIM_EXPECTED_FAIL` because the reference model has no machine timer, so a green job says
+  nothing about the one interrupt this core takes.
 
 ## Reference models
 

--- a/Makefile
+++ b/Makefile
@@ -37,10 +37,11 @@ sim: test/cxxrtl.cc test/rtl.cc
 # rule, and test/tool_cache_test.sh is what says the two still agree.
 TOOL_CACHE := $(if $(XDG_CACHE_HOME),$(XDG_CACHE_HOME),$(HOME)/.cache)/little-cpu
 
-# Sail co-simulation is opt-in. Nothing from here down to `cosim-suite` is
-# reachable from `make test` or `make test-units`. Keep it that way: the runner
-# stops with an error when Sail is not installed, so making any of this a
-# prerequisite would break the merge gate on every machine without it.
+# Nothing from here down to `cosim-suite` is reachable from `make test` or
+# `make test-units`. Keep it that way now that CI requires co-simulation: it is
+# a job of its own that fetches Sail first, so `make test` still runs on a
+# machine without Sail, and a divergence reads as co-sim rather than as a suite
+# failure.
 ifneq ($(filter command line environment,$(origin SAIL_RISCV_VERSION)),)
 $(error SAIL_RISCV_VERSION cannot be set from the command line or the \
   environment: it pins bytes this repo executes. Change it in the Makefile, \
@@ -71,6 +72,14 @@ SAIL_SHA256    := $(SAIL_SHA256_$(SAIL_ASSET))
 
 SAIL_STAMP := $(SAIL_RISCV_DIR)/.sail-pin
 SAIL_PIN   := $(SAIL_RISCV_VERSION) $(SAIL_ASSET) $(SAIL_SHA256)
+
+# The verified tarball is kept rather than deleted, so a CI cache can hold the
+# fetch without holding anything executable. A cache of the unpacked tree would
+# restore a binary that met no checksum in the run that executes it; a cache of
+# the tarball meets the digest below on every run, hit or miss.
+SAIL_DOWNLOAD_DIR := $(TOOL_CACHE)/download
+SAIL_TARBALL      := $(SAIL_DOWNLOAD_DIR)/$(SAIL_ASSET)-$(SAIL_RISCV_VERSION).tar.gz
+SAIL_CACHE_KEY    := sail-$(SAIL_RISCV_VERSION)-$(SAIL_ASSET)-$(SAIL_SHA256)
 
 # Only for the goals that run the binary. If this check could stop `make test`,
 # an out-of-date tools/sail would break the merge gate for everyone.
@@ -121,39 +130,55 @@ sail-setup:
 	  echo "sail-riscv $(SAIL_RISCV_VERSION) already verified in $(SAIL_RISCV_DIR)"; \
 	  exit 0; \
 	fi; \
-	url=https://github.com/riscv/sail-riscv/releases/download/$(SAIL_RISCV_VERSION)/$(SAIL_ASSET).tar.gz; \
-	mkdir -p '$(TOOL_CACHE)'; \
-	tmp=$$(mktemp -d '$(SAIL_RISCV_DIR)'.XXXXXX); tgz=$$tmp/$(SAIL_ASSET).tar.gz; \
-	echo "fetching $$url"; \
-	curl -fsSL -o $$tgz "$$url"; \
-	got=$$($$sha $$tgz | cut -d ' ' -f 1); \
+	mkdir -p '$(SAIL_DOWNLOAD_DIR)'; \
+	tgz='$(SAIL_TARBALL)'; \
+	if [ -f "$$tgz" ]; then \
+	  echo "using the tarball already in $(SAIL_DOWNLOAD_DIR)"; \
+	else \
+	  url=https://github.com/riscv/sail-riscv/releases/download/$(SAIL_RISCV_VERSION)/$(SAIL_ASSET).tar.gz; \
+	  echo "fetching $$url"; \
+	  curl -fsSL -o "$$tgz".part "$$url"; \
+	  mv "$$tgz".part "$$tgz"; \
+	fi; \
+	got=$$($$sha "$$tgz" | cut -d ' ' -f 1); \
 	if [ "$$got" != '$(SAIL_SHA256)' ]; then \
 	  echo "sail-riscv tarball SHA-256 MISMATCH -- refusing to extract:" >&2; \
 	  echo "  asset    : $(SAIL_ASSET).tar.gz at $(SAIL_RISCV_VERSION)" >&2; \
 	  echo "  expected : $(SAIL_SHA256)" >&2; \
 	  echo "  actual   : $$got" >&2; \
-	  rm -rf $$tmp; \
+	  echo "  tarball  : $$tgz (removed)" >&2; \
+	  rm -f "$$tgz"; \
 	  exit 1; \
 	fi; \
 	echo "sha256 ok: $$got"; \
-	tar tzf $$tgz | awk -v top='$(SAIL_ASSET)/' ' \
+	tmp=$$(mktemp -d '$(SAIL_RISCV_DIR)'.XXXXXX); \
+	tar tzf "$$tgz" | awk -v top='$(SAIL_ASSET)/' ' \
 	  index($$0, top) != 1 { print "member outside " top ": " $$0 > "/dev/stderr"; bad = 1 } \
 	  /(^|\/)\.\.(\/|$$)/  { print "traversal in member: " $$0 > "/dev/stderr"; bad = 1 } \
 	  END { exit bad ? 1 : 0 }' \
 	  || { echo "refusing to extract $(SAIL_ASSET).tar.gz" >&2; rm -rf $$tmp; exit 1; }; \
-	tar tvzf $$tgz | awk ' \
+	tar tvzf "$$tgz" | awk ' \
 	  substr($$1, 1, 1) !~ /^[-d]$$/ { print "not a file or directory: " $$0 > "/dev/stderr"; bad = 1 } \
 	  END { exit bad ? 1 : 0 }' \
 	  || { echo "refusing to extract $(SAIL_ASSET).tar.gz" >&2; rm -rf $$tmp; exit 1; }; \
-	tar xzf $$tgz -C $$tmp --strip-components=1 \
+	tar xzf "$$tgz" -C $$tmp --strip-components=1 \
 	  --no-same-owner --no-same-permissions; \
-	rm -f $$tgz; \
 	test -x $$tmp/bin/sail_riscv_sim; \
 	printf '%s\n' '$(SAIL_PIN)' > $$tmp/.sail-pin; \
 	$$sha $$tmp/bin/sail_riscv_sim | cut -d ' ' -f 1 >> $$tmp/.sail-pin; \
 	rm -rf '$(SAIL_RISCV_DIR)'; \
 	mv $$tmp '$(SAIL_RISCV_DIR)'
 	@'$(SAIL_SIM_BIN)' --version
+
+# Where the fetch is cached and under what key, read out of here rather than
+# spelled out in the workflow, so a cache key cannot go on naming bytes the pin
+# no longer has. `name=value` lines because a workflow step appends them to
+# $GITHUB_OUTPUT; test/probe_gates.sh seeds its fixture from the third.
+.PHONY: sail-pin
+sail-pin:
+	@printf 'key=%s\n' '$(SAIL_CACHE_KEY)'
+	@printf 'path=%s\n' '$(SAIL_DOWNLOAD_DIR)'
+	@printf 'tarball=%s\n' '$(SAIL_TARBALL)'
 
 cosim: test/cosim.cc test/rtl.cc
 	clang++ -O2 -DNDEBUG -std=c++17 -Wall -Wextra -Werror \
@@ -392,12 +417,12 @@ probe-gates:
 pin-bump-test:
 	@./formal/test-propose-pin-bump.sh
 
-# Reads the two directories this file resolves and checks them against
+# Reads the three directories this file resolves and checks them against
 # test/cosim.py's. Hangs off `test` like the other bash checks: python3 and a
 # shell, no cross compiler, no Sail, no yosys.
 .PHONY: tool-cache-test
 tool-cache-test:
-	@./test/tool_cache_test.sh '$(SAIL_RISCV_DIR)' '$(SVLINT_DIR)'
+	@./test/tool_cache_test.sh '$(SAIL_RISCV_DIR)' '$(SVLINT_DIR)' '$(SAIL_DOWNLOAD_DIR)'
 
 # Compares every file that describes the memory map against the RTL that
 # implements it. Hangs off `test` like the other bash checks -- grep and sed, no

--- a/docs/adr/0095-co-simulation-is-required-and-its-fetch-is-verified.md
+++ b/docs/adr/0095-co-simulation-is-required-and-its-fetch-is-verified.md
@@ -1,0 +1,213 @@
+# ADR-0095: Co-simulation is a required check, and the precondition for that was met two changes ago
+
+**Status:** Accepted · 2026-08-10 · *Amends
+[ADR-0032](0032-sail-co-simulation-is-worth-building-and-stays-opt-in.md)'s "stays opt-in" decision
+and [ADR-0033](0033-what-the-green-ladder-does-not-cover.md)'s decision 4, both of which named the
+same precondition. Adds a required check to `main`, which is a repository setting a human applies.*
+
+## Context
+
+[ADR-0032](0032-sail-co-simulation-is-worth-building-and-stays-opt-in.md) built the co-simulation
+harness and deliberately kept it off `make test` and off CI. It gave one reason, and it named
+exactly what would lift it:
+
+> The fetch has no checksum and no signature, and a GitHub release asset is mutable, so
+> `SAIL_RISCV_VERSION` pins a name rather than bytes. That is an accepted gap with a named
+> precondition: **integrating co-sim into `make test` or CI means giving this fetch `formal/pin.mk`'s
+> treatment first** — a checksum verified before anything out of the tarball runs.
+
+[ADR-0033](0033-what-the-green-ladder-does-not-cover.md)'s decision 4 restated it as the same
+condition and added two smaller notes about the target: that bumping the version did not re-fetch,
+and that a substituted install never showed up in `git status`.
+
+**That precondition has been met, and the ADRs were never amended to say so.** Reading the recipe
+today, `make sail-setup`:
+
+- refuses a `SAIL_RISCV_VERSION` set from the command line or the environment, `override`, in the
+  shape `formal/pin.mk` uses for the riscv-formal SHA;
+- rejects a version that is not three numeric parts, so a branch, a moving tag or a range cannot be
+  pinned;
+- carries a SHA-256 per platform asset, and refuses outright to fetch an asset it has no digest for;
+- refuses to unpack at all when neither `shasum` nor `sha256sum` is on PATH, rather than skipping
+  the comparison on a machine that cannot make it;
+- compares the digest **before extraction**, so nothing out of the tarball exists on disk, let
+  alone runs, unless the bytes are the pinned ones;
+- rejects a member outside the asset's top-level directory, a `..` component, or an entry that is
+  neither a file nor a directory;
+- records the pin and the unpacked binary's own digest in a stamp, and re-checks both on every
+  `cosim-run` and `cosim-suite`, so a stale or substituted install is an error instead of a silent
+  result.
+
+What remained was enforcement. Co-simulation ran when a person remembered: eight pull requests in
+one session carried its output because each engineer was asked for it, and nothing in the repository
+would have noticed if one had not been.
+
+**That matters more than for any other leg here, because of what only this one reads.** Every other
+oracle evaluates a spec model on the core's self-report. `test/monitor.v` and every generated
+`insn_*` check compare `rvfi_rd_wdata` against a model of `rvfi_insn` / `rvfi_rs1_rdata` /
+`rvfi_rs2_rdata`; a core that mis-reports a value and computes with that same mis-reported value
+tells all of them an internally consistent story. `test/cosim.cc` reads `uut regfile regs_a` through
+cxxrtl `debug_items` and no `rvfi_*` signal at all. ADR-0032 demonstrated the difference with an
+extra `regs[31] <=` write enabled only past the BMC bound: the whole `.S` suite passed, the
+generated riscv-formal checks matched `formal/EXPECTED_FAIL` exactly, and co-simulation reported it
+in 0.6 s.
+
+**The remaining objection was availability, and it does not survive inspection.** The asset comes
+from `github.com/riscv/sail-riscv/releases`; CI's checkout, its Actions and its runners already come
+from that same origin unconditionally. If GitHub is unreachable there is no job to block, so the
+fetch adds no failure mode this workflow does not already carry. That argument was about a
+dependency CI has had all along.
+
+## Decision
+
+**`make cosim-suite` runs as a required check on `main`, in a job of its own, and the fetch it needs
+is cached as bytes that still meet the pin in the run that executes them.**
+
+### The job
+
+`.github/workflows/ci.yml` gains `cosim`, on the same self-hosted runners as `test`: verify the
+cross compiler and `clang++` are in the image, put the OSS CAD Suite on PATH, restore the cached
+tarball, `make sail-setup`, `make cosim-suite`. What is graded is `test/run_cosim.sh`'s exit status
+— the set of programs that do not agree, against `test/COSIM_EXPECTED_FAIL`, under set equality in
+both directions, so an unexpected *agreement* is as red as an unexpected divergence and a baselined
+program diverging a different way is red too. The command is redirected to a file and its status
+re-raised, never piped: the default step shell is errexit without pipefail, and a graded command in
+a pipeline takes `tee`'s status, which is how the formal job stayed accidentally green for its whole
+life.
+
+**A job rather than a step of `test`, and it gates nothing else.** It needs a network fetch no other
+job here does, and a red result has to read as "co-simulation", not as a suite failure. Nothing on
+`make test`'s path reaches any of it, so the merge gate still runs whole on a machine with no Sail
+install.
+
+### The cache holds the tarball, not the unpacked tree
+
+`make sail-setup` now keeps the verified tarball under `~/.cache/little-cpu/download` instead of
+deleting it after extraction, and `actions/cache` is pointed at that directory with a key of
+`version + asset + digest`. `make sail-pin` prints the key and the path, so the workflow reads them
+out of the Makefile rather than restating them; a key cannot go on naming bytes the pin no longer
+has.
+
+**Caching the unpacked tree was the obvious thing and is the weaker one.** A restored tree is put on
+PATH and executed having met no checksum in that run — the stamp it would be checked against comes
+out of the same cache entry. The precedent next door,
+`.github/actions/setup-oss-cad-suite`, keys its cache on the published digest for exactly this
+reason and says so, and that mitigation is real but indirect. Caching the tarball needs no such
+argument: the cache holds an inert file, the pinned SHA-256 is compared on every run whether the
+entry hit or missed, and the binary that runs was produced in that job from bytes that had just met
+it. It costs 1.8 MB of cache and about 0.4 s of extraction.
+
+## Evidence
+
+Measured on this repository's runners, at `f144fc9` and its two deliberately-broken descendants.
+
+**Cold, cache miss, green:** `Cache not found for input keys:
+sail-0.13.1-sail-riscv-Linux-x86_64-ee052f…`, then `fetching …`, then `sha256 ok: ee052f…`, then
+`60/62 agreed` and `Divergence list matches test/COSIM_EXPECTED_FAIL exactly`. The cache saved under
+that key in the post step.
+
+**Warm, cache hit, green:** `Cache restored from key: sail-0.13.1-sail-riscv-Linux-x86_64-ee052f…`,
+`using the tarball already in /home/runner/.cache/little-cpu/download`, `sha256 ok: ee052f…`. The
+digest comparison ran on the restored bytes, which is the property the tarball cache exists for.
+
+**Wall time, four runs:**
+
+| run | fetch/verify/extract | `make cosim-suite` | job |
+|---|---|---|---|
+| cold, cache miss | 1 s | 58 s | 69 s |
+| warm, cache hit (the mutation below) | <1 s | 88 s | 100 s |
+| warm, cache hit | <1 s | 118 s | 131 s |
+
+**Read the fetch column, not the job column.** The cache is worth about a second, and the 69–131 s
+spread is contention: two self-hosted runners take the workflow's ten jobs, so `make cosim-suite`
+itself measures 58 s to 118 s for the same 62 programs. Locally it is 41 s. The cold run being the
+fastest of the three is that spread, not a result about caching.
+
+**The job can fail, for the reason it exists.** ADR-0032's canonical defect — an extra architectural
+write no retiring instruction names — reintroduced in `rtl/regfile.v` as `regs_a[31] <= wdata`
+alongside `regs_a[waddr]`, and the same for `regs_b`:
+
+| job | result |
+|---|---|
+| `test` (62 programs, per-retire RVFI monitor live, plus `regfile_tb`) | **success — misses it** |
+| `elaborate`, `lint`, `components`, `monitor-freshness`, `nonperturbation` | success |
+| `formal` | failure (`reg_ch0`, which is the one check that ties the report back to the register file) |
+| `cosim` | **failure**, `0/62 agreed` |
+
+```
+--- add.S ---
+DIVERGENCE at architectural change #0
+  sail instruction #5  pc=0x0000000c  c.li x3, 0x2
+  sail : x3=0x00000002
+  core : x3=0x00000002 x31=0x00000002   (cycle 12, decode pc=0x00000014)
+COSIM-STATUS DISAGREE AT 0
+```
+
+`fit` and `soc-timing` went red on the same commit as well, since two extra write ports cost area
+and period. This is the unconditional mutation, which `reg_ch0` reaches inside its bound; ADR-0032's
+gated variant is the one every check but this leg misses, and that measurement is not re-taken here.
+
+**The digest comparison fires in CI, and refuses rather than executing.** Pointing
+`SAIL_SHA256_sail-riscv-Linux-x86_64` at 64 zeroes:
+
+```
+Cache not found for input keys: sail-0.13.1-sail-riscv-Linux-x86_64-0000…
+fetching https://github.com/riscv/sail-riscv/releases/download/0.13.1/sail-riscv-Linux-x86_64.tar.gz
+sail-riscv tarball SHA-256 MISMATCH -- refusing to extract:
+  expected : 0000000000000000000000000000000000000000000000000000000000000000
+  actual   : ee052f64494a2f5f071afd9c2cb4aa5eaae4ba84753e4f77e442b4f83f2e9469
+  tarball  : /home/runner/.cache/little-cpu/download/sail-riscv-Linux-x86_64-0.13.1.tar.gz (removed)
+```
+
+The `make cosim-suite` step never ran. Note the cache missed too — a wrong digest is a different
+key, so a substituted pin cannot be served an entry fetched under the right one.
+
+**And the comparison is forced red without a network, in `make probe-gates`.** Three probes drive
+`make sail-setup` with a stub `curl` that substitutes the asset: the mismatch is refused before
+extraction; a refused download leaves nothing unpacked and does not survive to be served to the next
+run; and a tarball already in the cache is reused and still has to meet the digest. The second
+reports `refused=yes` alongside what it found on disk, so it cannot read clean because `make` died
+before reaching the comparison at all. `SAIL_ASSET` is fixed in those probes rather than taken from
+`uname`, so the fixture is the same on every host and `make test` does not start requiring a machine
+upstream ships a tarball for.
+
+## What a green `cosim` job does and does not mean
+
+- **It covers the programs it is given, and nothing else.** Co-simulation inherits the `.S` and `.c`
+  suite's coverage exactly. It says nothing about instructions or operand patterns those programs
+  never reach — including the real multiplier and divider on untested operands.
+- **It structurally cannot cover the interrupt path.** `test/COSIM_EXPECTED_FAIL`'s two entries,
+  `mtimer.S` and `mtimermask.S`, are `INCONCLUSIVE SAIL-LIMIT`: the reference model's timer is at a
+  different address with a different tick period, both conformant, so the model never takes the
+  interrupt and nothing is compared. That is weaker than a divergence and is recorded as such. The
+  entries stay exactly as they are; **a green `cosim` job is not evidence about the one interrupt
+  this core takes.** What covers that is `formal/traps.sv`, `test/decoder_tb.v`, `test/csr_tb.v` and
+  `test/timer_tb.v`, as `test/COSIM_EXPECTED_FAIL` already sets out at length.
+- **It is not a proof.** It compares two executions of the same program.
+
+## Consequences
+
+- **`main`'s required set gains `cosim`**, alongside `elaborate`, `test`, `components`,
+  `monitor-freshness`, `lint`, `formal`, `soc-timing` and `nonperturbation`. Which jobs are required
+  is a repository setting; read it live with
+  `gh api repos/thejefflarson/little-cpu/branches/main/protection`, never from a comment.
+- **The merge gate grows a tenth job on a two-runner pool, and that is what the contention above
+  is.** `components` was killed by its own `timeout-minutes: 5` in two of the four runs — after its
+  fourth proof had reported `DONE (PASS)`, so the gate read red for a busy pool. On `main` that job
+  measures 3:51 to 4:05, which is under a minute of headroom, and the tenth job is what pushed it
+  over. Its budget goes to 10, matching `test`. Nothing else in the set came close.
+- **CI now depends on `github.com/riscv/sail-riscv/releases` being reachable.** Stated plainly
+  because it is new, and bounded by the argument above: the same origin already serves the checkout
+  and the runners.
+- **A pinned release that upstream deletes or rewrites turns the gate red rather than quiet**, which
+  is the intended direction. Recovering means bumping `SAIL_RISCV_VERSION` and its three digests
+  together — the fetch refuses an asset it has no digest for, so a half-done bump cannot fetch.
+- **ADR-0033's two smaller notes are closed by the same recipe**: the stamp makes a version bump
+  re-fetch on its own, and it makes a substituted install an error rather than something only
+  `git status` could have shown, which it never could.
+- **The nightly job ADR-0032's integration list proposed is not built and is not wanted.** Nightly
+  was the right shape for a leg nothing verified the fetch of; a per-PR gate is the right shape for
+  one where every run checks the bytes it executes.
+- **What ADR-0032 said must stay true, stays true.** `test/cosim.cc` reads no `rvfi_*` signal, and
+  the retire sequencing is derived from the register file changing. The moment it samples one, the
+  mutation table above stops holding and this job stops being worth its runner.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -36,8 +36,8 @@ and what it costs. Reversing one is fine — write a new ADR that supersedes it.
 | [0029](0029-mtvec-resets-to-zero-and-a-pre-handler-trap-is-loud.md) | `mtvec` resets to zero, and a pre-handler trap is made loud | Accepted |
 | [0030](0030-trap-cause-priority-and-why-the-causes-are-disjoint.md) | Trap cause priority, and why the causes are disjoint | Accepted |
 | [0031](0031-the-vendored-genchecks-copy-tracks-the-pin.md) | The vendored `genchecks` copy tracks the pin, and only `basedir` differs | Accepted |
-| [0032](0032-sail-co-simulation-is-worth-building-and-stays-opt-in.md) | Sail co-simulation is worth building, and stays opt-in | Accepted |
-| [0033](0033-what-the-green-ladder-does-not-cover.md) | What a green ladder does not cover — three assurance gaps, named | Accepted |
+| [0032](0032-sail-co-simulation-is-worth-building-and-stays-opt-in.md) | Sail co-simulation is worth building, and stays opt-in | Accepted · its "stays opt-in" decision amended by 0095, whose precondition it named |
+| [0033](0033-what-the-green-ladder-does-not-cover.md) | What a green ladder does not cover — three assurance gaps, named | Accepted · decision 4 closed by 0095 |
 | [0034](0034-what-the-csr-ladder-checks-cannot-see.md) | What the CSR ladder checks cannot see, and the decisions the CSR file forced | Accepted · corrected by 0037 |
 | [0035](0035-the-baseline-pins-the-failure-mode.md) | `test/EXPECTED_FAIL` pins the failure mode, not just the file name | Accepted |
 | [0036](0036-three-gate-hardening-decisions-ratified-at-integration.md) | Three gate-hardening decisions ratified at integration, and a correction to ADR-0031 | Accepted |
@@ -96,6 +96,7 @@ and what it costs. Reversing one is fine — write a new ADR that supersedes it.
 | [0092](0092-the-writeback-slot-costs-more-than-the-bypass-it-replaces.md) | The writeback slot costs more than the bypass it replaces, and the two loops do not pay together | Accepted · declines the fourth scoreboard slot at 19.5% of suite cycles for period inside the churn band; measures the pairing claim 0091 shares and finds the pair no better than either half; the evidence for the second forwarding point 0064 and 0089 describe |
 | [0093](0093-the-compressed-successor-is-decoded-and-the-compiled-workload-is-what-moves.md) | The compressed successor is decoded, and the compiled workload is what moves | Accepted · reverses 0074's decline of its first variant on a ten-placement re-measurement: 16.3% of Dhrystone's cycles, 0.640 DMIPS/MHz, and 12.0 MHz cleared at ten placements of ten with the median a null. Collects the win 0089 named and could not take; puts the register-number mapping in one module read twice |
 | [0094](0094-the-compressed-decode-is-already-mapped-and-the-block-is-closed.md) | The compressed decode and the immediate generator are already mapped, and the block is closed | Accepted · 0088's question asked of the last block that had never had it, and answered with a null. Ceilings: the immediate mux is 101 LUTs whole, the compressed decode 253, and deleting the fetch window's upper-half mask *costs* 13. The one group built reads −50 LUTs on `fit` and −1 on the SoC — the ±50 churn band caught at synthesis, where neither count has a placement in it |
+| [0095](0095-co-simulation-is-required-and-its-fetch-is-verified.md) | Co-simulation is a required check, and the precondition for that was met two changes ago | Accepted · amends 0032's opt-in decision and closes 0033's decision 4: the fetch is digest-verified before extraction, so the leg that reads the real register file gates on every PR. The tarball is cached, not the unpacked tree. Both failure paths demonstrated in CI |
 
 0001–0007 came from the design brief
 ([`docs/ideas/finish-the-rewrite.md`](../ideas/finish-the-rewrite.md)). 0008–0011 came out of
@@ -207,7 +208,10 @@ trades away simplicity the current design depends on.
   sources and a vectored `mtvec` — the same mechanism with more inputs.
 - ~~**Spike or Sail co-simulation**~~ — **resolved by [ADR-0032](0032-sail-co-simulation-is-worth-building-and-stays-opt-in.md).**
   The old test ("revisit only if formal and simulation ever disagree") could only fire on a bug both
-  legs can see; a spike measured what neither can. The harness exists and is deliberately opt-in —
-  `make cosim-run` / `make cosim-suite`, never `make test`, never CI's required set.
+  legs can see; a spike measured what neither can.
   [ADR-0039](0039-co-simulation-runs-the-whole-suite-against-a-baseline.md) integrated it across the
-  whole suite against a baseline; a nightly job and memory comparison remain future work.
+  whole suite against a baseline, and
+  [ADR-0095](0095-co-simulation-is-required-and-its-fetch-is-verified.md) makes it a required check
+  on `main` once the digest-verified fetch ADR-0032 asked for existed. Still `make cosim-run` /
+  `make cosim-suite` and never `make test`. The memory comparison remains future work; the nightly
+  job does not, having been overtaken by the gate.

--- a/test/cosim.py
+++ b/test/cosim.py
@@ -2,10 +2,11 @@
 """Lockstep co-simulation of this core against the Sail RISC-V model.
 
 One program per invocation; test/run_cosim.sh runs the suite and grades it
-against test/COSIM_EXPECTED_FAIL. Opt-in, and it stays that way: `make test`
-neither builds nor runs any of this and CI does not gate on it. See
-docs/adr/0032 for what it is for and what it costs, and docs/adr/0039 for
-what suite-wide integration changed.
+against test/COSIM_EXPECTED_FAIL. `make test` neither builds nor runs any of
+this, and it stays that way: CI gates on it in a job of its own, which fetches
+Sail at a verified digest before running anything. See docs/adr/0032 for what
+it is for and what it costs, and docs/adr/0039 for what suite-wide integration
+changed.
 
 WHAT IS ACTUALLY COMPARED
 -------------------------

--- a/test/probe_gates.sh
+++ b/test/probe_gates.sh
@@ -27,7 +27,7 @@ REPO=$(cd "$HERE/.." && pwd)
 # Pinned as a literal: a probe that is deleted, or that stops being reached by
 # an early `return`, would otherwise cut this file's coverage while it kept
 # printing a green summary.
-PROBES_EXPECTED=188
+PROBES_EXPECTED=192
 
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/littlecpu-probe.XXXXXX") || {
   echo "error: could not create a temporary directory under ${TMPDIR:-/tmp}." >&2
@@ -207,9 +207,26 @@ STUB
   chmod +x "$1"
 }
 
+make_curl_stub() {  # $1 = path
+  cat > "$1" <<'STUB'
+#!/bin/sh
+# Stands in for curl in `make sail-setup`. Writes bytes that are NOT the pinned
+# release to wherever -o points and succeeds, so the digest comparison is the
+# only thing standing between a substituted asset and an executed binary.
+out=; prev=
+for a in "$@"; do
+  if [ "$prev" = "-o" ]; then out=$a; fi
+  prev=$a
+done
+[ -n "$out" ] && echo "not the pinned release" > "$out"
+exit 0
+STUB
+  chmod +x "$1"
+}
+
 # `leg-rt` / `leg-rc` are scratch copies of the two suite runners, because each
 # resolves its helper scripts relative to its own path.
-mkdir -p "$tmp/bin-none" "$tmp/leg-rt" "$tmp/leg-rc" "$tmp/leg-rc-nopy"
+mkdir -p "$tmp/bin-none" "$tmp/bin-curl" "$tmp/leg-rt" "$tmp/leg-rc" "$tmp/leg-rc-nopy"
 
 # For the one probe that claims "no cross compiler", `bin-none` has to be the
 # WHOLE path: with /usr/bin behind it, run_tests.sh finds a real
@@ -232,6 +249,7 @@ make_toolchain_stubs "$tmp/bin-noobjcopy"
 rm "$tmp/bin-noobjcopy/riscv64-elf-objcopy"
 make_sim_stub "$tmp/sim"
 make_sail_stub "$tmp/sail"
+make_curl_stub "$tmp/bin-curl/curl"
 make_cosim_bin_stub "$tmp/dut"
 cp "$HERE/run_tests.sh" "$HERE/check_suite_shape.sh" "$HERE/stall_report.py" "$tmp/leg-rt/"
 cp "$HERE/run_cosim.sh" "$HERE/check_suite_shape.sh" "$tmp/leg-rc/"
@@ -1072,25 +1090,83 @@ begin_group "test/tool_cache_test.sh"
 TCT="$HERE/tool_cache_test.sh"
 tc_cache="$tmp/cache/little-cpu"
 
-probe "control: two agreeing paths outside the checkout are green" 0 \
+probe "control: agreeing paths outside the checkout are green" 0 \
   "outside the checkout and agreed on" \
-  "XDG_CACHE_HOME=$tmp/cache $TCT $tc_cache/sail $tc_cache/svlint"
+  "XDG_CACHE_HOME=$tmp/cache $TCT $tc_cache/sail $tc_cache/svlint $tc_cache/download"
 
 probe "the Makefile and test/cosim.py drifting apart is red" 1 \
   "do not agree on where the Sail" \
-  "XDG_CACHE_HOME=$tmp/cache $TCT $tc_cache/elsewhere $tc_cache/svlint"
+  "XDG_CACHE_HOME=$tmp/cache $TCT $tc_cache/elsewhere $tc_cache/svlint $tc_cache/download"
 
 probe "a Sail install back inside the checkout is red" 1 \
   "test/cosim.py installs tools inside the checkout" \
-  "XDG_CACHE_HOME=$REPO/cache $TCT $REPO/cache/little-cpu/sail $tc_cache/svlint"
+  "XDG_CACHE_HOME=$REPO/cache $TCT $REPO/cache/little-cpu/sail $tc_cache/svlint $tc_cache/download"
 
 probe "an svlint install inside the checkout is red on its own" 1 \
   "$REPO/tools/svlint" \
-  "XDG_CACHE_HOME=$tmp/cache $TCT $tc_cache/sail $REPO/tools/svlint"
+  "XDG_CACHE_HOME=$tmp/cache $TCT $tc_cache/sail $REPO/tools/svlint $tc_cache/download"
+
+# The kept release tarball is what a CI cache holds, so a download directory
+# back inside the checkout would be cached under a path no worktree can read.
+probe "the Sail download directory inside the checkout is red on its own" 1 \
+  "$REPO/tools/download" \
+  "XDG_CACHE_HOME=$tmp/cache $TCT $tc_cache/sail $tc_cache/svlint $REPO/tools/download"
 
 probe "a relative install directory is red before it is compared" 1 \
   "names a relative tool install directory" \
-  "XDG_CACHE_HOME=$tmp/cache $TCT tools/sail tools/svlint"
+  "XDG_CACHE_HOME=$tmp/cache $TCT tools/sail tools/svlint tools/download"
+
+begin_group "make sail-setup"
+
+# The whole reason co-simulation is allowed in the merge gate is that this
+# recipe verifies the release tarball before anything comes out of it. A stub
+# curl substitutes the asset, so what is forced red below is exactly the
+# comparison that stands between a substituted download and an executed binary.
+#
+# SAIL_ASSET is fixed rather than left to `uname`, so the fixture is the same on
+# every host and `make test` does not start requiring a machine upstream ships a
+# tarball for. It is not `override` in the Makefile, and the three digests are
+# all pinned there, so naming one of them here cannot widen what may be fetched.
+SS_ASSET=SAIL_ASSET=sail-riscv-Linux-x86_64
+SS="MAKEFLAGS= MFLAGS= MAKELEVEL= PATH='$tmp/bin-curl:$PATH' \
+    make --no-print-directory -C '$REPO' $SS_ASSET sail-setup"
+
+# The tarball's name comes from the Makefile, not from a second copy of the
+# naming rule here -- a copy would agree with itself while the recipe wrote
+# somewhere else, and the probes would then be seeding a file nothing reads.
+ss_tarball() {  # $1 = case dir
+  XDG_CACHE_HOME="$1/cache" make --no-print-directory -C "$REPO" $SS_ASSET \
+    sail-pin | sed -n 's/^tarball=//p'
+}
+
+# Runs the recipe against a substituted download and reports what it left
+# behind: whether the digest comparison spoke at all, whether anything was
+# unpacked, and whether the bytes that failed it are still there for the next
+# run to serve. `refused` is in there so this cannot read clean because make
+# died before reaching the comparison.
+ss_aftermath() {  # $1 = case dir
+  local tgz log=$1/setup.log
+  eval "XDG_CACHE_HOME=$1/cache $SS" > "$log" 2>&1
+  tgz=$(ss_tarball "$1")
+  printf 'refused=%s unpacked=%s tarball=%s\n' \
+    "$(grep -qF 'refusing to extract' "$log" && echo yes || echo no)" \
+    "$([ -e "$1/cache/little-cpu/sail/bin/sail_riscv_sim" ] && echo yes || echo none)" \
+    "$([ -e "$tgz" ] && echo present || echo gone)"
+}
+
+d=$(new_case)
+# Exit 2, not 1: the recipe's own `exit 1` reaches the probe as make's status.
+probe "a download whose bytes are not the pin is refused before extraction" 2 \
+  "SHA-256 MISMATCH -- refusing to extract" "XDG_CACHE_HOME=$d/cache $SS"
+
+d=$(new_case)
+probe "the refused download is neither unpacked nor kept to be served again" 0 \
+  "refused=yes unpacked=none tarball=gone" "ss_aftermath $d"
+
+d=$(new_case); tgz=$(ss_tarball "$d"); mkdir -p "$(dirname "$tgz")"
+echo "not the pinned release either" > "$tgz"
+probe "a tarball already in the cache is reused, and still meets the digest" 2 \
+  "using the tarball already in" "XDG_CACHE_HOME=$d/cache $SS"
 
 begin_group "test/memmap_test.sh"
 

--- a/test/run_cosim.sh
+++ b/test/run_cosim.sh
@@ -5,12 +5,15 @@
 #
 # Usage: run_cosim.sh <cosim-binary> <asm-dir> <expected-fail-file> <manifest>
 #
-# Deliberately NOT on `make test`'s path and not in the set CI requires: it needs
-# a Sail install, and the merge gate has to keep working on machines without one.
-# It is also the only oracle here that reads the core's real register array
-# instead of the core's own report of what it retired, so a change to
-# rtl/regfile.v is checked against it by carrying this output in the pull
-# request rather than by a gate.
+# Deliberately NOT on `make test`'s path: it needs a Sail install and `make test`
+# has to keep working on machines without one. CI requires it all the same, in a
+# job of its own that fetches Sail at a verified digest first -- so it gates
+# without being a prerequisite of anything, and a red result here reads as
+# co-simulation rather than as a suite failure.
+#
+# It is the only oracle here that reads the core's real register array instead of
+# the core's own report of what it retired, which is what a change to
+# rtl/regfile.v is checked against.
 #
 # The guards below are run_tests.sh's, against the same false green: a run that
 # reports success having compared nothing.

--- a/test/tool_cache_test.sh
+++ b/test/tool_cache_test.sh
@@ -2,7 +2,8 @@
 # Asserts that the downloaded tools land somewhere every checkout can reach,
 # and that the two files which independently compute that location still agree.
 #
-# Usage: tool_cache_test.sh <sail-dir> <svlint-dir>   # the Makefile's values
+# Usage: tool_cache_test.sh <sail-dir> <svlint-dir> <sail-download-dir>
+#        # the Makefile's values
 #
 # WHY THIS EXISTS. `make sail-setup` used to unpack into the gitignored
 # `tools/sail`. A git worktree is given tracked files only, so the install was
@@ -24,13 +25,14 @@
 # inside `make test` anywhere that already ran.
 set -euo pipefail
 
-if [ "$#" -ne 2 ]; then
-  echo "usage: tool_cache_test.sh <sail-dir> <svlint-dir>" >&2
+if [ "$#" -ne 3 ]; then
+  echo "usage: tool_cache_test.sh <sail-dir> <svlint-dir> <sail-download-dir>" >&2
   exit 1
 fi
 
 MAKE_SAIL_DIR=$1
 MAKE_SVLINT_DIR=$2
+MAKE_SAIL_DOWNLOAD_DIR=$3
 HERE=$(cd "$(dirname "$0")" && pwd)
 REPO=$(cd "$HERE/.." && pwd)
 
@@ -95,6 +97,10 @@ outside_checkout() {
 outside_checkout Makefile "$MAKE_SAIL_DIR"
 outside_checkout test/cosim.py "$py_sail_dir"
 outside_checkout Makefile "$MAKE_SVLINT_DIR"
+# The kept release tarball is a downloaded tool too, and CI caches that
+# directory by name. Inside the checkout it would be gitignored, invisible from
+# every worktree, and swept up by whatever cleans the tree between jobs.
+outside_checkout Makefile "$MAKE_SAIL_DOWNLOAD_DIR"
 
 if [ "$rc" -ne 0 ]; then
   exit 1


### PR DESCRIPTION
Closes JEF-800

Co-simulation is the only oracle in this repo that reads the core's real
register array (`uut regfile regs_a`, through cxxrtl `debug_items`) instead of
the core's own report of what it retired. Every other leg evaluates a spec model
on `rvfi_*`, so a core that mis-reports a value and computes with that same
mis-reported value satisfies all of them. Until now it ran only when a person
remembered.

## The precondition was met, and the ADR was never amended

ADR-0032 kept it off CI for one reason and named exactly what would lift it: a
checksum verified before anything out of the tarball runs. Read against the
recipe today, `make sail-setup`:

- refuses a `SAIL_RISCV_VERSION` set from the command line or the environment
  (`override`, the shape `formal/pin.mk` uses);
- rejects a version that is not three numeric parts;
- carries a SHA-256 per platform asset and refuses to fetch one it has no digest
  for;
- refuses to unpack when neither `shasum` nor `sha256sum` is on PATH;
- compares the digest **before** extraction;
- rejects a member outside the asset's top-level directory, a `..` component, or
  an entry that is neither a file nor a directory;
- records the pin and the unpacked binary's digest in a stamp and re-checks both
  on every goal that executes it.

The availability objection was reasoning about a dependency CI already carries:
the asset comes from `github.com/riscv/sail-riscv/releases`, and the checkout,
Actions and runners already come from that origin unconditionally.

## What this changes

- **A `cosim` job**, on the same runners as `test`, running `make cosim-suite`.
  What is graded is `test/run_cosim.sh`'s exit status — the divergence set
  against `test/COSIM_EXPECTED_FAIL` under set equality in both directions, so
  an unexpected agreement is as red as an unexpected divergence. Redirected to a
  file and the status re-raised, never piped.
- **Not on `make test`'s path, and it gates nothing else.** `make test` still
  runs whole on a machine with no Sail install.
- **The cache holds the tarball, not the unpacked tree.** `make sail-setup` keeps
  the verified tarball under `~/.cache/little-cpu/download`; `actions/cache` is
  keyed on `version + asset + digest`, published by a new `make sail-pin` so the
  workflow reads the key out of the Makefile rather than restating it. A
  restored entry still meets the pinned SHA-256 in the run that executes what
  comes out of it — a cache of the tree would put a binary on PATH that met no
  checksum in that run at all.
- **`components` goes from a 5-minute budget to 10.** It measures 3:51–4:05 on
  main, and a tenth job on the two-runner pool killed it twice *after* its fourth
  proof reported PASS — a busy pool reading as a failed gate.
- **ADR-0095** records the amendment, and states plainly that co-simulation
  structurally cannot cover the interrupt path. (It was written as 0094; #156
  merged and took that number first, so it was renumbered on the rebase.)

## Evidence, from three CI runs on a throwaway branch (now closed)

**Cache hits.** Cold: `Cache not found for input keys: sail-0.13.1-sail-riscv-Linux-x86_64-ee052f…`
→ `fetching …` → `sha256 ok: ee052f…`, saved in the post step. Warm:
`Cache restored from key: sail-0.13.1-sail-riscv-Linux-x86_64-ee052f…` →
`using the tarball already in /home/runner/.cache/little-cpu/download` →
`sha256 ok: ee052f…`. The digest ran on the restored bytes.

**Wall time.** Cold 69 s (fetch+verify+extract 1 s, `make cosim-suite` 58 s);
warm 100 s and 131 s (fetch step under 1 s, suite 88 s and 118 s). Read the
fetch column: the cache is worth about a second, and the job spread is
contention on two runners shared by ten jobs.

**The job can fail, for the reason it exists.** ADR-0032's canonical defect —
`regs_a[31] <= wdata` alongside `regs_a[waddr]`, and the same for `regs_b`:

| job | result |
|---|---|
| `test` (62 programs, RVFI monitor live, `regfile_tb`) | **success — misses it** |
| `formal` | failure (`reg_ch0`) |
| `cosim` | **failure, 0/62 agreed** |

```
DIVERGENCE at architectural change #0
  sail instruction #5  pc=0x0000000c  c.li x3, 0x2
  sail : x3=0x00000002
  core : x3=0x00000002 x31=0x00000002   (cycle 12, decode pc=0x00000014)
COSIM-STATUS DISAGREE AT 0
```

**The digest check fires in CI.** With the Linux x86_64 digest pointed at 64
zeroes: cache miss (a wrong digest is a different key), fetch, then

```
sail-riscv tarball SHA-256 MISMATCH -- refusing to extract:
  expected : 0000…0000
  actual   : ee052f64494a2f5f071afd9c2cb4aa5eaae4ba84753e4f77e442b4f83f2e9469
  tarball  : /home/runner/.cache/little-cpu/download/sail-riscv-Linux-x86_64-0.13.1.tar.gz (removed)
```

The `make cosim-suite` step never ran. Both mutations were reverted.

## Tests

`make probe-gates` gains a `make sail-setup` group — three probes that drive the
real recipe with a stub `curl` that substitutes the asset: the mismatch is
refused before extraction; a refused download leaves nothing unpacked and does
not survive to be served again (reported as `refused=yes unpacked=none
tarball=gone`, so it cannot read clean because make died early); and a tarball
already in the cache is reused and still has to meet the digest. `SAIL_ASSET` is
fixed in the fixture rather than taken from `uname`, so `make test` does not
start requiring a machine upstream ships a tarball for.
`test/tool_cache_test.sh` takes the download directory as a third argument and
checks it is outside the checkout, with a probe for that direction.
`PROBES_EXPECTED` 188 → 192.

Local: `make test` 62/62 · `make test-units` 8/8 · 192 probe gates ·
`make cosim-suite` 60/62 matching the baseline · `make lint` clean both passes ·
a real cold-then-warm `make sail-setup` against a scratch `XDG_CACHE_HOME`.

## Required set

`cosim` was added to `main`'s required set (now `elaborate, test, components,
monitor-freshness, lint, formal, soc-timing, nonperturbation, cosim`).
Protection is `strict`, so any PR branched before this one has to bring main in
before merging, which is the same update that gives it the job.

`test/COSIM_EXPECTED_FAIL`, `test/EXPECTED_FAIL`, `test/OBSERVED_FLOOR`,
`formal/EXPECTED_FAIL` and `PROBES_EXPECTED`'s meaning are unchanged (only the
probe count moved, in the same commit that adds the probes).
