### PR TITLE
Tighten the fit ratchet to one churn band over CI's measurement (JEF-804)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -528,11 +528,13 @@ fit.json: $(FIT_SRCS)
 	@yosys -p 'read_verilog -sv $^; synth_ice40 -dsp -top littlecpu -json $@' \
 	  > fit.synth.log 2>&1 || { tail -40 fit.synth.log; exit 1; }
 
-# Set above the measurement, which is 3470 cells here. The number moves by tens
-# of cells on edits that build the same hardware, and CI's yosys reads about 21
-# higher than a local one, so the budget has to leave room for both. If this goes
-# red, find out what grew. Raising it to make it pass defeats the point.
-FIT_MAX_LC := 3700
+# 3625 is the `fit` job's 3543 plus a 50-cell churn band plus 32 for the
+# toolchain: identical RTL moves about 50 cells on ABC re-mapping alone, and this
+# tree read 3543 under CI's suite against 3575 under a local Homebrew yosys. CI
+# resolves the OSS CAD Suite rather than pinning it, so the second term is what
+# stops a suite bump going red on a pull request that changed no RTL.
+# If this goes red, find out what grew; raising it to pass defeats the point.
+FIT_MAX_LC := 3625
 
 .PHONY: fit
 fit: fit.json


### PR DESCRIPTION
Closes JEF-804

`FIT_MAX_LC` was **3700** against a `fit` job reading **3543** — 157 cells, about three churn bands, of slack a real area regression could land inside while staying green. This sets it to **3625**.

## Why it was loose

Legitimately, not through neglect. The executor work moved it 4100 → 3950 → 3750 → 3700 in three steps, each against its own measurement. The compressed-successor decode then added 79 cells for 16.3% of Dhrystone's cycles and landed *under* the existing number — correctly, since passing under a ratchet is not the decision that raising one is. Two changes after it declined to re-tighten on the way past, on the grounds that re-deciding someone else's budget without a measurement bearing on it is out of scope. That reasoning was right each time, and the slack is what it left behind.

## The number

**3625 = 3543 + 50 + 32.**

| Term | Value | Source |
|---|---|---|
| Measurement | 3543 | the `fit` job on `d3a9556`, not a local run |
| Churn band | 50 | CLAUDE.md's recorded ±50 for edits that build the same hardware |
| Toolchain spread | 32 | this tree: 3543 under CI's suite vs 3575 under local Homebrew yosys 0.68+post |

**The measurement is CI's, and it is stable.** 3543 is unmoved across the last three merges to `main` (`c3802d3`, `fbfd6bf`, `d3a9556`), and the earliest of those is the last commit to touch `rtl/`. `gh pr list` is empty, so nothing is in flight that could move it under a freshly-set ratchet.

**Why a toolchain term and not just the band.** `.github/actions/setup-oss-cad-suite` resolves the *latest* suite rather than a pin, deliberately. So CI's measurement can move with no RTL changing at all, and without an allowance for it a suite bump goes red on whichever PR happens to run next — whose author has no way to tell that from their own regression. This is the one place the floating toolchain has a practical consequence, so it is priced here rather than discovered later. The 32 is the larger of the two spreads on record (CLAUDE.md notes ~21) and is what I measured today, so it is the conservative bound.

That leaves **82 cells** over the measurement rather than 157. A regression now has to clear the band *plus* the toolchain spread to trip it, which is the tightest budget that cannot go red for a reason no author caused.

## Confirming it can trip

A ratchet that cannot fail is not a ratchet. Widening `rtl/executor.v`'s `mul_div_counter` from `[6:0]` to `[63:0]` took the local count 3575 → 3639:

```
*** make fit: 3639 logic cells is over the 3625-cell budget.
*** This is a ratchet (ADR-0042), not a suggestion. Find what grew;
*** raising FIT_MAX_LC in the Makefile needs a reason in the commit.
```

`make fit` exited 2. Reverted — `git status` clean apart from the Makefile.

## Checks

- `make fit` locally: **3575 of 3625 — OK** (50 cells of local headroom, so a same-hardware edit does not go red on a dev machine either)
- `make fit` with cells added: **red, exit 2**, as quoted above
- `make probe-gates`: 192 graded comparisons, every failure path executed
- Nothing in `rtl/` changed, so no baseline, depth, exclusion or other ratchet moves. `soc/fit_report.py`'s probe drives its own fixture and budget, independent of this constant.

## Scope

`FIT_MAX_LC` and the comment that justifies it. The old comment quoted a stale 3470 as "the measurement" and asserted CI reads ~21 *higher* than local; both are corrected against what was measured here (CI reads 32 *lower*). No ADRs, no other baselines, no `rtl/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)