### PR TITLE
Re-ground four comments whose reasons expired (JEF-818)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,7 +133,8 @@ pipeline drain — see the serialization commitment.
 
 **One interrupt: the machine timer, cause `0x8000_0007`.** `mie.MTIE` is the only writable bit of
 `mie`; `mip.MTIP` is `rtl/timer.v`'s line and read-only; `mip.MSIP`/`mip.MEIP` stay read-only zero,
-which is conformant WARL on a platform with neither source. `mtime`/`mtimecmp` are four words at
+which the spec allows in any position of `mip` whose interrupt can never become pending, and names
+outright for `mip.MSIP` on a single-hart system. `mtime`/`mtimecmp` are four words at
 `0x0002_0000`, in `rtl/littlesoc.v` and `test/testbench.v` alike. **It is taken on a cycle that
 would otherwise have issued**, because `stall` outranks the trap arm of `next_pc` — so it waits out
 a divide, a load turnaround and a serialization with no logic of its own, the displaced instruction

--- a/formal/EXPECTED_FAIL
+++ b/formal/EXPECTED_FAIL
@@ -53,7 +53,7 @@
 # counterexamples correctly; `sby` could not render the traces, because that step
 # shells out to `btorsim`. A real counterexample and a missing trace renderer
 # were the same result to this file. The inverse is the case that matters: if
-# `btorsim` left CI's pinned OSS CAD Suite, every red check would flip
+# `btorsim` left CI's OSS CAD Suite, every red check would flip
 # FAIL → ERROR, the set equality would still match, and the ladder would stay
 # green having stopped distinguishing a proof failure from a tooling failure.
 #

--- a/formal/components.sby
+++ b/formal/components.sby
@@ -21,7 +21,7 @@ all: smtbmc
 # Deliberately NOT the `btor` engine, which is what the generated ladder uses:
 # btormc does bmc and cover only, and this task is `mode prove`.
 #
-# boolector ships in the pinned OSS CAD Suite, which anything under formal/
+# boolector ships in the OSS CAD Suite, which anything under formal/
 # needs anyway. It is NOT in a bare `brew install
 # yosys` (ADR-0024 says so about the ladder's own engine choice); if that ever
 # has to hold, `smtbmc z3` is the next thing to measure rather than reverting to

--- a/formal/test-abc-engine.sh
+++ b/formal/test-abc-engine.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Drives formal/check-abc-engine.sh against a stub yosys and a stub sby, and
-# pins both directions: it goes red naming the pinned toolchain on a yosys that
+# pins both directions: it goes red naming the OSS CAD Suite on a yosys that
 # refuses sby's abc call, and it stays silently green on one that accepts it.
 #
 # The message is checked, not just the status. What this diagnostic is for is

--- a/rtl/decoder.v
+++ b/rtl/decoder.v
@@ -322,8 +322,9 @@ module decoder (
     instr[11:7] == 5'b0 && instr[6:2] == 5'b0;
   assign instr_ebreak = (instr_error && instr[31:20] == 12'h1) || instr_cebreak;
   assign instr_mret = instr_error && instr[31:20] == 12'h302;
-  // `wfi` is a NOP, which is spec-legal: `mie`/`mip` are read-only zero, so no
-  // interrupt could ever resume it.
+  // `wfi` is a NOP, which the spec permits outright: an implementation may
+  // resume for any reason, even with no enabled interrupt pending. The
+  // permission does not depend on which interrupts this core can post.
   assign instr_wfi = instr_error && instr[31:20] == 12'h105;
 
   // Both MISC-MEM forms are NOPs here -- one hart and no icache -- so only

--- a/test/asm/fencenop.S
+++ b/test/asm/fencenop.S
@@ -11,11 +11,14 @@
 // cause defect lived. `ecall` and `ebreak` are covered by trap.S,
 // `c.ebreak` by cebreak.S; these four had nothing.
 //
-// All four are NOPs here: one hart, no caches, no interrupt sources, so
-// there is nothing for a fence to order, nothing for fence.i to invalidate,
-// and nothing for wfi to wait on. What is checked is that they retire without
-// trapping and without disturbing architectural state -- the two ways a NOP
-// can be wrong.
+// Three of them are NOPs here: `c.nop` always, `fence` because one hart and no
+// caches leave it nothing to order, and `wfi` because the spec lets an
+// implementation resume for any reason. `fence.i` is not -- it waits until the
+// pipeline is empty, because text is writable and the fetch address goes out a
+// cycle early, so an older store's write edge has to land first. selfmod.S is
+// what checks that wait; nothing here would notice it gone. What is checked
+// here is that all four retire without trapping and without disturbing
+// architectural state -- the two ways any of them can be wrong.
 
 RVTEST_CODE_BEGIN
 

--- a/test/asm/fencenop.S
+++ b/test/asm/fencenop.S
@@ -15,9 +15,10 @@
 // caches leave it nothing to order, and `wfi` because the spec lets an
 // implementation resume for any reason. `fence.i` is not -- it waits until the
 // pipeline is empty, because text is writable and the fetch address goes out a
-// cycle early, so an older store's write edge has to land first. selfmod.S is
-// what checks that wait; nothing here would notice it gone. What is checked
-// here is that all four retire without trapping and without disturbing
+// cycle early, so an older store's write edge has to land first. Delete that
+// wait and no program in this suite goes red, this one included; the only
+// grader that currently catches it is test/decoder_tb.v. What is checked here
+// is that all four retire without trapping and without disturbing
 // architectural state -- the two ways any of them can be wrong.
 
 RVTEST_CODE_BEGIN


### PR DESCRIPTION
Closes JEF-818.

Four comments whose **conclusions are right and whose reasons have expired**. That is worse than a plainly wrong comment: a reader checks the reason, finds it plausible, and carries the stale premise somewhere it matters.

### 1. `rtl/decoder.v` — WFI

Was justified on `mie`/`mip` being read-only zero, so "no interrupt could ever resume it". The machine timer falsified both premises: `mie.MTIE` is writable and `mip.MTIP` is `rtl/timer.v`'s line. The conclusion survives on *stronger* ground — the spec's permission is unconditional:

> Implementations are permitted to resume execution for any reason, even if an enabled interrupt has not become pending. Hence, a legal implementation is to simply implement the WFI instruction as a NOP.

So the comment now says the permission does not depend on which interrupts this core can post, which is the fact that stops the old reasoning being written back in.

### 2. `test/asm/fencenop.S` — two stale premises in one sentence

"All four are NOPs here: one hart, no caches, no interrupt sources …". **"No interrupt sources" is false** since the timer, and **`fence.i` is not a NOP** — it serializes, which is a design commitment, so a test file calling it one contradicts the thing it exists to guard. The paragraph now names the three that are NOPs and says what the fourth does instead, plus which grader catches it (see the finding below).

### 3. `CLAUDE.md`, the machine-timer paragraph — right answer, wrong citation

Read-only-zero `mip.MSIP`/`mip.MEIP` is not a WARL field rule. It is the explicit clause:

> The `mip` register must always be implemented, but can contain read-only zeros in any position, indicating that interrupt can never become pending.

with a second, more direct one for MSIP: *"If a system has only one hart … then `mip.MSIP` and `mie.MSIE` may both be read-only zeros."* Every quote above was checked against the privileged machine-level chapter before being written down.

### 4. `formal/test-abc-engine.sh` — a pin that does not exist

The diagnostic it drives names the **OSS CAD Suite**, which CI resolves at its latest release rather than pinning; `formal/pin.mk`'s riscv-formal SHA is the pin. Phrasing matched to `CLAUDE.md`, the `Makefile`, `ci.yml` and the setup action, which were corrected in #165.

The same claim was left behind in two more places by that pass — `formal/components.sby` ("boolector ships in the pinned OSS CAD Suite") and `formal/EXPECTED_FAIL` ("if `btorsim` left CI's pinned OSS CAD Suite") — so all three move together, per the acceptance criterion that a repo-wide grep turns up nothing asserting a pin that does not exist. **The `EXPECTED_FAIL` edit is inside a `#` comment**; `check-baseline.sh` strips comments (`sed -e 's/#.*//'`) before comparing, so no graded name-and-status pair moved.

A repo-wide `grep -rn pinned` now turns up only real pins: riscv-formal by SHA, the sail-riscv release, svlint, the `uses:` lines, plus the word's other sense ("both the status and a fragment of the output are pinned"). `docs/` left as history.

### Finding — reported, deliberately not fixed here

**`fence.i`'s wait is currently caught by exactly one grader, and it is not an `.S` program.** Deleting `instr_fencei` from the serialize term on `3d183fe` turns `test/decoder_tb.v` red with five named mismatches and leaves **the `.S` suite at 62/62 PASS** — `selfmod.S` at retires=47 spec-checked=44, `textload.S` at 196/176, failure list still matching `test/EXPECTED_FAIL` exactly. `fencenop.S` has no store before its `fence.i` and no self-modifying code, so it observes nothing; no other program does either.

The first version of this PR asserted that `selfmod.S` was the backstop, inferred from `selfmod.S`'s own red-direction note rather than from a run. **That note is stale and the inference was wrong** — caught in review, measured, and corrected in 3eb8f02 before merge. Writing it in would have pointed the next reader at a dead oracle from a second file, which is the exact failure this PR exists to undo. A separate ticket owns the stale note and closing the gap; the comment states the situation without implying anyone decided it was acceptable, and widening the program is out of scope here.

### Testing

Comments and prose only, no behaviour change.

- `make test` — exit 0, 62/62, failure list matches `test/EXPECTED_FAIL` exactly, suite shape matches `OBSERVED_FLOOR`
- `make test-units` — exit 0
- `./formal/test-abc-engine.sh` — exit 0 (hermetic; its comment is the edited line)
- `fencenop.S` reads **retires=40 spec-checked=35**, exactly its `test/OBSERVED_FLOOR:142` line, which is untouched
- Rebased onto current `main` (#166); gates re-run green after the rebase and again after 3eb8f02

No ticket IDs, ADR numbers or invariant numbers in any added line. Every pre-existing "ladder" is untouched, including the two in `formal/EXPECTED_FAIL` and `formal/components.sby`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
