### PR TITLE
Say "the generated riscv-formal checks" where the prose said "ladder" (JEF-820)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -510,7 +510,7 @@ jobs:
           if [ "$missing" -ne 0 ]; then
             echo "::error::formal/check-baseline.sh cannot tell ERROR from FAIL," \
                  "so an incomplete toolchain would make this gate green on a" \
-                 "ladder that never really ran. Refusing to report a verdict."
+                 "check set that never really ran. Refusing to report a verdict."
             exit 1
           fi
 
@@ -520,7 +520,7 @@ jobs:
       # right on a workstation and wrong in a container, where a CPU quota does
       # not narrow the affinity mask. The diagnostics below print what the host
       # actually has; re-tune against those rather than guessing.
-      - name: Generate and run the ladder (make -C formal check)
+      - name: Generate and run the checks (make -C formal check)
         run: |
           set -uo pipefail
           echo "nproc:            $(nproc)"
@@ -548,14 +548,14 @@ jobs:
           set -e
           cat "$RUNNER_TEMP/baseline-report.txt"
           {
-            echo "### formal ladder vs formal/EXPECTED_{FAIL,CHECKS}"
+            echo "### riscv-formal checks vs formal/EXPECTED_{FAIL,CHECKS}"
             echo '```'
             cat "$RUNNER_TEMP/baseline-report.txt"
             echo '```'
-            echo "A match here means the ladder still agrees with its baseline."
+            echo "A match here means the check set still agrees with its baseline."
             echo "It is not a correctness result: every check is \`mode bmc\` (no"
             echo "counterexample within a bounded depth, not a proof), and the"
-            echo "ladder runs under \`RISCV_FORMAL_ALTOPS\`, so the mul/div checks"
+            echo "checks run under \`RISCV_FORMAL_ALTOPS\`, so the mul/div checks"
             echo "do not exercise the real multiplier or divider (ADR-0010)."
           } >> "$GITHUB_STEP_SUMMARY"
           exit "$status"

--- a/.github/workflows/riscv-formal-pin-bump.yml
+++ b/.github/workflows/riscv-formal-pin-bump.yml
@@ -5,7 +5,7 @@ name: riscv-formal pin bump
 # regenerated against the new pin, and opens an issue asking a human
 # to open the pull request from that branch. The existing gates --
 # monitor-freshness, formal/check-genchecks.py,
-# formal/check-complete-exclusions.py, the ladder itself -- grade the bump;
+# formal/check-complete-exclusions.py, the generated checks -- grade the bump;
 # this workflow only notices and proposes.
 #
 # It opens an issue rather than a pull request because a PR opened by this

--- a/.svlint.toml
+++ b/.svlint.toml
@@ -11,7 +11,7 @@
 # WHAT IT IS FOR. Almost every rule enabled below reports ZERO findings on
 # today's rtl/. That is the point, not an argument against it. Each one catches
 # a defect class that elaborates cleanly in BOTH existing frontends and that
-# neither the .S suite nor the bounded formal ladder reliably reaches:
+# neither the .S suite nor the bounded formal checks reliably reach:
 #
 #   - a blocking assignment in `always_ff`, or a non-blocking one in
 #     `always_comb`, is a simulation/synthesis mismatch that passes both sim

--- a/formal/EXPECTED_CHECKS
+++ b/formal/EXPECTED_CHECKS
@@ -1,4 +1,4 @@
-# The riscv-formal ladder's EXPECTED SHAPE: every check formal/checks.cfg's
+# The riscv-formal check set's EXPECTED SHAPE: every check formal/checks.cfg's
 # [depth] table causes genchecks to generate, one per line.
 #
 # WHY THIS FILE EXISTS (ADR-0033, gap 1). formal/EXPECTED_FAIL answers "did
@@ -8,7 +8,7 @@
 # mistyping one [depth] line removes a check silently -- no .sby, no
 # directory, no status file, no warning, exit 0. A never-generated check is
 # then absent from the results AND absent from EXPECTED_FAIL at once, so
-# that file's set-equality reports a clean match on a smaller ladder. The
+# that file's set-equality reports a clean match on a smaller set. The
 # worst single line to lose is `reg`: ADR-0023 calls reg_ch0 the check that
 # ties RVFI's self-report back to the actual register file.
 #
@@ -17,7 +17,7 @@
 #   formal/genchecks-audit.py  set-equalities the GENERATED set against it
 #                              at generation time, so a lost depth line
 #                              fails in a second rather than after a
-#                              three-minute ladder.
+#                              three-minute run.
 #   formal/check-baseline.sh   set-equalities the *.sby files on disk
 #                              against it after the run, and treats a name
 #                              here with no status file as non-PASS. That is
@@ -28,7 +28,7 @@
 # Set equality in BOTH directions, per ADR-0014's contract: an unexpected
 # ADDITION fails this as loudly as a disappearance. That is the case worth
 # having after a pin bump (ADR-0013) -- upstream growing a check nobody here
-# has ruled on should stop the ladder, not join it unexamined.
+# has ruled on should stop the gate, not join the set unexamined.
 #
 # Edit by hand, never regenerate from a run; regenerating launders exactly
 # the regression this file exists to catch. Adding a line is a claim that
@@ -37,7 +37,7 @@
 # corresponding check should no longer exist, which needs a `#omit` line in
 # checks.cfg saying why.
 #
-# Nothing here is a verdict. Every check on this ladder is `mode bmc`, so a
+# Nothing here is a verdict. Every check in this set is `mode bmc`, so a
 # PASS means "no counterexample found within the check's configured depth",
 # not that the property holds; and everything runs under
 # RISCV_FORMAL_ALTOPS, so insn_mul/insn_div/insn_rem passing says nothing
@@ -45,7 +45,7 @@
 # asserts only that the checks EXIST.
 #
 # Seeded from a from-scratch `python3 formal/genchecks-audit.py` against
-# main at 0d23294: 82 generated, 15 declined. The 79-check ladder recorded in
+# main at 0d23294: 82 generated, 15 declined. The 79-check set recorded in
 # ADR-0031 and ADR-0034 grew by three there -- causal_mem_ch0, hang and
 # ill_ch0 -- see checks.cfg's declined-checks block for why each.
 #

--- a/formal/EXPECTED_FAIL
+++ b/formal/EXPECTED_FAIL
@@ -1,4 +1,4 @@
-# The riscv-formal ladder's regression baseline (ADR-0022), the same contract
+# The riscv-formal check set's regression baseline (ADR-0022), the same contract
 # test/EXPECTED_FAIL applies to the `.S` suite (ADR-0014): formal/check-baseline.sh
 # exits 0 only when the set of `formal/checks/*` whose status is not PASS matches
 # this file EXACTLY — in both directions. A check that starts failing is caught;
@@ -47,14 +47,14 @@
 #
 # WHY THE STATUS IS HERE AT ALL. Matching on the name alone made this gate blind
 # to *why* a check was red, and ADR-0036 measured the consequence rather than
-# arguing it: a ladder run on a machine without `btorsim` printed "82 checks:
+# arguing it: a run on a machine without `btorsim` printed "82 checks:
 # 72 pass, 10 fail / Failure list matches EXPECTED_FAIL exactly" and exited 0,
 # with all ten of those checks at `ERROR 16 2`. `btormc` had found the
 # counterexamples correctly; `sby` could not render the traces, because that step
 # shells out to `btorsim`. A real counterexample and a missing trace renderer
 # were the same result to this file. The inverse is the case that matters: if
 # `btorsim` left CI's OSS CAD Suite, every red check would flip
-# FAIL → ERROR, the set equality would still match, and the ladder would stay
+# FAIL → ERROR, the set equality would still match, and the gate would stay
 # green having stopped distinguishing a proof failure from a tooling failure.
 #
 # CHANGING A LINE'S STATUS IS THE SAME KIND OF CLAIM AS REMOVING THE LINE, and
@@ -65,7 +65,7 @@
 # moved. It cannot report whether a check stopped existing — a check with no
 # formal/checks.cfg [depth] line is never generated, so it is absent from the
 # results AND absent from here at once, and set equality on this file alone would
-# call that a clean match on a smaller ladder (ADR-0033 gap 1). Its sibling
+# call that a clean match on a smaller check set (ADR-0033 gap 1). Its sibling
 # formal/EXPECTED_CHECKS asserts which checks exist; check-baseline.sh enforces
 # both, and a name in EXPECTED_CHECKS with no status file counts as non-PASS here.
 #
@@ -73,8 +73,8 @@
 # sufficient, M2 signal — ADR-0037 rewrote that criterion after an empty baseline
 # turned out to be reachable without the milestone. Read it beside:
 #
-#   - formal/EXPECTED_CHECKS, which is what asserts the ladder did not merely shrink
-#   - ADR-0023 and ADR-0033, which state what a green ladder does not cover
+#   - formal/EXPECTED_CHECKS, which is what asserts the set did not merely shrink
+#   - ADR-0023 and ADR-0033, which state what a green run does not cover
 #
 # Every check here is `mode bmc` (checks.cfg's `solver btormc`, which genchecks
 # turns into `btor btormc`). A PASS means "no counterexample found within the
@@ -86,7 +86,7 @@
 # says nothing whatever about the real multiplier or divider (ADR-0010).
 #
 # ADR-0006's guarantee that RVFI instrumentation does not perturb the core is
-# established by `make -C formal nonperturbation`, not by anything on this ladder.
+# established by `make -C formal nonperturbation`, not by any check listed here.
 # (This paragraph named formal/equiv.sh and said it "still does not converge"; that
 # script is deleted as of ADR-0047, which replaced it. The replacement is strictly
 # weaker than sequential equivalence — it proves the instrumentation is UNREAD.)

--- a/formal/bump-riscv-formal-pin.sh
+++ b/formal/bump-riscv-formal-pin.sh
@@ -10,7 +10,7 @@
 # how CI reaches the bump; opening the PR here does not work.
 #
 # The existing gates (monitor-freshness, formal/check-genchecks.py,
-# formal/check-complete-exclusions.py, the ladder itself) decide whether the
+# formal/check-complete-exclusions.py, the checks themselves) decide whether the
 # bump is safe; this script only notices and proposes.
 #
 # Usage: formal/bump-riscv-formal-pin.sh
@@ -126,7 +126,7 @@ BODY_FILE="$CLONE_DIR/issue-body.md"
   echo "\`test/monitor.v\` is regenerated against the new pin in this commit."
   echo "The existing gates decide whether the bump is safe: monitor-freshness,"
   echo "\`formal/check-genchecks.py\`, \`formal/check-complete-exclusions.py\`,"
-  echo "and the riscv-formal ladder itself."
+  echo "and the generated riscv-formal checks themselves."
   echo
   echo "### Diff under checks/, insns/, monitor/"
   echo

--- a/formal/check-baseline.sh
+++ b/formal/check-baseline.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
-# Checks the ladder two ways: the checks that were generated must match
-# formal/EXPECTED_CHECKS, and the ones that did not pass must match
-# formal/EXPECTED_FAIL. Both comparisons run in both directions, so a check that
-# starts passing fails this too, until someone moves its line.
+# Checks the generated riscv-formal checks two ways: the checks that were
+# generated must match formal/EXPECTED_CHECKS, and the ones that did not pass
+# must match formal/EXPECTED_FAIL. Both comparisons run in both directions, so a
+# check that starts passing fails this too, until someone moves its line.
 #
 # The first comparison is there because the [depth] table in checks.cfg is what
 # decides which checks exist. Delete a line and that check is never generated, so
@@ -14,7 +14,7 @@
 # different fixes, so the gate should not treat them as the same red.
 #
 # None of this says the core is correct. Every check searches to a fixed depth,
-# so passing means no counterexample was found that shallow. The ladder also
+# so passing means no counterexample was found that shallow. The check set also
 # defines RISCV_FORMAL_ALTOPS, which replaces multiply and divide with simpler
 # stand-ins, so insn_mul passing says nothing about the real multiplier.
 #
@@ -32,7 +32,7 @@ EXPECTED_CHECKS=${3:-$(dirname "$0")/EXPECTED_CHECKS}
 
 # READABLE, not merely present. This script sets `set -u` and neither `-e` nor
 # `pipefail`, so a `sed` that cannot open its input yields an EMPTY string — and
-# an empty expected set matches an all-passing ladder exactly.
+# an empty expected set matches an all-passing check set exactly.
 for f in "$EXPECTED_FAIL" "$EXPECTED_CHECKS"; do
   if [ ! -f "$f" ]; then
     echo "error: no such file: $f" >&2
@@ -41,7 +41,7 @@ for f in "$EXPECTED_FAIL" "$EXPECTED_CHECKS"; do
   if [ ! -r "$f" ]; then
     echo "error: $f exists but is not readable." >&2
     echo "An unreadable baseline reads as an EMPTY one here, which matches an" >&2
-    echo "all-passing ladder exactly and exits 0. Refusing to grade." >&2
+    echo "all-passing check set exactly and exits 0. Refusing to grade." >&2
     exit 2
   fi
 done
@@ -77,8 +77,8 @@ baselineable_status() {
   esac
 }
 
-# Exit 2 is "the inputs are broken" against exit 1's "the ladder disagrees with
-# them", so a rejected line cannot read as a regression in the ladder.
+# Exit 2 is "the inputs are broken" against exit 1's "the check set disagrees
+# with them", so a rejected line cannot read as a regression in the check set.
 baseline_errors=""
 while IFS= read -r line; do
   [ -n "$line" ] || continue
@@ -129,7 +129,7 @@ generated=$(find "$CHECKS_DIR" -maxdepth 1 -name '*.sby' \
   -exec basename {} .sby \; 2>/dev/null | sort)
 
 if [ -z "$generated" ]; then
-  echo "error: no *.sby files under $CHECKS_DIR -- the ladder was never" >&2
+  echo "error: no *.sby files under $CHECKS_DIR -- the check set was never" >&2
   echo "       generated. Run 'make -C formal checks' first." >&2
   exit 2
 fi

--- a/formal/components.sby
+++ b/formal/components.sby
@@ -18,14 +18,14 @@ all: smtbmc
 # k-induction` in about five seconds. Same task, same depth, same RTL -- only
 # the solver differs, which is exactly the shape ADR-0024 recorded for reg_ch0.
 #
-# Deliberately NOT the `btor` engine, which is what the generated ladder uses:
+# Deliberately NOT the `btor` engine, which is what the generated checks use:
 # btormc does bmc and cover only, and this task is `mode prove`.
 #
 # boolector ships in the OSS CAD Suite, which anything under formal/
-# needs anyway. It is NOT in a bare `brew install
-# yosys` (ADR-0024 says so about the ladder's own engine choice); if that ever
-# has to hold, `smtbmc z3` is the next thing to measure rather than reverting to
-# the default and calling a fourteen-minute non-answer a slow proof.
+# needs anyway. It is NOT in a bare `brew install yosys` (ADR-0024 says so about
+# the generated checks' own engine choice); if that ever has to hold, `smtbmc z3`
+# is the next thing to measure rather than reverting to the default and calling a
+# fourteen-minute non-answer a slow proof.
 pcloop: smtbmc boolector
 
 [script]

--- a/formal/genchecks-audit.py
+++ b/formal/genchecks-audit.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 #
-# Generates the riscv-formal ladder and checks which checks came out of it. Run
-# from formal/, the same way `python3 genchecks-local.py` was.
+# Generates the riscv-formal check set and reports which checks came out of it.
+# Run from formal/, the same way `python3 genchecks-local.py` was.
 #
 # The `[depth]` section of checks.cfg looks like a tuning table. It is really the
 # list of checks that exist. Both call sites in genchecks end with
@@ -91,7 +91,7 @@ def call_tracer(frame, event, arg):
 def main():
     # genchecks reads `checks.cfg` and writes `checks/` relative to the cwd and
     # takes `corename` from its last component, so running it elsewhere silently
-    # produces a ladder elsewhere.
+    # produces a check set elsewhere.
     if os.path.realpath(os.getcwd()) != os.path.realpath(HERE):
         print(f"error: run from {HERE}, not {os.getcwd()}", file=sys.stderr)
         return 1
@@ -156,14 +156,14 @@ def main():
 
     expected = set(read_name_list(EXPECTED_CHECKS))
     failed |= report_set_diff(
-        "generated ladder vs formal/EXPECTED_CHECKS",
+        "generated checks vs formal/EXPECTED_CHECKS",
         expected,
         generated,
         "EXPECTED_CHECKS",
         "generated",
     )
 
-    # Every check upstream offered and this ladder declined is declined in
+    # Every check upstream offered and this repo declined is declined in
     # writing, next to [depth].
     omitted = read_omit_decls(CFG)
     failed |= report_set_diff(
@@ -175,12 +175,12 @@ def main():
     )
 
     print(
-        f"Ladder shape: {len(generated)} generated, {len(dropped)} declined "
+        f"Check-set shape: {len(generated)} generated, {len(dropped)} declined "
         f"for want of a [depth] line."
     )
     if failed:
         print(
-            "\nThe ladder is not the shape this repo committed to. Either the\n"
+            "\nThe check set is not the shape this repo committed to. Either the\n"
             "change was intended -- in which case update formal/EXPECTED_CHECKS\n"
             "and/or checks.cfg's #omit list in the same commit, and say why --\n"
             "or a [depth] line was lost, which is the failure ADR-0033 named.",

--- a/formal/pcloop.sv
+++ b/formal/pcloop.sv
@@ -243,7 +243,7 @@ module pcloop (
   // must be imem_addr next cycle. rtl/decoder.v checks the same thing one level
   // up, on pc and next_pc. This one is on the fetcher's output ports, so it
   // also covers the two word-alignment masks: change one and forget the other
-  // and only this fails. Nothing on the riscv-formal ladder reads either port.
+  // and only this fails. No generated riscv-formal check reads either port.
   logic [31:0] past_imem_addr_next;
   always_ff @(posedge clk) past_imem_addr_next <= imem_addr_next;
   always_comb if (clocked) assert(imem_addr == past_imem_addr_next);

--- a/formal/pin.mk
+++ b/formal/pin.mk
@@ -3,7 +3,7 @@
 # exactly one recipe that materialises the clone.
 #
 # Bumping this requires regenerating test/monitor.v (`make monitor-check`
-# will fail until you do) and rerunning the formal ladder. See ADR-0006.
+# will fail until you do) and rerunning the generated checks. See ADR-0006.
 #
 # `override` so the pin cannot be defeated with `make RISCV_FORMAL_SHA=...`
 # from a script or CI job: this is a supply-chain control, not a knob. The

--- a/formal/traps.sv
+++ b/formal/traps.sv
@@ -1,10 +1,11 @@
 // The fetcher, the decoder and the CSR file, wired together the way
 // rtl/littlecpu.v wires them, so that mtvec, mepc, mcause and mstatus are real
 // registers rather than free inputs. That is the whole reason this file exists.
-// The riscv-formal ladder stops comparing values the moment an instruction
-// traps -- its instruction check keeps only the trap flag itself -- and its two
-// pc checks accept any target the core reports, mtvec of 0 included. So nothing
-// else in the tree says where a trap goes or what it writes.
+// The generated riscv-formal checks stop comparing values the moment an
+// instruction traps -- the instruction check keeps only the trap flag itself --
+// and the two pc checks accept any target the core reports, mtvec of 0
+// included. So nothing else in the tree says where a trap goes or what it
+// writes.
 //
 // Keep reading the RTL without -formal for this task; formal/components.sby
 // does. With -formal the decoder brings its own assume(in.pc == pc) along, and

--- a/formal/wrapper.v
+++ b/formal/wrapper.v
@@ -18,7 +18,7 @@ module rvfi_wrapper (
   (* keep *) logic [31:0] imem_addr2;
   // The fetch address one cycle early, for a synchronous memory. Unread here:
   // this environment answers `imem_data` against `imem_addr` in the same cycle,
-  // so the whole ladder sees a combinational fetch bus and never the port the
+  // so every check sees a combinational fetch bus and never the port the
   // shipping SoC uses.
   (* keep *) logic [31:0] imem_addr_next;
   (* keep *) logic [31:0] mem_addr;
@@ -65,7 +65,7 @@ module rvfi_wrapper (
   // counterexamples at k = 30.
   //
   // What it costs: a defect that shows up only when one address answers two
-  // different ways in consecutive cycles is invisible to the whole ladder. No
+  // different ways in consecutive cycles is invisible to every check. No
   // memory does that, but the narrowing is real.
   //
   // Stability across two cycles rather than a full memory model, because that is

--- a/rtl/regfile.v
+++ b/rtl/regfile.v
@@ -49,7 +49,7 @@ module regfile(
   // write-first term above it makes the operand the current architectural value
   // including a writeback committed this cycle, which is why decode's stall-only
   // scoreboard needs no forwarding path for the writeback slot. Deleting the rs2
-  // half is the formal ladder's liveness probe for `reg_ch0`.
+  // half is the formal check set's liveness probe for `reg_ch0`.
   //
   // The select and the x0 test read the held pair, not `rs1`/`rs2`. `rs1` is
   // instruction bits, so selecting on it puts these comparators after the

--- a/rtl/writeback.v
+++ b/rtl/writeback.v
@@ -66,7 +66,7 @@ module writeback(
  `ifdef RISCV_FORMAL
   // What this core reports on a trapping retire, and what no oracle checks.
   // riscv-formal's checks/rvfi_insn_check.sv puts rd_addr, rd_wdata, pc_wdata
-  // and every mem_* assertion inside `if (!spec_trap)`, so the ladder cannot
+  // and every mem_* assertion inside `if (!spec_trap)`, so those checks cannot
   // tell a core that traps correctly from one that traps and also corrupts rd,
   // writes memory and redirects somewhere arbitrary. The convention is
   // rvfi_valid 1 (a trapping instruction does retire), rvfi_trap 1, rd_addr /

--- a/test/asm/fencenop.S
+++ b/test/asm/fencenop.S
@@ -5,8 +5,8 @@
 // spec model at the pin AND no other test.
 //
 // formal/EXPECTED_CHECKS is set-equal to riscv-formal's own
-// insns/isa_rv32imc.txt, so every other instruction in the ISA has an `insn_*`
-// ladder check. The pin models none of `c_nop`, `c_ebreak`, `fence`, `ecall`,
+// insns/isa_rv32imc.txt, so every other instruction in the ISA has a generated
+// `insn_*` check. The pin models none of `c_nop`, `c_ebreak`, `fence`, `ecall`,
 // `ebreak` -- and that five-instruction blind spot is where the c.ebreak trap
 // cause defect lived. `ecall` and `ebreak` are covered by trap.S,
 // `c.ebreak` by cebreak.S; these four had nothing.

--- a/test/asm/minstret.S
+++ b/test/asm/minstret.S
@@ -17,9 +17,9 @@
 # increment `minstret`, because it did not retire architecturally — is checked
 # in test/asm/trap.S, next to the trap that provokes it. No trap is taken here.
 #
-# The riscv-formal ladder cannot see either rule — rvfi_csrw_check checks that
+# The riscv-formal checks cannot see either rule — rvfi_csrw_check checks that
 # a CSR *write* lands, not that a counter's increment semantics are right, and
-# the csrc_* checks are not on this ladder (formal/checks.cfg's [csrs] note).
+# the csrc_* checks are not in that set (formal/checks.cfg's [csrs] note).
 # So simulation is the only mechanised check of them today.
 #
 # No trap is expected anywhere in this file, so it installs the *fatal*

--- a/test/check_suite_shape.sh
+++ b/test/check_suite_shape.sh
@@ -40,7 +40,7 @@
 # BOTH DIRECTIONS, and the second one is the one worth arguing for. A program
 # present in the tree but absent from the manifest is red, so a program that lands
 # without being wired into the floor file fails immediately rather than joining
-# the suite unmeasured. That is why the ladder's version is bidirectional too.
+# the suite unmeasured. That is why formal/EXPECTED_CHECKS is bidirectional too.
 #
 # This script reads ONLY the first field of each manifest line. The remaining
 # fields are the floor numbers, and grading those is test/run_tests.sh's job —

--- a/test/cosim.cc
+++ b/test/cosim.cc
@@ -7,7 +7,7 @@
 //
 // WHY A SEPARATE BINARY, AND WHY IT READS `regs` RATHER THAN RVFI.
 //
-// The RVFI monitor (test/monitor.v) and the riscv-formal ladder both check
+// The RVFI monitor (test/monitor.v) and the riscv-formal check set both check
 // what the core SAYS it did: rvfi_rd_wdata against a spec model evaluated on
 // rvfi_rs1_rdata / rvfi_rs2_rdata / rvfi_insn. A core that mis-reports a
 // value and then computes with that same mis-reported value tells an

--- a/test/cosim.py
+++ b/test/cosim.py
@@ -14,7 +14,7 @@ The core's REAL architectural register file -- `uut regfile regs`, read
 through cxxrtl `debug_items` by test/cosim.cc -- against the register file of
 RISC-V International's own executable specification.  No rvfi_* signal is read
 on either side.  That is the whole point: test/monitor.v and the riscv-formal
-ladder both check the core's SELF-REPORT (rvfi_rd_wdata against a spec model
+check set both check the core's SELF-REPORT (rvfi_rd_wdata against a spec model
 evaluated on rvfi_rs1_rdata / rvfi_rs2_rdata / rvfi_insn), so a core that
 mis-reports a value and computes with that same mis-reported value satisfies
 both.  This compares state that neither side got to describe.

--- a/test/csr_tb.v
+++ b/test/csr_tb.v
@@ -8,7 +8,7 @@
 // rtl/decoder.v's `instr_valid`, so an address wrongly accepted becomes an
 // instruction the core executes and one wrongly rejected becomes an illegal
 // instruction -- in a `.S` test either reads as an execution bug rather than a
-// CSR one. And the WARL masks cannot be checked on the riscv-formal ladder at
+// CSR one. And the WARL masks cannot be checked by riscv-formal at
 // all: rvfi_csrw_check.sv compares the write against the value the core says it
 // wrote, with no model of a register that legally keeps only some bits, so a
 // correctly masked CSR fails it. That is why mtvec, mepc and mstatus are kept
@@ -275,7 +275,7 @@ module csr_tb;
     // 64-bit counter, not just for the half the address names, so the carry
     // boundary is the one place the rule can be broken: with the low half at
     // 0xffff_ffff a write to it must also suppress the carry into the high
-    // half. Nothing else reaches that cycle -- the ladder's CSR checks read
+    // half. Nothing else reaches that cycle -- the generated CSR checks read
     // only what the core reports writing and never look at the register, and a
     // `.S` program lands a write there only by calibrating instruction spacing.
     poke(12'hB80, 32'h0000_0000);
@@ -356,10 +356,11 @@ module csr_tb;
     check_read("minstret still answers 0xb02, one below mhpmcounter3", 12'hB02, 32'h5a5a_5a5a);
     check_read("mscratch still answers 0x340, one past mhpmevent31", 12'h340, 32'hdead_beef);
 
-    // Nothing on the riscv-formal ladder sees any of this. Its per-instruction
-    // checks drop every value assertion for a retire that traps, and the CSRs a
-    // trap writes are the WARL ones the header explains cannot go on the
-    // `[csrs]` list, so this bench and test/asm/trap.S are all there is.
+    // Nothing in the generated riscv-formal checks sees any of this. Their
+    // per-instruction checks drop every value assertion for a retire that
+    // traps, and the CSRs a trap writes are the WARL ones the header explains
+    // cannot go on the `[csrs]` list, so this bench and test/asm/trap.S are all
+    // there is.
     poke(12'h305, 32'h0000_0100);   // mtvec = 0x100
     poke(12'h300, 32'h0000_0008);   // mstatus.MIE = 1, MPIE = 0
     check_hex("mtvec_value echoes mtvec for the decoder", mtvec_value, 32'h0000_0100);

--- a/test/decoder_tb.v
+++ b/test/decoder_tb.v
@@ -97,8 +97,8 @@ module decoder_tb;
   // pc must have exactly one driver, and it must be next_pc. The memory latches
   // its address off next_pc one cycle before the fetch that reads it. Give pc a
   // second driver and the memory runs a cycle out of step with decode, so the
-  // core executes whatever is at the wrong addresses. Nothing on the
-  // riscv-formal ladder reads that port.
+  // core executes whatever is at the wrong addresses. No riscv-formal check
+  // reads that port.
   //
   // Checked on every edge rather than in one vector, because a change like that
   // shows up on some instructions and not on others.

--- a/test/probe_gates.sh
+++ b/test/probe_gates.sh
@@ -137,7 +137,7 @@ make_sim_stub() {  # $1 = path
 #!/bin/sh
 # Stands in for ./sim (test/cxxrtl.cc). Reproduces its output contract -- one
 # `RETIRES <n> SPEC-CHECKED <m>` line and one verdict line -- and its exit
-# ladder, so run_tests.sh's grading of that ladder can be probed without the
+# statuses, so run_tests.sh's grading of them can be probed without the
 # elaborated design.
 [ -z "${STUB_SIM_NOCOUNTS:-}" ] && \
   echo "RETIRES ${STUB_SIM_RETIRES:-10} SPEC-CHECKED ${STUB_SIM_SPEC:-10}"
@@ -639,10 +639,10 @@ cb_fixture() {
 cbs() { printf "%s %s/checks %s/EXPECTED_FAIL %s/EXPECTED_CHECKS" "$CB" "$1" "$1" "$1"; }
 
 d=$(cb_fixture)
-probe "control: a full-pass ladder against an empty baseline is green" 0 \
+probe "control: a full-pass check set against an empty baseline is green" 0 \
   "Failure list matches" "$(cbs "$d")"
 
-probe "wrong argument count is exit 2 -- the inputs are broken, not the ladder" 2 \
+probe "wrong argument count is exit 2 -- the inputs are broken, not the checks" 2 \
   "usage:" "$CB $d/checks"
 
 probe "a missing baseline file is exit 2, not an empty expected set" 2 \
@@ -659,8 +659,8 @@ probe "and the same for the check-set baseline" 2 \
 chmod 644 "$d/EXPECTED_CHECKS"
 
 d=$(cb_fixture); rm "$d/checks/alpha.sby" "$d/checks/beta.sby"
-probe "a ladder that was never generated is exit 2, not zero checks passing" 2 \
-  "the ladder was never" "$(cbs "$d")"
+probe "a check set that was never generated is exit 2, not zero checks passing" 2 \
+  "the check set was never" "$(cbs "$d")"
 
 d=$(cb_fixture); printf 'beta\n' > "$d/EXPECTED_FAIL"
 probe "a pre-ADR-0036 one-field baseline line is named, not half-matched" 2 \


### PR DESCRIPTION
Closes JEF-820.

"Ladder" was this repo's informal name for the generated riscv-formal check set.
It was retired from `CLAUDE.md` and never cleaned up elsewhere. The ticket
estimated eight files; grepping found it live in **23**.

Each site now says what the thing actually is — the generated riscv-formal
checks, or the check set. **The term is renamed, not the content.** Every fact
those sentences carried survives verbatim in substance: that the checks run
under `RISCV_FORMAL_ALTOPS` and therefore never exercise the real multiplier or
divider, that both baseline comparisons are set equalities in both directions,
and that a check set which was never generated must not read as zero checks
passing.

### The diagnostics, which were the sharp part

| File | What a reader saw | What they see now |
|---|---|---|
| `formal/check-baseline.sh` | `-- the ladder was never` / `generated.` | `-- the check set was never` / `generated.` |
| `formal/check-baseline.sh` | `matches an all-passing ladder exactly and exits 0. Refusing to grade.` | `matches an all-passing check set exactly and exits 0. Refusing to grade.` |
| `test/probe_gates.sh` | `a ladder that was never generated is exit 2…` | `a check set that was never generated is exit 2…` |
| `.github/workflows/ci.yml` (step name) | `Generate and run the ladder` | `Generate and run the checks` |
| `.github/workflows/ci.yml` (step summary) | `### formal ladder vs …` | `### riscv-formal checks vs …` |

**Renaming a diagnostic did not change when it fires** — only what it says.

### Two sites where the word had a different sense

Recorded because they are more than a noun swap:

- `test/probe_gates.sh`'s sim stub reproduced `./sim`'s **"exit ladder"** — a
  hierarchy of exit codes, not the riscv-formal check set at all. It now says
  "exit statuses".
- `test/check_suite_shape.sh` pointed at "the **ladder's** version" of its
  bidirectional set equality. It now names `formal/EXPECTED_CHECKS`, the file
  that actually holds that property.

### Did a grader compare a probe name?

**No.** `probe()` uses its `<label>` only for `printf`; the sole pinned quantity
is `PROBES_EXPECTED=211`, a count. One probe's **assertion string** did depend on
the word — `"the ladder was never"`, matched against `check-baseline.sh`'s
output — so both sides moved in this commit.

Likewise, the header prose in `formal/EXPECTED_FAIL` and `formal/EXPECTED_CHECKS`
cannot reach a graded set: `check-baseline.sh`'s `strip()` runs `sed -e 's/#.*//'`
and `genchecks-audit.py`'s `read_name_list()` does `line.split("#", 1)[0]`. No
name-and-status pair was touched.

### Testing

- `make probe-gates` — **211 graded comparisons before, 211 after**, every
  failure path executed.
- `make test` — 63/63, failure list matches `test/EXPECTED_FAIL` exactly.
- `make test-units` — green.
- **Refusal paths forced by hand** (both of `check-baseline.sh`'s, plus the
  control), each firing on the same condition at the same exit 2:

```
=== control: full pass against an empty baseline
2 checks: 2 pass, 0 fail
Failure list matches …/EXPECTED_FAIL exactly (name and status).
exit=0

=== refusal 1: the checks were never generated (no *.sby)
error: no *.sby files under …/checks -- the check set was never
       generated. Run 'make -C formal checks' first.
exit=2

=== refusal 2: an unreadable baseline is not an empty one
error: …/EXPECTED_FAIL exists but is not readable.
An unreadable baseline reads as an EMPTY one here, which matches an
all-passing check set exactly and exits 0. Refusing to grade.
exit=2
```

- **The `formal` job's step summary still renders.** Both workflows parse, and I
  extracted the summary block out of the YAML and executed it — the brace group,
  the fenced code block and the escaped backticks all survive:

```
### riscv-formal checks vs formal/EXPECTED_{FAIL,CHECKS}
```` ```  ````
85 checks: 85 pass, 0 fail
Failure list matches formal/EXPECTED_FAIL exactly (name and status).
```` ```  ````
A match here means the check set still agrees with its baseline.
It is not a correctness result: every check is `mode bmc` (no
counterexample within a bounded depth, not a proof), and the
checks run under `RISCV_FORMAL_ALTOPS`, so the mul/div checks
do not exercise the real multiplier or divider (ADR-0010).
```

No `run:` block was restructured and no graded command was put in a pipeline.

### Scope

`grep -rni ladder` outside `docs/` now returns only `CODE_OF_CONDUCT.md`'s
Mozilla URL, which is not this word. `docs/adr/` and `docs/ideas/` are
untouched — rewriting a merged decision record to match current vocabulary is
worse than the inconsistency.

**One deliberate call worth a second opinion:** `docs/THREAT_MODEL.md` is left
alone. It is live prose rather than history, so it arguably belongs in this
sweep — but it is under `docs/`, which the acceptance criterion exempts, and one
of its two matches ("the milestone **ladder** is defined against specific gates")
is a *different sense of the word* — a stepwise sequence of milestones, not the
check set. Renaming that one would be changing content, not the term. Its other
match, "the riscv-formal ladder's failure set", is a genuine leftover and a
clean follow-up.

No behaviour change, no baseline edits, no ADR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
