### PR TITLE
Re-take the placed-versus-synthesised gate's red direction on both cores (JEF-824)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -326,11 +326,16 @@ and times.
   depend on the datapath measures nothing**: an all-NOP ROM placed 449 cells of a 1711-cell core and
   reported a critical path, so `soc/compare/placed_vs_synth.py` grades the placed count against the
   core's own synthesis, `make compare-smoke` requires both cores to publish the same values, and the
-  Dhrystone run compares the two cores' whole data RAMs word for word. **That stimulus is still a
+  Dhrystone run compares the two cores' whole data RAMs word for word. **That stimulus is a
   live control on one side only**: a NOP image makes every ROM word identical, which collapses
-  VexRiscv's read-only array and most of its core with it — still red at 0.64× — while this
-  harness's instruction memory is written by the design and survives whatever it holds, so on this
-  side the gate's demonstrated red direction is `test/probe_gates.sh`'s fixture, not a placement.
+  VexRiscv's read-only array and most of its core with it — still red at 0.64×, weaker than the
+  0.26× that founded the gate — while this harness's instruction memory is written by the design, so
+  its contents are never a constant and the datapath survives whatever it holds, at 1.10×. **What
+  folds this side makes the datapath dead rather than uniform**: the same NOP image with the text
+  write port disconnected is 0.02×, a core handed a constant instruction instead of the memory's
+  answer is 0.02×, and a core input left unconnected — which is how the gate last went red for real,
+  on a harness an `rtl/` change did not update — is 0.09×, with icetime reporting 50.77 MHz for one
+  sixth of the core.
   **That harness gives VexRiscv no data path to its ROM** — a load from a ROM address reads zero
   there — so anything run in it keeps its read-only data out of ROM until that is fixed.
 - **Taking the instruction memory out of that fetch loop is priced and declined** (ADR-0087). A

--- a/docs/adr/0086-both-cores-in-one-harness-and-the-gap-is-the-fetch-loop.md
+++ b/docs/adr/0086-both-cores-in-one-harness-and-the-gap-is-the-fetch-loop.md
@@ -2,7 +2,9 @@
 
 Status: Accepted · *The 1.6× below is this tree's, 2026-08-08. Re-swept over the same seed set on
 2026-08-12 it is 1.48×, and the throughput product it feeds is in
-[ADR-0098](0098-dhrystone-on-both-cores-and-their-published-rate-reproduces.md)'s amendment.*
+[ADR-0098](0098-dhrystone-on-both-cores-and-their-published-rate-reproduces.md)'s amendment. The
+all-NOP demonstration under "the first attempt produced no number" no longer folds this core, and
+the amendment at the end says what does.*
 
 ## Context
 
@@ -229,3 +231,75 @@ because a branch predictor had to fit beside it, not because of a register file.
   Three separate defects in this one flow produced a green run and a number: the folded core, the
   saturating program, and the sweep that never re-placed. The first two are checks now; the third is a
   fixed prerequisite order with the reason written beside it.
+
+## Amendment, 2026-08-12 — the all-NOP stimulus no longer folds this core, and what does
+
+The all-NOP ROM above is quoted as the demonstration that this gate discriminates. **On this core's
+side it no longer does.** Re-run live rather than trusted, on `d8ecfa2` with the toolchain this ADR
+records — Yosys 0.68+post (`c12172fb`), nextpnr-0.10-108-g68c1acd8 — one placement at the default
+seed each, the placed `ICESTORM_LC` against the same standalone `SB_LUT4` the gate reads:
+
+| stimulus | this core, against 6006 | verdict | VexRiscv, against 1711 | verdict |
+|---|---|---|---|---|
+| the real program, `bench.S` | 6635 — **1.10×** | green, 30.21 ns | 2356 — **1.38×** | green, 20.66 ns |
+| all-NOP ROM image | 6628 — **1.10×** | **green — no fold at all** | 1101 — **0.64×** | red |
+| both pads tied off | 1 — 0.00× | red, 0.24 ns | 1 — 0.00× | red |
+| reset held asserted | 1 — 0.00× | red | 1 — 0.00× | red |
+| a constant instruction in place of the memory's answer | 125 — **0.02×** | red, 10.59 ns | 1 — 0.00× | red |
+| all-NOP image, text write port disconnected | 129 — **0.02×** | red, 10.63 ns | no write port to remove | — |
+| a core input left unconnected, as found | 536 — **0.09×** | red, 19.70 ns | not applicable | — |
+
+The ratios differ by factors of fifty, so nothing here turns on which placement is read and no sweep
+was taken; the whole-design rows reproduce the amended clock figures to within their spread.
+
+**The reason is the write port, and yosys's own memory map says so in one line.** Under the NOP
+image `bench_littlecpu.imem.rom_even` and `imem.rom_odd` are still `mapping memory ... via
+$__ICE40_RAM4K_`; disconnect `mem_wstrb` and both disappear from that list entirely. A memory the
+design writes cannot be a constant whatever it was initialised with, so the instruction word is not
+a constant, so the decoder that reads it is live and the datapath behind it with it. VexRiscv's
+`bench_vexriscv.rom` is read-only, and it is exactly the memory that leaves the map under the same
+image — 30 block RAMs to 21 — while its register file, its data RAM and its branch predictor's
+history stay. **Text became writable for the `fence.i` reason and took a red direction with it as a
+side effect nobody chose.**
+
+**So the shape of a stimulus that works here is not "make the contents uniform" but "make the
+datapath dead".** Three do. Tying the harness's two pads off is the most direct statement of the
+property under test and deletes everything, which makes it a poor diagnostic — one placed cell is
+obviously wrong, where the defect this gate exists to catch looks like a measurement. The other two
+leave a plausible fragment and a plausible number: a core handed a constant instruction instead of
+the memory's answer places 125 cells and icetime times them at 94.41 MHz, and the all-NOP image with
+the write port taken away places 129 at 94.10 MHz. **The NOP image and that last row differ in one
+connection**, which is what makes it the successor to the founding experiment rather than a new one.
+
+**The founding 0.26× is a weaker red than it was.** The same image against the same SHA-pinned
+VexRiscv now leaves 1101 of 1711 rather than 449 — 0.64× against a 0.80× floor, 0.16 of margin where
+there was 0.54 — because the harness it was first measured in is not this one, and in this one the
+predictor's write-driven history table holds most of that core up on its own. The verdict travelled
+and the ratio did not. A red direction with 0.16 of margin is one flow change from expiring on that
+side too, so the number to re-take on a pin bump or a harness edit is this one, not the 449.
+
+**While this was being measured the gate went red for real, on this core's side, for a defect
+already merged.** Adding an instruction access fault gave `littlecpu` an `imem_fault` input and
+`imemory` an output to drive it, and `soc/compare/bench_littlecpu.v` was not in that change:
+the input was left unconnected. Yosys said `Warning: Wire ... is used but has no driver` and
+carried on; the harness synthesised to 473 `SB_LUT4`, placed 536 cells, and icetime reported
+**19.70 ns — 50.77 MHz, better than the real design's 30.21** for a design that was one sixth of the
+core. `make compare-timing` is not on CI, so nothing had failed. That is the founding defect
+recurring from a different cause, caught by the check written for it, and the fix is in this
+change. **`make compare-smoke` could not have caught it**: it publishes the same six values before
+and after the fix, to the byte, because `bench.S` never fetches outside the ROM window and so never
+asserts the signal that was floating.
+
+**A red direction is a property of the design at the moment it was taken.** This is the third this
+week to expire because the design improved rather than because it broke — `test/asm/selfmod.S` when
+the bus transaction moved to the execute slot, `fence.i`'s half of serialization structurally, and
+now this one when text became writable. A fixture probe survives that, because it drives the
+comparison against numbers on disk and asks only whether the comparison can fail. A live stimulus
+does not, because it asks whether *today's* design still fails, and the answer is allowed to change
+without anyone touching the check. `test/probe_gates.sh`'s five probes for this gate are unchanged
+here and still pass, and they are what keeps it honest in CI; this amendment is what keeps the
+live demonstration true.
+
+Nothing above moves the floor. 0.02× and 0.09× clear 0.80× by more than an order of magnitude, and
+1.10× and 1.38× sit above it by a quarter and a half, so no measurement here argues about where it
+sits.

--- a/soc/compare/bench_littlecpu.v
+++ b/soc/compare/bench_littlecpu.v
@@ -44,7 +44,7 @@ module bench_littlecpu #(
   logic [31:0] mem_addr, mem_wdata, mem_rdata;
   logic [31:0] imem_mem_rdata, dmem_mem_rdata;
   logic [3:0]  mem_wstrb;
-  logic        mem_ren, fetch_stall, irq_timer;
+  logic        mem_ren, fetch_stall, irq_timer, imem_fault;
 
   // Stands in for rtl/timer.v's `mtip` line, which there is no room on the part
   // for. Tying it to zero instead would let yosys constant-fold `mip.MTIP`, the
@@ -57,6 +57,10 @@ module bench_littlecpu #(
   logic [31:0] imem_addr, imem_addr2, imem_addr_next;
   logic [31:0] imem_data, imem_data2;
 
+  // A port added to littlecpu and left unconnected here floats, and yosys folds
+  // the whole core away behind it -- this instance once missed `imem_fault` and
+  // placed a sixth of the design, which icetime timed faster than the real one.
+  // Only soc/compare/placed_vs_synth.py notices, and it is not on CI.
   littlecpu riscv (
     .clk(clk),
     .reset(reset),
@@ -72,6 +76,7 @@ module bench_littlecpu #(
     .mem_rdata(mem_rdata),
     .fetch_stall(fetch_stall),
     .irq_timer(irq_timer),
+    .imem_fault(imem_fault),
     .trap(trap)
   );
 
@@ -89,7 +94,8 @@ module bench_littlecpu #(
     .mem_wstrb(mem_wstrb),
     .mem_ren(mem_ren),
     .mem_rdata(imem_mem_rdata),
-    .fetch_stall(fetch_stall)
+    .fetch_stall(fetch_stall),
+    .imem_fault(imem_fault)
   );
 
   // The same module soc/compare/bench_vexriscv.v instantiates, at the same base

--- a/soc/compare/placed_vs_synth.py
+++ b/soc/compare/placed_vs_synth.py
@@ -12,11 +12,22 @@ the flow said a word.
 So the placed cell count is compared against what the core synthesises to
 ON ITS OWN, with no harness around it to fold against. The harness adds
 memories and a few registers and takes nothing away, so the placed count is
-normally ABOVE the standalone one -- 1.13x for this core and 1.41x for VexRiscv
+normally ABOVE the standalone one -- 1.10x for this core and 1.38x for VexRiscv
 as measured. The floor is a fraction rather than an equality because packing,
 `abc9` and the harness's own glue all move the number by more than a percent,
 and because nothing here needs to be precise: the defect it catches is a factor
 of four.
+
+An all-NOP ROM no longer folds this core, so it is not the stimulus to reach for
+when checking that this gate still discriminates. That image only makes every
+ROM word identical, which collapses a read-only instruction array -- VexRiscv's,
+still red at 0.64x -- and this core's instruction memory carries a write port
+the design drives, so its contents are never a constant whatever it holds. What
+folds this side makes the datapath dead rather than uniform: the same image with
+that write port disconnected, a core given a constant instruction instead of the
+memory's answer, and a core port left unconnected, which is how this gate last
+went red for real. All three still place and icetime still times the fragment,
+which is what makes them the shape of defect worth catching.
 
 Reads nextpnr's utilisation table for the placed count and yosys's cell census
 for the synthesised one, both of which the flow already writes. It does not
@@ -81,8 +92,8 @@ def main():
             f"*** synthesis, under the {args.min_ratio:.2f}x floor. Most of the core is\n"
             f"*** not in what was placed, so the timing number describes a fragment.\n"
             f"*** The usual cause is a harness whose outputs do not depend on the\n"
-            f"*** datapath -- an all-NOP ROM does exactly this. Fix the program or\n"
-            f"*** the harness; do not lower the floor."
+            f"*** datapath -- an unconnected core port and an all-NOP ROM both do\n"
+            f"*** exactly this. Fix the harness or the program; do not lower the floor."
         )
     print(f"RATCHET: {ratio:.2f}x against a {args.min_ratio:.2f}x floor -- OK")
 


### PR DESCRIPTION
Closes JEF-824.

The all-NOP ROM is the demonstration ADR-0086 quotes for the placed-versus-synthesised
check. Re-run live rather than trusted, **it no longer folds this core at all**, and the
ADR now says so, says why, and names three stimuli that do.

All figures on `d8ecfa2` with the toolchain ADR-0086 records — Yosys 0.68+post
(`c12172fb`), nextpnr-0.10-108-g68c1acd8 — one placement at the default seed each, the
placed `ICESTORM_LC` against the same standalone `SB_LUT4` the check reads.

| stimulus | this core, against 6006 | verdict | VexRiscv, against 1711 | verdict |
|---|---|---|---|---|
| the real program, `bench.S` | 6635 — 1.10× | green, 30.21 ns | 2356 — 1.38× | green, 20.66 ns |
| all-NOP ROM image | 6628 — 1.10× | **green — no fold at all** | 1101 — 0.64× | red |
| both pads tied off | 1 — 0.00× | red, 0.24 ns | 1 — 0.00× | red |
| reset held asserted | 1 — 0.00× | red | 1 — 0.00× | red |
| a constant instruction in place of the memory's answer | 125 — 0.02× | red, 10.59 ns | 1 — 0.00× | red |
| all-NOP image, text write port disconnected | 129 — 0.02× | red, 10.63 ns | no write port to remove | — |
| a core input left unconnected, as found | 536 — 0.09× | red, 19.70 ns | not applicable | — |

**The cause is one line of yosys's own memory map.** Under the NOP image
`bench_littlecpu.imem.rom_even` and `imem.rom_odd` are still `mapping memory ... via
$__ICE40_RAM4K_`; disconnect `mem_wstrb` and both vanish from that list. A memory the
design writes cannot be a constant whatever it was initialised with, so the instruction
word is not one either and the datapath behind it is live. VexRiscv's `bench_vexriscv.rom`
is read-only and is exactly the memory that leaves the map under the same image, 30 block
RAMs to 21 — while its register file, data RAM and branch-predictor history stay, which is
why the founding **0.26× is only 0.64× today**: 0.16 of margin against the 0.80× floor
where there was 0.54. The verdict travelled; the ratio did not.

So the shape that works here makes the datapath **dead**, not its contents uniform. Tying
the pads off states the property most directly and deletes everything, which makes it a
poor diagnostic — one placed cell is obviously wrong, where the defect this check exists
to catch looks like a measurement. The other two leave a plausible fragment *and a
plausible number*, and the NOP image differs from the write-port row in exactly one
connection, which makes that row the successor to the founding experiment rather than a
new one.

## The check went red for real while this was being measured

Adding the instruction access fault (#169) gave `littlecpu` an `imem_fault` input and
`imemory` an output to drive it. `soc/compare/bench_littlecpu.v` was not in that change,
so the input floated: yosys warned and carried on, the harness synthesised to 473
`SB_LUT4`, placed 536 cells — one sixth of the core — and **icetime reported 50.77 MHz
against the whole design's 33.10**, a better number for a fragment. `make compare-timing`
is not on CI, so nothing had failed, and `make compare-smoke` cannot see it: it publishes
the same six values before and after the fix, to the byte, because `bench.S` never fetches
outside the ROM window and so never asserts the signal that was floating. The two
connections are restored here, with a tripwire comment at the instance.

## What changed

- `soc/compare/bench_littlecpu.v` — wire `imem_fault` from `imemory` to `littlecpu`, plus
  the tripwire.
- `docs/adr/0086-*.md` — dated amendment: the table above, the memory-map mechanism, the
  weakened founding ratio, the defect found, and the general point that **a red direction
  is a property of the design at the moment it was taken** — a fixture probe survives that,
  a live stimulus does not. Third this week to expire because the design improved.
- `soc/compare/placed_vs_synth.py` — docstring says which stimulus to reach for now; the
  failure message names an unconnected core port beside the all-NOP ROM. Refreshed the two
  measured ratios (1.13/1.41 → 1.10/1.38).
- `CLAUDE.md` — the sentence claiming this side's only demonstrated red direction is the
  fixture probe is superseded by the placements above.

## No ratchet moves

`COMPARE_MIN_RATIO` stays 0.80, `SOC_MIN_MHZ` and `FIT_MAX_LC` untouched, every baseline
unchanged. `test/probe_gates.sh`'s five fixture probes for this check are **not edited**
and still pass; none of them matches the message text I changed.

## How I tested it

- `make test` — 64/64, failure list matches `test/EXPECTED_FAIL` exactly.
- `make probe-gates` — 211 graded comparisons, every failure path executed.
- `make compare-smoke` — PASS, both cores agree on all six published values.
- `make compare-timing` — green both sides, 1.10× and 1.38×.
- The seven stimuli above, each synthesised and placed through the same flow from a
  scratch directory; no tracked file was touched by any experiment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
