### PR TITLE
Vector the eleven A instructions in the suite, and give the -march string one source (JEF-813)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,15 +167,32 @@ pipeline drain — see the serialization commitment.
 **The eleven A instructions are decoded and executed, and `misa` does not claim them yet**
 (ADR-0106). `rtl/` implements Zaamo and Zalrsc in full — nine AMOs, `lr.w`, `sc.w`, `.aq`/`.rl`
 decoded and ignored, cause 4 for a misaligned `lr.w` and cause 6 for the other ten — while
-`misa` stays `0x4000_1104` and all three of the suite's build sites stay at
-`-march=rv32imc_zicsr_zifencei`. So no program in `test/asm` executes one and the graded suite says
-nothing about them; `test/accessor_tb.v`, `test/decoder_tb.v`, `components_accessor` and `dmemcheck`
-are what do. Claiming the bit and moving `-march` is one later change, and it has to move both
-together or the ISA string and the register disagree. **The reservation is refused outside the
+`misa` stays `0x4000_1104`. **The suite builds at `-march=rv32imac_zicsr_zifencei`**, so six
+programs execute atomics — `amo.S`, `amominmax.S`, `amotrap.S`, `lrsc.S`, `lrsclock.S` and
+`amoregion.S` — and four of the six **agree with the reference model**, which is the semantic oracle
+for the nine functions, LR/SC's five invalidation events and the two misalignment causes. The `.S`
+suite is not one: **`test/monitor.sim.v` value-checks nothing in an A retire**, because the pin
+ships no spec model for any of the eleven, so an `OBSERVED_FLOOR` line for one of those programs is
+a retire count and not evidence anything was compared. Every claim they make is an in-band
+assertion, and every one reads its memory result back into a register because `test/cosim.cc`
+compares registers and never compares memory.
+**Claiming the `misa` bit is still a later change** — it moves `rtl/csrs.v` and the Sail model's
+`A` key together, and `misa` is what an ISA string cannot say.
+**The reservation is refused outside the
 region `rtl/memory.v` answers**, which is the whole of the A extension's region attribute here: a
 `sc.w` where nothing is reserved fails and issues no transaction, so it cannot report success for a
 store that went nowhere. The decode-time region test that would instead raise causes 5 and 7 is the
-one ADR-0104 measured at four logic levels in the fetch loop and declined.
+one ADR-0104 measured at four logic levels in the fetch loop and declined — and that deviation is
+the suite's one co-simulation divergence, because the model has RsrvEventual (the `sc.w` succeeds)
+and RsrvNone (the `lr.w` faults, cause 5) and this core is neither.
+
+**The ISA string has one source and `make test` grades it**: `test/march_test.sh` declares
+`rv32imac_zicsr_zifencei` and checks all six sites that state it, three of which are silent when
+wrong — the Makefile's `soc-rom` builds a program with no atomic in it, and `DHRY_CFLAGS` is copied
+verbatim into `soc/depth/cycles.py` with nothing else comparing the two. Two spellings that look
+identical must **not** move with it: `formal/checks.cfg`'s `isa rv32imc` and `MONITOR_GEN -i
+rv32imc` name what riscv-formal generates a spec model for, and the pin has none for A, so widening
+either generates nothing.
 
 **One interrupt: the machine timer, cause `0x8000_0007`.** `mie.MTIE` is the only writable bit of
 `mie`; `mip.MTIP` is `rtl/timer.v`'s line and read-only; `mip.MSIP`/`mip.MEIP` stay read-only zero,

--- a/Makefile
+++ b/Makefile
@@ -487,6 +487,15 @@ port-connect-test:
 retired-term-test:
 	@./test/retired_term_test.sh
 
+# The ISA string is stated at six sites and three of them build programs that
+# use no atomic, so a site left behind goes on producing numbers rather than
+# failing to assemble. Hangs off `test` like the other bash checks -- git, grep,
+# sed and awk only -- because the two sites it would otherwise take a Dhrystone
+# run and an SoC place-and-route to notice are exactly the silent ones.
+.PHONY: march-test
+march-test:
+	@./test/march_test.sh
+
 # Forces the elaboration checks in rtl/imemory.v, rtl/memory.v and rtl/timer.v
 # to fire, in both frontends. Hangs off `test` because the parameter shapes they
 # guard are the ones the SoC and the benches pass, so nothing else here would
@@ -525,8 +534,8 @@ mutation-probe:
 
 .PHONY: test
 test: sim test-units probe-gates pin-bump-test tool-cache-test memmap-test \
-      compare-geometry-test retired-term-test port-connect-test window-test \
-      abc-engine-test mutation-probe
+      compare-geometry-test retired-term-test port-connect-test march-test \
+      window-test abc-engine-test mutation-probe
 	@./test/run_tests.sh ./sim test/asm test/EXPECTED_FAIL test/OBSERVED_FLOOR
 
 # The same suite `make test` runs, with the runner charging every cycle to the
@@ -565,7 +574,7 @@ cycles: sim
 # residual so the number is checked rather than assumed.
 DHRY_RUNS   ?= 2000
 DHRY_CYCLES ?= 4000000
-DHRY_CFLAGS := -march=rv32imc_zicsr_zifencei -mabi=ilp32 -O2 -std=c11 \
+DHRY_CFLAGS := -march=rv32imac_zicsr_zifencei -mabi=ilp32 -O2 -std=c11 \
                -ffreestanding -fno-tree-loop-distribute-patterns \
                -Wall -Wextra -Werror
 
@@ -666,12 +675,12 @@ soc-rom:
 	test -n "$$tmp" -a -d "$$tmp"; \
 	trap 'rm -rf "$$tmp"' EXIT; \
 	case '$(SOC_PROG)' in \
-	  *.c) $$CC -march=rv32imc_zicsr_zifencei -mabi=ilp32 -nostdlib \
+	  *.c) $$CC -march=rv32imac_zicsr_zifencei -mabi=ilp32 -nostdlib \
 	         -Os -std=c11 -ffreestanding -fno-tree-loop-distribute-patterns \
 	         -Wall -Wextra -Werror -I test/asm -T test/asm/boot.lds \
 	         -o "$$tmp/prog.elf" test/crt0.S test/asm/$(SOC_PROG); \
 	       sections='-j .text -j .data' ;; \
-	  *)   $$CC -march=rv32imc_zicsr_zifencei -mabi=ilp32 -nostdlib -I test/asm \
+	  *)   $$CC -march=rv32imac_zicsr_zifencei -mabi=ilp32 -nostdlib -I test/asm \
 	         -T test/asm/sections.lds -o "$$tmp/prog.elf" test/asm/$(SOC_PROG); \
 	       sections='-j .text' ;; \
 	esac; \

--- a/soc/depth/cycles.py
+++ b/soc/depth/cycles.py
@@ -157,7 +157,7 @@ def main():
 
     dhry_log = work / "dhry.redirects"
     dhry_log.unlink(missing_ok=True)
-    dhry_flags = ("-march=rv32imc_zicsr_zifencei -mabi=ilp32 -O2 -std=c11 -ffreestanding "
+    dhry_flags = ("-march=rv32imac_zicsr_zifencei -mabi=ilp32 -O2 -std=c11 -ffreestanding "
                   "-fno-tree-loop-distribute-patterns -Wall -Wextra -Werror")
     subprocess.run(["./test/bench/run_dhrystone.sh", str(binary), str(args.runs),
                     "4000000", dhry_flags],

--- a/test/COSIM_EXPECTED_FAIL
+++ b/test/COSIM_EXPECTED_FAIL
@@ -2,10 +2,11 @@
 # programs that do NOT agree with the Sail RISC-V model matches this file
 # exactly, in both directions — so an unexpected *agreement* is caught too.
 #
-# THIS FILE IS EMPTY, AND EMPTY IS NOT THE SAME AS ABSENT. Both directions
-# still run: every program in test/asm must AGREE, and any one that does not is
-# red. Deleting the file does not turn the gate green — test/run_cosim.sh
-# refuses to start without a readable baseline, on purpose.
+# A SHORT FILE IS NOT AN ABSENT ONE, AND NEITHER IS AN EMPTY ONE. Both
+# directions still run: every program in test/asm not named below must AGREE,
+# and any one that does not is red. Deleting the file does not turn the gate
+# green — test/run_cosim.sh refuses to start without a readable baseline, on
+# purpose.
 #
 # FORMAT — two fields, not one:
 #
@@ -125,9 +126,65 @@
 # still checked on the other 59 programs, which is where the property it was
 # built for lives.
 #
+# lrsclock.S IS THE SAME ENTRY FOR THE SAME REASON, and it is here rather than
+# folded into the paragraph above because a reader looking it up should not have
+# to decide whether "the two timer-interrupt programs" now means three. It runs
+# an LR/SC critical section with this platform's machine timer armed underneath
+# it, and its wait for the first interrupt is the wait described above: the
+# model's CLINT is elsewhere with a different tick period, so the store that
+# arms this timer lands nowhere on it and the wait never ends. NOTHING WAS
+# COMPARED. What that costs is worth stating plainly, because it is the one
+# property of the A extension that co-simulation would otherwise be the natural
+# oracle for: whether a reservation survives a trap and an mret. It is checked
+# instead by test/sail/reservation_probe.sh, which asks the model that question
+# with no core involved (docs/adr/0102), and in band by lrsclock.S itself.
+#
+# amoregion.S IS THE SUITE'S ONE REAL DIVERGENCE FOR THE A EXTENSION, and it is
+# question 1 of the procedure above answered NO after the configuration was
+# actually tried both ways rather than reasoned about.
+#
+# What the program asserts is this core's reservability attribute: rtl/memory.v
+# exports the range test it already computes, so a reservation is refused
+# anywhere but the 64 KB data RAM and an sc.w there fails and issues no
+# transaction. The divergence is at test 5's sc.w to 0x0004_0000, where the core
+# writes rd=1 and the model writes rd=0.
+#
+# THE MODEL HAS EXACTLY TWO SETTINGS FOR A REGION AND THIS CORE IS NEITHER.
+# Measured on 0.13.1 with the region split at the data RAM's bounds:
+#
+#   reservability     what the model does at 0x0004_0000
+#   RsrvEventual      the lr.w takes a reservation and the sc.w SUCCEEDS
+#   RsrvNone          the lr.w raises a LOAD ACCESS FAULT, cause 5
+#
+# This core does a third thing: it answers the lr.w with zero, takes no
+# reservation, and raises nothing. That is not a choice made here to dodge the
+# model — it is ADR-0104's recorded deviation, where the decode-time region test
+# that would raise causes 5 and 7 was built, measured at four logic levels in
+# the fetch loop and 10.57-11.00 MHz against a 12.00 MHz requirement, and
+# declined. So RsrvNone would trade this divergence for a worse one: a control
+# flow difference rather than a register value, on a fault the core is recorded
+# as not raising. The region split is therefore NOT in
+# test/sail/rv32imc_zicsr.json, and that file's region comment carries the same
+# measurement so the next person to reach for the knob finds it there.
+#
+# Question 2 does not fit either: an sc.w's result IS the branch condition three
+# instructions later, so the two runs take different paths and no value
+# exemption can be scoped narrowly enough. That leaves question 3, and the
+# honest answer to it is that the program asserts an implementation-defined
+# platform attribute the model is entitled to answer differently. Everything
+# about the A extension that IS co-simulable was deliberately kept out of this
+# program and lives in amo.S, amominmax.S, amotrap.S and lrsc.S, all four of
+# which AGREE — so the semantic oracle for the nine AMO functions, for LR/SC's
+# five invalidation events and for the two misalignment causes is live, and this
+# entry costs exactly the region attribute and nothing else.
+#
 # THE FAILURE DIRECTION IS STILL LIVE. These are name-and-status pairs under set
-# equality, so if a future change makes either program AGREE, or makes it
+# equality, so if a future change makes any of these programs AGREE, or makes it
 # diverge some other way, this gate goes red and these paragraphs get re-read.
+# amoregion.S pins the divergence POINT as well: an sc.w that starts failing
+# somewhere else is failing for a new reason.
 
+amoregion.S   DISAGREE AT 18
+lrsclock.S    INCONCLUSIVE SAIL-LIMIT
 mtimer.S      INCONCLUSIVE SAIL-LIMIT
 mtimermask.S  INCONCLUSIVE SAIL-LIMIT

--- a/test/MUTATION_DETECTORS
+++ b/test/MUTATION_DETECTORS
@@ -64,6 +64,25 @@ fencei-wait-and-store-port  bench decoder_tb
 fencei-wait-and-store-port  bench imem_tb
 fencei-wait-and-store-port  asm   selfmod.S FAIL 2
 
+# A store-conditional that reports SUCCESS whatever the reservation says. rd is
+# the only thing an sc.w writes, so this is the whole instruction going wrong,
+# and it is caught at the two places the suite asks for a FAILURE: lrsc.S's
+# first case, which is an sc.w with no lr.w anywhere before it, and
+# amoregion.S's, which is one outside the region the platform will reserve.
+# lrsclock.S is NOT a detector and that is right -- every sc.w in it is meant to
+# succeed, so a core that always says so finishes it.
+sc-reports-success          bench accessor_tb
+sc-reports-success          asm   lrsc.S FAIL 2
+sc-reports-success          asm   amoregion.S FAIL 5
+
+# All four min/max compares read unsigned: the sign-bit correction on the shared
+# 33-bit adder/subtractor deleted. amominmax.S is the ONLY program that catches
+# it and amo.S is measured not to, which is the whole argument for the two being
+# separate files -- amo.S's operands are 5 against 3, where the signed and
+# unsigned answers agree and a comparator read either way looks right.
+amo-compares-unsigned       bench accessor_tb
+amo-compares-unsigned       asm   amominmax.S FAIL 4
+
 # The load half of the same shared port: a load from .text no longer takes the
 # port, so it answers with whatever the fetch put there. Four programs watch
 # this one, and textload.S is the only one of the four that neither writes text

--- a/test/OBSERVED_FLOOR
+++ b/test/OBSERVED_FLOOR
@@ -12,8 +12,9 @@
 # about what the suite is either.
 #
 # THE MANIFEST HALF ANSWERS A QUESTION NEITHER BASELINE CAN. test/EXPECTED_FAIL
-# and test/COSIM_EXPECTED_FAIL record which programs are known to fail; they are
-# both empty, so nothing in them would disappear if the suite itself did. A bad
+# and test/COSIM_EXPECTED_FAIL record which programs are known to fail; between
+# them they name four of seventy, so almost nothing in them would disappear if
+# the suite itself did. A bad
 # rebase, a directory rename, a .gitignore change or a glob that stopped
 # matching would leave `make test` reporting `12/12 passed`, matching an empty
 # baseline exactly, and exiting 0. The formal side has the same shape: a verdict
@@ -100,8 +101,9 @@
 # allowed not to be checked" here, on purpose.
 #
 # A LOW SPEC-CHECKED NUMBER IS EXPECTED AND IS NOT A DEFECT. riscv-formal ships
-# NO SPEC MODEL AT ALL for `ecall`, `ebreak`, `mret` or the `csrr*` family at
-# the pinned SHA (formal/pin.mk), so `spec_valid` is 0 for every one of those
+# NO SPEC MODEL AT ALL for `ecall`, `ebreak`, `mret`, the `csrr*` family or ANY
+# OF THE ELEVEN A ENCODINGS at the pinned SHA (formal/pin.mk), so `spec_valid`
+# is 0 for every one of those
 # retires by design and the monitor's whole semantic block is skipped for them.
 # The behaviour M3 added is checked by test/asm/trap.S, test/csr_tb.v and
 # test/decoder_tb.v instead, against assertions this repo wrote rather than
@@ -109,6 +111,19 @@
 # between the two columns, and that gap is the pin's coverage boundary, not a
 # bug in this core. Whoever first sees a low number here should not have to
 # rediscover that.
+#
+# THE SIX A PROGRAMS ARE THE SHARPEST CASE OF THAT, AND A LINE HERE SAYS LESS
+# ABOUT THEM THAN ABOUT ANY OTHER PROGRAM. test/monitor.sim.v wraps every value
+# comparison in `if (ch0_spec_valid)` with no `else`, so on an lr.w, an sc.w or
+# any of the nine AMOs the per-retire oracle grades pc continuity and nothing
+# else — not the register written, not the memory access. A number in the
+# `spec-checked` column below therefore counts the ORDINARY instructions
+# surrounding the atomics, and the difference between the two columns is roughly
+# the count of atomics executed. So the floor on amo.S, amominmax.S,
+# amoregion.S, amotrap.S, lrsc.S and lrsclock.S is a bound on those programs
+# still RUNNING, and every claim they make about the A extension is an in-band
+# assertion in the program itself. Reading a green line here as "the atomics
+# were checked" is exactly the inference this file exists to prevent.
 #
 # HOW TO RE-MEASURE, FOR `.S` LINES ONLY. Run `make test` and copy the table's
 # third column. Record the commit SHA it was measured at in the PR that changes
@@ -123,6 +138,10 @@
 # riscv-formal monitor, and CYCLES=5000 in test/run_tests.sh.
 add.S               429    429
 addi.S              206    206
+amo.S               294    272
+amominmax.S         513    472
+amoregion.S         121    107
+amotrap.S           646    564
 and.S               449    449
 andi.S              162    162
 auipc.S              25     25
@@ -149,6 +168,8 @@ lb.S                209    209
 lbu.S               209    209
 lh.S                220    220
 lhu.S               228    228
+lrsc.S              315    283
+lrsclock.S          159    144   # a retry loop under a live timer, like mtimer.S: how far it goes depends on when the interrupt lands
 lui.S                28     28
 lw.S                230    230
 minstret.S           42     31

--- a/test/asm/amo.S
+++ b/test/asm/amo.S
@@ -1,0 +1,163 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# amo.S
+#-----------------------------------------------------------------------------
+#
+# The nine AMO functions, each against the word it must leave behind as well as
+# the word it must return.
+#
+# EVERY CASE READS THE MEMORY BACK INTO A REGISTER, and that is not decoration.
+# test/cosim.cc compares the core's architectural registers against the Sail
+# model and never compares memory, so an AMO whose only effect stayed in RAM
+# would be checked by nothing anywhere. The per-retire RVFI monitor is no help
+# either: riscv-formal ships no spec model for any A encoding at the pinned SHA,
+# so `spec_valid` is 0 for all eleven and test/monitor.sim.v's whole value block
+# is skipped for them. This file self-checks in band for the same reason
+# test/asm/trap.S does.
+#
+# The four min/max functions get one straightforward case each here. Their
+# signed boundaries are test/asm/amominmax.S, which is where a comparator read
+# the wrong way round actually shows.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # The nine functions.
+  #-------------------------------------------------------------
+
+  TEST_AMO(  2, amoswap.w, 0x12345678, 0xdeadbeef, 0x12345678, 0xdeadbeef );
+  TEST_AMO(  3, amoadd.w,  0x00000010, 0x00000022, 0x00000010, 0x00000032 );
+  TEST_AMO(  4, amoxor.w,  0x0ff00ff0, 0x00ff00ff, 0x0ff00ff0, 0x0f0f0f0f );
+  TEST_AMO(  5, amoand.w,  0x0ff00ff0, 0x00ff00ff, 0x0ff00ff0, 0x00f000f0 );
+  TEST_AMO(  6, amoor.w,   0x0ff00ff0, 0x00ff00ff, 0x0ff00ff0, 0x0fff0fff );
+  TEST_AMO(  7, amomin.w,  0x00000005, 0x00000003, 0x00000005, 0x00000003 );
+  TEST_AMO(  8, amomax.w,  0x00000005, 0x00000003, 0x00000005, 0x00000005 );
+  TEST_AMO(  9, amominu.w, 0x00000005, 0x00000003, 0x00000005, 0x00000003 );
+  TEST_AMO( 10, amomaxu.w, 0x00000005, 0x00000003, 0x00000005, 0x00000005 );
+
+  # The add really is 32-bit modular arithmetic: the carry out of bit 31 is
+  # dropped rather than landing in the 33rd bit the accessor's shared
+  # adder/subtractor carries for the compares.
+  TEST_AMO( 11, amoadd.w,  0xffffffff, 0x00000001, 0xffffffff, 0x00000000 );
+  TEST_AMO( 12, amoadd.w,  0x7fffffff, 0x00000001, 0x7fffffff, 0x80000000 );
+
+  #-------------------------------------------------------------
+  # The ordering suffixes are decoded and ignored: one hart, in order, one
+  # outstanding access. All four spellings of amoadd.w must therefore do the
+  # same arithmetic rather than decode as an illegal instruction.
+  #-------------------------------------------------------------
+
+  TEST_AMO( 13, amoadd.w.aq,   0x00000010, 0x00000022, 0x00000010, 0x00000032 );
+  TEST_AMO( 14, amoadd.w.rl,   0x00000010, 0x00000022, 0x00000010, 0x00000032 );
+  TEST_AMO( 15, amoadd.w.aqrl, 0x00000010, 0x00000022, 0x00000010, 0x00000032 );
+
+  #-------------------------------------------------------------
+  # Register aliasing. rd is written from the bus a cycle after rs1 and rs2 were
+  # spent on the request, so an AMO naming the same register twice is the case
+  # where a held operand and a writeback could collide.
+  #-------------------------------------------------------------
+
+  # rd == rs2: the returned word overwrites the operand that was added to it.
+  TEST_CASE( 16, x4, 0x00000010, \
+    la  x1, amodat; \
+    li  x2, 0x00000010; \
+    sw  x2, 0(x1); \
+    li  x4, 0x00000022; \
+    amoadd.w x4, x4, (x1); \
+  )
+  TEST_CASE( 17, x6, 0x00000032, la x1, amodat; lw x6, 0(x1); )
+
+  # rd == rs1: the returned word overwrites the address it came from.
+  TEST_CASE( 18, x1, 0x00000010, \
+    la  x1, amodat; \
+    li  x2, 0x00000010; \
+    sw  x2, 0(x1); \
+    li  x4, 0x00000022; \
+    amoadd.w x1, x4, (x1); \
+  )
+  TEST_CASE( 19, x6, 0x00000032, la x1, amodat; lw x6, 0(x1); )
+
+  # rd == x0: the write to memory still happens, and nothing lands in x0.
+  TEST_CASE( 20, x0, 0, \
+    la  x1, amodat; \
+    li  x2, 0x00000010; \
+    sw  x2, 0(x1); \
+    li  x4, 0x00000022; \
+    amoadd.w x0, x4, (x1); \
+  )
+  TEST_CASE( 21, x6, 0x00000032, la x1, amodat; lw x6, 0(x1); )
+
+  #-------------------------------------------------------------
+  # An AMO spends the cycle after its read keeping everything else off the bus.
+  # These interlock a dependent instruction and a second memory instruction
+  # immediately behind one, which is where a wait that ended a cycle early would
+  # show as a wrong answer rather than as a stall.
+  #-------------------------------------------------------------
+
+  TEST_CASE( 22, x7, 0x00000042, \
+    la  x1, amodat; \
+    li  x2, 0x00000010; \
+    sw  x2, 0(x1); \
+    li  x4, 0x00000022; \
+    amoadd.w x5, x4, (x1); \
+    addi x7, x5, 0x32; \
+  )
+
+  TEST_CASE( 23, x7, 0x00000032, \
+    la  x1, amodat; \
+    li  x2, 0x00000010; \
+    sw  x2, 0(x1); \
+    li  x4, 0x00000022; \
+    amoadd.w x5, x4, (x1); \
+    lw  x7, 0(x1); \
+  )
+
+  # Two AMOs back to back on the same word: the second must see the first's
+  # write, which is only true if the read-modify-write really landed before the
+  # next read went out.
+  TEST_CASE( 24, x8, 0x00000021, \
+    la  x1, amodat; \
+    li  x2, 0x00000010; \
+    sw  x2, 0(x1); \
+    li  x4, 0x00000011; \
+    amoadd.w x5, x4, (x1); \
+    amoadd.w x8, x4, (x1); \
+  )
+  TEST_CASE( 25, x6, 0x00000032, la x1, amodat; lw x6, 0(x1); )
+
+  # A divide in flight holds the AMO in decode before the executor takes it, so
+  # no read has gone out and no write cycle is next. The arithmetic on both
+  # sides has to survive that.
+  TEST_CASE( 26, x11, 0x00000007, \
+    la  x1, amodat; \
+    li  x2, 0x00000010; \
+    sw  x2, 0(x1); \
+    li  x9, 63; \
+    li  x10, 9; \
+    div x11, x9, x10; \
+    li  x4, 0x00000022; \
+    amoadd.w x8, x4, (x1); \
+  )
+  TEST_CASE( 27, x8, 0x00000010, nop; )
+  TEST_CASE( 28, x6, 0x00000032, la x1, amodat; lw x6, 0(x1); )
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+  .align 2
+amodat:
+  .word 0x00000000
+
+RVTEST_DATA_END

--- a/test/asm/amominmax.S
+++ b/test/asm/amominmax.S
@@ -1,0 +1,114 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# amominmax.S
+#-----------------------------------------------------------------------------
+#
+# The four min/max AMOs at the only operands where a wrong compare shows:
+# 0x8000_0000 and -1, against each other and against small positives.
+#
+# WHY THESE OPERANDS. rtl/accessor.v serves the add and all four compares from
+# ONE 33-bit adder/subtractor. The borrow out is unsigned less-than; signed
+# less-than is the same fact except where the sign bits disagree, and then the
+# negative operand is the smaller. Every case below where the two answers differ
+# is a case where the sign bits disagree, so a comparator that dropped the
+# correction, or read the shared `less` term the wrong way round, is only
+# visible here. Ordinary operands like 5 against 3 agree under both readings and
+# are in test/asm/amo.S for that reason.
+#
+# BOTH OPERAND ORDERS for every pair. The memory word and rs2 are not
+# interchangeable in the hardware -- one arrives on the bus and the other was
+# held from the request a cycle earlier -- so a keep-the-memory-word term
+# inverted answers half of these correctly.
+#
+# Each case reads the memory back, for the reason the TEST_AMO comment in
+# riscv_test.h gives: nothing else in this repository looks at what an AMO left
+# in RAM.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # amomin.w -- signed. 0x8000_0000 is the smallest word there is.
+  #-------------------------------------------------------------
+
+  TEST_AMO(  2, amomin.w, 0x80000000, 0xffffffff, 0x80000000, 0x80000000 );
+  TEST_AMO(  3, amomin.w, 0xffffffff, 0x80000000, 0xffffffff, 0x80000000 );
+  TEST_AMO(  4, amomin.w, 0x80000000, 0x7fffffff, 0x80000000, 0x80000000 );
+  TEST_AMO(  5, amomin.w, 0x7fffffff, 0x80000000, 0x7fffffff, 0x80000000 );
+  TEST_AMO(  6, amomin.w, 0x80000000, 0x00000001, 0x80000000, 0x80000000 );
+  TEST_AMO(  7, amomin.w, 0x00000001, 0x80000000, 0x00000001, 0x80000000 );
+  TEST_AMO(  8, amomin.w, 0xffffffff, 0x00000001, 0xffffffff, 0xffffffff );
+  TEST_AMO(  9, amomin.w, 0x00000001, 0xffffffff, 0x00000001, 0xffffffff );
+  TEST_AMO( 10, amomin.w, 0xffffffff, 0x00000000, 0xffffffff, 0xffffffff );
+  TEST_AMO( 11, amomin.w, 0x00000000, 0xffffffff, 0x00000000, 0xffffffff );
+
+  # Equal operands: neither is less, so the answer must be that value however
+  # the tie is broken.
+  TEST_AMO( 12, amomin.w, 0x80000000, 0x80000000, 0x80000000, 0x80000000 );
+  TEST_AMO( 13, amomin.w, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff );
+
+  #-------------------------------------------------------------
+  # amomax.w -- signed, the same pairs read the other way.
+  #-------------------------------------------------------------
+
+  TEST_AMO( 14, amomax.w, 0x80000000, 0xffffffff, 0x80000000, 0xffffffff );
+  TEST_AMO( 15, amomax.w, 0xffffffff, 0x80000000, 0xffffffff, 0xffffffff );
+  TEST_AMO( 16, amomax.w, 0x80000000, 0x7fffffff, 0x80000000, 0x7fffffff );
+  TEST_AMO( 17, amomax.w, 0x7fffffff, 0x80000000, 0x7fffffff, 0x7fffffff );
+  TEST_AMO( 18, amomax.w, 0x80000000, 0x00000001, 0x80000000, 0x00000001 );
+  TEST_AMO( 19, amomax.w, 0x00000001, 0x80000000, 0x00000001, 0x00000001 );
+  TEST_AMO( 20, amomax.w, 0xffffffff, 0x00000001, 0xffffffff, 0x00000001 );
+  TEST_AMO( 21, amomax.w, 0x00000001, 0xffffffff, 0x00000001, 0x00000001 );
+  TEST_AMO( 22, amomax.w, 0x80000000, 0x80000000, 0x80000000, 0x80000000 );
+
+  #-------------------------------------------------------------
+  # amominu.w -- unsigned. Every pair below has a sign disagreement in it, so
+  # each answer is the OPPOSITE of the signed one above; that is what says the
+  # correction is applied to the signed pair and only to them.
+  #-------------------------------------------------------------
+
+  TEST_AMO( 23, amominu.w, 0x80000000, 0xffffffff, 0x80000000, 0x80000000 );
+  TEST_AMO( 24, amominu.w, 0xffffffff, 0x80000000, 0xffffffff, 0x80000000 );
+  TEST_AMO( 25, amominu.w, 0x80000000, 0x7fffffff, 0x80000000, 0x7fffffff );
+  TEST_AMO( 26, amominu.w, 0x7fffffff, 0x80000000, 0x7fffffff, 0x7fffffff );
+  TEST_AMO( 27, amominu.w, 0x80000000, 0x00000001, 0x80000000, 0x00000001 );
+  TEST_AMO( 28, amominu.w, 0x00000001, 0x80000000, 0x00000001, 0x00000001 );
+  TEST_AMO( 29, amominu.w, 0xffffffff, 0x00000001, 0xffffffff, 0x00000001 );
+  TEST_AMO( 30, amominu.w, 0x00000001, 0xffffffff, 0x00000001, 0x00000001 );
+  TEST_AMO( 31, amominu.w, 0xffffffff, 0x00000000, 0xffffffff, 0x00000000 );
+  TEST_AMO( 32, amominu.w, 0x00000000, 0xffffffff, 0x00000000, 0x00000000 );
+  TEST_AMO( 33, amominu.w, 0x80000000, 0x80000000, 0x80000000, 0x80000000 );
+
+  #-------------------------------------------------------------
+  # amomaxu.w -- unsigned, the other way again.
+  #-------------------------------------------------------------
+
+  TEST_AMO( 34, amomaxu.w, 0x80000000, 0xffffffff, 0x80000000, 0xffffffff );
+  TEST_AMO( 35, amomaxu.w, 0xffffffff, 0x80000000, 0xffffffff, 0xffffffff );
+  TEST_AMO( 36, amomaxu.w, 0x80000000, 0x7fffffff, 0x80000000, 0x80000000 );
+  TEST_AMO( 37, amomaxu.w, 0x7fffffff, 0x80000000, 0x7fffffff, 0x80000000 );
+  TEST_AMO( 38, amomaxu.w, 0x80000000, 0x00000001, 0x80000000, 0x80000000 );
+  TEST_AMO( 39, amomaxu.w, 0x00000001, 0x80000000, 0x00000001, 0x80000000 );
+  TEST_AMO( 40, amomaxu.w, 0xffffffff, 0x00000001, 0xffffffff, 0xffffffff );
+  TEST_AMO( 41, amomaxu.w, 0x00000001, 0xffffffff, 0x00000001, 0xffffffff );
+  TEST_AMO( 42, amomaxu.w, 0x00000000, 0x00000000, 0x00000000, 0x00000000 );
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+  .align 2
+amodat:
+  .word 0x00000000
+
+RVTEST_DATA_END

--- a/test/asm/amoregion.S
+++ b/test/asm/amoregion.S
@@ -1,0 +1,148 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# amoregion.S
+#-----------------------------------------------------------------------------
+#
+# An atomic outside the data RAM, where the platform refuses the reservation.
+#
+# WHAT THE HARDWARE DOES AND WHY. rtl/memory.v exports the range test it already
+# computes, rtl/littlecpu.v routes it in, and rtl/accessor.v sets no reservation
+# on an lr.w where it is low. So a store-conditional anywhere but the data RAM
+# always fails and issues no transaction at all. A spurious failure is
+# architecturally permitted anywhere, and the eventual-success guarantee
+# attaches only to a region whose reservability attribute claims it -- which is
+# the one region here that does. The outcome the specification has no room for
+# is the other one: an sc.w reporting 0 for a store that went nowhere.
+#
+# THE REST OF THE DEVIATION IS UNCHANGED AND IS ASSERTED HERE AS WHAT IT IS. An
+# address no memory answers still reads as zero and is still written nowhere,
+# silently, for loads, stores and AMOs alike -- the decode-time region test that
+# would raise causes 5 and 7 instead was measured at four logic levels in the
+# fetch loop and declined. So the AMO cases below assert a documented deviation
+# rather than a specification requirement, and they are here so that a change to
+# it is a change to a graded program rather than a discovery.
+#
+# THIS PROGRAM IS THE SUITE'S ONE CO-SIMULATION DIVERGENCE FOR THE A EXTENSION.
+# The Sail model has no third setting: a region is RsrvEventual, where the sc.w
+# below SUCCEEDS, or RsrvNone, where the lr.w raises a load access fault the
+# core does not raise. Measured both ways; test/COSIM_EXPECTED_FAIL carries the
+# entry and the paragraph. Everything about the A extension that IS
+# co-simulable was kept out of this file for that reason.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+# Above the machine timer's four words and below the 1 MB the linker script may
+# grow into. Nothing on this bus answers it.
+#define UNMAPPED 0x00040000
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # The control. The same sequence inside the data RAM succeeds, so a failure
+  # below is the region attribute and not the mechanism.
+  #-------------------------------------------------------------
+
+  TEST_CASE(  2, a2, 0, \
+    la  a0, rdat; \
+    lr.w a1, (a0); \
+    li  a5, 0x12345678; \
+    sc.w a2, a5, (a0); \
+  )
+  TEST_CASE(  3, a4, 0x12345678, la a0, rdat; lw a4, 0(a0); )
+
+  #-------------------------------------------------------------
+  # An address no memory answers. The lr.w reads zero and takes no reservation,
+  # so the sc.w behind it fails and stores nothing.
+  #-------------------------------------------------------------
+
+  TEST_CASE(  4, a1, 0, li a0, UNMAPPED; lr.w a1, (a0); )
+
+  TEST_CASE(  5, a2, 1, li a5, 0x5a5a5a5a; sc.w a2, a5, (a0); )
+  TEST_CASE(  6, a4, 0, li a0, UNMAPPED; lw a4, 0(a0); )
+
+  # A second lr.w there does not accumulate a reservation either.
+  TEST_CASE(  7, a2, 1, \
+    li  a0, UNMAPPED; \
+    lr.w a1, (a0); \
+    lr.w a1, (a0); \
+    li  a5, 0x5a5a5a5a; \
+    sc.w a2, a5, (a0); \
+  )
+  TEST_CASE(  8, a4, 0, li a0, UNMAPPED; lw a4, 0(a0); )
+
+  # ...and a reservation taken in RAM is not honoured at an address outside it,
+  # which is the same word-address comparison test/asm/lrsc.S makes inside RAM.
+  TEST_CASE(  9, a2, 1, \
+    la  a3, rdat; \
+    lr.w a1, (a3); \
+    li  a0, UNMAPPED; \
+    li  a5, 0x5a5a5a5a; \
+    sc.w a2, a5, (a0); \
+  )
+  TEST_CASE( 10, a4, 0, li a0, UNMAPPED; lw a4, 0(a0); )
+  TEST_CASE( 11, a4, 0x12345678, la a0, rdat; lw a4, 0(a0); )
+
+  #-------------------------------------------------------------
+  # An AMO out there is not refused -- it executes, reads zero, and writes its
+  # result nowhere. That is the recorded deviation, one shape wider than a plain
+  # load and store, and it is bounded by the measurement that declined the
+  # decode-time region test rather than by an argument.
+  #-------------------------------------------------------------
+
+  TEST_CASE( 12, a4, 0, \
+    li  a0, UNMAPPED; \
+    li  a3, 0x00000007; \
+    amoadd.w a4, a3, (a0); \
+  )
+  TEST_CASE( 13, a4, 0, li a0, UNMAPPED; lw a4, 0(a0); )
+
+  #-------------------------------------------------------------
+  # The machine timer's four words get a refused reservation for free: they are
+  # not the data RAM, so rtl/memory.v's range test is low for them. The sc.w
+  # below therefore leaves mtimecmp exactly as the disarm left it, which is a
+  # readable device register rather than a hole in the map.
+  #-------------------------------------------------------------
+
+  RVTEST_DISARM_TIMER
+
+  TEST_CASE( 14, a1, -1, \
+    li  a0, MTIMER_BASE + MTIMECMP_OFFSET; \
+    lr.w a1, (a0); \
+  )
+  TEST_CASE( 15, a2, 1, sc.w a2, x0, (a0); )
+  TEST_CASE( 16, a4, -1, \
+    li  a0, MTIMER_BASE + MTIMECMP_OFFSET; \
+    lw  a4, 0(a0); \
+  )
+
+  #-------------------------------------------------------------
+  # ...and the data RAM is still reservable afterwards, so nothing above left
+  # the reservation state stuck.
+  #-------------------------------------------------------------
+
+  TEST_CASE( 17, a2, 0, \
+    la  a0, rdat; \
+    lr.w a1, (a0); \
+    li  a5, 0x0000c0de; \
+    sc.w a2, a5, (a0); \
+  )
+  TEST_CASE( 18, a4, 0x0000c0de, la a0, rdat; lw a4, 0(a0); )
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+  .align 2
+rdat:
+  .word 0x0ff00ff0
+
+RVTEST_DATA_END

--- a/test/asm/amotrap.S
+++ b/test/asm/amotrap.S
@@ -1,0 +1,174 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# amotrap.S
+#-----------------------------------------------------------------------------
+#
+# A misaligned atomic, for all eleven encodings and at all three misalignments.
+#
+# AN ATOMIC IS WORD-WIDE AND NEVER SPLIT, so an unaligned one faults rather than
+# being emulated, and the cause depends on which way the instruction goes:
+# lr.w reports LOAD address misaligned, cause 4, and the ten that write --
+# sc.w and the nine AMOs -- report STORE/AMO address misaligned, cause 6. That
+# split is what the privileged specification asks for, and it is decided in
+# decode alongside every other cause rather than after it.
+#
+# Each case also asserts that the faulting instruction wrote NO REGISTER and NO
+# MEMORY. Those are the two things a fault detected too late would get wrong,
+# and the per-retire monitor cannot see either: riscv-formal ships no spec model
+# for an A encoding at the pin, and it drops every value comparison once an
+# instruction traps in any case.
+#
+# Every trapping instruction is wrapped in `.option norvc` per riscv_test.h's
+# first constraint. No atomic has a compressed form, so the directive changes no
+# bytes here; it is the rule the handler's unconditional mepc+4 depends on and
+# is written out rather than left to a reader to re-derive.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+# A misaligned AMO or sc.w: the cause, then that rd and the word are untouched.
+# `x10` is the misaligned address, `x11` is rd, `x12` is rs2, `x13` reads back.
+#define TEST_MIS_AMO( testnum, inst, off, cause ) \
+test_ ## testnum: \
+    li  TESTNUM, testnum; \
+    la  x1, trap_cause; \
+    sw  x0, 0(x1); \
+    la  x10, mdat; \
+    addi x10, x10, off; \
+    li  x11, 0x5a5; \
+    li  x12, 0x3c3; \
+    .option push; \
+    .option norvc; \
+    inst x11, x12, (x10); \
+    .option pop; \
+    la  x1, trap_cause; \
+    lw  x13, 0(x1); \
+    li  x29, cause; \
+    bne x13, x29, fail; \
+    li  x29, 0x5a5; \
+    bne x11, x29, fail; \
+    la  x1, mdat; \
+    lw  x13, 0(x1); \
+    li  x29, 0x0ff00ff0; \
+    bne x13, x29, fail;
+
+# The same for lr.w, which takes no rs2.
+#define TEST_MIS_LR( testnum, off ) \
+test_ ## testnum: \
+    li  TESTNUM, testnum; \
+    la  x1, trap_cause; \
+    sw  x0, 0(x1); \
+    la  x10, mdat; \
+    addi x10, x10, off; \
+    li  x11, 0x5a5; \
+    .option push; \
+    .option norvc; \
+    lr.w x11, (x10); \
+    .option pop; \
+    la  x1, trap_cause; \
+    lw  x13, 0(x1); \
+    li  x29, 4; \
+    bne x13, x29, fail; \
+    li  x29, 0x5a5; \
+    bne x11, x29, fail; \
+    la  x1, mdat; \
+    lw  x13, 0(x1); \
+    li  x29, 0x0ff00ff0; \
+    bne x13, x29, fail;
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  # mtvec resets to 0, which is _start -- install before faulting.
+  RVTEST_INSTALL_TRAP_HANDLER
+
+  #-------------------------------------------------------------
+  # lr.w: cause 4, at each of the three misalignments a word address can have.
+  #-------------------------------------------------------------
+
+  TEST_MIS_LR(  2, 1 );
+  TEST_MIS_LR(  3, 2 );
+  TEST_MIS_LR(  4, 3 );
+
+  #-------------------------------------------------------------
+  # sc.w: cause 6. A store-conditional that faults must not report a result
+  # either -- rd is checked above with everything else, and a 1 in it would be
+  # a failure report for an instruction that never ran.
+  #-------------------------------------------------------------
+
+  TEST_MIS_AMO(  5, sc.w, 1, 6 );
+  TEST_MIS_AMO(  6, sc.w, 2, 6 );
+  TEST_MIS_AMO(  7, sc.w, 3, 6 );
+
+  #-------------------------------------------------------------
+  # The nine AMOs: cause 6 apiece. All nine rather than a representative, since
+  # the flags are decoded one per function rather than from funct5.
+  #-------------------------------------------------------------
+
+  TEST_MIS_AMO(  8, amoswap.w, 2, 6 );
+  TEST_MIS_AMO(  9, amoadd.w,  2, 6 );
+  TEST_MIS_AMO( 10, amoxor.w,  2, 6 );
+  TEST_MIS_AMO( 11, amoand.w,  2, 6 );
+  TEST_MIS_AMO( 12, amoor.w,   2, 6 );
+  TEST_MIS_AMO( 13, amomin.w,  2, 6 );
+  TEST_MIS_AMO( 14, amomax.w,  2, 6 );
+  TEST_MIS_AMO( 15, amominu.w, 1, 6 );
+  TEST_MIS_AMO( 16, amomaxu.w, 3, 6 );
+
+  #-------------------------------------------------------------
+  # mepc holds the address of the faulting instruction, so resuming at mepc+4
+  # landed on the one after it -- which is where this is running.
+  #-------------------------------------------------------------
+
+test_17:
+  la    x10, mdat
+  addi  x10, x10, 2
+  li    x12, 0x3c3
+  .option push
+  .option norvc
+mis_amo:
+  amoadd.w x11, x12, (x10)
+  .option pop
+
+  la    x1, trap_epc
+  lw    x13, 0(x1)
+  la    x29, mis_amo
+  li    TESTNUM, 17
+  bne   x13, x29, fail
+
+  # Fifteen misaligned atomics before test 17, and test 17's own.
+  TEST_CASE( 18, x13, 16, la x1, trap_count; lw x13, 0(x1); )
+
+  #-------------------------------------------------------------
+  # An aligned atomic at the same address still works, so the cases above
+  # failed on the alignment and not on the encoding.
+  #-------------------------------------------------------------
+
+  TEST_CASE( 19, x11, 0x0ff00ff0, \
+    la  x10, mdat; \
+    li  x12, 0x00000001; \
+    amoadd.w x11, x12, (x10); \
+  )
+  TEST_CASE( 20, x13, 0x0ff00ff1, la x1, mdat; lw x13, 0(x1); )
+  TEST_CASE( 21, x13, 16, la x1, trap_count; lw x13, 0(x1); )
+
+  TEST_PASSFAIL
+
+  RVTEST_TRAP_HANDLER
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+  RVTEST_TRAP_DATA
+
+  .align 2
+mdat:
+  .word 0x0ff00ff0
+  .word 0x00000000
+
+RVTEST_DATA_END

--- a/test/asm/lrsc.S
+++ b/test/asm/lrsc.S
@@ -1,0 +1,244 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# lrsc.S
+#-----------------------------------------------------------------------------
+#
+# lr.w and sc.w, and the five events that decide whether a store-conditional
+# stores: no reservation at all, this hart writing the reserved word, a write
+# somewhere else, a second reservation replacing the first, and the
+# store-conditional itself.
+#
+# A FAILED sc.w MUST LEAVE THE WORD ALONE, and that is the half no register
+# value can show on its own -- rd is 1 either way a wrong design might reach it.
+# So every case here loads the word back afterwards. test/cosim.cc compares
+# architectural registers and never compares memory, and riscv-formal ships no
+# spec model for lr.w/sc.w at the pinned SHA, so a store that happened and
+# should not have is invisible to every oracle unless the program reads it.
+#
+# The value this core writes for a failure is 1. The specification asks only for
+# a nonzero code, so an assertion of exactly 1 is an assertion about THIS
+# implementation; it is written that way on purpose, because a core that started
+# returning some other nonzero value has changed something nobody decided.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  #-------------------------------------------------------------
+  # A store-conditional with no reservation behind it. This is first in the
+  # program on purpose: nothing before it has executed an lr.w, so there is no
+  # stale reservation for it to be passing against.
+  #-------------------------------------------------------------
+
+  TEST_CASE(  2, a2, 1, \
+    la  a0, ldat; \
+    li  a5, 0xbad0bad0; \
+    sc.w a2, a5, (a0); \
+  )
+  TEST_CASE(  3, a4, 0x0ff00ff0, la a0, ldat; lw a4, 0(a0); )
+
+  #-------------------------------------------------------------
+  # lr.w reads the word, and the sc.w behind it stores rs2.
+  #-------------------------------------------------------------
+
+  TEST_CASE(  4, a1, 0x0ff00ff0, la a0, ldat; lr.w a1, (a0); )
+
+  TEST_CASE(  5, a2, 0, li a5, 0x12345678; sc.w a2, a5, (a0); )
+  TEST_CASE(  6, a4, 0x12345678, la a0, ldat; lw a4, 0(a0); )
+
+  # The store-conditional consumed the reservation, so the next one fails with
+  # no other event in between.
+  TEST_CASE(  7, a2, 1, li a5, 0xbad0bad0; sc.w a2, a5, (a0); )
+  TEST_CASE(  8, a4, 0x12345678, la a0, ldat; lw a4, 0(a0); )
+
+  #-------------------------------------------------------------
+  # A plain store from this hart to the reserved word clears the reservation.
+  # One hart is all there is, so this is the only invalidation source that can
+  # be exercised at all.
+  #-------------------------------------------------------------
+
+  TEST_CASE(  9, a2, 1, \
+    la  a0, ldat; \
+    lr.w a1, (a0); \
+    li  a5, 0x0000f00d; \
+    sw  a5, 0(a0); \
+    li  a6, 0xbad0bad0; \
+    sc.w a2, a6, (a0); \
+  )
+  # The word holds what the plain store put there, not what the sc.w carried.
+  TEST_CASE( 10, a4, 0x0000f00d, la a0, ldat; lw a4, 0(a0); )
+
+  # A byte store to the reserved word counts: the set is the whole word.
+  TEST_CASE( 11, a2, 1, \
+    la  a0, ldat; \
+    lr.w a1, (a0); \
+    li  a5, 0x77; \
+    sb  a5, 0(a0); \
+    li  a6, 0xbad0bad0; \
+    sc.w a2, a6, (a0); \
+  )
+  TEST_CASE( 12, a4, 0x0000f077, la a0, ldat; lw a4, 0(a0); )
+
+  # A halfword store, for the same reason.
+  TEST_CASE( 13, a2, 1, \
+    la  a0, ldat; \
+    lr.w a1, (a0); \
+    li  a5, 0x1234; \
+    sh  a5, 0(a0); \
+    li  a6, 0xbad0bad0; \
+    sc.w a2, a6, (a0); \
+  )
+  TEST_CASE( 14, a4, 0x00001234, la a0, ldat; lw a4, 0(a0); )
+
+  # An AMO to the reserved word is a write of this hart's too.
+  TEST_CASE( 15, a2, 1, \
+    la  a0, ldat; \
+    lr.w a1, (a0); \
+    li  a5, 0x1000; \
+    amoadd.w a7, a5, (a0); \
+    li  a6, 0xbad0bad0; \
+    sc.w a2, a6, (a0); \
+  )
+  TEST_CASE( 16, a4, 0x00002234, la a0, ldat; lw a4, 0(a0); )
+
+  #-------------------------------------------------------------
+  # ...and the other direction, which is the half a design clearing on EVERY
+  # store would pass the cases above while failing.
+  #-------------------------------------------------------------
+
+  # A store to a different word leaves the reservation alone.
+  TEST_CASE( 17, a2, 0, \
+    la  a0, ldat; \
+    la  a3, ldat2; \
+    lr.w a1, (a0); \
+    li  a5, 0x5a5a5a5a; \
+    sw  a5, 0(a3); \
+    li  a6, 0x0000cafe; \
+    sc.w a2, a6, (a0); \
+  )
+  TEST_CASE( 18, a4, 0x0000cafe, la a0, ldat; lw a4, 0(a0); )
+
+  # A LOAD from the reserved word leaves it alone as well.
+  TEST_CASE( 19, a2, 0, \
+    la  a0, ldat; \
+    lr.w a1, (a0); \
+    lw  a5, 0(a0); \
+    li  a6, 0x0000beef; \
+    sc.w a2, a6, (a0); \
+  )
+  TEST_CASE( 20, a4, 0x0000beef, la a0, ldat; lw a4, 0(a0); )
+
+  #-------------------------------------------------------------
+  # The address the reservation is held at. This core reserves ONE aligned word
+  # and compares word addresses, which is the specification's minimum set.
+  #-------------------------------------------------------------
+
+  # A store-conditional at the next word up finds nothing reserved there.
+  TEST_CASE( 21, a2, 1, \
+    la  a0, ldat; \
+    la  a3, ldat2; \
+    li  a5, 0x11112222; \
+    sw  a5, 0(a3); \
+    lr.w a1, (a0); \
+    li  a6, 0xbad0bad0; \
+    sc.w a2, a6, (a3); \
+  )
+  TEST_CASE( 22, a4, 0x11112222, la a3, ldat2; lw a4, 0(a3); )
+  # ...and the reserved word is untouched by that attempt too.
+  TEST_CASE( 23, a4, 0x0000beef, la a0, ldat; lw a4, 0(a0); )
+
+  # A second lr.w moves the reservation: the store-conditional that matches the
+  # SECOND one succeeds.
+  TEST_CASE( 24, a2, 0, \
+    la  a0, ldat; \
+    la  a3, ldat2; \
+    lr.w a1, (a0); \
+    lr.w a1, (a3); \
+    li  a6, 0x0000d00d; \
+    sc.w a2, a6, (a3); \
+  )
+  TEST_CASE( 25, a4, 0x0000d00d, la a3, ldat2; lw a4, 0(a3); )
+  # ...and the first word is no longer reserved.
+  TEST_CASE( 26, a2, 1, \
+    la  a0, ldat; \
+    li  a6, 0xbad0bad0; \
+    sc.w a2, a6, (a0); \
+  )
+  TEST_CASE( 27, a4, 0x0000beef, la a0, ldat; lw a4, 0(a0); )
+
+  #-------------------------------------------------------------
+  # The pair through the pipeline. A store-conditional is the one store that
+  # also writes a register, so its rd has to be visible to the scoreboard for
+  # exactly as long as a load's.
+  #-------------------------------------------------------------
+
+  # rd consumed by the very next instruction.
+  TEST_CASE( 28, a7, 1, \
+    la  a0, ldat; \
+    lr.w a1, (a0); \
+    li  a6, 0x0000abcd; \
+    sc.w a2, a6, (a0); \
+    addi a7, a2, 1; \
+  )
+  TEST_CASE( 29, a4, 0x0000abcd, la a0, ldat; lw a4, 0(a0); )
+
+  # rd of a FAILED one, consumed the same way.
+  TEST_CASE( 30, a7, 2, \
+    la  a0, ldat; \
+    li  a6, 0xbad0bad0; \
+    sc.w a2, a6, (a0); \
+    addi a7, a2, 1; \
+  )
+  TEST_CASE( 31, a4, 0x0000abcd, la a0, ldat; lw a4, 0(a0); )
+
+  # sc.w naming the address register as its destination.
+  TEST_CASE( 32, a0, 0, \
+    la  a0, ldat; \
+    lr.w a1, (a0); \
+    li  a6, 0x00005555; \
+    sc.w a0, a6, (a0); \
+  )
+  TEST_CASE( 33, a4, 0x00005555, la a0, ldat; lw a4, 0(a0); )
+
+  # sc.w naming its own data register as its destination.
+  TEST_CASE( 34, a6, 0, \
+    la  a0, ldat; \
+    lr.w a1, (a0); \
+    li  a6, 0x00006666; \
+    sc.w a6, a6, (a0); \
+  )
+  TEST_CASE( 35, a4, 0x00006666, la a0, ldat; lw a4, 0(a0); )
+
+  # A divide in flight holds the pair in decode before the executor takes it.
+  TEST_CASE( 36, a2, 0, \
+    la  a0, ldat; \
+    li  a5, 63; \
+    li  a6, 9; \
+    div a7, a5, a6; \
+    lr.w a1, (a0); \
+    li  a6, 0x00007777; \
+    sc.w a2, a6, (a0); \
+  )
+  TEST_CASE( 37, a7, 7, nop; )
+  TEST_CASE( 38, a4, 0x00007777, la a0, ldat; lw a4, 0(a0); )
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+  .align 2
+ldat:
+  .word 0x0ff00ff0
+ldat2:
+  .word 0x00000000
+
+RVTEST_DATA_END

--- a/test/asm/lrsclock.S
+++ b/test/asm/lrsclock.S
@@ -1,0 +1,185 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# lrsclock.S
+#-----------------------------------------------------------------------------
+#
+# An LR/SC critical section with the machine timer running underneath it.
+#
+# THE PROPERTY. A reservation is NOT cleared on a trap or on an mret. It is
+# cleared by a store-conditional and by a write of this hart's to the reserved
+# word, and by nothing else. That is what lets a constrained LR/SC sequence keep
+# the specification's eventual-success guarantee while interrupts are running: a
+# handler that never touches the lock word cannot make the sequence fail, so a
+# retry loop is not livelocked by a periodic timer. The reference model was
+# measured to do the same, which is why the two agree about it wherever they can
+# be compared at all.
+#
+# THE RETRY LOOP IS BOUNDED, AND THAT IS THE POINT OF THE WATCHDOG. An unbounded
+# retry against a core that cleared the reservation on entry to the handler
+# would spin until test/run_tests.sh's 5000-cycle budget ran out and be graded
+# TIMEOUT -- the same verdict a hung fetch gets, at a place in the program the
+# verdict does not name. The counters below turn that into a numbered failure
+# instead. They are the only reason a program in this suite may loop on a
+# condition the hardware is supposed to make true.
+#
+# WHAT PART 1 ASSERTS AND PART 2 DOES NOT. Part 1 spins between the lr.w and the
+# sc.w until the handler has really run, so the trap is inside the window by
+# construction and the sc.w is not retried: it must succeed the first time. Part
+# 2 is the retry loop, and a core that dropped the reservation at every trap
+# would still finish it -- one retry per interrupt. So the sharp assertion is
+# part 1's and part 2 is the shape a lock actually has.
+#
+# CO-SIMULATION CANNOT REACH THIS PROGRAM, for the reason test/asm/mtimer.S and
+# test/asm/mtimermask.S cannot be reached either: the Sail model's timer is at a
+# different address with a different tick period, so a store that arms this
+# platform's timer lands nowhere on the model and the wait below never ends
+# there. test/COSIM_EXPECTED_FAIL carries it as INCONCLUSIVE SAIL-LIMIT --
+# nothing was compared, which is a weaker entry than a divergence and is
+# recorded as one.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+# How many acquisitions part 2 may make before giving up on the second
+# interrupt, and how many times one acquisition may retry its sc.w. Both are
+# far above what the hardware needs and are watchdogs rather than expectations.
+#define ACQUIRE_LIMIT 200
+#define RETRY_LIMIT   64
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  RVTEST_INSTALL_TIMER_HANDLER
+  # mtimecmp resets to zero, so mtip is asserted before the enables go on.
+  RVTEST_DISARM_TIMER
+  RVTEST_ENABLE_MTIE
+  RVTEST_ENABLE_MIE
+
+  #-------------------------------------------------------------
+  # Part 1: a reservation held across a real timer trap.
+  #
+  # The delay is long enough that the interrupt cannot land before the lr.w,
+  # and the wait after it is unbounded on purpose -- on this machine it ends on
+  # the first pass after the handler has run.
+  #-------------------------------------------------------------
+
+  la    a0, lock
+  RVTEST_ARM_TIMER( 40 )
+  lr.w  a1, (a0)
+
+irq_wait:
+  la    a3, irq_count
+  lw    a4, 0(a3)
+  beqz  a4, irq_wait
+
+  li    a5, 0x0000a5a5
+  sc.w  a2, a5, (a0)
+
+  # The store-conditional succeeded with a whole trap entry and mret between it
+  # and its lr.w.
+  TEST_CASE(  2, a2, 0, nop; )
+  TEST_CASE(  3, a4, 0x0000a5a5, la a3, lock; lw a4, 0(a3); )
+
+  # ...and the trap really was a machine timer interrupt, so test 2 did not pass
+  # because nothing had happened.
+  TEST_CASE(  4, a4, 1, la a3, irq_count; lw a4, 0(a3); )
+  TEST_CASE(  5, a4, 0x80000007, la a3, irq_cause; lw a4, 0(a3); )
+
+  # The lr.w read the word the disarm sequence left alone.
+  TEST_CASE(  6, a1, 0x0ff00ff0, nop; )
+
+  #-------------------------------------------------------------
+  # Part 2: the lock loop. Each acquisition increments the word under lr.w/sc.w
+  # and retries a bounded number of times; the loop runs until a SECOND timer
+  # interrupt has been taken, so at least one acquisition overlaps a live timer.
+  #
+  # s1 counts acquisitions completed and s3 the retries within the current one.
+  # The memory word is graded against s1 afterwards rather than against a
+  # constant, because how many times the loop goes round depends on when the
+  # interrupt lands.
+  #-------------------------------------------------------------
+
+  la    a0, lock
+  li    s1, 0
+  RVTEST_ARM_TIMER( 24 )
+
+acquire:
+  li    s3, 0
+retry:
+  lr.w  a4, (a0)
+  addi  a5, a4, 1
+  sc.w  a6, a5, (a0)
+  beqz  a6, acquired
+
+  addi  s3, s3, 1
+  li    a7, RETRY_LIMIT
+  blt   s3, a7, retry
+  # The reservation is being lost by something that is not a write to the lock
+  # word. A numbered failure, not a hang.
+  li    TESTNUM, 7
+  j     fail
+
+acquired:
+  # The word this acquisition's lr.w read, kept for the check below.
+  mv    s4, a4
+  addi  s1, s1, 1
+  la    a3, irq_count
+  lw    a3, 0(a3)
+  li    a7, 2
+  bge   a3, a7, acquired_all
+  li    a7, ACQUIRE_LIMIT
+  blt   s1, a7, acquire
+  # The second interrupt never arrived, so nothing below would be a statement
+  # about a lock loop under a live timer.
+  li    TESTNUM, 8
+  j     fail
+
+acquired_all:
+
+  # The word holds its part 1 value plus one per completed acquisition. This is
+  # the loop's own bookkeeping checked against memory, which is the only place
+  # an acquisition that "succeeded" without storing would show. Computed at run
+  # time because how many times the loop goes round depends on when the
+  # interrupt lands.
+test_9:
+  la    a3, lock
+  lw    a4, 0(a3)
+  li    a5, 0x0000a5a5
+  add   a5, a5, s1
+  li    TESTNUM, 9
+  bne   a4, a5, fail
+
+  # The last lr.w saw the word one short of what the last sc.w left.
+test_10:
+  addi  a5, s4, 1
+  li    TESTNUM, 10
+  bne   a4, a5, fail
+
+  # At least one acquisition really happened, so tests 9 and 10 are not both
+  # true of a loop that never ran.
+test_11:
+  li    TESTNUM, 11
+  beqz  s1, fail
+
+  # ...and the second interrupt really was taken during the loop.
+  TEST_CASE( 12, a4, 2, la a3, irq_count; lw a4, 0(a3); )
+
+  TEST_PASSFAIL
+
+  RVTEST_TIMER_HANDLER
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+  RVTEST_TIMER_DATA
+
+  .align 2
+lock:
+  .word 0x0ff00ff0
+
+RVTEST_DATA_END

--- a/test/asm/riscv_test.h
+++ b/test/asm/riscv_test.h
@@ -8,9 +8,9 @@
 //
 //   1. Wrap every trapping instruction in `.option norvc` / `.option pop`. The
 //      handler resumes at mepc+4 unconditionally, because Harvard buses mean it
-//      cannot read the faulting instruction to tell 2 bytes from 4, and the
-//      assembler compresses freely at -march=rv32imc_zicsr. Tests that
-//      terminate from inside the handler are unconstrained.
+//      cannot read the faulting instruction to tell 2 bytes from 4, and this
+//      suite's ISA string has C in it, so the assembler compresses freely.
+//      Tests that terminate from inside the handler are unconstrained.
 //   2. Install the handler before faulting. `mtvec` resets to 0, which is
 //      `_start`, so a trap before installation restarts the program.
 //   3. Assert in band. riscv-formal has no spec model for csrr*/ecall/ebreak/
@@ -72,6 +72,28 @@ tohost:                                                                      \
         .align  2;
 
 #define RVTEST_DATA_END
+
+// One AMO, graded on the word it RETURNS and the word it LEAVES BEHIND. The
+// read-back is the half that matters: test/cosim.cc compares architectural
+// registers and never compares memory, and riscv-formal ships no spec model for
+// any A encoding at the pin, so an AMO's effect on RAM is checked by nothing
+// anywhere unless the program loads it into a register itself.
+//
+// Needs an aligned word named `amodat` in `.data`. Clobbers x1, x2, x4, x5, x6
+// and x29, and sets TESTNUM.
+#define TEST_AMO( testnum, inst, memval, rs2val, oldval, newval )            \
+test_ ## testnum:                                                            \
+        li      TESTNUM, testnum;                                           \
+        la      x1, amodat;                                                 \
+        li      x2, memval;                                                 \
+        sw      x2, 0(x1);                                                  \
+        li      x4, rs2val;                                                 \
+        inst    x5, x4, (x1);                                               \
+        li      x29, oldval;                                                \
+        bne     x5, x29, fail;                                              \
+        lw      x6, 0(x1);                                                  \
+        li      x29, newval;                                                \
+        bne     x6, x29, fail;
 
 // Invoke after RVTEST_DATA_BEGIN so it lands in RAM, the only memory a load can
 // reach on this Harvard core.

--- a/test/cosim.py
+++ b/test/cosim.py
@@ -297,7 +297,7 @@ def assemble(cc, src, outdir):
     ram = os.path.join(outdir, base + ".ram.hex")
     objcopy = cc[: -len("gcc")] + "objcopy"
     if src.endswith(".c"):
-        build = [cc, "-march=rv32imc_zicsr_zifencei", "-mabi=ilp32", "-nostdlib",
+        build = [cc, "-march=rv32imac_zicsr_zifencei", "-mabi=ilp32", "-nostdlib",
                  "-Os", "-std=c11", "-ffreestanding",
                  "-fno-tree-loop-distribute-patterns",
                  "-Wall", "-Wextra", "-Werror", "-I", ASM_DIR,
@@ -306,7 +306,7 @@ def assemble(cc, src, outdir):
         rom_args = ["--only-section=.text", "--only-section=.data"]
         ram_args = ["--only-section=.tohost"]
     else:
-        build = [cc, "-march=rv32imc_zicsr_zifencei", "-mabi=ilp32", "-nostdlib",
+        build = [cc, "-march=rv32imac_zicsr_zifencei", "-mabi=ilp32", "-nostdlib",
                  "-I", ASM_DIR,
                  "-T", os.path.join(ASM_DIR, "sections.lds"), src, "-o", elf]
         rom_args = ["--only-section=.text"]

--- a/test/march_test.sh
+++ b/test/march_test.sh
@@ -1,0 +1,343 @@
+#!/bin/bash
+# Asserts that every place naming the ISA this suite builds for names the same
+# one, and that the two places naming a DIFFERENT ISA on purpose still do.
+#
+# Usage: march_test.sh [repo-root]     # defaults to this script's parent
+#
+# WHY THIS EXISTS. The ISA string is stated at six sites and three of them are
+# silent when they are wrong. test/run_tests.sh and test/cosim.py's assemble()
+# are loud -- the assembler rejects `amoadd.w` outright -- but the Makefile's
+# soc-rom target builds test/asm/datainit.c, which uses no atomics and would go
+# on building for years at the old string; DHRY_CFLAGS builds a benchmark that
+# uses none either; and DHRY_CFLAGS is duplicated VERBATIM into
+# soc/depth/cycles.py with nothing anywhere comparing the two. So the failure
+# this guards against is not "the build broke": it is two measurements taken of
+# two different machines, reported in one table.
+#
+# WHY IT IS NOT A GREP-AND-REPLACE, IN BOTH DIRECTIONS. Two strings that look
+# like the ones above must NOT move with them. formal/checks.cfg's `isa rv32imc`
+# and the Makefile's `MONITOR_GEN -i rv32imc` name the instruction set
+# riscv-formal GENERATES A SPEC MODEL FOR, and the pinned clone has no model for
+# any A encoding -- so widening either produces nothing and makes the generated
+# check set describe an ISA it is not checking. Two more are a different ISA on
+# purpose: soc/compare/bench.S is deliberately rv32i so the cross-core harness
+# can hand one image to a core with no M and no privileged architecture, and
+# COMPARE_DHRY_CFLAGS is rv32ic because that is what VexRiscv implements. A
+# sweep is wrong at four sites and incomplete at three others.
+#
+# So the table below states the allowed set and the comparison runs BOTH WAYS,
+# like every other table in this repo: a site that stops carrying the string is
+# as red as the string appearing where nothing allows it, and an exception whose
+# site no longer carries the value it names is red too.
+#
+# Hermetic: git, grep, sed and awk. No cross compiler, no Sail, no yosys, so
+# this runs inside `make test` anywhere.
+set -euo pipefail
+
+HERE=$(cd "$(dirname "$0")" && pwd)
+REPO=${1:-$(cd "$HERE/.." && pwd)}
+
+if [ ! -d "$REPO" ]; then
+  echo "error: '$REPO' is not a directory, so there is nothing to scan." >&2
+  exit 1
+fi
+
+# THE ONE SOURCE. Everything below is graded against this string; changing it
+# alone, with no site changed, is red at every site.
+#
+# `a` is here while `misa` still reads 0x4000_1104, which is deliberate and
+# temporary: rtl/ decodes and executes the eleven A instructions, and claiming
+# the misa bit is a separate change that has to move rtl/csrs.v and the Sail
+# model's `A` key together. Nothing about a `-march` string is a claim about
+# misa -- it is what the assembler will accept.
+DECLARED_MARCH='rv32imac_zicsr_zifencei'
+
+# The sites, with the exact number of times each states it. An exact count
+# rather than "at least one", because two of these files state it twice for two
+# program shapes and a deleted arm is the failure that leaves the other one
+# looking fine.
+required_sites() {
+  sed -e 's/#.*//' -e 's/[[:space:]]*$//' -e '/^$/d' <<'SITES'
+# The rulebook. The ISA target section quotes the string the suite builds at, so
+# the prose and the flags cannot drift apart without this going red.
+CLAUDE.md 1
+
+# Two arms, one per program shape: a `.c` program linked through test/crt0.S and
+# a freestanding `.S` one. Loud if wrong -- the assembler refuses an atomic.
+test/run_tests.sh 2
+
+# test/cosim.py's assemble(), the same two shapes for the reference model's side
+# of the comparison. Loud for the same reason.
+test/cosim.py 2
+
+# THREE, and two of them are the silent ones: soc-rom's two program shapes build
+# test/asm/datainit.c and the `.S` suite for the SoC's ROM image, neither of
+# which executes an atomic, and DHRY_CFLAGS compiles a benchmark that does not
+# either. A wrong string here changes what is measured, not whether it builds.
+Makefile 3
+
+# DHRY_CFLAGS again, copied verbatim into the depth sweep. The two full strings
+# are compared below as well, because agreeing about `-march` and disagreeing
+# about `-O` would be the same defect one flag over.
+soc/depth/cycles.py 1
+
+# The Sail reservation probe. It is not part of the graded suite and no core
+# runs it, but it is assembled by the same cross compiler and asks the reference
+# model about lr.w/sc.w -- so it is exactly the file that must not be left
+# behind at a narrower string.
+test/sail/reservation_probe.sh 1
+SITES
+}
+
+# Every OTHER `-march=` in the tree, as `<path> <ISA>`. A path may be a
+# directory ending in `/`, and the ISA may be `(any)` where the point of the
+# entry is the file rather than one string in it; `(empty)` is a `-march=` with
+# no ISA after it. A path alone teaches the next reader nothing and gets deleted
+# by the next person tidying, so each entry says which ISA it names and why.
+exception_sites() {
+  sed -e 's/#.*//' -e 's/[[:space:]]*$//' -e '/^$/d' <<'EXCEPTIONS'
+# Dated decision records, and dated proposals. Both are history, and several of
+# them quote the flags a measurement was taken with -- which is the whole value
+# of the record. Editing them would rewrite what was measured to agree with a
+# later decision.
+docs/adr/ (any)
+docs/ideas/ (any)
+
+# This file: the declaration above, the table, and the diagnostics. A check has
+# to be able to name what it is looking for, and every occurrence here is
+# either a shell variable or a pattern rather than a flag.
+test/march_test.sh (any)
+
+# The probes that force this check red plant wrong ISA strings in their
+# fixtures and quote them in their labels. A probe that cannot name what it is
+# planting is not a probe.
+test/probe_gates.sh (any)
+
+# soc/compare/bench.S, built for the cross-core harness. VexRiscv there is
+# RV32IC with no privileged architecture, and the whole point of that harness is
+# that ONE image runs on both cores -- so the image may use only what the
+# narrower core has. rv32i, not even rv32ic, because the image is also this
+# core's and nothing in it needs the density.
+Makefile rv32i
+
+# COMPARE_DHRY_CFLAGS: Dhrystone for the same harness, at the ISA VexRiscv
+# actually implements. Quoting this core's number against theirs means compiling
+# for each core's own ISA, which is why this one is not the string above.
+Makefile rv32ic
+
+# Not a flag at all: a grep pattern that finds the `-march=` in the command line
+# the Dhrystone runner PRINTS, so the flags travel with the number. It has no
+# ISA after it, which is what the `(empty)` says.
+soc/compare/run_dhrystone.sh (empty)
+EXCEPTIONS
+}
+
+# The look-alikes that must NOT move, as <file> <exact text> <why>. These name
+# the ISA riscv-formal generates a spec model for, not the one gcc assembles.
+FORMAL_ISA='rv32imc'
+
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/littlecpu-march.XXXXXX") || {
+  echo "error: could not create a temporary directory under ${TMPDIR:-/tmp}." >&2
+  exit 1
+}
+trap 'rm -rf "$tmp"' EXIT
+
+required_sites  > "$tmp/required"
+exception_sites > "$tmp/exceptions"
+
+# Tracked files only, and git's index rather than a `find` with a prune list,
+# for the reason test/retired_term_test.sh gives: what this guards against is a
+# string arriving in a commit, and a checkout carries build artifacts,
+# downloaded tools and whole agent worktrees a merge cannot bring anything
+# through.
+if ! git -C "$REPO" ls-files -z > "$tmp/files" 2>/dev/null || [ ! -s "$tmp/files" ]; then
+  echo "error: cannot enumerate any tracked files under $REPO. This check reads" >&2
+  echo "git's index, because what it guards is a build flag arriving in a" >&2
+  echo "commit; a tree git cannot list is a scan of nothing reporting green." >&2
+  exit 1
+fi
+
+# `/dev/null` first so grep always prefixes the filename, and `-o` so a line
+# stating the flag twice is two hits rather than one. No match at all leaves
+# grep at 1 and xargs at 123, which is not an error here.
+hits=$( (cd "$REPO" && xargs -0 grep -noI -E -e '-march=[A-Za-z0-9_]*' -- /dev/null < "$tmp/files") || true)
+
+rc=0
+
+: > "$tmp/found"
+: > "$tmp/unexpected"
+: > "$tmp/covered"
+
+# Which exception entry covers a path carrying a value, or nothing. A directory
+# entry matches on the `/` it ends with, so `docs/adr/` cannot quietly cover a
+# `docs/adrenaline.md` nobody meant to exempt.
+match_exception() {  # $1 = path, $2 = value
+  local path=$1 value=$2 entry epath evalue
+  while IFS= read -r entry; do
+    epath=${entry%% *}
+    evalue=${entry#* }
+    [ "$evalue" = "(any)" ] || [ "$evalue" = "$value" ] || continue
+    case "$epath" in
+      */) case "$path" in "$epath"*) printf '%s' "$entry"; return 0 ;; esac ;;
+      *)  if [ "$path" = "$epath" ]; then printf '%s' "$entry"; return 0; fi ;;
+    esac
+  done < "$tmp/exceptions"
+  return 0
+}
+
+while IFS= read -r hit; do
+  [ -n "$hit" ] || continue
+  path=${hit%%:*}
+  rest=${hit#*:}
+  line=${rest%%:*}
+  value=${hit##*-march=}
+  [ -n "$value" ] || value='(empty)'
+
+  if [ "$value" = "$DECLARED_MARCH" ]; then
+    printf '%s\n' "$path" >> "$tmp/found"
+    continue
+  fi
+  entry=$(match_exception "$path" "$value")
+  if [ -n "$entry" ]; then
+    printf '%s\n' "$entry" >> "$tmp/covered"
+    continue
+  fi
+  printf '%s:%s: -march=%s\n' "$path" "$line" "$value" >> "$tmp/unexpected"
+done <<< "$hits"
+
+if [ -s "$tmp/unexpected" ]; then
+  rc=1
+  echo "error: an -march= that is neither the declared ISA nor a named exception:" >&2
+  sed -e 's|^|  |' "$tmp/unexpected" >&2
+  echo >&2
+  echo "This suite builds at -march=$DECLARED_MARCH, stated once in" >&2
+  echo "test/march_test.sh and graded at every site from there. If the site" >&2
+  echo "above deliberately names a DIFFERENT instruction set -- the cross-core" >&2
+  echo "harness compiling for the narrower core, a pattern that is not a flag" >&2
+  echo "-- add it to the exception list in this file, with which ISA it names" >&2
+  echo "and why that one. An entry that is only a path is one the next person" >&2
+  echo "tidying will delete." >&2
+fi
+
+while read -r path want; do
+  got=$(grep -cxF -- "$path" "$tmp/found" || true)
+  if [ "$got" -ne "$want" ]; then
+    rc=1
+    echo >&2
+    echo "error: $path states -march=$DECLARED_MARCH $got time(s), not $want." >&2
+    echo "Every site below builds something this suite measures, and three of" >&2
+    echo "them build programs that use no atomic at all -- so a site left behind" >&2
+    echo "goes on producing numbers for a machine nobody asked about rather" >&2
+    echo "than failing. If the count moved for a good reason, move it here in" >&2
+    echo "the same commit, with the reason above the line." >&2
+  fi
+done < "$tmp/required"
+
+while IFS= read -r entry; do
+  if ! grep -qxF -- "$entry" "$tmp/covered"; then
+    rc=1
+    echo >&2
+    echo "error: the exception list names \`$entry\`, and it is not" >&2
+    echo "there any more. Delete the entry -- or if that build moved, move the" >&2
+    echo "entry with it. An exemption kept past its reason is how the next one" >&2
+    echo "gets waved through, and it is why this comparison runs both ways." >&2
+  fi
+done < "$tmp/exceptions"
+
+# ---- the two spellings that must NOT move ----------------------------------
+#
+# Read as their own patterns rather than as `-march=` hits, because that is how
+# they are spelled: neither is a compiler flag.
+
+if ! grep -qE "^[[:space:]]*isa[[:space:]]+$FORMAL_ISA[[:space:]]*$" "$REPO/formal/checks.cfg"; then
+  rc=1
+  echo >&2
+  echo "error: formal/checks.cfg no longer says \`isa $FORMAL_ISA\`." >&2
+  echo "That line picks which instructions riscv-formal GENERATES a spec model" >&2
+  echo "for, and the pinned clone has no model for any A encoding: its" >&2
+  echo "insn_amo generator has every call site commented out, it covers neither" >&2
+  echo "min/max nor LR/SC, and there is no isa_rv32ia*.txt. Widening it" >&2
+  echo "generates nothing and leaves the check set claiming an ISA it does not" >&2
+  echo "check. formal/COMPLETE_EXCLUSIONS is where that boundary is recorded," >&2
+  echo "and formal/check-complete-exclusions.py re-derives it from the clone." >&2
+fi
+
+if ! grep -qE -- "-i[[:space:]]+$FORMAL_ISA([[:space:]]|$)" "$REPO/Makefile"; then
+  rc=1
+  echo >&2
+  echo "error: the Makefile's MONITOR_GEN no longer passes \`-i $FORMAL_ISA\`." >&2
+  echo "It generates test/monitor.v, the per-retire oracle both sim legs read," >&2
+  echo "from the same pinned clone as the line above and with the same gap in" >&2
+  echo "it. Widening this regenerates the same file and changes nothing except" >&2
+  echo "what the command line claims." >&2
+fi
+
+# ---- the Dhrystone flags, whole -------------------------------------------
+#
+# Not just the ISA: the two copies of DHRY_CFLAGS are one measurement's other
+# half, and agreeing about -march while disagreeing about -O would be the same
+# defect one flag over.
+
+# One line, single-spaced and untrimmed at both ends, so the two copies are
+# compared on what they SAY rather than on how they were wrapped: one is a make
+# variable over three backslash-continued lines and the other is a Python
+# implicit concatenation over two.
+one_line() { tr -s '[:space:]' ' ' | sed -e 's/^ //' -e 's/ $//'; }
+
+# A string this cannot read is fatal rather than empty. Comparing against
+# something the script failed to parse is how a check goes on reporting green
+# over a file it has stopped understanding.
+need_flags() {  # $1 = file, $2 = what was read
+  [ -n "$2" ] && return 0
+  echo >&2
+  echo "error: no Dhrystone flag string could be read out of $1." >&2
+  echo "This check reads both copies and compares them; if the declaration" >&2
+  echo "was respelled, teach this script the new spelling rather than" >&2
+  echo "dropping the comparison." >&2
+  exit 1
+}
+
+mk_flags=$(awk '
+  /^DHRY_CFLAGS[[:space:]]*:=/ { collecting = 1 }
+  collecting {
+    line = $0
+    sub(/^DHRY_CFLAGS[[:space:]]*:=[[:space:]]*/, "", line)
+    cont = (line ~ /\\[[:space:]]*$/)
+    sub(/\\[[:space:]]*$/, "", line)
+    out = out " " line
+    if (!cont) { print out; exit }
+  }' "$REPO/Makefile" | one_line)
+need_flags Makefile "$mk_flags"
+
+py_flags=$(awk '
+  index($0, "dhry_flags") && index($0, "=") { collecting = 1 }
+  collecting {
+    line = $0
+    while (match(line, /"[^"]*"/)) {
+      out = out substr(line, RSTART + 1, RLENGTH - 2)
+      line = substr(line, RSTART + RLENGTH)
+    }
+    if (line ~ /\)/) { print out; exit }
+  }' "$REPO/soc/depth/cycles.py" | one_line)
+need_flags soc/depth/cycles.py "$py_flags"
+
+if [ "$mk_flags" != "$py_flags" ]; then
+  rc=1
+  echo >&2
+  echo "error: the Dhrystone flags are stated twice and they disagree." >&2
+  echo "  Makefile           : $mk_flags" >&2
+  echo "  soc/depth/cycles.py: $py_flags" >&2
+  echo "The flags are the measurement's other half -- they are compiled INTO" >&2
+  echo "the benchmark and printed beside the number, precisely so the two" >&2
+  echo "cannot be quoted apart. Two copies that differ produce two numbers for" >&2
+  echo "two machines under one heading." >&2
+fi
+
+if [ "$rc" -ne 0 ]; then
+  exit 1
+fi
+
+sites=$(wc -l < "$tmp/required" | tr -d ' ')
+excepted=$(wc -l < "$tmp/exceptions" | tr -d ' ')
+files=$(tr -cd '\0' < "$tmp/files" | wc -c | tr -d ' ')
+echo "-march=$DECLARED_MARCH at all $sites sites, $excepted named exceptions, over $files tracked files"

--- a/test/mutations/amo-compares-unsigned.patch
+++ b/test/mutations/amo-compares-unsigned.patch
@@ -1,0 +1,13 @@
+diff --git a/rtl/accessor.v b/rtl/accessor.v
+index f43d4aa..581b4c8 100644
+--- a/rtl/accessor.v
++++ b/rtl/accessor.v
+@@ -217,7 +217,7 @@ module accessor(
+   // signed expression, so no arm can take its signedness from a neighbour.
+   logic amo_compare, amo_signed;
+   assign amo_compare = take_amo_min || take_amo_max || take_amo_minu || take_amo_maxu;
+-  assign amo_signed  = take_amo_min || take_amo_max;
++  assign amo_signed  = 1'b0;
+ 
+   logic [32:0] amo_wide_mem, amo_wide_arg, amo_addend, amo_sum;
+   assign amo_wide_mem = {1'b0, amo_mem};

--- a/test/mutations/sc-reports-success.patch
+++ b/test/mutations/sc-reports-success.patch
@@ -1,0 +1,13 @@
+diff --git a/rtl/accessor.v b/rtl/accessor.v
+index f43d4aa..b881b31 100644
+--- a/rtl/accessor.v
++++ b/rtl/accessor.v
+@@ -336,7 +336,7 @@ module accessor(
+       // cycle the reservation is still the one it was tested against: 0 for the
+       // store that went out, 1 for the one that did not.
+       take_is_sc <= requesting && launch_is_sc;
+-      take_sc_failed <= !sc_store;
++      take_sc_failed <= 1'b0;
+       take_amo <= requesting && launch_is_amo;
+       take_amo_addr <= word_aligned_addr;
+       take_amo_arg <= launch_mem_data;

--- a/test/probe_gates.sh
+++ b/test/probe_gates.sh
@@ -27,7 +27,7 @@ REPO=$(cd "$HERE/.." && pwd)
 # Pinned as a literal: a probe that is deleted, or that stops being reached by
 # an early `return`, would otherwise cut this file's coverage while it kept
 # printing a green summary.
-PROBES_EXPECTED=236
+PROBES_EXPECTED=251
 
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/littlecpu-probe.XXXXXX") || {
   echo "error: could not create a temporary directory under ${TMPDIR:-/tmp}." >&2
@@ -1342,6 +1342,132 @@ probe "an allow-list entry whose site no longer has the word is red" 1 \
 d=$(new_case)
 probe "a tree git cannot list is a scan of nothing, not a green one" 1 \
   "cannot enumerate any tracked files" "$RN $d"
+
+begin_group "test/march_test.sh"
+
+# A COPY OF THE SHIPPING FILES again, plus a `git init` over it, for the reasons
+# the two fixtures above give: the control is then the real set of build sites
+# and every red probe is one edit away from it. A hand-written fixture would
+# drift from the flags it is supposed to be comparing, which is the defect.
+MA="$HERE/march_test.sh"
+
+ma_fixture() {
+  local d; d=$(new_case)
+  mkdir -p "$d/test/sail" "$d/soc/depth" "$d/soc/compare" "$d/formal" \
+           "$d/docs/adr" "$d/docs/ideas"
+  cp "$REPO/CLAUDE.md" "$REPO/Makefile" "$d/"
+  cp "$REPO/test/run_tests.sh" "$REPO/test/cosim.py" "$REPO/test/march_test.sh" \
+     "$REPO/test/probe_gates.sh" "$d/test/"
+  cp "$REPO/test/sail/reservation_probe.sh" "$d/test/sail/"
+  cp "$REPO/soc/depth/cycles.py" "$d/soc/depth/"
+  cp "$REPO/soc/compare/run_dhrystone.sh" "$d/soc/compare/"
+  cp "$REPO/formal/checks.cfg" "$d/formal/"
+  # One real file under each history directory: those two entries are
+  # directories, and a hundred more copies per fixture would buy only wall time.
+  cp "$REPO/docs/adr/0106-the-a-extension-is-built-and-the-board-still-closes.md" "$d/docs/adr/"
+  cp "$REPO/docs/ideas/the-a-extension-lands-single-hart.md" "$d/docs/ideas/"
+  git -c init.defaultBranch=main -C "$d" init -q
+  git -C "$d" add -A
+  printf '%s' "$d"
+}
+
+# sed's backup goes away before the tree is re-indexed. This check scans every
+# TRACKED file, so a leftover `Makefile.bak` would be a second copy of the
+# unedited flags for it to grade -- the probes would still go red, for a reason
+# that is not the one they name.
+ma_edit() {  # $1 = fixture dir, $2 = path within it, $3 = sed expression
+  sed -i.bak "$3" "$1/$2"
+  rm -f "$1/$2.bak"
+  git -C "$1" add -A
+}
+
+d=$(ma_fixture)
+probe "control: the shipping tree names one ISA at every site" 0 \
+  "at all 6 sites" "$MA $d"
+
+probe "a repo root that does not exist is red before anything is scanned" 1 \
+  "is not a directory" "$MA $d/nowhere"
+
+# THE ONE THAT MATTERS: a site left behind. The `.c` arm of the suite runner
+# assembles a program with no atomic in it either way.
+d=$(ma_fixture)
+ma_edit "$d" test/run_tests.sh '158s/rv32imac_zicsr_zifencei/rv32imc_zicsr_zifencei/'
+probe "one build site left at the narrower ISA is red, and located" 1 \
+  "test/run_tests.sh:158: -march=rv32imc_zicsr_zifencei" "$MA $d"
+
+probe "...and the count that site was declared with is red too" 1 \
+  "test/run_tests.sh states -march=rv32imac_zicsr_zifencei 1 time(s), not 2" "$MA $d"
+
+# The silent one. Nothing about this changes whether anything builds.
+d=$(ma_fixture)
+ma_edit "$d" Makefile \
+  's/^DHRY_CFLAGS := -march=rv32imac_zicsr_zifencei/DHRY_CFLAGS := -march=rv32imc_zicsr_zifencei/'
+probe "the Dhrystone flags drifting from the suite's ISA is red" 1 \
+  "Makefile states -march=rv32imac_zicsr_zifencei 2 time(s), not 3" "$MA $d"
+
+probe "...and their second copy is compared whole, not just its ISA" 1 \
+  "the Dhrystone flags are stated twice and they disagree" "$MA $d"
+
+# The whole-string comparison on its own: same ISA, different optimiser.
+d=$(ma_fixture)
+ma_edit "$d" soc/depth/cycles.py \
+  's/-mabi=ilp32 -O2 -std=c11 -ffreestanding/-mabi=ilp32 -O3 -std=c11 -ffreestanding/'
+probe "two copies of the flags agreeing about -march and nothing else" 1 \
+  "-O3" "$MA $d"
+
+# The other direction, which is the half a one-way sweep would not have. This
+# is the one probe that runs the FIXTURE'S copy of the script rather than the
+# shipping one, because what it moves is the declaration inside it.
+d=$(ma_fixture)
+ma_edit "$d" test/march_test.sh 's/rv32imac_zicsr_zifencei/rv32imafc_zicsr_zifencei/'
+probe "moving the declared string alone, with every site unchanged, is red" 1 \
+  "CLAUDE.md states -march=rv32imafc_zicsr_zifencei 0 time(s), not 1" \
+  "$d/test/march_test.sh $d"
+
+# The two spellings that must not move with it. Widening either generates
+# nothing at the pin.
+d=$(ma_fixture)
+ma_edit "$d" formal/checks.cfg 's/^isa rv32imc$/isa rv32imac/'
+probe "the generated check set's isa line swept along with the flags is red" 1 \
+  "formal/checks.cfg no longer says \`isa rv32imc\`" "$MA $d"
+
+d=$(ma_fixture)
+ma_edit "$d" Makefile 's/generate.py -i rv32imc /generate.py -i rv32imac /'
+probe "the monitor generator's -i swept along with them is red as well" 1 \
+  "MONITOR_GEN no longer passes \`-i rv32imc\`" "$MA $d"
+
+# An unnamed ISA anywhere, which is what a new build site arriving looks like.
+d=$(ma_fixture)
+printf '#!/bin/sh\nriscv64-elf-gcc -march=rv32e -o x y.c\n' > "$d/test/newbuild.sh"
+git -C "$d" add -A
+probe "a new site naming an ISA nothing declared is red, and located" 1 \
+  "test/newbuild.sh:2: -march=rv32e" "$MA $d"
+
+# ...and the exception list's own both-ways direction.
+d=$(ma_fixture)
+ma_edit "$d" Makefile 's/-march=rv32i -mabi=ilp32/-march=rv32imac_zicsr_zifencei -mabi=ilp32/'
+probe "an exception whose site stopped naming that ISA is red" 1 \
+  "the exception list names \`Makefile rv32i\`" "$MA $d"
+
+# A directory entry has to match on the path separator, or it silently exempts
+# every sibling whose name it happens to prefix.
+d=$(ma_fixture)
+printf 'built at -march=rv32im_zicsr once.\n' > "$d/docs/adrenaline.md"
+git -C "$d" add -A
+probe "a lookalike sibling is not covered by the directory entry above it" 1 \
+  "docs/adrenaline.md:1: -march=rv32im_zicsr" "$MA $d"
+
+# A declaration this cannot read must stop the run rather than compare against
+# an empty string, which is how a check reports green over a file it has
+# stopped understanding.
+d=$(ma_fixture)
+ma_edit "$d" Makefile 's/^DHRY_CFLAGS :=/DHRY_CFLAGS_RENAMED :=/'
+probe "a respelled flag declaration stops rather than comparing nothing" 1 \
+  "no Dhrystone flag string could be read out of Makefile" "$MA $d"
+
+d=$(new_case)
+probe "a tree git cannot list is a scan of nothing, not a green one" 1 \
+  "cannot enumerate any tracked files" "$MA $d"
 
 begin_group "soc/fit_report.py"
 

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -155,7 +155,7 @@ for src in "${programs[@]}"; do
 
   case $name in
     *.c)
-      build=("$CC" -march=rv32imc_zicsr_zifencei -mabi=ilp32 -nostdlib
+      build=("$CC" -march=rv32imac_zicsr_zifencei -mabi=ilp32 -nostdlib
              -Os -std=c11 -ffreestanding -fno-tree-loop-distribute-patterns
              -Wall -Wextra -Werror -I "$ASM_DIR"
              -T "$ASM_DIR/boot.lds" "$HERE/crt0.S" "$src" -o "$elf")
@@ -163,7 +163,7 @@ for src in "${programs[@]}"; do
       ram_flags=(--only-section=.tohost)
       ;;
     *)
-      build=("$CC" -march=rv32imc_zicsr_zifencei -mabi=ilp32 -nostdlib
+      build=("$CC" -march=rv32imac_zicsr_zifencei -mabi=ilp32 -nostdlib
              -I "$ASM_DIR" -T "$ASM_DIR/sections.lds" "$src" -o "$elf")
       rom_flags=(--only-section=.text)
       ram_flags=(--remove-section=.text)

--- a/test/sail/reservation_probe.S
+++ b/test/sail/reservation_probe.S
@@ -1,7 +1,8 @@
 // An LR/SC reservation probe for the Sail model ALONE. No core runs this, and
-// it is deliberately not in test/asm: both sim legs glob that directory, this
-// core does not decode lr.w/sc.w yet, and the graded suite must keep assembling
-// at -march=rv32imc_zicsr_zifencei. Built and run by
+// it is deliberately not in test/asm: both sim legs glob that directory and
+// would grade this against a core, which is exactly what it must not be. The
+// graded programs that DO exercise lr.w/sc.w against the core are
+// test/asm/lrsc.S and its neighbours. Built and run by
 // test/sail/reservation_probe.sh; see docs/adr/0102.
 //
 // WHAT IT ASKS. The reservation policy is the one part of LR/SC the spec leaves

--- a/test/sail/reservation_probe.sh
+++ b/test/sail/reservation_probe.sh
@@ -9,10 +9,10 @@
 # executable in this repo that asks the model a question instead of grading it
 # against something.
 #
-# IT BUILDS AT -march=rv32imac_zicsr_zifencei, and nothing else here does. The
-# graded suite's three build sites -- test/run_tests.sh, test/cosim.py's
-# assemble() and the Makefile's soc-rom -- stay at rv32imc_zicsr_zifencei,
-# because this core does not implement A. Do not "unify" them.
+# IT BUILDS AT THE SUITE'S ISA STRING, which it did not always: this file
+# carried the only `a` in the tree while the core decoded no atomic. The whole
+# set is graded by test/march_test.sh now, this is one of the sites it grades,
+# and the two spellings that must NOT move with it are named there.
 #
 # The probe is graded, not merely printed: bit 0 is a control case whose SC
 # nothing could have invalidated, and a run where it failed exits nonzero

--- a/test/sail/rv32imc_zicsr.json
+++ b/test/sail/rv32imc_zicsr.json
@@ -211,6 +211,26 @@
     // refused one would diverge from the core on a program that made one. That
     // is the half of the map this core does not yet enforce.
     //
+    // THE SECOND REGION IS NOT SPLIT AT THE DATA RAM'S BOUNDS, and the reason
+    // is a measurement rather than tidiness. rtl/memory.v refuses a reservation
+    // outside the 64 KB it answers, so an sc.w anywhere else on this core fails
+    // and stores nothing. Splitting the region and marking everything but the
+    // RAM `RsrvNone` looks like the way to say that here, and it is not: the
+    // model's `RsrvNone` makes an lr.w raise a LOAD ACCESS FAULT, cause 5,
+    // which this core does not raise anywhere -- the decode-time region test
+    // that would was measured at four logic levels in the fetch loop and
+    // declined (docs/adr/0104). Both settings were run against
+    // test/asm/amoregion.S:
+    //
+    //   RsrvEventual   the sc.w at 0x0004_0000 SUCCEEDS on the model
+    //   RsrvNone       the lr.w before it traps, cause 5
+    //
+    // The first is one register value apart from this core; the second is a
+    // different control flow AND a fault the core is recorded as not raising.
+    // So the region stays whole, amoregion.S carries the one divergence, and
+    // test/COSIM_EXPECTED_FAIL carries the paragraph. Nothing else in the suite
+    // reaches a reservation outside the data RAM.
+    //
     // The model's default RV32 map puts MainMemory at
     // 0x8000_0000, where nothing this suite builds is executable or loadable.
     //


### PR DESCRIPTION
Closes JEF-813.

The A extension merged (ADR-0106) with nothing behavioural behind it. No program in `test/asm` executed an atomic, so `make test`, `make cycles` and `make cosim-suite` said nothing about eleven instructions — and both sim legs are structurally blind to them anyway: `test/monitor.sim.v:129` wraps every value comparison in `if (ch0_spec_valid)` with no `else`, and riscv-formal ships no spec model for any A encoding at the pin, so the per-retire oracle grades pc continuity and nothing else. An `OBSERVED_FLOOR` line for an A program is a retire count, not evidence.

## The six programs, and what each catches

Every one reads its memory result back into a register, because `test/cosim.cc` compares `regs_a` and never compares memory.

| program | what it catches |
|---|---|
| `amo.S` | the nine functions against the word returned **and** the word left behind; 32-bit modular wrap; all four `.aq`/`.rl` spellings; `rd == rs1`, `rd == rs2`, `rd == x0`; a dependent instruction and a second memory instruction interlocked behind an AMO; an AMO held under a divide |
| `amominmax.S` | the four min/max at `0x8000_0000` and `-1`, against each other and against small positives, **both operand orders**, plus equal operands. Every pair has a sign disagreement in it, so each unsigned answer is the opposite of its signed one |
| `lrsc.S` | LR/SC's five invalidation events: an `sc.w` with no `lr.w` **as the first thing in the program**, a `sw`/`sb`/`sh`/AMO to the reserved word, a store and a load elsewhere (which must *not* clear it), a second `lr.w` moving the reservation, the `sc.w` consuming it; word-address matching; `rd` aliasing; the pair under a divide |
| `amotrap.S` | cause 4 for `lr.w` at all three misalignments and cause 6 for the ten that write, each asserting `rd` and the word are untouched; `mepc` at the faulting instruction; an aligned atomic at the same address still working |
| `amoregion.S` | an atomic outside the data RAM: `lr.w` reads zero and takes no reservation, so `sc.w` fails and stores nothing; a RAM reservation not honoured outside it; an AMO out there executing and writing nowhere; the machine timer's `mtimecmp` getting a refused reservation for free and surviving an `sc.w` intact |
| `lrsclock.S` | a reservation held across a real timer trap — the `lr.w`, then an unbounded wait until the handler has run, then a **first-try** `sc.w` — followed by a lock loop with a bounded-retry watchdog, so a lost reservation is a numbered failure rather than a `TIMEOUT` indistinguishable from a hang |

`make cycles`: the `atomic` bucket goes from 0 to 66 of 32885 suite cycles, and the columns still add up with `unattributed` 0.

## Co-simulation, before and after

**Before:** `62/64 agreed`, matching the baseline (`mtimer.S`, `mtimermask.S`).
**After:** `66/70 agreed`, matching the baseline.

`amo.S`, `amominmax.S`, `amotrap.S` and `lrsc.S` **AGREE** — so co-sim is a live semantic oracle for the nine AMO functions, LR/SC's invalidation events and both misalignment causes. Two new baseline entries, each with a paragraph in `test/COSIM_EXPECTED_FAIL`:

- **`amoregion.S DISAGREE AT 18`.** Question 1 of that file's decision procedure was tried rather than reasoned about. The model has exactly two settings and this core is neither: at `RsrvEventual` the `sc.w` at `0x0004_0000` **succeeds**; at `RsrvNone` the `lr.w` before it raises a **load access fault, cause 5**. This core answers the `lr.w` with zero, takes no reservation and raises nothing — ADR-0104's recorded deviation. So the region split is *not* in `test/sail/rv32imc_zicsr.json`, and that file's region comment now carries the measurement so the next person to reach for the knob finds it there. Everything co-simulable was deliberately kept out of this program.
- **`lrsclock.S INCONCLUSIVE SAIL-LIMIT`**, for `mtimer.S`'s reason: the model's CLINT is elsewhere with a different tick period, so the arming store lands nowhere and the wait never ends. Nothing was compared.

## The `-march` half

Flipped to `rv32imac_zicsr_zifencei` at all five sites, and `test/march_test.sh` now declares the string **once** and grades every site both ways, hanging off `make test` beside `memmap_test.sh` (git, grep, sed, awk — no cross compiler, no Sail, no yosys). It follows `test/retired_term_test.sh`'s shape.

Six required sites, each with its reason above the line: `test/run_tests.sh` (2), `test/cosim.py` (2), `Makefile` (3 — `soc-rom`'s two shapes plus `DHRY_CFLAGS`), `soc/depth/cycles.py` (1), `test/sail/reservation_probe.sh` (1), and `CLAUDE.md` (1), so the rulebook and the flags cannot drift apart. It also compares the **whole** `DHRY_CFLAGS` string against its verbatim copy in `soc/depth/cycles.py` — agreeing about `-march` and disagreeing about `-O` is the same defect one flag over.

Named exceptions, each stating which ISA it names and why: `Makefile rv32i` (`soc/compare/bench.S`, deliberately RV32I so one image runs on both cores), `Makefile rv32ic` (`COMPARE_DHRY_CFLAGS`, what VexRiscv implements), `soc/compare/run_dhrystone.sh (empty)` (a grep pattern, not a flag), `docs/adr/` and `docs/ideas/` (dated history quoting the flags a measurement was taken with), `test/march_test.sh` and `test/probe_gates.sh` (the declaration and the probes that plant wrong strings).

**Two look-alikes are asserted NOT to move**: `formal/checks.cfg`'s `isa rv32imc` and `MONITOR_GEN -i rv32imc`. The pin has no A model, so widening either generates nothing.

Three prose sites quoting a stale ISA string were reworded rather than left to rot: `test/asm/riscv_test.h`, `test/sail/reservation_probe.S` and `test/sail/reservation_probe.sh` (which used to say it was the only `rv32imac` in the tree).

## Graders

`make probe-gates` gains a 15-probe group for `test/march_test.sh` including both halves of the ticket's requirement — one build site left behind fails naming file and line, and moving the declared string alone with every site unchanged also fails. `PROBES_EXPECTED` 220 → **251** (main moved it to 236 mid-flight).

The hardware red directions go where they can actually run — `make mutation-check`, not the hermetic `probe-gates`:

- **`sc-reports-success`** (`take_sc_failed <= 1'b0`): caught by `accessor_tb`, `lrsc.S FAIL 2` and `amoregion.S FAIL 5`. `lrsclock.S` is deliberately **not** a detector — every `sc.w` in it is meant to succeed.
- **`amo-compares-unsigned`** (`amo_signed <= 1'b0`): caught by `accessor_tb` and **`amominmax.S FAIL 4` alone**. `amo.S` is measured not to catch it, which is the whole argument for the boundaries being a separate file.

## Gates

| gate | result |
|---|---|
| `make test` | **70/70**, `EXPECTED_FAIL` exact both ways |
| `make probe-gates` | 251 graded comparisons, every failure path executed |
| `make mutation-check` | 6 mutations, each caught by exactly its detectors |
| `make cosim-suite` | 66/70, `COSIM_EXPECTED_FAIL` exact both ways |
| `make cycles` | columns add up, `unattributed` 0, `atomic` 66 of 32885 |
| `make lint` | clean in both passes |
| `make waves` | PASS |
| `make soc-rom` | builds, 71 words |
| `make dhrystone` | **0.727 DMIPS/MHz, 3568 of 8192 ROM bytes — both unmoved** under the new flags |

Nothing in `rtl/` changed, so `fit`, `soc-timing`, `formal`, `components`, `nonperturbation` and `monitor-freshness` are untouched. `misa` stays `0x4000_1104`; the Sail model's `A` key stays false. No baseline weakened.

Rebased once onto `2ea5e13`; conflicts were the `make test` prerequisite list and `PROBES_EXPECTED`, both resolved by taking both changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)