### PR TITLE
Derive FIT_MAX_LC from a band measured on the tree, and report the move (JEF-828)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -369,7 +369,9 @@ jobs:
             cat "$RUNNER_TEMP/fit.txt"
             echo '```'
             echo "Logic cells on up5k/sg48, memories external. This job is a ratchet"
-            echo "against \`FIT_MAX_LC\`, and it is NOT in main's required set."
+            echo "against \`FIT_MAX_LC\`, and it is in main's required set -- so a"
+            echo "re-mapping that moves the count blocks a merge, which is why the"
+            echo "budget is derived to clear a whole churn band."
           } >> "$GITHUB_STEP_SUMMARY"
           exit "$status"
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -334,10 +334,25 @@ and times.
 
 - **`make fit` has a churn band of about ±50 cells**: functionally identical edits move the count
   that much from ABC/nextpnr re-mapping alone. A delta inside the band is not evidence of
-  anything, and a ratchet (`FIT_MAX_LC`) must sit outside it. **The number is also
-  toolchain-dependent** — the `fit` job reads 3543 on `d3a9556` where a local Homebrew yosys reads
-  3575 on the same tree, 32 cells apart with the local one higher — so quote the `fit` job's number;
-  a local run is a sanity check. **The suite is not pinned** — CI installs the latest release — so
+  anything, and a ratchet (`FIT_MAX_LC`) must sit outside it. **±50 is the nominal figure and the
+  band measures wider than it**: setting one further bit of the read-only `misa` constant spans 68
+  cells on `64759da` (3988, 3979 and 3920 against a base of 3935) and 63 on `2007d9d` (3958, 3971,
+  3987, 3925 and 3980 against 3988), all of them edits that change no logic at all — which is why
+  `FIT_MAX_LC` is derived from a span measured on the tree rather than from ±50. Budget the whole
+  span rather than its upward half: every probe on the second tree came out *below* its base, so a
+  count can sit anywhere in that window including the bottom.
+  **The number is also toolchain-dependent, by as much as the band** — the `fit` job reads **3934**
+  on `2007d9d` where both a local Homebrew yosys and a cached OSS CAD Suite read **3988**, 54 cells
+  apart on one tree; other trees read 32 apart (3543 job, 3575 local on `d3a9556`) and 3 apart
+  twice, with the sign not the same either time (3938 against 3935 on `64759da`, 3966 against 3969
+  on `421947f`). The sharp form: the one-bit `misa` edit
+  between `64759da` and `2007d9d` moved the local count **+53** and the job's **−4**, so the gap is the
+  same re-mapping and has no fixed size or sign. Quote the `fit` job's number, budget for the gap's
+  size rather than its direction, and treat a local run as a sanity check. The other instrument
+  answers this with tooling rather than a convention now, and it is the same argument:
+  `soc/baseline_sweep.sh` stamps a sweep with its base commit and its resolved tool versions, and
+  `soc/baseline_summary.py` **refuses** to subtract two sweeps whose stamps disagree.
+  **The suite is not pinned** — CI installs the latest release — so
   `FIT_MAX_LC` and `SOC_MIN_MHZ` are graded against a toolchain that can move under them, and a
   suite bump belongs on the list of causes when either trips. **And it is top-dependent**: one
   decode edit measured −50 `SB_LUT4` synthesising `littlecpu` and −1 synthesising `littlesoc`, both

--- a/Makefile
+++ b/Makefile
@@ -603,32 +603,52 @@ fit.json: $(FIT_SRCS)
 	@yosys -p 'read_verilog -sv $^; synth_ice40 -dsp -top littlecpu -json $@' \
 	  > fit.synth.log 2>&1 || { tail -40 fit.synth.log; exit 1; }
 
-# 3625 is a measurement of 3543 under CI's suite plus a 50-cell churn band plus
-# 32 for the toolchain: identical RTL moves about 50 cells on ABC re-mapping
-# alone, and that tree read 3543 under CI against 3575 under a local Homebrew
-# yosys. CI resolves the OSS CAD Suite rather than pinning it, so the second term
-# is what stops a suite bump going red on a pull request that changed no RTL.
-# Launching the bus from the execute slot took the job's number to 3469, leaving
-# more slack than the derivation left.
+# THE INSTRUMENT IS THE `fit` CI JOB, not a local run. Three yosys builds of one
+# version read this design three ways, so a local `make fit` is the sanity check
+# and the job's count is the figure this budget is derived from and graded
+# against.
 #
-# The A extension spent all of it and more. The `fit` job reads 3486 on the base
-# and **3938** here, **+452 cells** for eleven instructions -- decode and its
-# flags through two pipeline registers, a 30-bit reservation, the 33-bit
-# adder/subtractor and the result mux, the held address and rs2, and the two
-# 32-bit muxes that give the read-modify-write the bus for its write cycle. A
-# local Homebrew yosys reads 3464 and 3935 on the same two trees, which is the
-# sanity check and not the figure: 4000 is the job's 3938 plus the ±50 churn
-# band, so the ratchet sits outside it. That is a tenth of the whole core spent
-# on instructions no current workload executes, and the reason to spend it is in
-# the ADR rather than here.
+# 4088 = 3966 + 68 + 54:
+#   3966  the `fit` job's count on 421947f, run 31984969180. It has read 3966 on
+#         five consecutive trees, none of which touched an input to this target.
+#    +68  the churn band, measured rather than quoted at ±50. Setting one further
+#         bit of the read-only `misa` constant spans 68 cells on 64759da (3988,
+#         3979 and 3920 against a base of 3935) and 63 on 2007d9d (3958, 3971,
+#         3987, 3925 and 3980 against 3988) -- edits that change no logic at all.
+#         Budget the whole span and not just its upward half: every probe on the
+#         second tree came out BELOW the base, so a count can sit anywhere in
+#         that window, including at the bottom with the whole of it still to
+#         come.
+#    +54  the widest gap measured between two toolchains on one tree, which is
+#         2007d9d: the job read 3934 where both a local Homebrew yosys and a
+#         cached OSS CAD Suite read 3988. Other trees read 32 (3543 job, 3575
+#         local on d3a9556) and 3 twice (3938 against 3935 on 64759da, 3966
+#         against 3969 here, the sign not the same either time), so the gap is
+#         re-mapping too and has no fixed size or sign. CI resolves the suite
+#         rather than pinning it, so a release moves the count with nothing
+#         committed against it.
+#
+# The budget clears the higher of each tree's pair by more than a band -- 3969
+# here, 3988 on 2007d9d. Preserve that when this is next re-derived.
+#
+# This raise buys band clearance and nothing else. No cells were spent for it and
+# none of the headroom is a budget for a design change. A raise that pays for one
+# reads differently and names what it bought: 3625 -> 4000 was +452 measured
+# cells for the eleven A instructions.
 # If this goes red, find out what grew; raising it to pass defeats the point.
-FIT_MAX_LC := 4000
+FIT_MAX_LC := 4088
+
+# The count above, printed as a delta beside the verdict: a pass says only "under
+# the budget", where a real +50 and a churn +50 read identically. It grades
+# nothing and cannot fail, which is what `test/probe_gates.sh` pins. It is the
+# job's count, so a local run prints the gap between the instruments as well.
+FIT_LAST_LC := 3966
 
 .PHONY: fit
 fit: fit.json
 	@nextpnr-ice40 --up5k --package sg48 --json $< --pcf-allow-unconstrained \
 	  > fit.log 2>&1 || true
-	@python3 soc/fit_report.py fit.log --max-lc $(FIT_MAX_LC)
+	@python3 soc/fit_report.py fit.log --max-lc $(FIT_MAX_LC) --previous $(FIT_LAST_LC)
 
 # This builds `littlesoc`, not the `littlecpu` that `make fit` measures. It
 # includes the ROM and the data RAM, so its cell count is bigger and the two

--- a/soc/fit_report.py
+++ b/soc/fit_report.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-"""Read nextpnr's fit.log, print the utilisation table, and apply the
-FIT_MAX_LC ratchet.
+"""Read nextpnr's fit.log, print the utilisation table and the move against the
+count the Makefile records, and apply the FIT_MAX_LC ratchet.
 
 Replaces the Makefile's inline grep/sed/awk chain so `test/probe_gates.sh`
 can drive both checks against a fixture log without running nextpnr --
@@ -33,6 +33,12 @@ def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("log", help="nextpnr's fit.log")
     parser.add_argument("--max-lc", type=int, required=True, help="FIT_MAX_LC budget")
+    parser.add_argument(
+        "--previous",
+        type=int,
+        help="FIT_LAST_LC: the count the budget was derived from, printed as a "
+        "delta. Diagnostic only -- it never changes the exit status.",
+    )
     args = parser.parse_args()
 
     try:
@@ -77,6 +83,17 @@ def main():
         print("Placement did not report an IO error -- read fit.log before quoting this.")
 
     got = int(lc)
+
+    # Printed before the verdict so a trip carries it too, which is the run that
+    # most needs to say how far the count moved and not just that it moved.
+    if args.previous is not None:
+        print(
+            f"\nTREND: {got - args.previous:+d} cells against the {args.previous} the "
+            "Makefile records -- a move inside\nthe churn band is noise, and that "
+            "count is the `fit` job's, so a local delta\ncarries the gap between the "
+            "two instruments. A diagnostic: only the budget\nbelow can fail."
+        )
+
     if got > args.max_lc:
         sys.exit(
             f"\n*** make fit: {got} logic cells is over the {args.max_lc}-cell budget.\n"

--- a/test/probe_gates.sh
+++ b/test/probe_gates.sh
@@ -27,7 +27,7 @@ REPO=$(cd "$HERE/.." && pwd)
 # Pinned as a literal: a probe that is deleted, or that stops being reached by
 # an early `return`, would otherwise cut this file's coverage while it kept
 # printing a green summary.
-PROBES_EXPECTED=267
+PROBES_EXPECTED=270
 
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/littlecpu-probe.XXXXXX") || {
   echo "error: could not create a temporary directory under ${TMPDIR:-/tmp}." >&2
@@ -1609,6 +1609,21 @@ probe "over budget names the count and the budget" 1 \
 d=$(fr_fixture); sed -i.bak '/ICESTORM_LC:/d' "$d/fit.log"
 probe "no utilisation table is a failure, not a 0% fit" 1 \
   "printed no utilisation table" "$FR $d/fit.log --max-lc 4100"
+
+# The trend line is a diagnostic and these three probes are what keep it one: a
+# second number that could redden the job would be a ratchet nobody derived, and
+# it would go red for churn, which is the thing it exists to make legible.
+d=$(fr_fixture)
+probe "the trend against the recorded count is printed beside the verdict" 0 \
+  "TREND: +75 cells against the 3800" "$FR $d/fit.log --max-lc 4100 --previous 3800"
+
+d=$(fr_fixture)
+probe "a move far outside the churn band still cannot fail the job" 0 "TREND: +875" \
+  "$FR $d/fit.log --max-lc 4100 --previous 3000"
+
+d=$(fr_fixture)
+probe "a trip prints the trend too, since that is the run that needs it" 1 \
+  "TREND: +75" "$FR $d/fit.log --max-lc 3800 --previous 3800"
 
 begin_group "formal/check-interrupt-tie-off.py"
 


### PR DESCRIPTION
Closes JEF-828.

`FIT_MAX_LC` is derived instead of rounded, from a band and an instrument gap both measured on the trees it grades. Rebased onto **`421947f`**.

## The ticket's premise, demonstrated by this PR's own lifetime

`fit` is a **required check**. `FIT_MAX_LC` has been **4000 against a job reading 3966 — 34 cells — for every hour this PR has been open**, across nine merges to main. A functionally-null edit could have blocked any one of them: the measurements below show one bit of a read-only constant moving the count 53 cells on one toolchain and 63 across probes on another. Nothing tripped it, which is luck rather than margin.

## CI's number

**The `fit` job reads 3966** on `421947f` — [run 31984969180](https://github.com/thejefflarson/little-cpu/actions/runs/31984969180). It has read **3966 on five consecutive trees** — `fe618f4`, `4c1958c`, `9e26cfd`, `c13ed54`, `421947f` — none of which touched an input to `make fit`. Five CI runs, one number: the figure is stable, and this PR has simply been chasing a moving *base*, not a moving measurement.

## The new value

```
4088 = 3966 + 68 + 54
```

- **3966** — the `fit` job's count on `421947f`, run 31984969180.
- **+68** — the widest span measured for edits that change no logic: 68 on `64759da` (3988, 3979, 3920 against a base of 3935) and 63 on `2007d9d` (3958, 3971, 3987, 3925, 3980 against 3988).
- **+54** — the widest gap measured between two toolchains on one tree, `2007d9d`: the job read 3934 where both a local Homebrew yosys and a cached OSS CAD Suite read 3988.

**68 over the narrower 63:** every probe on that tree came out *below* its base, so a count can sit anywhere in the window with the whole span still ahead of it — budget the span, not its upward half. In the Makefile comment so it is not re-litigated from the smaller number.

**Cross-check, stated as the property to preserve:** the budget clears the higher of *each* tree's instrument pair by more than a band — 3969 here, 3988 on `2007d9d`.

## The instrument gap is not an offset

| tree | `fit` job | local | gap |
|---|---|---|---|
| `d3a9556` | 3543 | 3575 | 32, local higher |
| `64759da` | 3938 | 3935 | 3, job higher |
| `2007d9d` | **3934** | **3988** | **54, local higher** |
| `421947f` (this base) | 3966 | 3969 | 3, local higher |

The sharp form: the one-bit `misa` edit between `64759da` and `2007d9d` moved the local count **+53** and the job's **−4**. Three builds of yosys 0.68 — CI's `0.68+64`, a cached OSS CAD Suite `0.68+48`, Homebrew `0.68+post` — reading one design three ways. Adding a fixed offset to a local run was never a valid way to predict the graded number, which is why the derivation takes both terms from measurements rather than from the recorded 32.

## The trend line — optional improvement (2), taken

`FIT_LAST_LC := 3966`, the job's count on the merge tree, so the first report is not wrong by 32 cells. `make fit` now prints:

```
TREND: +3 cells against the 3966 the Makefile records -- a move inside
the churn band is noise, and that count is the `fit` job's, so a local delta
carries the gap between the two instruments. A diagnostic: only the budget
below can fail.

RATCHET: 3969 of 4088 cells budgeted -- OK
```

On an earlier base it printed `+54` locally and `+0` in CI — the same diagnostic reading the instrument gap from both sides. **Not a second ratchet**: three probes pin that it prints beside the verdict on a pass, that a **+875** delta still exits 0, and that a run tripping the budget prints the trend too.

`PROBES_EXPECTED` **267 → 270** (main's value plus these three). If anything touching `test/probe_gates.sh` lands before this merges, the resolution is that file's new value plus 3 — the only line in this diff that collides with anything.

## Also in this diff

- **`CLAUDE.md`'s `make fit` bullet** — the rule this derivation quotes: ±50 is nominal and the band measures 63–68; budget the whole span; the toolchain gap is as wide as the band with no fixed size or sign, with all four measurements and the +53/−4 pair as evidence. It now **points at `soc/baseline_sweep.sh` and `soc/baseline_summary.py`** rather than describing the problem abstractly — that PR built the mechanism this argues for on the other instrument, stamping each sweep's base and resolved tool versions and refusing to subtract two whose stamps disagree. Sits beside #187's and #189's additions to the same section without touching them.
- **One stale sentence in `.github/workflows/ci.yml`.** The `fit` job's step summary told every reader `it is NOT in main's required set`. It is — which is exactly why a churn trip blocks a merge.

## Decisions I made alone

1. **Used the measured 54 rather than the recorded 32** for the instrument term; ratified once, and a fourth measurement has since confirmed the gap is re-mapping rather than an offset.
2. **68 over 63**, on the every-probe-below-base argument.
3. **Did not fold in the Fmax-across-toolchains observation** from the atomic-region work: it is a second sign of the same instrument-dependence, but it belongs to the `soc-timing` bullet and its own ADR, and citing that from here would duplicate the record.
4. **No ADR**, ratified: a ratchet value is not a design commitment, and the band and instrument facts belong in CLAUDE.md's measurements section.

## Gates

| gate | result |
|---|---|
| `make test` | **70/70**, `EXPECTED_FAIL` exact both ways |
| `make test-units` | 9 benches, matching `test/*_tb.v` exactly, all PASS |
| `make probe-gates` | **270** graded comparisons, every failure path executed |
| `make fit` | **3969 of 4088** local; TREND +3 |
| `/soundcheck:pr-review` | no Critical or High findings |

Nothing in `rtl/` changed, so no baseline, depth, exclusion or `SOC_MIN_MHZ` moves.

**Two instrument notes**, follow-ups rather than this diff:

- A Homebrew boost upgrade broke `/usr/local/bin/nextpnr-ice40` mid-ticket (`Symbol not found: __ZN5boost15program_options3argE`); local figures here come from the cached OSS CAD Suite. `make fit` reported the break as `no utilisation table, so NO measurement was taken` rather than as a 0% fit — that graded comparison doing its job.
- `mutation-check` is timing-marginal on `little-cpu-runners`: it failed on this branch once with the step never completing after 14m01s and passed on re-run in 7m20s, against main's 8m27s; #180 lost it twice at 20m01s the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
