### PR TITLE
Name the baseline sweep's cell-count unit: packed ICESTORM_LC, not SB_LUT4

### DIFF
--- a/soc/baseline_summary.py
+++ b/soc/baseline_summary.py
@@ -128,8 +128,12 @@ def report(path, provenance, rows):
     for label in ("worst", "median", "best"):
         field(label, f"{s[label]:6.2f} ns  {1000 / s[label]:6.2f} MHz")
     field("spread", f"{s['spread']:.1f}% of the best placement")
+    # `packed LC` names the unit on purpose: the row's cell count is nextpnr's
+    # ICESTORM_LC out of the placement, which is what the +/-50 band is in, and
+    # not the `SB_LUT4` count synthesis prints.
     field("LUT levels", f"{span(rows, 'lut_levels')}   "
-                        f"carry hops: {span(rows, 'carry_hops')}   LC: {span(rows, 'lc')}")
+                        f"carry hops: {span(rows, 'carry_hops')}   "
+                        f"packed LC: {span(rows, 'lc')}")
     field("worst path", f"{rows[-1]['start']} -> {rows[-1]['end']}")
     print()
 

--- a/soc/baseline_sweep.sh
+++ b/soc/baseline_sweep.sh
@@ -170,6 +170,10 @@ for seed in $seeds; do
   cp soc.timing.rpt "$out/$name.$seed.rpt"
   cp soc.asc "$out/$name.$seed.asc"
   cp soc.pnr.log "$out/$name.$seed.pnr.log"
+  # The PACKED cell count out of the placement, not `SB_LUT4` out of synthesis.
+  # The two disagree in magnitude and in sign -- a LUT the flops beside it were
+  # sharing a cell with is not a LUT anyone can spend -- so a row that carried
+  # the other unit would be graded against the wrong band.
   lc=$(sed -n 's/.*ICESTORM_LC: *\([0-9]*\)\/.*/\1/p' "$out/$name.$seed.pnr.log" | tail -1)
   if [ -z "$lc" ]; then
     echo "*** soc/baseline_sweep.sh: seed '$seed' placed with no ICESTORM_LC in" >&2


### PR DESCRIPTION
Follow-up to #186 (JEF-832), responding to the rule #187 added to CLAUDE.md: *"Grade a ceiling on packed `ICESTORM_LC`, not on `SB_LUT4`."*

The baseline sweep's `lc` column was already the right unit — it is `sed`'d out of nextpnr's `ICESTORM_LC` utilisation line in the retained placement log, the same source `soc/depth/sweep.sh` uses — so nothing about the measurement changes here. What changes is that the unit is now **stated** at both ends: a comment where the count is read, and `packed LC:` rather than `LC:` on the summary's line. Two counts that disagree in magnitude *and* in sign are exactly the pair a reader should not have to infer from a three-letter column name.

This commit was written before #186 merged and did not make it into that squash; it is on its own branch rather than amended in.

## Testing

- `make probe-gates` 267/267 on this branch — no probe reads the relabelled line, and this touches no probe count, so it cannot interfere with the `PROBES_EXPECTED` resolution #188 is carrying.
- `soc/baseline_summary.py` re-run over a real 2-seed sweep taken earlier on this ticket: `LUT levels : 21   carry hops: 0-1   packed LC: 4754`.
- Touches `soc/baseline_sweep.sh` and `soc/baseline_summary.py` only — no `rtl/`, no Makefile, no gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
