### PR TITLE
Model a load or store access fault in the trap proof (JEF-841)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,10 @@ formal/pcloop_cover
 # from checks.cfg on every run.
 formal/fg-probe.cfg
 formal/fg-probe/
+# `make -C formal traps-region-probe`: the two mutated cores it proves the
+# region cause arm against, and their sby workdirs. Rebuilt from rtl/ and
+# formal/traps.sv on every run.
+formal/region-probe/
 __pycache__/
 test/rtl.cc
 test/monitor.sim.v

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -290,6 +290,16 @@ What a green result does and does not mean:
   check also drops every value comparison once an instruction traps, keeping only the trap flag,
   and its two pc checks accept whatever target the core reports — so `components_traps` is the only
   thing that says a trap lands on `mtvec` and saves the right state.
+  **Its model states a load or store access fault ahead of the mechanism**, and states only half of
+  one: an access the map does not answer is excused from `must_not_trap`, and a core that faults it
+  must report cause 5 or 7 — the trap itself is not required, because reading zero is what this
+  platform does and the spec only recommends otherwise. That is why the map has to reach
+  `formal/traps.sv`, which no port of the core carries it to, so it restates it and
+  `test/memmap_test.sh` compares the copy. An arm no core reaches is worth nothing until it has been
+  shown to fail: `make -C formal traps-region-probe` builds two cores one line of `rtl/decoder.v`
+  apart, requires the one that faults with the right cause to prove and the one that faults with the
+  wrong cause to go red **at that comparison's own line**, and is a prerequisite of the proof for the
+  reason `pcloop_cover` is one.
 - **It ships no model of an INTERRUPT either**, so the core's timer input is tied off in all five
   harnesses under `formal/` and the generated checks run with no interrupt in the trace.
   `formal/INTERRUPT_TIE_OFF` mechanises that the same way, in both directions and re-derived from
@@ -627,7 +637,9 @@ make -C formal components_decoder   # component proofs by k-induction (mode prov
 make -C formal components_executor  #   read the sby summaries, not the job colour
 make -C formal components_pcloop    #   pcloop runs pcloop_cover first, its anti-vacuity
                                     #   control, as a prerequisite of the same target
-make -C formal components_traps     #   traps is the only proof over real mtvec/mepc/mcause/mstatus
+make -C formal components_traps     #   traps is the only proof over real mtvec/mepc/mcause/mstatus,
+                                    #   and runs traps-region-probe first the same way -- the red
+                                    #   direction for the load/store region cause arm, two sby runs
 make -C formal complete             # depth-50 whole-ISA walk minus COMPLETE_EXCLUSIONS
 make -C formal complete_cover       # its anti-vacuity control
 make -C formal nonperturbation      # RVFI instrumentation is unread by the core;

--- a/formal/Makefile
+++ b/formal/Makefile
@@ -180,16 +180,25 @@ components_pcloop: components.sby pcloop_cover ../rtl/fetcher.v ../rtl/decoder.v
 # traps, keeping only the trap flag, and their pc checks accept whatever target
 # the core reports -- so nothing else says a trap lands on mtvec, or that the
 # state it saved is right.
-components_traps: components.sby ../rtl/fetcher.v ../rtl/decoder.v ../rtl/regsel.v ../rtl/csrs.v \
-                  ../rtl/structs.v traps.sv
+#
+# traps-region-probe is a prerequisite for the reason pcloop_cover is one of the
+# proof it controls: this core raises no load or store access fault, so the arm
+# that models one is satisfied by never being reached, and a control that can be
+# run separately from the thing it controls eventually is not run at all.
+components_traps: components.sby traps-region-probe ../rtl/fetcher.v ../rtl/decoder.v \
+                  ../rtl/regsel.v ../rtl/csrs.v ../rtl/structs.v traps.sv
 	rm -rf $@
 	sby -f $< traps
+
+.PHONY: traps-region-probe
+traps-region-probe: traps-region-probe.py traps.sv ../rtl/decoder.v
+	python3 $<
 
 # Written out rather than brace-expanded: `rm -rf {a,b,c}` is a bashism that
 # /bin/sh, make's default shell, passes through literally and deletes nothing.
 clean:
 	rm -rf checks complete complete_cover cover dmemcheck imemcheck components components_*
-	rm -rf pcloop_cover fg-probe fg-probe.cfg
+	rm -rf pcloop_cover fg-probe fg-probe.cfg region-probe
 	rm -rf $(RISCV_FORMAL_DIR) $(RISCV_FORMAL_DIR).tmp
 
 .PHONY: all clean

--- a/formal/traps-region-probe.py
+++ b/formal/traps-region-probe.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""Forces formal/traps.sv's load/store region cause arm to fail, and requires it
+to fail as that arm rather than as anything else.
+
+Usage: traps-region-probe.py [--repo DIR] [--workdir DIR] [--sby SBY]
+
+WHY THIS EXISTS. formal/traps.sv models a load or store access fault the way it
+models a refused atomic: it does not require the trap -- an address no memory
+answers is read as zero here, and the privileged spec only recommends faulting
+-- but it does require the CAUSE, 5 for a load and 7 for a store, and it excuses
+only an access the map does not answer from `must_not_trap`. Today's core raises
+neither cause for a plain access, so that arm is satisfied by a core that never
+reaches it. An arm in that position is worth nothing until it has been shown to
+fail, which is what `make probe-gates` demands of every other graded comparison
+in this tree and what this file does for one that needs a solver.
+
+Two cores are built, each one line of rtl/decoder.v away from the shipping one,
+and each faults an aligned `lw` whose address has bit 31 set -- an address
+outside all three windows of any map this platform can be given:
+
+  right-cause  raises cause 5, and the proof must still PASS. This is the half
+               that says the model does not simply forbid the mechanism: every
+               prototype of precise load/store faults so far turned this proof
+               red for the missing model rather than for a defect.
+  wrong-cause  raises cause 7 for that same load, and the proof must go FAIL at
+               the mcause comparison. A core that faults the right access with
+               the wrong cause is the defect this arm exists to catch.
+
+The failing assertion is pinned by line, read out of traps.sv here rather than
+written down: a probe that only checked the status would be satisfied by a proof
+that went red for an unrelated reason, which is the failure mode this whole
+mechanism is about.
+
+NOT HERMETIC -- it runs sby twice, about six seconds. So it is a prerequisite of
+`make -C formal components_traps` rather than of `make test`, for the reason
+pcloop_cover is one: a control that can be run separately from the thing it
+controls eventually is not run at all. test/probe_gates.sh covers this file's own
+comparisons, against a stub sby.
+"""
+
+import argparse
+import pathlib
+import re
+import shutil
+import subprocess
+import sys
+
+# The design under proof, exactly formal/components.sby's `traps` task. Read
+# WITHOUT -formal, because -formal would compile rtl/decoder.v's own
+# assume(in.pc == pc) into the instance and the fetcher below is what answers
+# that here.
+SBY = """[options]
+mode prove
+
+[engines]
+smtbmc
+
+[script]
+read -sv structs.v fetcher.v decoder.v regsel.v csrs.v
+read -sv -formal structs.v traps.sv
+prep -top traps
+
+[files]
+src/structs.v
+src/fetcher.v
+src/decoder.v
+src/regsel.v
+src/csrs.v
+src/traps.sv
+"""
+
+SOURCES = ("structs.v", "fetcher.v", "decoder.v", "regsel.v", "csrs.v")
+
+# The comparison being probed, found in traps.sv by its text. It is the only
+# statement in that file comparing a CSR read-back against the modelled cause.
+MCAUSE_ASSERT = "assert(csr_rdata == prev_cause);"
+
+# The two lines of rtl/decoder.v the mutation replaces, matched in full so a
+# respelling stops this file rather than silently probing nothing.
+FAULT_SITE = """  assign load_access_fault  = atomic_fault && instr_lr;
+  assign store_access_fault = atomic_fault && instr_atomic_write;
+"""
+
+TRAP_SITE = "                        load_misaligned || store_misaligned || atomic_fault;"
+
+# An aligned `lw` at an address with bit 31 set. No window of this machine's map
+# reaches there, whatever the four parameters are set to, so the model's region
+# terms hold for it and its misalignment terms do not.
+FAULT_TERM = "instr_lw && !word_misaligned && mem_addr_calc[31]"
+
+# Which of the two assignments above the term is added to, and so which cause
+# the mutated core reports for one and the same access. Each is a line of
+# FAULT_SITE, so the two cases differ by exactly that and nothing else.
+CASES = {
+    "right-cause": "assign load_access_fault  = atomic_fault && instr_lr",
+    "wrong-cause": "assign store_access_fault = atomic_fault && instr_atomic_write",
+}
+
+
+def stop(message):
+    """Exit 2: the probe's own inputs are broken, which is not a red proof.
+
+    A status of its own, because the two are acted on differently: 1 says the
+    arm does not behave, and 2 says this file could not ask.
+    """
+    print(f"error: {message}", file=sys.stderr)
+    sys.exit(2)
+
+
+def mcause_assert_line(traps_sv):
+    """The line traps.sv states the cause comparison on, 1-based."""
+    hits = [n for n, line in enumerate(traps_sv.splitlines(), 1) if MCAUSE_ASSERT in line]
+    if len(hits) != 1:
+        stop(
+            f"formal/traps.sv states `{MCAUSE_ASSERT}` {len(hits)} times, and this\n"
+            "probe pins the failing assertion by its line. Teach it the new spelling\n"
+            "rather than dropping the comparison: a probe that only reads the status\n"
+            "passes for a proof that went red somewhere else entirely."
+        )
+    return hits[0]
+
+
+def mutate(decoder_v, case):
+    """rtl/decoder.v with one region fault added, at the case's cause."""
+    if FAULT_SITE not in decoder_v:
+        stop(
+            "rtl/decoder.v no longer spells its two access-fault assignments the way\n"
+            "this probe patches them. Re-anchor the mutation on the new spelling --\n"
+            "left alone it would build the shipping core twice and report that an\n"
+            "arm which was never exercised is fine."
+        )
+    if TRAP_SITE not in decoder_v:
+        stop(
+            "rtl/decoder.v no longer spells the last line of `trap_pending` the way\n"
+            "this probe patches it. Without that line the mutated core computes a\n"
+            "fault it never commits, so the proof stays green having asked nothing."
+        )
+    site = FAULT_SITE.replace(CASES[case] + ";", CASES[case] + " || probe_region_fault;")
+    if site == FAULT_SITE:
+        stop(
+            f"this probe's own {case} line is not one of the two it patches, so the\n"
+            "mutation is a no-op and both cores below would be the shipping one."
+        )
+    body = (
+        "  logic probe_region_fault;\n"
+        f"  assign probe_region_fault = {FAULT_TERM};\n" + site
+    )
+    out = decoder_v.replace(FAULT_SITE, body)
+    return out.replace(
+        TRAP_SITE,
+        "                        load_misaligned || store_misaligned || atomic_fault ||\n"
+        "                        probe_region_fault;",
+    )
+
+
+def run_case(repo, workdir, sby, case):
+    """Builds the mutated tree, runs sby, and returns (status, failing lines)."""
+    root = workdir / case
+    shutil.rmtree(root, ignore_errors=True)
+    (root / "src").mkdir(parents=True)
+    for name in SOURCES:
+        shutil.copy(repo / "rtl" / name, root / "src" / name)
+    shutil.copy(repo / "formal" / "traps.sv", root / "src" / "traps.sv")
+    decoder = (repo / "rtl" / "decoder.v").read_text()
+    (root / "src" / "decoder.v").write_text(mutate(decoder, case))
+    (root / "probe.sby").write_text(SBY)
+
+    # sby's own exit status is not read: FAIL is the required outcome of one of
+    # the two cases, and a non-zero status there says nothing this file does not
+    # read out of the workdir instead.
+    proc = subprocess.run(
+        [sby, "-f", "probe.sby"], cwd=root, capture_output=True, text=True
+    )
+    status_file = root / "probe" / "status"
+    if not status_file.is_file():
+        stop(
+            f"sby wrote no status for the {case} core, so nothing was proved or\n"
+            "disproved. Its output follows.\n\n" + proc.stdout + proc.stderr
+        )
+    status = status_file.read_text().split()
+    if not status:
+        stop(f"sby's status file for the {case} core is empty.")
+    log = (root / "probe" / "logfile.txt").read_text()
+    failed = sorted(set(int(n) for n in re.findall(r"Assert failed in traps: traps\.sv:(\d+)", log)))
+    return status[0], failed
+
+
+def main():
+    here = pathlib.Path(__file__).resolve().parent
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default=str(here.parent), help="tree to read the RTL from")
+    parser.add_argument("--workdir", default=str(here / "region-probe"))
+    parser.add_argument("--sby", default="sby")
+    args = parser.parse_args()
+
+    repo = pathlib.Path(args.repo).resolve()
+    for name in ("formal/traps.sv", "rtl/decoder.v"):
+        if not (repo / name).is_file():
+            stop(f"{name} is missing from {repo}, so there is nothing to probe.")
+    workdir = pathlib.Path(args.workdir).resolve()
+    workdir.mkdir(parents=True, exist_ok=True)
+
+    line = mcause_assert_line((repo / "formal" / "traps.sv").read_text())
+    print(f"formal/traps.sv states the cause comparison on line {line}.")
+
+    red = []
+
+    status, failed = run_case(repo, workdir, args.sby, "right-cause")
+    print(f"  right-cause: {status}, assertions failed at {failed or 'none'}")
+    if status != "PASS":
+        red.append(
+            "the right-cause core does not prove. The model must ADMIT a core that\n"
+            "faults an access no memory answers, or it is the reason a prototype of\n"
+            "one goes red rather than a check on it."
+        )
+
+    status, failed = run_case(repo, workdir, args.sby, "wrong-cause")
+    print(f"  wrong-cause: {status}, assertions failed at {failed or 'none'}")
+    if status != "FAIL":
+        red.append(
+            "the wrong-cause core proves. A load faulting with cause 7 is what the\n"
+            "region arm was written to catch, so an arm that admits it is asking\n"
+            "nothing at all."
+        )
+    elif failed != [line]:
+        red.append(
+            f"the wrong-cause core went red at {failed}, not at line {line} alone.\n"
+            "That is the mcause comparison's line; a proof failing anywhere else is\n"
+            "one this probe cannot read as evidence about the region arm."
+        )
+
+    if red:
+        print()
+        for why in red:
+            print("*** " + why.replace("\n", "\n*** "), file=sys.stderr)
+        sys.exit(1)
+
+    print("The load/store region cause arm admits the mechanism and fails on the cause.")
+
+
+if __name__ == "__main__":
+    main()

--- a/formal/traps.sv
+++ b/formal/traps.sv
@@ -18,7 +18,22 @@
 // anywhere it likes on any cycle -- including the cycle after a trap.
 `default_nettype none
 
-module traps (
+module traps #(
+    // The data bus's map: the addresses at which some memory on it answers a
+    // plain load or store. rtl/memory.v's and rtl/timer.v's own parameter
+    // defaults and the text window rtl/littlesoc.v gives its `imemory`,
+    // restated here because a module cannot read another module's parameters;
+    // test/memmap_test.sh is what compares the copies.
+    //
+    // It is a map here and a port for an atomic because that is how the core
+    // is built: the platform answers about an atomic's address on
+    // `atomic_supported`, and about a plain load's or store's it is never
+    // asked. So the model is the only place that question has an answer.
+    parameter integer      LS_TEXT_WORDS = 2048,
+    parameter logic [31:0] LS_RAM_BASE   = 32'h0001_0000,
+    parameter integer      LS_RAM_WORDS  = 16384,
+    parameter logic [31:0] LS_TIMER_BASE = 32'h0002_0000
+) (
     input logic clk,
     input logic reset,
     input logic [31:0] imem_data,
@@ -33,9 +48,10 @@ module traps (
     // `branch_jump` names the trap it raises.
     input logic imem_fault,
     // The platform's answer about the address an atomic in decode would use.
-    // Free, like the fetch bus's refusal: this file models no address map, and
-    // the two causes it decides are asserted below against the encodings the ISA
-    // fixes rather than against a map.
+    // Free, like the fetch bus's refusal, so the two causes it decides are
+    // asserted below against the encodings the ISA fixes rather than against
+    // the map above. That map is about a plain load or store instead, an
+    // access the core asks the platform nothing about.
     input logic atomic_supported,
     input logic accessor_out_valid,
     // The platform's timer line, free every cycle. rtl/csrs.v decides what to
@@ -228,6 +244,42 @@ module traps (
   assign sw_misaligned = is_store_op && funct3 == 3'b010 && store_addr[1:0] != 2'b00;
   assign sh_misaligned = is_store_op && funct3 == 3'b001 && store_addr[0];
 
+  // Which of those addresses a memory answers. Three ranges compared against
+  // the whole sum, not the window equalities rtl/{imemory,memory,timer}.v
+  // reduce them to: nothing in a model is timed, so it may add the immediate to
+  // rs1 and wait for the carry out of the top, which is exactly what the core
+  // cannot afford in the cycle it chooses the next pc.
+  localparam logic [31:0] LS_TEXT_TOP  = LS_TEXT_WORDS * 4;
+  localparam logic [31:0] LS_RAM_TOP   = LS_RAM_BASE + LS_RAM_WORDS * 4;
+  // rtl/timer.v's four words.
+  localparam logic [31:0] LS_TIMER_TOP = LS_TIMER_BASE + 32'd16;
+
+  // Selected here rather than added here: each sum above is a self-determined
+  // signed statement and stays one. Every reader below is an opcode test, so
+  // the arm this picks for anything else is not read.
+  logic [31:0] data_addr;
+  logic        data_mapped;
+  assign data_addr = is_store_op ? store_addr : load_addr;
+  assign data_mapped = data_addr < LS_TEXT_TOP ||
+                       (data_addr >= LS_RAM_BASE && data_addr < LS_RAM_TOP) ||
+                       (data_addr >= LS_TIMER_BASE && data_addr < LS_TIMER_TOP);
+
+  // The eight plain load and store encodings. The other three funct3 values of
+  // each opcode are not instructions in RV32 and are left out for the reason the
+  // list here is small: this core may call them illegal, and a model must not
+  // hold an opinion about the cause of an encoding it does not recognise.
+  logic is_load, is_store;
+  assign is_load  = is_load_op && (funct3 == 3'b000 || funct3 == 3'b001 ||
+                                   funct3 == 3'b010 || funct3 == 3'b100 || funct3 == 3'b101);
+  assign is_store = is_store_op && (funct3 == 3'b000 || funct3 == 3'b001 || funct3 == 3'b010);
+
+  // A plain load or store at an address no memory answers. Misalignment
+  // outranks the region, the order the atomic term states, so the four data
+  // causes stay disjoint.
+  logic load_region_fault, store_region_fault;
+  assign load_region_fault  = is_load  && !data_mapped && !lw_misaligned && !lh_misaligned;
+  assign store_region_fault = is_store && !data_mapped && !sw_misaligned && !sh_misaligned;
+
   // The A encodings, read off the ISA's table rather than off the decoder's
   // flags. An atomic's effective address is rs1: funct5, aq, rl and rs2 occupy
   // the bits an I-immediate would come from, so there is no immediate to add.
@@ -265,10 +317,11 @@ module traps (
 
   // The order is illegal, breakpoint, environment call, load misaligned, store
   // misaligned, load access fault, store access fault. No two of the terms above
-  // can hold at once -- a reserved opcode is not a load, and an atomic the
-  // platform refuses is aligned by construction -- so the chain states the order
-  // rather than resolving anything. Make two causes overlap and this is what
-  // decides which one the core is allowed to report.
+  // can hold at once -- a reserved opcode is not a load, an atomic the platform
+  // refuses is aligned by construction, and a plain load or store is neither --
+  // so the chain states the order rather than resolving anything. Make two
+  // causes overlap and this is what decides which one the core is allowed to
+  // report.
   logic expected_trap;
   logic [31:0] expected_cause;
   assign expected_trap = is_illegal || is_ebreak || is_ecall ||
@@ -280,19 +333,36 @@ module traps (
     else if (is_ecall) expected_cause = CAUSE_ECALL_M;
     else if (lw_misaligned || lh_misaligned) expected_cause = CAUSE_LOAD_MIS;
     else if (sw_misaligned || sh_misaligned) expected_cause = CAUSE_STORE_MIS;
+    else if (load_region_fault) expected_cause = CAUSE_LOAD_FAULT;
+    else if (store_region_fault) expected_cause = CAUSE_STORE_FAULT;
     else if (is_lr) expected_cause = CAUSE_LOAD_FAULT;
     else expected_cause = CAUSE_STORE_FAULT;
   end
 
+  // Whether a trap is required and what its cause must be are two questions,
+  // and the two region terms answer only the second. An address no memory
+  // answers is read as zero and a store to one is dropped: this core does not
+  // fault there, the privileged spec only recommends that it should, and
+  // requiring the trap here would state a decision this platform has not taken.
+  // Requiring the CAUSE costs nothing while that holds and is what a core that
+  // does fault has to agree with -- which is the half every prototype of it has
+  // had to write for itself.
+  logic cause_modelled;
+  assign cause_modelled = expected_trap || load_region_fault || store_region_fault;
+
   // The other direction. Without these a core that trapped on everything would
-  // satisfy most of this file. The last one is the half that keeps the region
-  // decode honest: an atomic at an address the platform DOES answer executes,
-  // so a core that faulted all eleven would not pass here.
+  // satisfy most of this file. The last three are the half that keeps a region
+  // decode honest: an access at an address the platform DOES answer executes,
+  // so a core that faulted every atomic, or every load past some line it drew
+  // for itself, would not pass here. `data_mapped` is what a load and a store
+  // are excused by, and it is the reason those two lines can be narrowed
+  // without narrowing what they say -- an aligned `lw` the map answers still
+  // must not trap.
   logic must_not_trap;
   assign must_not_trap =
       (uncompressed && opcode == 5'b01100 && instr[31:25] == 7'b0 && funct3 == 3'b000) ||
-      (is_load_op && funct3 == 3'b010 && load_addr[1:0] == 2'b00) ||
-      (is_store_op && funct3 == 3'b010 && store_addr[1:0] == 2'b00) ||
+      (is_load_op && funct3 == 3'b010 && load_addr[1:0] == 2'b00 && data_mapped) ||
+      (is_store_op && funct3 == 3'b010 && store_addr[1:0] == 2'b00 && data_mapped) ||
       (is_atomic && atomic_supported && atomic_word_aligned);
 
   // mstatus changes on three edges and no others: a write to it, a trap and an
@@ -323,7 +393,7 @@ module traps (
   logic [31:0] past_pc, prev_mtvec, prev_mepc, prev_rdata, prev_cause;
   logic [11:0] prev_csr_addr;
   logic prev_reset, prev_trap_entry, prev_mret_entry, prev_csr_wen;
-  logic prev_expected_trap, prev_counter_ticking, prev_written_by_trap;
+  logic prev_cause_modelled, prev_counter_ticking, prev_written_by_trap;
   logic prev_mstatus_addressed, prev_mstatus_static;
   logic prev_interrupt_pending, prev_interrupt_entry, prev_imem_fault;
   logic [31:0] prev2_rdata;
@@ -339,7 +409,7 @@ module traps (
     prev_trap_entry        <= trap_entry;
     prev_mret_entry        <= mret_entry;
     prev_cause             <= expected_cause;
-    prev_expected_trap     <= expected_trap;
+    prev_cause_modelled    <= cause_modelled;
     prev_counter_ticking   <= counter_ticking;
     prev_written_by_trap   <= csr_written_by_trap;
     prev_mstatus_addressed <= mstatus_addressed;
@@ -406,7 +476,7 @@ module traps (
   // earlier: a word the memory never supplied has no cause of its own, and the
   // instruction access fault is what mcause holds instead.
   always_comb if (settled && prev_trap_entry && !prev_interrupt_pending &&
-                  !prev_imem_fault && prev_expected_trap && csr_addr == MCAUSE)
+                  !prev_imem_fault && prev_cause_modelled && csr_addr == MCAUSE)
     assert(csr_rdata == prev_cause);
 
   // ...and that is the cause it holds. The two together are the whole of what a

--- a/test/memmap_test.sh
+++ b/test/memmap_test.sh
@@ -19,7 +19,8 @@
 # back, and it would otherwise be invisible.
 #
 # The rest cannot share a parameter, because they are C++, linker scripts,
-# assembly and make. For those a comparison is the only instrument left.
+# assembly, make -- and one SystemVerilog module that instantiates no memory at
+# all. For those a comparison is the only instrument left.
 #
 # Hermetic: grep, sed and shell arithmetic. No toolchain, no simulator, no
 # yosys, so this runs inside `make test` anywhere.
@@ -53,7 +54,7 @@ need() {
 
 for f in rtl/memory.v rtl/timer.v rtl/imemory.v rtl/littlesoc.v test/testbench.v \
          test/cxxrtl.cc test/cosim.cc test/asm/riscv_test.h test/asm/sections.lds \
-         test/asm/boot.lds test/bench/bench.lds Makefile; do
+         test/asm/boot.lds test/bench/bench.lds formal/traps.sv Makefile; do
   need "$f"
 done
 
@@ -278,6 +279,34 @@ rtl/littlesoc.v's $SOC_ROM_WORDS_RTL. The harness is allowed to be larger --
 simulation has no block RAM to run out of, and rvc.S needs it -- but never
 smaller, or a program the part can hold would fail in simulation."
 fi
+
+# ---- 8. the trap proof's copy ----------------------------------------------
+#
+# formal/traps.sv models a load or store access fault, so it needs to know which
+# addresses a memory here answers -- and no port of the core carries that, so it
+# restates the map. Nothing else reads its copy, which is why a drifted one is
+# silent: the proof would go on passing, having excused the wrong accesses from
+# `must_not_trap` and demanded causes 5 and 7 for a machine no file describes.
+
+TRAPS_RAM_BASE=$(hex_param formal/traps.sv LS_RAM_BASE)
+TRAPS_RAM_WORDS=$(int_param formal/traps.sv LS_RAM_WORDS)
+TRAPS_TIMER_BASE=$(hex_param formal/traps.sv LS_TIMER_BASE)
+TRAPS_TEXT_WORDS=$(int_param formal/traps.sv LS_TEXT_WORDS)
+
+traps_copy() {  # $1 = what, $2 = the proof's copy, $3 = the memory's, $4 = whose
+  if [ "$2" -ne "$3" ]; then
+    fail "formal/traps.sv's $1 is $2 against $4's $3. That copy decides which
+addresses the trap proof excuses from \`must_not_trap\`, so a drifted one proves
+something about a machine neither file describes."
+  fi
+}
+
+traps_copy LS_RAM_BASE   "$TRAPS_RAM_BASE"   "$RAM_BASE"   rtl/memory.v
+traps_copy LS_RAM_WORDS  "$TRAPS_RAM_WORDS"  "$RAM_WORDS"  rtl/memory.v
+traps_copy LS_TIMER_BASE "$TRAPS_TIMER_BASE" "$TIMER_BASE" rtl/timer.v
+# The part's text window, not the harness's larger simulated one: the proof has
+# no imemory in it to size, so what it describes is the machine that ships.
+traps_copy LS_TEXT_WORDS "$TRAPS_TEXT_WORDS" "$SOC_ROM_WORDS_RTL" rtl/littlesoc.v
 
 if [ "$rc" -ne 0 ]; then
   echo >&2

--- a/test/probe_gates.sh
+++ b/test/probe_gates.sh
@@ -27,7 +27,7 @@ REPO=$(cd "$HERE/.." && pwd)
 # Pinned as a literal: a probe that is deleted, or that stops being reached by
 # an early `return`, would otherwise cut this file's coverage while it kept
 # printing a green summary.
-PROBES_EXPECTED=286
+PROBES_EXPECTED=300
 
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/littlecpu-probe.XXXXXX") || {
   echo "error: could not create a temporary directory under ${TMPDIR:-/tmp}." >&2
@@ -1400,13 +1400,14 @@ MM="$HERE/memmap_test.sh"
 
 mm_fixture() {
   local d; d=$(new_case)
-  mkdir -p "$d/rtl" "$d/test/asm" "$d/test/bench"
+  mkdir -p "$d/rtl" "$d/test/asm" "$d/test/bench" "$d/formal"
   cp "$REPO"/rtl/memory.v "$REPO"/rtl/timer.v "$REPO"/rtl/imemory.v \
      "$REPO"/rtl/littlesoc.v "$d/rtl/"
   cp "$REPO"/test/testbench.v "$REPO"/test/cxxrtl.cc "$REPO"/test/cosim.cc "$d/test/"
   cp "$REPO"/test/asm/riscv_test.h "$REPO"/test/asm/sections.lds \
      "$REPO"/test/asm/boot.lds "$d/test/asm/"
   cp "$REPO"/test/bench/bench.lds "$d/test/bench/"
+  cp "$REPO"/formal/traps.sv "$d/formal/"
   cp "$REPO"/Makefile "$d/"
   printf '%s' "$d"
 }
@@ -1490,6 +1491,25 @@ probe "a file that moved away takes the check with it, loudly" 1 \
 d=$(mm_fixture); sed -i.bak 's/LENGTH = 64K/LENGTH = LOTS/' "$d/test/asm/sections.lds"
 probe "a size the parser cannot read stops rather than comparing as zero" 1 \
   "is not a size this check can read" "$MM $d"
+
+# The trap proof's copy of the map. Nothing but that proof reads it, so each of
+# these drifts is silent everywhere else: components_traps goes on passing,
+# having excused the wrong accesses from `must_not_trap`.
+d=$(mm_fixture); sed -i.bak "s/LS_RAM_BASE   = 32'h0001_0000/LS_RAM_BASE   = 32'h0002_0000/" "$d/formal/traps.sv"
+probe "the proof's copy of the RAM base drifting from the RAM is red" 1 \
+  "formal/traps.sv's LS_RAM_BASE is 131072 against rtl/memory.v's 65536" "$MM $d"
+
+d=$(mm_fixture); sed -i.bak 's/LS_RAM_WORDS  = 16384/LS_RAM_WORDS  = 8192/' "$d/formal/traps.sv"
+probe "a RAM half the size in the proof's copy is red" 1 \
+  "LS_RAM_WORDS is 8192 against rtl/memory.v's 16384" "$MM $d"
+
+d=$(mm_fixture); sed -i.bak "s/LS_TIMER_BASE = 32'h0002_0000/LS_TIMER_BASE = 32'h0003_0000/" "$d/formal/traps.sv"
+probe "the timer moving in the proof's copy alone is red" 1 \
+  "LS_TIMER_BASE is 196608 against rtl/timer.v's 131072" "$MM $d"
+
+d=$(mm_fixture); sed -i.bak 's/LS_TEXT_WORDS = 2048/LS_TEXT_WORDS = 4096/' "$d/formal/traps.sv"
+probe "the proof describes the part's text window, not the harness's" 1 \
+  "LS_TEXT_WORDS is 4096 against rtl/littlesoc.v's 2048" "$MM $d"
 
 begin_group "test/retired_term_test.sh"
 
@@ -2195,6 +2215,98 @@ probe "a tree that instantiates the core nowhere is not a clean one" 1 \
 d=$(new_case); mkdir -p "$d/rtl"; cp "$REPO/rtl/littlecpu.v" "$d/rtl/"
 probe "a tree git cannot list is a scan of nothing, not a green one" 1 \
   "cannot enumerate any tracked Verilog" "$PC $d"
+
+begin_group "formal/traps-region-probe.py"
+
+# That file is itself the demonstrated red direction for formal/traps.sv's
+# load/store region cause arm, and it needs a solver to be one -- so it runs
+# under `make -C formal components_traps` rather than here. What is probed here
+# is its own grading: it builds two mutated cores and requires one to prove and
+# the other to go red at one named line, and each of those comparisons has a
+# failure path of its own.
+#
+# The stub reads the tree it is handed and answers the way sby does, so the
+# control below is the real script over the real RTL with only the solver
+# replaced. A stub that answered from its arguments alone would make every probe
+# here a test of the stub.
+TR="python3 $REPO/formal/traps-region-probe.py"
+
+cat > "$tmp/sby-stub" <<'STUB'
+#!/bin/sh
+# Stands in for sby. The case being run is the name of the directory it is run
+# in, and the assertion line is read out of the copy of traps.sv it was handed,
+# so PASS and FAIL land where the real solver puts them.
+mkdir -p probe
+line=$(grep -n 'assert(csr_rdata == prev_cause);' src/traps.sv | cut -d: -f1)
+case $(basename "$PWD") in
+  right-cause) status=${STUB_SBY_RIGHT:-PASS} ;;
+  wrong-cause) status=${STUB_SBY_WRONG:-FAIL}; line=${STUB_SBY_WRONG_LINE:-$line} ;;
+esac
+: > probe/logfile.txt
+if [ "$status" = FAIL ]; then
+  echo "SBY [probe] engine_0.basecase: Assert failed in traps: traps.sv:$line.5-$line.36" \
+    > probe/logfile.txt
+fi
+[ -n "${STUB_SBY_NO_STATUS:-}" ] && exit 1
+if [ -n "${STUB_SBY_EMPTY_STATUS:-}" ]; then : > probe/status; exit 1; fi
+echo "$status 2 0" > probe/status
+STUB
+chmod +x "$tmp/sby-stub"
+
+tr_fixture() {
+  local d; d=$(new_case)
+  mkdir -p "$d/rtl" "$d/formal"
+  cp "$REPO"/rtl/structs.v "$REPO"/rtl/fetcher.v "$REPO"/rtl/decoder.v \
+     "$REPO"/rtl/regsel.v "$REPO"/rtl/csrs.v "$d/rtl/"
+  cp "$REPO"/formal/traps.sv "$d/formal/"
+  printf '%s' "$d"
+}
+
+trs() { printf "%s --repo %s --workdir %s/work --sby %s" "$TR" "$1" "$1" "$tmp/sby-stub"; }
+
+d=$(tr_fixture)
+probe "control: the arm admits one core and fails on the other" 0 \
+  "admits the mechanism and fails on the cause" "$(trs "$d")"
+
+d=$(tr_fixture)
+probe "a model that refuses the mechanism outright is red, not a proof" 1 \
+  "The model must ADMIT a core that" "STUB_SBY_RIGHT=FAIL $(trs "$d")"
+
+# THE ONE THAT MATTERS: an arm that cannot fail is the whole reason this file
+# exists.
+d=$(tr_fixture)
+probe "an arm that admits the wrong cause is red" 1 \
+  "the wrong-cause core proves" "STUB_SBY_WRONG=PASS $(trs "$d")"
+
+d=$(tr_fixture)
+probe "a proof going red somewhere else is not evidence about this arm" 1 \
+  "not at line" "STUB_SBY_WRONG_LINE=9 $(trs "$d")"
+
+d=$(tr_fixture)
+probe "a solver that wrote no verdict is exit 2, not a red arm" 2 \
+  "wrote no status for the" "STUB_SBY_NO_STATUS=1 $(trs "$d")"
+
+d=$(tr_fixture)
+probe "an empty status file is refused rather than read as a verdict" 2 \
+  "status file for the right-cause core is empty" "STUB_SBY_EMPTY_STATUS=1 $(trs "$d")"
+
+# The three parses. Each one is what the probe pins its answer to, so a
+# respelling has to stop the run rather than quietly probe nothing.
+d=$(tr_fixture); sed -i.bak 's/assert(csr_rdata == prev_cause);/assert(csr_rdata == prev_cause2);/' "$d/formal/traps.sv"
+probe "a respelled cause comparison stops rather than pinning nothing" 2 \
+  "0 times" "$(trs "$d")"
+
+d=$(tr_fixture); sed -i.bak 's/assign load_access_fault  = atomic_fault/assign load_access_fault = atomic_fault/' "$d/rtl/decoder.v"
+probe "a respelled fault site stops rather than building the shipping core twice" 2 \
+  "no longer spells its two access-fault assignments" "$(trs "$d")"
+
+d=$(tr_fixture); sed -i.bak 's/load_misaligned || store_misaligned || atomic_fault;/load_misaligned || atomic_fault || store_misaligned;/' "$d/rtl/decoder.v"
+probe "a respelled trap_pending stops: an uncommitted fault proves nothing" 2 \
+  "no longer spells the last line of" "$(trs "$d")"
+
+d=$(tr_fixture); rm "$d/formal/traps.sv"
+probe "the model moving away takes the probe with it, loudly" 2 \
+  "formal/traps.sv is missing from" "$(trs "$d")"
 
 echo
 if [ "$probes" -ne "$PROBES_EXPECTED" ]; then


### PR DESCRIPTION
Closes JEF-841.

`formal/traps.sv` is the only thing in the tree that says a trap lands on `mtvec` and saves the right state, and it could not express causes 5 and 7 arising from a plain load or store. That is not a gap you find by reading it: `must_not_trap` claimed an aligned `lw` or `sw` never traps, so a core that raised the cause the spec names went red there.

**Measured, not asserted.** Against the model as it stood on `main`, a core one line of `rtl/decoder.v` away that faults an unmapped `lw` with cause 5 goes `FAIL` at `traps.sv:481` — `assert(!trap_entry)`. That is the cost every prototype has paid, reproduced here before anything was changed.

## What the model says now, and what it deliberately does not

* An access the map does not answer is **excused** from `must_not_trap` — that arm is narrowed by `data_mapped`, and an aligned `lw` the map *does* answer still must not trap.
* A core that faults such an access must report **5 for a load and 7 for a store**. The cause chain gains two arms and the mcause assertion's gate becomes `cause_modelled` rather than `expected_trap`.
* The **trap itself is not required**. An out-of-region load reads zero here and an out-of-region store is dropped; the privileged spec only recommends faulting, and requiring it in the model would state a decision this platform has not taken. Requiring the cause costs nothing while that holds, and it is exactly the half each prototype has had to write for itself.
* Misalignment outranks the region, the order the atomic term already states, so the four data causes stay disjoint. The eight plain encodings only: `funct3` values that are not instructions in RV32 are left out, because the core may call them illegal and a model must not hold an opinion about the cause of an encoding it does not recognise.

The model computes `immediate + reg_rs1` and compares it against three ranges — nothing in a model is timed, which is the whole reason it can ask the question the core cannot afford in the cycle it chooses the next pc.

## The map, and why it cannot drift

No port of the core carries a plain load's or store's region answer (`atomic_supported` is the atomic's, and stays a free input), so `formal/traps.sv` restates the map as four parameters and `test/memmap_test.sh` compares that copy against `rtl/memory.v`'s and `rtl/timer.v`'s defaults and `rtl/littlesoc.v`'s text window. Nothing else reads the copy, which is why a drifted one is silent: the proof would go on passing, having excused the wrong accesses. The text window is pinned to **the part's** 2048 words, not the harness's 4096, because the proof has no `imemory` in it to size — `formal/wrapper.v` gets the same default.

No elaboration `$fatal` guards on those four: this model uses plain magnitude compares, so it has no power-of-two or alignment dependence to refuse at.

## The demonstrated red direction

`make -C formal traps-region-probe` builds two cores one line of `rtl/decoder.v` apart, each faulting an aligned `lw` at an address with bit 31 set — outside every window of any map this platform can be given — and requires:

```
formal/traps.sv states the cause comparison on line 480.
  right-cause: PASS, assertions failed at none
  wrong-cause: FAIL, assertions failed at [480]
The load/store region cause arm admits the mechanism and fails on the cause.
```

Both halves are load-bearing. `right-cause` says the model **admits** the mechanism rather than forbidding it; `wrong-cause` says the arm **fails**, and at the cause comparison's own line — read out of `traps.sv` at run time rather than written down, so a proof that went red somewhere else cannot be read as evidence about this arm. Against `main`'s model both cases go red at 481 instead, which is the two results this ticket exists to separate.

It is a prerequisite of `components_traps` for the reason `pcloop_cover` is one of `components_pcloop`: this core reaches the arm never, and a control that can be run separately from the thing it controls eventually is not run at all. Two sby runs, ~6 s.

`make probe-gates` stays hermetic, so what it covers is the probe's **own** grading — ten probes against a stub `sby` that reads the tree it is handed: the arm admitting the wrong cause, a model refusing the mechanism, a proof red at another line, no verdict written, an empty status, and the three parses (the cause comparison, the fault site, `trap_pending`) each stopping rather than probing nothing. `PROBES_EXPECTED` 286 → 300 (four of the fourteen are the new map comparisons).

## Verification

* `make -C formal components_traps` — `successful proof by k-induction`, `DONE (PASS, rc=0)`, read from the sby summary.
* `make -C formal check` — **86 checks: 86 pass, 0 fail**, failure list and check set match their baselines.
* `components_decoder`, `components_executor`, `components_accessor`, `components_pcloop` (with `pcloop_cover`) — all `successful proof by k-induction`, unchanged.
* `make test` — **70/70**, failure list matches `EXPECTED_FAIL`; `probe-gates`, `memmap-test` and `window-test` inside it.
* `make probe-gates` — `300 graded comparisons, every failure path executed`.
* `make fit` and a placement: **nulls by construction** — no file under `rtl/` is touched.

## Decisions taken, and one to ratify

* **The must-trap direction is not stated.** Modelling it would go red against today's core, and the ticket asks for an arm that is vacuously satisfied now. When the mechanism lands, moving the two region terms into `expected_trap` is the one-line change that closes it — the priority chain and the map are already right.
* **The RVFI fault masks are not modelled here.** The prototype's correction (`rvfi_mem_fault_rmask` is `store_access_fault && instr_amo`, not `&& !instr_sc` — a plain store reads nothing) lives behind `` `ifdef RISCV_FORMAL ``, which this task deliberately does not define, and the prototype's own note puts that half in both sim legs' monitor gate. Compiling the instrumentation into the proof to reach it is a bigger change than the ticket, and the monitor is where it belongs.
* **Merge order with #195.** That PR adds the same four `LS_*` parameter names to `rtl/littlecpu.v`, its own section 8 to `test/memmap_test.sh`, and moves `PROBES_EXPECTED` to 298. Names were chosen to match it deliberately. Whichever lands second renumbers one section and sets `PROBES_EXPECTED` to 312; the three conflicts are the `for f in ...` list, the section number, and that literal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
