### PR TITLE
Stamp every graded synthesis job with the toolchain that produced its number (JEF-845)

### DIFF
--- a/.github/actions/setup-oss-cad-suite/action.yml
+++ b/.github/actions/setup-oss-cad-suite/action.yml
@@ -3,7 +3,10 @@ description: >-
   Put the OSS CAD Suite (yosys, iverilog, sby, nextpnr-ice40, icetime, the
   solvers) on PATH. Uses the copy in the runner image when there is one,
   otherwise downloads the latest release and verifies it against the digest
-  GitHub publishes for the asset.
+  GitHub publishes for the asset. The two are different builds, so which branch
+  a job took is part of what its number means: the self-hosted pool always takes
+  the image's copy and only the GitHub-hosted `formal` job downloads anything.
+  The step summary records which, and the tag.
 runs:
   using: composite
   steps:
@@ -23,8 +26,10 @@ runs:
           echo "no copy in the runner image -- downloading the latest release"
         fi
 
-    # Latest, not a pin. A toolchain bump that changes the hardware shows up in
-    # `make fit` and `make soc-timing`, both of which ratchet: 32 cells were
+    # Latest, and reached only when the step above found nothing -- which on the
+    # self-hosted pool is never, so the graded synthesis jobs run the image's
+    # build and not this one. A toolchain bump that changes the hardware shows up
+    # in `make fit` and `make soc-timing`, both of which ratchet: 32 cells were
     # measured between two yosys builds on identical RTL. formal/pin.mk is a
     # different question and stays pinned -- test/monitor.v is generated from it
     # and tracked, so bumping that one means regenerating the monitor.
@@ -72,14 +77,38 @@ runs:
 
     - name: Add OSS CAD Suite to PATH
       shell: bash
+      # The tag reaches the shell through the environment rather than through
+      # `${{ }}`: it is a release name resolved from an upstream API, and an
+      # expression is pasted into the script before bash parses it.
+      env:
+        RELEASE_TAG: ${{ steps.release.outputs.tag }}
       run: |
         set -euo pipefail
         if [ "${{ steps.image.outputs.found }}" = "true" ]; then
           root=/opt/oss-cad-suite
+          # Whatever the runner image was built with: a de facto pin nothing in
+          # this repo declares or moves, and it does move -- the self-hosted pool
+          # read Yosys 0.68+40 on one day and 0.68+71 eight days later. Which of
+          # the two branches a job took decides which toolchain its number came
+          # from, so it is recorded rather than left in the step log.
+          origin="the runner image's copy at $root"
+          tag=$(sed -n '1p' "$root/VERSION" 2> /dev/null || true)
         else
           root="$GITHUB_WORKSPACE/oss-cad-suite"
+          origin="a downloaded release"
+          tag="$RELEASE_TAG"
         fi
         echo "$root/bin" >> "$GITHUB_PATH"
         echo "$root/py3bin" >> "$GITHUB_PATH"
+        {
+          echo "### OSS CAD Suite"
+          echo "- source: $origin"
+          echo "- tag: ${tag:-unrecorded}"
+          echo "- yosys: \`$("$root/bin/yosys" -V 2> /dev/null || echo 'could not be asked for its version')\`"
+          echo
+          echo "Not pinned, and the two sources are two different builds. \`make"
+          echo "print-toolchain\` is what stamps a graded number with the one that"
+          echo "produced it; this says which install that came out of."
+        } >> "$GITHUB_STEP_SUMMARY"
         # Fail here rather than in whichever job first reaches for yosys.
         test -x "$root/bin/yosys"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -372,6 +372,11 @@ jobs:
             echo "against \`FIT_MAX_LC\`, and it is in main's required set -- so a"
             echo "re-mapping that moves the count blocks a merge, which is why the"
             echo "budget is derived to clear a whole churn band."
+            echo "The \`#\` lines above the count are the toolchain that produced it,"
+            echo "from \`make fit-toolchain\`. They are the first thing \`make fit\`"
+            echo "prints, so a synthesis or placement that dies still records what"
+            echo "was running -- and \"did the tool move?\" is answerable from this"
+            echo "run rather than from a guess about which release CI resolved."
           } >> "$GITHUB_STEP_SUMMARY"
           exit "$status"
 
@@ -426,6 +431,11 @@ jobs:
             echo "logic/routing split. This job grades \`SOC_MIN_MHZ\`, which is"
             echo "the 12 MHz board clock rather than a margin under the last"
             echo "measurement (ADR-0066), and it is in main's required set."
+            echo "The \`#\` lines above the report are the toolchain that produced"
+            echo "it, from \`make soc-timing-toolchain\` -- the same three lines"
+            echo "\`soc/baseline_sweep.sh\` stamps a sweep with, so a placement here"
+            echo "and one in a sweep can be told apart from a toolchain that moved"
+            echo "under both."
           } >> "$GITHUB_STEP_SUMMARY"
           exit "$status"
 

--- a/Makefile
+++ b/Makefile
@@ -650,9 +650,20 @@ FIT_MAX_LC := 4088
 # job's count, so a local run prints the gap between the instruments as well.
 FIT_LAST_LC := 3966
 
+# The two tools this number is a property of. icetime is not among them: this
+# top never places, so nothing here reads a `.asc`.
+FIT_TOOLS := yosys nextpnr-ice40
+
+.PHONY: fit-toolchain
+fit-toolchain:
+	@soc/print_toolchain.sh $(FIT_TOOLS)
+
+# The stamp is a prerequisite rather than the recipe's first line so that it is
+# printed before yosys runs: a synthesis that dies, a placement that dies and a
+# tripped ratchet then all leave a run that says which toolchain produced them.
 .PHONY: fit
-fit: fit.json
-	@nextpnr-ice40 --up5k --package sg48 --json $< --pcf-allow-unconstrained \
+fit: fit-toolchain fit.json
+	@nextpnr-ice40 --up5k --package sg48 --json fit.json --pcf-allow-unconstrained \
 	  > fit.log 2>&1 || true
 	@python3 soc/fit_report.py fit.log --max-lc $(FIT_MAX_LC) --previous $(FIT_LAST_LC)
 
@@ -767,8 +778,15 @@ soc.asc: soc.json soc/littlesoc.pcf
 # clock.
 SOC_MIN_MHZ := 12.0
 
+# All three, unlike `fit`: this flow places and then reads the placement back.
+SOC_TIMING_TOOLS := yosys nextpnr-ice40 icetime
+
+.PHONY: soc-timing-toolchain
+soc-timing-toolchain:
+	@soc/print_toolchain.sh $(SOC_TIMING_TOOLS)
+
 .PHONY: soc-timing
-soc-timing: soc.asc
+soc-timing: soc-timing-toolchain soc.asc
 	@sed -n '/^Info: Device utilisation:/,/^$$/s/^Info: //p' soc.pnr.log
 	@grep -E "Max frequency for clock .*'clk" soc.pnr.log | tail -1 \
 	  | sed -e 's/^Info: /nextpnr /' -e 's/^ERROR: /nextpnr /'
@@ -797,6 +815,21 @@ soc-timing: soc.asc
 # were not built from the moment either one moves.
 print-%:
 	@echo '$($*)'
+
+# Which toolchain a graded number was measured with; soc/print_toolchain.sh
+# carries why that has to travel with the number.
+#
+# Every tool list is a variable here and never a second copy in the workflow:
+# the `elaborate` job spelled a source list out in YAML once, it drifted from
+# this file's, and the gate spent a run elaborating a testbench whose memory
+# instances resolved to nothing. `fit-toolchain` and `soc-timing-toolchain` are
+# the two graded flows' own lists and are what those jobs print; this target
+# takes any list, and defaults to every tool either of them grades.
+TOOLS ?= $(sort $(FIT_TOOLS) $(SOC_TIMING_TOOLS))
+
+.PHONY: print-toolchain
+print-toolchain:
+	@soc/print_toolchain.sh $(TOOLS)
 
 # ---- the cross-core comparison harness -------------------------------------
 #

--- a/soc/baseline_sweep.sh
+++ b/soc/baseline_sweep.sh
@@ -51,63 +51,11 @@ name=${BASELINE_NAME:-baseline}
 csv="$out/$name.csv"
 
 # A tool with no resolved path and no version is a sweep nobody can reproduce,
-# so both are stamped for each and a missing one stops the run here.
-tool_path() {
-  path=$(command -v "$1") || {
-    echo "*** soc/baseline_sweep.sh: no $1 on PATH, so there is nothing to" >&2
-    echo "*** stamp this sweep with." >&2
-    exit 1
-  }
-  printf '%s' "$path"
-}
-
-# Graded on the tool's own status and not merely on whether it printed: the
-# local nextpnr on one machine here answers `--version` with a dynamic-linker
-# error, which is a non-empty first line and would otherwise be stamped as this
-# sweep's toolchain version.
-first_line() {
-  if ! said=$("$@" 2>&1); then
-    echo "*** soc/baseline_sweep.sh: '$1' could not be asked for its version:" >&2
-    printf '%s\n' "$said" >&2
-    exit 1
-  fi
-  line=$(printf '%s\n' "$said" | sed -n '1p')
-  if [ -z "$line" ]; then
-    echo "*** soc/baseline_sweep.sh: '$1' printed no version string." >&2
-    exit 1
-  fi
-  printf '%s' "$line"
-}
-
-digest() {
-  if command -v shasum > /dev/null 2>&1; then
-    shasum -a 256 "$1" | cut -c1-16
-  elif command -v sha256sum > /dev/null 2>&1; then
-    sha256sum "$1" | cut -c1-16
-  else
-    printf 'no-digest-tool'
-  fi
-}
-
-# icetime publishes no version string -- every flag it does not recognise gets
-# the same usage message -- so the suite's own VERSION file beside the binary and
-# a digest of the binary stand in for one. Two installs that both stamped
-# "unknown" would compare equal, which is the mismatch this block exists to
-# catch.
-icetime_version() {
-  version_file=$(dirname "$1")/../VERSION
-  if [ -r "$version_file" ]; then
-    printf 'oss-cad-suite %s sha256:%s' "$(sed -n '1p' "$version_file")" "$(digest "$1")"
-  else
-    printf 'no version string sha256:%s' "$(digest "$1")"
-  fi
-}
-
-yosys_path=$(tool_path yosys)
-nextpnr_path=$(tool_path nextpnr-ice40)
-icetime_path=$(tool_path icetime)
-yosys_version=$(first_line yosys -V)
-nextpnr_version=$(first_line nextpnr-ice40 --version)
+# so soc/print_toolchain.sh stamps both for each and stops the run when one
+# cannot be asked. Asked through `make soc-timing-toolchain` because that is the
+# target the CI job grading SOC_MIN_MHZ stamps itself with, so a sweep's
+# provenance and CI's cannot become two answers to one question.
+tools=$(make -s soc-timing-toolchain "$@")
 
 # Asked of make rather than repeated here: a second copy of either default would
 # stamp the sweep with a program the build did not use the moment one moves, and
@@ -128,9 +76,7 @@ block=$(
   echo "# date: $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
   echo "# base: $base"
   echo "# dirty: $dirty"
-  echo "# yosys: $yosys_version [$yosys_path]"
-  echo "# nextpnr-ice40: $nextpnr_version [$nextpnr_path]"
-  echo "# icetime: $(icetime_version "$icetime_path") [$icetime_path]"
+  printf '%s\n' "$tools"
   echo "# prog: $prog"
   echo "# rom_words: $rom_words"
   echo "# seeds: $seeds"

--- a/soc/print_toolchain.sh
+++ b/soc/print_toolchain.sh
@@ -1,0 +1,92 @@
+#!/bin/sh
+# Prints the toolchain a measurement was taken with: one line per tool, its
+# resolved path and the version it answers with, refusing rather than guessing
+# when a tool cannot be asked.
+#
+#   soc/print_toolchain.sh yosys nextpnr-ice40 icetime
+#   make print-toolchain TOOLS='yosys nextpnr-ice40'
+#
+# `make fit` and `make soc-timing` are graded against FIT_MAX_LC and
+# SOC_MIN_MHZ, and both numbers move with a toolchain CI resolves rather than
+# pins -- 54 cells between two builds on one tree, with no fixed sign either
+# time. Without this block the first question a tripped ratchet raises, "did the
+# tool move?", is unanswerable from the run that failed, which is the whole
+# reason the repo's answer to a moving toolchain is a budgeted band PLUS a
+# stamped comparison rather than the band alone.
+#
+# The lines are soc/baseline_sweep.sh's provenance lines verbatim, so a sweep
+# and a CI job stamp from one source and soc/baseline_summary.py's field names
+# are these. A second copy of "which toolchain" that can disagree with this one
+# is worse than none, because both look authoritative.
+set -eu
+
+if [ "$#" -eq 0 ]; then
+  echo "usage: soc/print_toolchain.sh <tool>..." >&2
+  echo "*** soc/print_toolchain.sh: no tools named, so there is nothing to" >&2
+  echo "*** stamp a measurement with." >&2
+  exit 2
+fi
+
+digest() {
+  if command -v shasum > /dev/null 2>&1; then
+    shasum -a 256 "$1" | cut -c1-16
+  elif command -v sha256sum > /dev/null 2>&1; then
+    sha256sum "$1" | cut -c1-16
+  else
+    printf 'no-digest-tool'
+  fi
+}
+
+# icetime publishes no version string -- every flag it does not recognise gets
+# the same usage message -- so the suite's own VERSION file beside the binary and
+# a digest of the binary stand in for one. Two installs that both stamped
+# "unknown" would compare equal, which is the mismatch a stamp exists to catch.
+icetime_version() {
+  version_file=$(dirname "$1")/../VERSION
+  if [ -r "$version_file" ]; then
+    printf 'oss-cad-suite %s sha256:%s' "$(sed -n '1p' "$version_file")" "$(digest "$1")"
+  else
+    printf 'no version string sha256:%s' "$(digest "$1")"
+  fi
+}
+
+# Graded on the tool's own status and not merely on whether it printed: the
+# local nextpnr on one machine here answers `--version` with a dynamic-linker
+# error, which is a non-empty first line and would otherwise be stamped as the
+# toolchain that produced the number.
+first_line() {
+  if ! said=$("$@" 2>&1); then
+    echo "*** soc/print_toolchain.sh: '$1' could not be asked for its version:" >&2
+    printf '%s\n' "$said" >&2
+    exit 1
+  fi
+  line=$(printf '%s\n' "$said" | sed -n '1p')
+  if [ -z "$line" ]; then
+    echo "*** soc/print_toolchain.sh: '$1' printed no version string." >&2
+    exit 1
+  fi
+  printf '%s' "$line"
+}
+
+# Collected and printed at the end rather than a line at a time: a refusal
+# halfway down would otherwise leave a short block on stdout that reads exactly
+# like a complete one, and the callers splice this into a CSV header and a step
+# summary where nobody counts the lines.
+nl='
+'
+block=
+for tool in "$@"; do
+  path=$(command -v "$tool") || {
+    echo "*** soc/print_toolchain.sh: no $tool on PATH, so there is nothing to" >&2
+    echo "*** stamp this measurement with." >&2
+    exit 1
+  }
+  # The three ways a tool here answers the question, in one table.
+  case $tool in
+    icetime)        version=$(icetime_version "$path") ;;
+    yosys|iverilog) version=$(first_line "$tool" -V) ;;
+    *)              version=$(first_line "$tool" --version) ;;
+  esac
+  block=${block:+$block$nl}"# $tool: $version [$path]"
+done
+printf '%s\n' "$block"

--- a/test/probe_gates.sh
+++ b/test/probe_gates.sh
@@ -27,7 +27,7 @@ REPO=$(cd "$HERE/.." && pwd)
 # Pinned as a literal: a probe that is deleted, or that stops being reached by
 # an early `return`, would otherwise cut this file's coverage while it kept
 # printing a green summary.
-PROBES_EXPECTED=312
+PROBES_EXPECTED=317
 
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/littlecpu-probe.XXXXXX") || {
   echo "error: could not create a temporary directory under ${TMPDIR:-/tmp}." >&2
@@ -225,6 +225,34 @@ STUB
   chmod +x "$1"
 }
 
+# Three ways a tool answers when soc/print_toolchain.sh asks it for a version.
+# Stubs rather than the real toolchain: the two red ones are what a broken
+# install does, and no probe here may need yosys or nextpnr to be present.
+make_version_stubs() {  # $1 = bin dir
+  local bin=$1
+  mkdir -p "$bin"
+  cat > "$bin/goodtool" <<'STUB'
+#!/bin/sh
+# The control: answers --version the way every tool in the real toolchain does.
+echo "GoodTool 1.2.3"
+STUB
+  cat > "$bin/mutetool" <<'STUB'
+#!/bin/sh
+# Succeeds having printed nothing, which a stamp built from the first line alone
+# would record as this toolchain's version.
+exit 0
+STUB
+  cat > "$bin/brokentool" <<'STUB'
+#!/bin/sh
+# The case the refusal was written for, and it is live: the Homebrew
+# nextpnr-ice40 on one machine here answers --version with a dynamic-linker
+# error, which is a non-empty first line under a nonzero status.
+echo "dyld: Symbol not found: __ZN5boost15program_options3argE" >&2
+exit 1
+STUB
+  chmod +x "$bin/goodtool" "$bin/mutetool" "$bin/brokentool"
+}
+
 # `leg-rt` / `leg-rc` are scratch copies of the two suite runners, because each
 # resolves its helper scripts relative to its own path.
 mkdir -p "$tmp/bin-none" "$tmp/bin-curl" "$tmp/leg-rt" "$tmp/leg-rc" "$tmp/leg-rc-nopy"
@@ -251,6 +279,7 @@ rm "$tmp/bin-noobjcopy/riscv64-elf-objcopy"
 make_sim_stub "$tmp/sim"
 make_sail_stub "$tmp/sail"
 make_curl_stub "$tmp/bin-curl/curl"
+make_version_stubs "$tmp/bin-tools"
 make_cosim_bin_stub "$tmp/dut"
 cp "$HERE/run_tests.sh" "$HERE/check_suite_shape.sh" "$HERE/stall_report.py" "$tmp/leg-rt/"
 cp "$HERE/run_cosim.sh" "$HERE/check_suite_shape.sh" "$tmp/leg-rc/"
@@ -1091,6 +1120,41 @@ begin_group "soc/baseline_sweep.sh"
 # asked for none.
 probe "an empty seed list stops the sweep instead of placing the default" 2 \
   "SOC_SEEDS is empty" "SOC_SEEDS= sh $REPO/soc/baseline_sweep.sh"
+
+begin_group "soc/print_toolchain.sh"
+
+# The stamp `make fit`, `make soc-timing` and the sweep above all print. What is
+# forced red here is the refusal: a tool that cannot be asked has to stop the
+# run rather than be recorded as whatever it said, because a version nobody can
+# reproduce reads exactly like one anybody can and the number underneath it is
+# graded against a ratchet.
+#
+# The script is reached by its own path and its shebang rather than through an
+# interpreter on PATH, because the PATH set here is the fixture: it holds the
+# three stubs and the utilities the script itself runs, and nothing else.
+PT="PATH='$tmp/bin-tools:$tmp/bin-none' $REPO/soc/print_toolchain.sh"
+
+probe "control: a tool that answers is stamped with its version and its path" 0 \
+  "# goodtool: GoodTool 1.2.3 [$tmp/bin-tools/goodtool]" "$PT goodtool"
+
+probe "a tool that prints nothing is refused, not stamped blank" 1 \
+  "printed no version string" "$PT mutetool"
+
+probe "a tool that exits nonzero while printing is refused on its status" 1 \
+  "could not be asked for its version" "$PT brokentool"
+
+# Whether the good tool's line survives the refusal, not merely whether the exit
+# status did: a short block spliced into a CSV header or a step summary looks
+# exactly like a whole one.
+pt_partial() {
+  local said
+  said=$(eval "$PT goodtool brokentool" 2> /dev/null) || true
+  printf 'stdout=%s\n' "${said:-empty}"
+}
+probe "one red tool leaves no partial stamp on stdout" 0 "stdout=empty" pt_partial
+
+probe "a tool that is not installed names itself rather than the list" 1 \
+  "no nosuchtool on PATH" "$PT nosuchtool"
 
 begin_group "soc/routing_bins.py"
 


### PR DESCRIPTION
Closes JEF-845.

## The finding, first: CI runs an undeclared pin, and it moves

`.github/actions/setup-oss-cad-suite` prefers `/opt/oss-cad-suite` from the runner image over downloading, so the action's documented "latest release" story holds for exactly one job. Read out of the job logs on `main`:

| job | pool | branch taken | yosys |
|---|---|---|---|
| `fit`, `soc-timing`, `test`, `elaborate`, … | `little-cpu-runners` (self-hosted) | runner image's copy | `Yosys 0.68+71 (git sha1 dbe5b7c03-dirty)` on 18 Aug |
| `formal` | `ubuntu-latest` | downloaded release | `2026-08-18`, resolved that run |

So **both graded synthesis jobs run the image's build, not a release**, and that build is not stable: the same job read `Yosys 0.68+40 (git sha1 0f2bcb94b-dirty)` on 10 Aug and `0.68+71` on 18 Aug. Nothing in the repo declares, moves or recorded it. The action's own step echoed a yosys version and never nextpnr or icetime, and nothing carried any of it to the run that grades `FIT_MAX_LC` or `SOC_MIN_MHZ`.

CLAUDE.md currently says "CI installs the latest release" and "CI takes at the latest release rather than a pin". That is true only of `formal`. I did not edit CLAUDE.md — whether to correct the sentence, or to pin the image copy outright, is a decision for the architect, not a drive-by in this PR. Flagging it, not taking it.

## What changed

`soc/baseline_sweep.sh` had already built the block this ticket asks for, so it was extracted rather than rewritten:

- **`soc/print_toolchain.sh`** (new) — one line per tool, resolved path and version, exiting nonzero and naming the tool when one cannot be asked. `first_line()`'s status check, `icetime_version()`'s VERSION-file-plus-digest fallback (icetime publishes no version string) and the `# key: value` shape `soc/baseline_summary.py` parses are all the sweep's, verbatim.
- **`make print-toolchain TOOLS='…'`**, plus `fit-toolchain` and `soc-timing-toolchain` naming the two graded flows' own lists (`icetime` is not in `fit`'s — that top never places, so nothing reads an `.asc`). Each is a **prerequisite** of its flow, not the recipe's first line, so the block prints before yosys runs: a synthesis that dies, a placement that dies and a tripped ratchet all leave a run that says what produced them. The lists are make variables and never YAML, per the `elaborate` job's duplicated-source-list comment.
- **`soc/baseline_sweep.sh`** drops its three helpers and asks `make -s soc-timing-toolchain`, so a sweep's provenance and CI's are one source and cannot become two answers.
- **`.github/workflows/ci.yml`** — the summary already fences the whole captured log on both the pass and the fail path, so the block lands there for free; the added prose says what the `#` lines are. No tool list in YAML, and no new pipeline around a graded command.
- **The setup action** writes source (image copy vs downloaded release), tag and yosys version into the step summary, on both branches and before the `test -x` that can fail. The release tag now reaches the shell through `env:` rather than a `${{ }}` expression pasted in before bash parses it.

## Tests

`test/probe_gates.sh` gains a `soc/print_toolchain.sh` group using the existing stub-bin machinery — a tool printing nothing, a tool exiting nonzero while printing (a stub of the live Homebrew `nextpnr-ice40` dynamic-linker failure, which is the case `first_line()` was written for), a tool absent from PATH, a check that a refusal leaves **no partial stamp** on stdout, and a control that succeeds and pins the full line including the resolved path. `PROBES_EXPECTED` 312 → 317, read live off `main` at push time.

Verified locally against the cached OSS CAD Suite (`Yosys 0.68+48`, `nextpnr-0.11-1-g62e659ed`, suite `20260811`):

- `make test` — 70/70, matches `test/EXPECTED_FAIL`
- `test/probe_gates.sh` — 317 graded comparisons, every failure path executed
- `make fit` — stamp above the number, `RATCHET: 3945 of 4088 cells budgeted -- OK`
- `make soc-timing` — stamp above the report, `RATCHET: 12.71 MHz against a 12.00 MHz floor -- OK`
- `soc/baseline_sweep.sh` at two seeds, then `soc/baseline_summary.py` on the result — the provenance block still parses, field for field
- the real refusal, not a stub: the Homebrew `nextpnr-ice40` on this machine exits 1 on `--version` with a boost symbol error and is refused rather than stamped
- both branches of the setup action's summary step, replayed locally against a fake suite root, including one with no `VERSION` file

No RTL, no pin, no new gate on the design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJ77ZZJ6pDiL3vj3Qw9hKs
