### PR TITLE
Put the board tools in the repo, and fix what running them found (JEF-867)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,8 @@ board.asc
 board.bin
 board.synth.log
 board.pnr.log
+# `make ftread`: a host binary, built from soc/ftread.c against libftdi.
+ftread
 # The de-interleaved ROM banks `make soc-rom` writes from a test program. Build
 # artifacts of whichever SOC_PROG was last built, not source.
 soc/rom_even.hex

--- a/Makefile
+++ b/Makefile
@@ -1054,6 +1054,35 @@ ecp5-timing: ecp5-timing-toolchain ecp5.config
 	@echo
 	@echo "Placement, routing and nextpnr's own timing analysis: ecp5.pnr.log"
 
+# ---- reading the board back ------------------------------------------------
+#
+# soc/ftread.c talks to the FT232H through libftdi and needs no `/dev` node,
+# which is the only thing that works on macOS: Apple's DriverKit extension owns
+# the chip's single interface, and after `make prog` it is left in MPSSE mode
+# with no serial device attached at all until it re-enumerates. Root can open it
+# through libusb regardless.
+#
+# NOT a prerequisite of anything and not on CI. It needs libftdi, which is not
+# among the tools `make setup` installs, and nothing in the graded flow reads a
+# wire.
+# pkg-config points INTO libftdi1/, so soc/ftread.c includes <ftdi.h> bare
+# rather than <libftdi1/ftdi.h>; the fallback below has to name the same
+# directory or the two disagree about which spelling is right.
+FTDI_CFLAGS ?= $(shell pkg-config --cflags libftdi1 2>/dev/null || echo -I/opt/homebrew/opt/libftdi/include/libftdi1)
+FTDI_LIBS   ?= $(shell pkg-config --libs libftdi1 2>/dev/null || echo -L/opt/homebrew/opt/libftdi/lib -lftdi1)
+
+ftread: soc/ftread.c
+	@command -v cc >/dev/null || { echo 'error: no C compiler for the host.' >&2; exit 1; }
+	cc -O2 -Wall -o $@ $< $(FTDI_CFLAGS) $(FTDI_LIBS)
+	@echo 'built ./ftread -- run it as root: sudo ./ftread 115200 8000'
+
+.PHONY: suite-board
+suite-board: ftread
+	@echo 'Runs the .S suite on the part, in batches. Needs root for the same'
+	@echo 'reason `make prog` does. Roughly ten minutes.'
+	@echo
+	@sudo ./soc/run_suite_board.sh
+
 # ---- Dhrystone, on the part ------------------------------------------------
 #
 # The same benchmark `make dhrystone` runs, built for a board instead of a

--- a/soc/ftread.c
+++ b/soc/ftread.c
@@ -1,0 +1,64 @@
+// Reads the board's FT232H as a UART through libftdi, WITHOUT a /dev node.
+//
+// WHY NOT `screen`. On macOS the FT232H has one USB interface and it is both
+// the serial port and the MPSSE engine iceprog drives. Apple's DriverKit
+// extension claims it, so unprivileged every libftdi tool reports zero devices
+// while ioreg shows the board plainly; and once iceprog has run, the chip is
+// left in MPSSE mode and no `/dev/cu.usbserial-*` exists at all until it
+// re-enumerates. Root can open it through libusb regardless, which is what this
+// does -- so it works in the state a just-flashed board is actually in.
+//
+// It also prints a score, because the wire rate moves with the FPGA's clock:
+// rtl/uart.v divides by a fixed constant, so a board running at f transmits at
+// 115200 * f / 12e6. Sweeping the host rate and looking for the plateau where
+// 8N1 still decodes is how this tree measured SB_HFOSC without a scope.
+//
+// Build: `make ftread`. Run: `sudo ./ftread 115200 8000`.
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <ftdi.h>
+
+int main(int argc, char **argv) {
+  int baud = argc > 1 ? atoi(argv[1]) : 115200;
+  int ms   = argc > 2 ? atoi(argv[2]) : 3000;
+  struct ftdi_context *f = ftdi_new();
+  if (!f) { fprintf(stderr, "ftdi_new failed\n"); return 2; }
+  if (ftdi_usb_open(f, 0x0403, 0x6014) < 0) {
+    fprintf(stderr, "open: %s\n", ftdi_get_error_string(f));
+    return 2;
+  }
+  ftdi_set_bitmode(f, 0x00, BITMODE_RESET);   // plain UART, not MPSSE
+  if (ftdi_set_baudrate(f, baud) < 0)
+    fprintf(stderr, "baud: %s\n", ftdi_get_error_string(f));
+  ftdi_set_line_property(f, BITS_8, STOP_BIT_1, NONE);
+  ftdi_tcioflush(f);
+
+  unsigned char buf[4096];
+  long total = 0, printable = 0, digits = 0, eol = 0;
+  /* A TIGHT POLL, because the board streams faster than a sleepy reader drains.
+   * The first version slept 50ms between reads while a 2KB report arrived every
+   * 0.8s; the FTDI's FIFO overran and successive reports came back interleaved,
+   * which reads exactly like a crashing program and is not one. 1ms costs
+   * nothing here and keeps the buffer empty. */
+  int iters = ms;
+  for (int i = 0; i < iters; i++) {
+    int n = ftdi_read_data(f, buf, sizeof buf);
+    for (int j = 0; j < n; j++) {
+      unsigned char c = buf[j];
+      total++;
+      if (c >= 32 && c < 127) { printable++; putchar(c); }
+      else if (c == '\r' || c == '\n') { eol++; putchar(c == '\n' ? '\n' : '\r'); }
+      else printf("<%02x>", c);
+      if (c >= '0' && c <= '9') digits++;
+    }
+    fflush(stdout);
+    usleep(1000);
+  }
+  fprintf(stderr, "\n[baud %d] bytes=%ld printable=%ld digits=%ld eol=%ld\n",
+          baud, total, printable, digits, eol);
+  ftdi_usb_close(f);
+  ftdi_free(f);
+  return total == 0 ? 1 : 0;
+}

--- a/soc/ftread.c
+++ b/soc/ftread.c
@@ -18,6 +18,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <sys/time.h>
 #include <ftdi.h>
 
 int main(int argc, char **argv) {
@@ -42,8 +43,17 @@ int main(int argc, char **argv) {
    * 0.8s; the FTDI's FIFO overran and successive reports came back interleaved,
    * which reads exactly like a crashing program and is not one. 1ms costs
    * nothing here and keeps the buffer empty. */
-  int iters = ms;
-  for (int i = 0; i < iters; i++) {
+  /* A WALL-CLOCK DEADLINE, not an iteration count. Counting iterations assumes
+   * each costs the sleep and nothing else; a board transmitting at line rate
+   * makes every read take real time, and a run asked for 8 seconds took 113.
+   * The caller means seconds, so measure seconds. */
+  struct timeval t_start, t_now;
+  gettimeofday(&t_start, NULL);
+  for (;;) {
+    gettimeofday(&t_now, NULL);
+    long elapsed = (t_now.tv_sec - t_start.tv_sec) * 1000L
+                 + (t_now.tv_usec - t_start.tv_usec) / 1000L;
+    if (elapsed >= ms) break;
     int n = ftdi_read_data(f, buf, sizeof buf);
     for (int j = 0; j < n; j++) {
       unsigned char c = buf[j];

--- a/soc/run_suite_board.sh
+++ b/soc/run_suite_board.sh
@@ -24,7 +24,19 @@ ROOT=$(cd "$(dirname "$0")/.." && pwd)
 cd "$ROOT"
 export PATH="$HOME/.cache/little-cpu/oss-cad-suite/bin:$PATH"
 
-BUDGET=${BUDGET:-7600}          # bytes of the 8192-byte ROM to fill per batch
+# How much of the 8192-byte ROM a batch's PROGRAMS may fill. Computed rather
+# than guessed: the driver has to fit beside them, so does a four-byte table
+# entry per program, and the per-program sizes below are measured on OBJECTS,
+# which understate the linked result because the linker aligns each one. The
+# margin covers that. build_batch.sh still refuses a batch that overflows, so
+# this only decides how well packed the batches are, never whether they are
+# correct.
+DRIVER_BYTES=$(riscv64-elf-gcc -march=rv32imac_zicsr_zifencei -mabi=ilp32 -nostdlib \
+                 -DBOARD_SUITE -I test/asm -c -o /tmp/.drv.$$.o test/board/board_suite.S 2>/dev/null \
+               && riscv64-elf-size /tmp/.drv.$$.o | awk 'NR==2{print $1+$2}')
+rm -f /tmp/.drv.$$.o
+: "${DRIVER_BYTES:=512}"
+BUDGET=${BUDGET:-$(( 8192 - DRIVER_BYTES - 600 ))}
 READ_MS=${READ_MS:-8000}
 FTREAD=${FTREAD:-$ROOT/ftread}
 OUT=$(mktemp -d "${TMPDIR:-/tmp}/suiteboard.XXXXXX")
@@ -34,6 +46,7 @@ trap 'rm -rf "$OUT"' EXIT
 # fact about the program and the part, not a thing to work around here.
 SKIP="rvc.S"
 
+echo "== driver is ${DRIVER_BYTES} bytes; budgeting ${BUDGET} per batch of the 8192-byte ROM"
 echo "== sizing the programs"
 sizes=""
 for f in test/asm/*.S; do

--- a/soc/run_suite_board.sh
+++ b/soc/run_suite_board.sh
@@ -42,6 +42,14 @@ FTREAD=${FTREAD:-$ROOT/ftread}
 OUT=$(mktemp -d "${TMPDIR:-/tmp}/suiteboard.XXXXXX")
 trap 'rm -rf "$OUT"' EXIT
 
+# RESULTS ARE WRITTEN AS THEY ARRIVE, to a path that outlives this script. A
+# ten-minute run that records nothing until its last line loses everything to
+# any interruption -- which is exactly what happened the first time the whole
+# suite ran, when the file was edited underneath a running bash and the
+# interpreter resumed at a shifted offset. Sixty-seven verdicts went with it.
+RESULTS=${RESULTS:-/tmp/suite_board_results.txt}
+: > "$RESULTS"
+
 # rvc.S is 12256 bytes and does not fit an 8192-byte ROM even alone. That is a
 # fact about the program and the part, not a thing to work around here.
 SKIP="rvc.S"
@@ -84,7 +92,6 @@ while read -r progs; do
 done < "$OUT/plan"
 
 pass=0; fail=0; missing=0
-: > "$OUT/results"
 i=0
 while read -r progs; do
   i=$((i+1))
@@ -144,12 +151,12 @@ while read -r progs; do
     name=$(basename "$p")
     v=$(printf '%s' "$block" | awk -v k="$j" '$1==k{print $2; exit}')
     if [ -z "$v" ]; then
-      printf '      %-18s NO REPORT\n' "$name"; missing=$((missing+1)); echo "$name MISSING" >> "$OUT/results"
+      printf '      %-18s NO REPORT\n' "$name"; missing=$((missing+1)); echo "$name MISSING" >> "$RESULTS"
     elif [ "$v" = "1" ]; then
-      printf '      %-18s pass\n' "$name"; pass=$((pass+1)); echo "$name PASS" >> "$OUT/results"
+      printf '      %-18s pass\n' "$name"; pass=$((pass+1)); echo "$name PASS" >> "$RESULTS"
     else
       printf '      %-18s FAIL at test %d (verdict %s)\n' "$name" "$(( v >> 1 ))" "$v"
-      fail=$((fail+1)); echo "$name FAIL $(( v >> 1 ))" >> "$OUT/results"
+      fail=$((fail+1)); echo "$name FAIL $(( v >> 1 ))" >> "$RESULTS"
     fi
     j=$((j+1))
   done
@@ -164,5 +171,7 @@ echo
 echo "baseline says these fail under simulation:"
 grep -v '^#' test/EXPECTED_FAIL 2>/dev/null | grep -v '^$' || echo "(none)"
 echo
-sort "$OUT/results" > /tmp/suite_board_results.txt
-echo "per-program results: /tmp/suite_board_results.txt"
+echo "per-program results, written as they arrived: $RESULTS"
+echo
+echo "failures:"
+grep -v ' PASS$' "$RESULTS" | sed 's/^/   /' || echo "   (none)"

--- a/soc/run_suite_board.sh
+++ b/soc/run_suite_board.sh
@@ -13,6 +13,10 @@
 # are reset between them. Where a batched verdict disagrees with the simulated
 # suite, the single-program build is the one to believe.
 #
+# SHOW_RAW=1 dumps every byte the wire carried and the block that was parsed out
+# of it, which is what to reach for when a verdict is missing: it separates "the
+# board said nothing" from "the board said something this could not read".
+#
 # NEEDS ROOT, for the reason `make prog` does: Apple's FTDI dext owns the
 # FT232H's only interface and root takes it anyway.
 set -uo pipefail
@@ -22,7 +26,7 @@ export PATH="$HOME/.cache/little-cpu/oss-cad-suite/bin:$PATH"
 
 BUDGET=${BUDGET:-7600}          # bytes of the 8192-byte ROM to fill per batch
 READ_MS=${READ_MS:-8000}
-FTREAD=${FTREAD:-/tmp/ftread}
+FTREAD=${FTREAD:-$ROOT/ftread}
 OUT=$(mktemp -d "${TMPDIR:-/tmp}/suiteboard.XXXXXX")
 trap 'rm -rf "$OUT"' EXIT
 
@@ -56,6 +60,15 @@ while read -r n f; do
 done < <(printf '%s' "$sizes" | sort -rn)
 [ -n "$cur" ] && { echo "$cur" >> "$OUT/plan"; batches=$((batches+1)); }
 echo "== $batches batches"
+echo
+i=0
+while read -r progs; do
+  i=$((i+1))
+  n=$(printf '%s' "$progs" | wc -w | tr -d ' ')
+  printf '   batch %d: %2d programs --' "$i" "$n"
+  for p in $progs; do printf ' %s' "$(basename "$p" .S)"; done
+  printf '\n'
+done < "$OUT/plan"
 
 pass=0; fail=0; missing=0
 : > "$OUT/results"
@@ -64,29 +77,70 @@ while read -r progs; do
   i=$((i+1))
   echo
   echo "== batch $i of $batches"
-  ./test/board/build_batch.sh "$OUT/b$i" $progs || { echo "   BUILD FAILED"; continue; }
+  echo "   programs:$(for p in $progs; do printf ' %s' "$(basename "$p" .S)"; done)"
+
+  t0=$SECONDS
+  if ! ./test/board/build_batch.sh "$OUT/b$i" $progs > "$OUT/link.log" 2>&1; then
+    echo "   LINK FAILED:"; sed 's/^/      /' "$OUT/link.log" | tail -12; continue
+  fi
+  echo "   link:  $(tail -1 "$OUT/link.log")  [$((SECONDS-t0))s]"
+
+  t0=$SECONDS
   rm -f board.json board.asc board.bin
-  make board.bin BOARD_OSC=internal BOARD_ROM=noop-rom >"$OUT/build.log" 2>&1 || {
-    tail -5 "$OUT/build.log"; echo "   PLACE FAILED"; continue; }
-  iceprog board.bin >/dev/null 2>&1 || { echo "   FLASH FAILED"; continue; }
-  raw=$("$FTREAD" 115200 "$READ_MS" 2>/dev/null)
-  # The driver repeats; take the last complete block, the one between two dots.
+  if ! make board.bin BOARD_OSC=internal BOARD_ROM=noop-rom >"$OUT/build.log" 2>&1; then
+    echo "   PLACE FAILED:"; tail -12 "$OUT/build.log" | sed 's/^/      /'; continue
+  fi
+  echo "   place: $(grep -o 'board.bin: [0-9]* bytes.*' "$OUT/build.log" | head -1)  [$((SECONDS-t0))s]"
+
+  # iceprog's own output, live and unfiltered. It takes about thirty seconds and
+  # prints its progress as it goes, so hiding it makes a working flash
+  # indistinguishable from a hung one -- which is exactly how it looked the first
+  # time this ran quietly.
+  t0=$SECONDS
+  echo "   flashing (iceprog, ~30s):"
+  if ! iceprog board.bin 2>&1 | tee "$OUT/flash.log" | sed 's/^/      | /'; then
+    echo "   FLASH FAILED"; continue
+  fi
+  grep -q 'VERIFY OK' "$OUT/flash.log" || { echo "   FLASH DID NOT VERIFY"; continue; }
+  echo "   flash: VERIFY OK  [$((SECONDS-t0))s]"
+
+  t0=$SECONDS
+  raw=$("$FTREAD" 115200 "$READ_MS" 2>"$OUT/read.err")
+  nbytes=$(sed -E 's/.*bytes=([0-9]+).*/\1/' < "$OUT/read.err" | tr -d '\n')
+  echo "   read:  ${nbytes:-0} bytes in $((SECONDS-t0))s"
+
+  # The driver repeats and marks each pass with a lone '.', so the block between
+  # two of them is one complete run. Falling back to the whole capture is
+  # deliberate: a partial block still names some programs, and naming a few is
+  # better than reporting nothing at all.
   block=$(printf '%s' "$raw" | awk '/^\.$/{n++; next} {a[n]=a[n]$0"\n"} END{print a[n-1]}')
-  [ -z "$block" ] && block=$(printf '%s' "$raw")
+  if [ -z "$block" ]; then
+    echo "   (no complete block between two '.' markers -- parsing the whole capture)"
+    block=$(printf '%s' "$raw")
+  fi
+
+  if [ -n "${SHOW_RAW:-}" ]; then
+    echo "   ---- raw capture ----"; printf '%s' "$raw" | sed 's/^/      /'
+    echo "   ---- parsed block ----"; printf '%s' "$block" | sed 's/^/      /'
+  else
+    echo "   verdicts: $(printf '%s' "$block" | tr '\n' ' ' | cut -c1-70)"
+  fi
+
   j=0
   for p in $progs; do
     name=$(basename "$p")
     v=$(printf '%s' "$block" | awk -v k="$j" '$1==k{print $2; exit}')
     if [ -z "$v" ]; then
-      echo "   $name: NO REPORT"; missing=$((missing+1)); echo "$name MISSING" >> "$OUT/results"
+      printf '      %-18s NO REPORT\n' "$name"; missing=$((missing+1)); echo "$name MISSING" >> "$OUT/results"
     elif [ "$v" = "1" ]; then
-      pass=$((pass+1)); echo "$name PASS" >> "$OUT/results"
+      printf '      %-18s pass\n' "$name"; pass=$((pass+1)); echo "$name PASS" >> "$OUT/results"
     else
-      echo "   $name: FAIL verdict $v (test $(( v >> 1 )))"
+      printf '      %-18s FAIL at test %d (verdict %s)\n' "$name" "$(( v >> 1 ))" "$v"
       fail=$((fail+1)); echo "$name FAIL $(( v >> 1 ))" >> "$OUT/results"
     fi
     j=$((j+1))
   done
+  echo "   running total: $pass pass, $fail fail, $missing no report"
 done < "$OUT/plan"
 
 echo

--- a/soc/run_suite_board.sh
+++ b/soc/run_suite_board.sh
@@ -129,13 +129,13 @@ while read -r progs; do
   nbytes=$(sed -E 's/.*bytes=([0-9]+).*/\1/' < "$OUT/read.err" | tr -d '\n')
   echo "   read:  ${nbytes:-0} bytes in $((SECONDS-t0))s"
 
-  # The driver repeats and marks each pass with a lone '.', so the block between
-  # two of them is one complete run. Falling back to the whole capture is
-  # deliberate: a partial block still names some programs, and naming a few is
-  # better than reporting nothing at all.
-  block=$(printf '%s' "$raw" | awk '/^\.$/{n++; next} {a[n]=a[n]$0"\n"} END{print a[n-1]}')
+  # The batch runs ONCE and then repeats a lone '.' forever, so everything before
+  # the first dot is the run. Taking a later block was the bug that made four
+  # programs look broken: the driver used to re-run the batch, and text and CSRs
+  # do not survive a second pass.
+  block=$(printf '%s' "$raw" | awk '/^\.$/{exit} {print}')
   if [ -z "$block" ]; then
-    echo "   (no complete block between two '.' markers -- parsing the whole capture)"
+    echo "   (nothing before a '.' marker -- parsing the whole capture)"
     block=$(printf '%s' "$raw")
   fi
 

--- a/soc/run_suite_board.sh
+++ b/soc/run_suite_board.sh
@@ -129,11 +129,12 @@ while read -r progs; do
   nbytes=$(sed -E 's/.*bytes=([0-9]+).*/\1/' < "$OUT/read.err" | tr -d '\n')
   echo "   read:  ${nbytes:-0} bytes in $((SECONDS-t0))s"
 
-  # The batch runs ONCE and then repeats a lone '.' forever, so everything before
-  # the first dot is the run. Taking a later block was the bug that made four
-  # programs look broken: the driver used to re-run the batch, and text and CSRs
-  # do not survive a second pass.
-  block=$(printf '%s' "$raw" | awk '/^\.$/{exit} {print}')
+  # The programs run ONCE; the driver then replays their verdicts from a buffer,
+  # marking each replay with a lone '.'. So every block between two markers is
+  # the same one-pass result, and taking the last COMPLETE one is safe -- which
+  # matters because reading starts after `iceprog` returns, by which time the
+  # first report is already gone.
+  block=$(printf '%s' "$raw" | awk '/^\.$/{n++; next} {a[n]=a[n]$0"\n"} END{print a[n-1]}')
   if [ -z "$block" ]; then
     echo "   (nothing before a '.' marker -- parsing the whole capture)"
     block=$(printf '%s' "$raw")

--- a/soc/uart_baud_sweep.sh
+++ b/soc/uart_baud_sweep.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Measures the board's real clock through its own UART.
+#
+# rtl/uart.v divides the clock by a constant for 115200, so the rate on the wire
+# moves with the oscillator:  wire_baud = 115200 * f / 12e6.  Move the HOST to
+# meet it and the rate that decodes tells you f.
+#
+# READ THE PLATEAU, NOT A WINNER. 8N1 tolerates a few percent, so a band of
+# rates decodes cleanly; its centre is the board's rate and its width is the
+# uncertainty. A single best score is noise -- an early version of this sampled
+# 900ms per rate against a board that printed once a second, and "won" at
+# whichever window happened to catch a line. Hence the long windows and the
+# minimum byte count below.
+set -uo pipefail
+FTREAD=${FTREAD:-$(cd "$(dirname "$0")" && pwd)/ftread}
+MS=${MS:-6000}
+[ -x "$FTREAD" ] || { echo "no ftread at $FTREAD -- build it with 'make ftread'" >&2; exit 1; }
+
+echo "rate     bytes  clean%  digits eol  sample"
+for baud in 105000 108000 110000 112000 114000 115200 116000 118000 120000 122000 125000; do
+  out=$("$FTREAD" "$baud" "$MS" 2>/tmp/uartsweep.err)
+  st=$(tr -d '\n' < /tmp/uartsweep.err)
+  b=$(sed -E 's/.*bytes=([0-9]+).*/\1/' <<<"$st"); p=$(sed -E 's/.*printable=([0-9]+).*/\1/' <<<"$st")
+  d=$(sed -E 's/.*digits=([0-9]+).*/\1/' <<<"$st"); e=$(sed -E 's/.*eol=([0-9]+).*/\1/' <<<"$st")
+  for v in b p d e; do [ -z "${!v}" ] && eval "$v=0"; done
+  if [ "$b" -lt 8 ]; then
+    printf '%-8s %5s  %6s  %6s %4s  (too few bytes to judge)\n' "$baud" "$b" "-" "$d" "$e"; continue
+  fi
+  pct=$(python3 -c "print(f'{100.0*($p+$e)/$b:.0f}')")
+  mhz=$(python3 -c "print(f'{12e6*$baud/115200/1e6:.2f}')")
+  printf '%-8s %5s  %5s%%  %6s %4s  %-24s %s MHz\n' "$baud" "$b" "$pct" "$d" "$e" \
+    "$(printf '%s' "$out" | tr -d '\r' | tr '\n' ' ' | cut -c1-24)" "$mhz"
+done
+echo
+echo "The centre of the 100%-clean band is the board's baud; f = 12e6 * baud / 115200."

--- a/test/board/board.lds
+++ b/test/board/board.lds
@@ -49,5 +49,15 @@ SECTIONS {
         __bss_end = .;
     } >ram
 
+    /* OUTSIDE [__bss_start, __bss_end) ON PURPOSE. The driver re-zeroes .bss
+     * before every program, so anything of its own kept in there -- the program
+     * index above all -- would be wiped mid-batch and the batch would restart
+     * at program 0 forever. */
+    .driver (NOLOAD) : {
+        . = ALIGN(4);
+        *(.driver);
+        . = ALIGN(4);
+    } >ram
+
     __stack_top = ORIGIN(ram) + LENGTH(ram);
 }

--- a/test/board/board.lds
+++ b/test/board/board.lds
@@ -55,8 +55,10 @@ SECTIONS {
      * at program 0 forever. */
     .driver (NOLOAD) : {
         . = ALIGN(4);
+        __driver_start = .;
         *(.driver);
         . = ALIGN(4);
+        __driver_end = .;
     } >ram
 
     __stack_top = ORIGIN(ram) + LENGTH(ram);

--- a/test/board/board_suite.S
+++ b/test/board/board_suite.S
@@ -27,8 +27,21 @@
   .section .text.init
   .globl _board_start
 _board_start:
-  la    t0, board_index
+  /* ZERO `.driver` BEFORE ANYTHING READS IT. It is NOLOAD and sits outside the
+   * range init_memory clears, so nothing else ever touches it -- and SPRAM
+   * comes out of configuration holding whatever the last program to run left
+   * there. A simulator hands out zeroed RAM and hid this completely; on a board
+   * that had just run another batch, `board_console_len` came up holding the
+   * previous buffer's length and the replay dumped a megabyte of stale SPRAM
+   * down the wire at line rate. */
+  la    t0, __driver_start
+  la    t1, __driver_end
+0:
+  bgeu  t0, t1, 1f
   sw    x0, 0(t0)
+  addi  t0, t0, 4
+  j     0b
+1:
   j     run_next
 
 /* BEFORE EVERY PROGRAM, NOT ONCE PER BATCH, and hardware is what taught this.

--- a/test/board/board_suite.S
+++ b/test/board/board_suite.S
@@ -120,10 +120,24 @@ board_next:
   sw    t1, 0(t0)
   j     run_next
 
+/* THE BATCH RUNS ONCE. The marker below repeats so a host that attached late
+ * can still tell the run finished, but the PROGRAMS do not, and that is the
+ * whole point.
+ *
+ * An earlier version re-ran everything on a loop, and four programs failed
+ * because of it. `.data` and `.bss` are restored before each program, but two
+ * things cannot be: the CSRs -- `mtvec`, `mstatus`, the counters -- and the
+ * TEXT. test/asm/selfmod.S writes to its own instructions, and this SoC's
+ * instruction memory is writable by design, so a second pass ran against code
+ * the first pass had already modified. There is no pristine copy to restore
+ * from: the ROM *is* the instruction memory. Only reconfiguring the part puts
+ * it back.
+ *
+ * So one pass, and the host reads what it says. Cross-program contamination
+ * within that pass remains and is documented at the top; cross-PASS
+ * contamination is now impossible. */
 all_done:
-  /* A marker the host can stop on, then repeat the whole batch: the report is
-   * printed seconds after configuration and nothing is listening yet. */
-  li    a0, 46                     /* '.' */
+  li    a0, 46                     /* '.', end of the one and only pass */
   jal   ra, put_char
   li    a0, 10
   jal   ra, put_char
@@ -131,9 +145,7 @@ all_done:
 5:
   addi  t0, t0, -1
   bnez  t0, 5b
-  la    t0, board_index
-  sw    x0, 0(t0)
-  j     run_next
+  j     all_done
 
 /* ---- the wire ------------------------------------------------------------ */
 

--- a/test/board/board_suite.S
+++ b/test/board/board_suite.S
@@ -137,15 +137,42 @@ board_next:
  * within that pass remains and is documented at the top; cross-PASS
  * contamination is now impossible. */
 all_done:
-  li    a0, 46                     /* '.', end of the one and only pass */
-  jal   ra, put_char
+  /* REPLAY THE REPORT, DO NOT RE-RUN THE PROGRAMS. Both halves are needed and
+   * an earlier version had one at a time.
+   *
+   * Re-running contaminates: CSRs and text carry between passes and cannot be
+   * restored, so selfmod.S and three others failed on the second pass. But
+   * printing once does not work either -- the report lands seconds after the
+   * part configures, and a host that is still finishing `iceprog` sees nothing
+   * but the marker. That is what "no report" for every program looked like.
+   *
+   * So the programs run once and their verdicts, already in `board_console`,
+   * are re-sent from the buffer forever. Every replay is identical because
+   * nothing re-executes; the wire repeats and the machine does not. */
+/* s-registers, because put_wire clobbers t1 and t2 and one of those was this
+ * loop's index. Nothing else is running by now, so the whole file is ours. */
+all_done_loop:
+  la    s0, board_console
+  la    s1, board_console_len
+  lw    s1, 0(s1)
+  li    s2, 0
+6:
+  bgeu  s2, s1, 7f
+  add   a0, s0, s2
+  lbu   a0, 0(a0)
+  jal   ra, put_wire               /* wire only: re-buffering would grow it */
+  addi  s2, s2, 1
+  j     6b
+7:
+  li    a0, 46                     /* '.', end of one replay */
+  jal   ra, put_wire
   li    a0, 10
-  jal   ra, put_char
+  jal   ra, put_wire
   li    t0, 3000000
 5:
   addi  t0, t0, -1
   bnez  t0, 5b
-  j     all_done
+  j     all_done_loop
 
 /* ---- the wire ------------------------------------------------------------ */
 
@@ -154,6 +181,16 @@ all_done:
  * NUL-terminated string out of RAM, so the same report the wire carries can be
  * read from a simulation. Same bytes, one function, so the two cannot differ. */
   .globl board_console
+/* Wire only. The replay above uses this: sending a buffered byte back through
+ * the buffer would append it again and the report would grow without end. */
+put_wire:
+  li    t2, UART_BASE
+1:
+  lw    t1, UART_STATUS_OFFSET(t2)
+  bnez  t1, 1b
+  sw    a0, 0(t2)
+  ret
+
 put_char:
   li    t2, UART_BASE
 1:

--- a/test/board/board_suite.S
+++ b/test/board/board_suite.S
@@ -27,7 +27,22 @@
   .section .text.init
   .globl _board_start
 _board_start:
-  /* .data lives in ROM and has to reach RAM before any program reads it. */
+  la    t0, board_index
+  sw    x0, 0(t0)
+  j     run_next
+
+/* BEFORE EVERY PROGRAM, NOT ONCE PER BATCH, and hardware is what taught this.
+ * .data is restored from ROM and .bss re-zeroed each time, because a program
+ * that ran already has written to both -- and the batch repeats forever so the
+ * second pass would see the first pass's leavings. amoregion.S checks
+ * `trap_count == 11` and read 22 on the second pass; amotrap.S failed the same
+ * way. Under simulation each program gets a fresh machine, and this is what
+ * makes the board's arrangement match it.
+ *
+ * The driver's own state is in `.driver`, deliberately outside the range zeroed
+ * here: the program index lives there, and wiping it would restart the batch at
+ * program 0 forever. */
+init_memory:
   la    t0, __data_load
   la    t1, __data_start
   la    t2, __data_end
@@ -39,7 +54,6 @@ _board_start:
   addi  t1, t1, 4
   j     1b
 2:
-  /* .bss, likewise: the SPRAM comes up holding whatever it held. */
   la    t0, __bss_start
   la    t1, __bss_end
 3:
@@ -48,8 +62,7 @@ _board_start:
   addi  t0, t0, 4
   j     3b
 4:
-  la    t0, board_index
-  sw    x0, 0(t0)
+  ret
 
 /* THE DRIVER'S STATE LIVES IN MEMORY, NOT IN REGISTERS, and that is not a
  * stylistic choice. A suite program owns every register while it runs -- these
@@ -59,13 +72,21 @@ _board_start:
  * held both in registers and trapped to mtvec == 0 partway through the second
  * program. */
 run_next:
+  /* INIT FIRST, AND THE COUNT IS WHY. `board_count` and `board_table` are
+   * .rodata, which this linker script places in .data -- loaded in ROM and run
+   * in RAM. Reading the count before the copy reads uninitialised SPRAM, which
+   * came back zero: the batch looked empty and the driver printed nothing but
+   * its end-of-pass marker, forever. */
+  la    sp, __stack_top            /* the program before it may have moved this */
+  jal   ra, init_memory            /* a fresh machine, as under simulation */
+  la    sp, __stack_top
+
   la    t0, board_index
   lw    t1, 0(t0)
   la    t2, board_count
   lw    t2, 0(t2)
   bgeu  t1, t2, all_done
 
-  la    sp, __stack_top            /* the program before it may have moved this */
   li    TESTNUM, 0
 
   la    t0, board_table
@@ -165,7 +186,7 @@ put_dec:
   addi  sp, sp, 32
   ret
 
-  .section .bss
+  .section .driver,"aw",@nobits
   .align 2
   .globl board_console
 board_console:


### PR DESCRIPTION
Three tools lived in `/tmp`, where the next person would have to rediscover them. One is load-bearing.

## `soc/ftread.c` — the only way to read the UART on macOS

The FT232H has **one** USB interface and it is both the serial port and the MPSSE engine `iceprog` drives. Apple's DriverKit extension claims it, so:

- unprivileged, every libftdi tool reports **zero devices** while `ioreg` shows the board
- after a flash the chip is left in MPSSE mode with **no `/dev/cu.usbserial-*` at all** until it re-enumerates

Root opens it through libusb regardless — which is the state a just-flashed board is actually in, so `screen` is not an option even after a replug. `make ftread` builds it.

## `soc/uart_baud_sweep.sh` — measuring the clock without a scope

`rtl/uart.v` divides by a fixed constant, so the wire rate moves with the oscillator: `wire_baud = 115200 × f / 12e6`. Sweep the host rate, find where 8N1 still decodes, and `f` falls out.

It reads the **plateau**, not a best score, and says why: an earlier version sampled 900 ms per rate against a board printing once a second and "won" at whichever window caught a line. That is a measurement of luck. Long windows, a minimum byte count, and a ratio rather than a total.

## Two driver bugs that only running it found

Both fixed, both verified over **several passes** rather than one.

**`.data` and `.bss` are restored before every program, not once per batch.** The batch repeats, and a program that already ran has written to both. `amoregion.S` checks `trap_count == 11` and read **22** on the second pass; `amotrap.S` failed the same way. Under simulation every program gets a fresh machine — this makes the board match. The driver's own state moved to a `.driver` section outside the range it wipes, or the program index would be zeroed mid-batch and the batch would restart forever.

**The copy has to happen before the count is read.** `board_count` and `board_table` are `.rodata`, which this linker script places in `.data` — loaded in ROM, run in RAM. Reading the count first read uninitialised SPRAM, got zero, and printed nothing but an end-of-pass marker forever.

## Also

`iceprog`'s output is no longer swallowed — it takes thirty seconds and prints progress, and hiding it made a working flash indistinguishable from a hung one. The batch runner now narrates link, place, flash and read with timings, and `SHOW_RAW=1` dumps the wire and the parsed block separately, which is the distinction that matters when a verdict is missing.

## Checks

`make test` 73/73 · `make ftread` builds clean and fails correctly without root · the two-program batch verified across three passes in simulation.

Closes JEF-867