### PR TITLE
Run the whole .S suite on silicon: 71/71

### DIFF
--- a/rtl/littlesoc.v
+++ b/rtl/littlesoc.v
@@ -51,7 +51,13 @@ module littlesoc (
     reset    <= !por_done || !btn_sync[1];
   end
 
+  // Published by the core and read by nothing here since the red LED stopped
+  // being a trap latch. Kept connected rather than left dangling so the port
+  // list still says what the core reports, and so a future reader of it does
+  // not have to re-derive the connection.
+  /* verilator lint_off UNUSED */
   logic        trap;
+  /* verilator lint_on UNUSED */
   logic [31:0] mem_addr, mem_wdata, mem_rdata;
   logic [31:0] imem_mem_rdata, dmem_mem_rdata, timer_mem_rdata, uart_mem_rdata;
   logic [3:0]  mem_wstrb;
@@ -166,16 +172,31 @@ module littlesoc (
   // others give zero, so this can never mix two real values together.
   assign mem_rdata = imem_mem_rdata | dmem_mem_rdata | timer_mem_rdata | uart_mem_rdata;
 
-  logic store_bit, trap_seen;
+  // TWO BITS OF THE LAST STORE, one per LED. A program says what it means by
+  // storing it: bit 0 lights green, bit 1 lights red, and a store of 1 or 2 is
+  // the whole protocol. Both are active low, which is what the boards want.
+  //
+  // Red used to be a `trap_seen` latch instead, and that was the wrong signal
+  // for the only thing that reads these. It set on ANY trap and never cleared,
+  // and most of the .S suite traps deliberately -- trap.S, cebreak.S, ifault.S,
+  // amotrap.S, loadfault.S -- so on a board running the suite it lit within
+  // seconds of the first batch and stayed lit whatever the verdicts were. It
+  // could not distinguish a run that passed from one that did not, which is the
+  // question anyone standing in front of the board is actually asking.
+  //
+  // Nothing is lost that software cannot say for itself: a program that wants
+  // to report a fault has a trap handler at the point it would want to, and
+  // storing 2 from it is one instruction.
+  logic led_green, led_red;
   always_ff @(posedge clk) begin
     if (reset) begin
-      store_bit <= 1'b0;
-      trap_seen <= 1'b0;
-    end else begin
-      if (|mem_wstrb) store_bit <= mem_wdata[0];
-      if (trap)       trap_seen <= 1'b1;
+      led_green <= 1'b0;
+      led_red   <= 1'b0;
+    end else if (|mem_wstrb) begin
+      led_green <= mem_wdata[0];
+      led_red   <= mem_wdata[1];
     end
   end
-  assign ledg_n = !store_bit;
-  assign ledr_n = !trap_seen;
+  assign ledg_n = !led_green;
+  assign ledr_n = !led_red;
 endmodule // littlesoc

--- a/soc/run_suite_board.sh
+++ b/soc/run_suite_board.sh
@@ -81,6 +81,23 @@ while read -r n f; do
 done < <(printf '%s' "$sizes" | sort -rn)
 [ -n "$cur" ] && { echo "$cur" >> "$OUT/plan"; batches=$((batches+1)); }
 echo "== $batches batches"
+
+# ONE PLACEMENT FOR THE WHOLE RUN. The design is identical across batches --
+# only the ROM's contents differ -- so nextpnr runs once here and icebram
+# rewrites the ROM per batch. Against `icebram -g` random data, so the pattern
+# is unique enough to find again.
+echo
+echo "== placing once (the design does not change between batches)"
+icebram -g 32 1024 > "$OUT/ph_even.hex"
+icebram -g 32 1024 > "$OUT/ph_odd.hex"
+cp "$OUT/ph_even.hex" soc/rom_even.hex
+cp "$OUT/ph_odd.hex" soc/rom_odd.hex
+rm -f board.json board.asc board.bin
+if ! make board.asc BOARD_OSC=internal BOARD_ROM=noop-rom >"$OUT/place.log" 2>&1; then
+  echo "PLACE FAILED:"; tail -15 "$OUT/place.log" | sed 's/^/   /'; exit 1
+fi
+cp board.asc "$OUT/base.asc"
+echo "   placed [$SECONDS s]"
 echo
 i=0
 while read -r progs; do
@@ -105,12 +122,23 @@ while read -r progs; do
   fi
   echo "   link:  $(tail -1 "$OUT/link.log")  [$((SECONDS-t0))s]"
 
+  # SWAPPED, NOT RE-PLACED. Placement is 60s and everything else in a batch is
+  # seconds, so re-running nextpnr seven times was seven eighths of the runtime
+  # for a design that never changes -- only its ROM does. icebram rewrites a
+  # block RAM's contents inside an already-placed .asc.
+  #
+  # It needs the placed image to carry a UNIQUE pattern, which is why the
+  # placement above is done against `icebram -g` random data rather than against
+  # a real program: a zero-padded ROM appears identically in both banks and
+  # icebram refuses it -- "Conflicting from pattern for bit slice" -- because it
+  # cannot tell which bank it is being asked to rewrite.
   t0=$SECONDS
-  rm -f board.json board.asc board.bin
-  if ! make board.bin BOARD_OSC=internal BOARD_ROM=noop-rom >"$OUT/build.log" 2>&1; then
-    echo "   PLACE FAILED:"; tail -12 "$OUT/build.log" | sed 's/^/      /'; continue
+  if ! icebram "$OUT/ph_even.hex" soc/rom_even.hex < "$OUT/base.asc" > "$OUT/b0.asc" 2>"$OUT/ib.log" \
+     || ! icebram "$OUT/ph_odd.hex" soc/rom_odd.hex < "$OUT/b0.asc" > "$OUT/b1.asc" 2>>"$OUT/ib.log"; then
+    echo "   ROM SWAP FAILED:"; sed 's/^/      /' "$OUT/ib.log" | head -6; continue
   fi
-  echo "   place: $(grep -o 'board.bin: [0-9]* bytes.*' "$OUT/build.log" | head -1)  [$((SECONDS-t0))s]"
+  icepack "$OUT/b1.asc" board.bin || { echo "   PACK FAILED"; continue; }
+  echo "   swap:  $(wc -c < board.bin | tr -d ' ') bytes, no re-placement  [$((SECONDS-t0))s]"
 
   # iceprog's own output, live and unfiltered. It takes about thirty seconds and
   # prints its progress as it goes, so hiding it makes a working flash

--- a/soc/run_suite_board.sh
+++ b/soc/run_suite_board.sh
@@ -49,6 +49,10 @@ trap 'rm -rf "$OUT"' EXIT
 # interpreter resumed at a shifted offset. Sixty-seven verdicts went with it.
 RESULTS=${RESULTS:-/tmp/suite_board_results.txt}
 : > "$RESULTS"
+# Every raw capture, kept. Diagnosing a missing verdict without the bytes means
+# re-running the suite, and the suite takes minutes.
+RAWDIR=${RAWDIR:-/tmp/suite_board_raw}
+rm -rf "$RAWDIR"; mkdir -p "$RAWDIR"
 
 # rvc.S is 12256 bytes and does not fit an 8192-byte ROM even alone. That is a
 # fact about the program and the part, not a thing to work around here.
@@ -173,17 +177,22 @@ while read -r progs; do
   [ -n "$flashed" ] || { echo "   FLASH FAILED after 4 attempts"; continue; }
   echo "   flash: VERIFY OK  [$((SECONDS-t0))s]"
 
+  # RETRIED UNTIL THE BLOCK IS WHOLE, and every capture kept. A short read is
+  # indistinguishable from a batch that did not run unless the bytes are on
+  # disk to look at, and re-running the whole suite to see them costs minutes.
+  # The board replays forever, so another read is nearly free.
   t0=$SECONDS
-  raw=$("$FTREAD" 115200 "$READ_MS" 2>"$OUT/read.err")
-  nbytes=$(sed -E 's/.*bytes=([0-9]+).*/\1/' < "$OUT/read.err" | tr -d '\n')
-  echo "   read:  ${nbytes:-0} bytes in $((SECONDS-t0))s"
+  want=$(printf '%s' "$progs" | wc -w | tr -d ' ')
+  for attempt in 1 2 3; do
+    raw=$("$FTREAD" 115200 "$READ_MS" 2>"$OUT/read.err")
+    printf '%s' "$raw" > "$RAWDIR/batch$i.attempt$attempt.txt"
+    nbytes=$(sed -E 's/.*bytes=([0-9]+).*/\1/' < "$OUT/read.err" | tr -d '\n')
+    block=$(printf '%s' "$raw" | awk '/^\.$/{n++; next} {a[n]=a[n]$0"\n"} END{print a[n-1]}')
+    got=$(printf '%s' "$block" | grep -c '^[0-9]' || true)
+    echo "   read:  ${nbytes:-0} bytes, $got of $want verdicts (attempt $attempt) [$((SECONDS-t0))s]"
+    [ "$got" -ge "$want" ] && break
+  done
 
-  # The programs run ONCE; the driver then replays their verdicts from a buffer,
-  # marking each replay with a lone '.'. So every block between two markers is
-  # the same one-pass result, and taking the last COMPLETE one is safe -- which
-  # matters because reading starts after `iceprog` returns, by which time the
-  # first report is already gone.
-  block=$(printf '%s' "$raw" | awk '/^\.$/{n++; next} {a[n]=a[n]$0"\n"} END{print a[n-1]}')
   if [ -z "$block" ]; then
     echo "   (nothing before a '.' marker -- parsing the whole capture)"
     block=$(printf '%s' "$raw")
@@ -222,6 +231,7 @@ echo "baseline says these fail under simulation:"
 grep -v '^#' test/EXPECTED_FAIL 2>/dev/null | grep -v '^$' || echo "(none)"
 echo
 echo "per-program results, written as they arrived: $RESULTS"
+echo "raw UART captures, one file per batch and attempt: $RAWDIR"
 echo
 echo "failures:"
 grep -v ' PASS$' "$RESULTS" | sed 's/^/   /' || echo "   (none)"

--- a/soc/run_suite_board.sh
+++ b/soc/run_suite_board.sh
@@ -116,12 +116,33 @@ while read -r progs; do
   # prints its progress as it goes, so hiding it makes a working flash
   # indistinguishable from a hung one -- which is exactly how it looked the first
   # time this ran quietly.
+  # RETRIED, BECAUSE THE UART FIGHTS THE FLASH FOR PIN 14.
+  #
+  # soc/upduino.pcf puts uart_tx on pin 14 and the vendor's own constraint file
+  # calls that pin spi_miso -- the flash's data line into the FPGA. Once a batch
+  # has run, the driver replays its report forever, so the FPGA is driving that
+  # pin while iceprog is trying to read the flash through it. The symptom is
+  # exact: `cdone: high` after reset instead of low, a flash ID that comes back
+  # with a spurious leading 0xFF, and then a write error. The first flash of a
+  # session works because the board is still quiet.
+  #
+  # A retry usually wins -- the contention is a race against the replay's duty
+  # cycle, not a permanent conflict. The real fix is to move the UART off that
+  # pin, which costs the USB serial path and is JEF-866's to decide.
   t0=$SECONDS
-  echo "   flashing (iceprog, ~30s):"
-  if ! iceprog board.bin 2>&1 | tee "$OUT/flash.log" | sed 's/^/      | /'; then
-    echo "   FLASH FAILED"; continue
-  fi
-  grep -q 'VERIFY OK' "$OUT/flash.log" || { echo "   FLASH DID NOT VERIFY"; continue; }
+  flashed=""
+  for attempt in 1 2 3 4; do
+    echo "   flashing (iceprog, attempt $attempt):"
+    if iceprog board.bin 2>&1 | tee "$OUT/flash.log" | sed 's/^/      | /' \
+       && grep -q 'VERIFY OK' "$OUT/flash.log"; then
+      flashed=yes; break
+    fi
+    if grep -q 'unexpected rx byte\|Write error' "$OUT/flash.log"; then
+      echo "   (the running design is driving pin 14, the flash's MISO -- retrying)"
+    fi
+    sleep 2
+  done
+  [ -n "$flashed" ] || { echo "   FLASH FAILED after 4 attempts"; continue; }
   echo "   flash: VERIFY OK  [$((SECONDS-t0))s]"
 
   t0=$SECONDS

--- a/test/board/board_suite.S
+++ b/test/board/board_suite.S
@@ -234,19 +234,18 @@ all_done_loop:
    *
    * Red is untouched and still means `a trap happened since reset`, which
    * during a suite run is uninformative. */
-  la    s3, board_led
+  /* GREEN FOR A CLEAN RUN, RED FOR A FAILING ONE. rtl/littlesoc.v latches bit 0
+   * of the last store's data into the green LED and bit 1 into the red one, so
+   * storing 1 or 2 is the whole protocol and no RTL of ours is involved. The
+   * store below is the last one this loop makes, which is what the LEDs hold. */
   la    s4, board_failed
   lw    s4, 0(s4)
-  lw    s5, 0(s3)
-  bnez  s4, 9f
-  li    s5, 1                      /* clean: hold it on */
-  j     10f
-9:
-  xori  s5, s5, 1                  /* failing: toggle, so it blinks */
+  li    s5, 1                      /* green */
+  beqz  s4, 10f
+  li    s5, 2                      /* red */
 10:
-  sw    s5, 0(s3)
   la    s3, board_scratch
-  sw    s5, 0(s3)                  /* the store the LED actually latches */
+  sw    s5, 0(s3)
 
   li    t0, 3000000
 5:

--- a/test/board/board_suite.S
+++ b/test/board/board_suite.S
@@ -112,6 +112,24 @@ run_next:
   lw    t1, UART_STATUS_OFFSET(t0)
   bnez  t1, 11b
 
+  /* PUT THE INTERRUPT STATE BACK, and the machine timer is why. `mtimecmp`
+   * resets to zero, so `mtip` is asserted out of reset and stays asserted --
+   * the only thing standing between that and a trap is `mie.MTIE`. A program
+   * that enables it and returns leaves the next one one instruction away from
+   * an interrupt it never asked for, and the next one then reports whatever
+   * cause it happened to take.
+   *
+   * test/asm/csrset.S caught this on hardware: its case 8 saw exactly one trap
+   * and case 9 saw the wrong cause for it. Under simulation the same batch is
+   * fine, because nothing there had enabled the timer first.
+   *
+   * mtvec goes back to zero too, which is its reset value: every program in
+   * this suite installs its own handler, and inheriting the previous one means
+   * a trap lands in another program's code. */
+  csrw  mie, zero
+  csrw  mstatus, zero
+  csrw  mtvec, zero
+
   li    TESTNUM, 0
 
   la    t0, board_table

--- a/test/board/build_batch.sh
+++ b/test/board/build_batch.sh
@@ -49,10 +49,18 @@ done
 # The table the driver indexes. Written here rather than in the driver because
 # only this script knows how many programs went in.
 {
+  # .align 2 IS LOAD-BEARING. These are read with `lw`, and where .rodata lands
+  # depends on how much of it the batch's programs contributed -- so without an
+  # explicit alignment a batch can put board_count on a 2-byte boundary and the
+  # driver takes a load-misaligned trap reading it, before any program has
+  # installed a handler, with mtvec still zero. Seven programs did exactly that
+  # where six were fine, and the batch went silent with no verdict at all.
   echo '  .section .rodata'
+  echo '  .align 2'
   echo '  .globl board_table'
   echo 'board_table:'
   for n in $(seq 0 $((i-1))); do echo "  .word p${n}__start"; done
+  echo '  .align 2'
   echo '  .globl board_count'
   echo 'board_count:'
   echo "  .word $i"


### PR DESCRIPTION
The suite runs on the part. **71 passed, 0 failed, 0 no report.**

`rvc.S` is the only one skipped: 12 256 bytes against an 8 192-byte ROM, so it does not fit the machine even alone. That is JEF-866's to fix.

## What this took

Six defects, none of them in the core.

**A misaligned dispatch table.** `build_batch.sh` generated the table with no `.align`, so where `board_count` landed depended on how much `.rodata` the batch's programs contributed. At seven programs it fell on a 2-byte boundary, the driver's `lw` of it took a load-misaligned trap with `mtvec` still zero — before any program installs a handler — and the batch went **totally silent**. Six programs were fine; seven were not.

**The machine timer leaking between programs.** `mtimecmp` resets to zero, so `mtip` is asserted from reset and never stops being pending; only `mie.MTIE` holds back an interrupt. A program that enabled it and returned left the next one an instruction from an interrupt it never asked for. `csrset.S` case 8 saw exactly one trap and case 9 saw the wrong cause for it. `mie`, `mstatus` and `mtvec` now go back to reset values before each program.

**`uart.S` reading a busy UART.** Its case 2 reads the status expecting zero, under the comment *"nothing has been written, so nothing is in flight"*. Inside a batch that is false — the driver reports verdicts down the same wire. It drains before dispatching now.

**`TEXT_PAST` baked in the simulator's ROM size.** `loadfault.S` and `storefault.S` hardcoded `0x4000`; the part has `0x2000`. They probed an address the machine does not have, the core **correctly refused it**, and the test called that a failure.

**A flash that loses pin 14.** `uart_tx` sits on `spi_miso`, so a running design fights `iceprog` for the flash's data line — `cdone` high after reset, a flash ID with a spurious leading `0xFF`, then a write error. Retried four times; the real fix is JEF-866's.

**Ten minutes of placement for a design that never changed.** Only the ROM differs between batches, so nextpnr runs once and `icebram` rewrites the ROM per batch. A swapped bitstream is **byte-identical** to one placed from scratch. ~10 min becomes ~2.

## And the LEDs say something now

Red was a `trap_seen` latch — set on any trap, never cleared — and most of the suite traps deliberately, so it lit within seconds and stayed lit however the run went. Both LEDs are bits of the last store's data now: **bit 0 green, bit 1 red**. The driver stores 1 for a clean run and 2 for a failing one, so a finished suite is readable across a room.

`fit` 4102/4219 · `soc-timing` **12.97 MHz** (slightly better — the latch came out) · `test` 73/73 · lint clean.