### PR TITLE
Isolate tracked_ignored_test.sh from per-developer git excludes

### DIFF
--- a/test/probe_gates.sh
+++ b/test/probe_gates.sh
@@ -29,7 +29,7 @@ REPO=$(cd "$HERE/.." && pwd)
 # Pinned as a literal: a probe that is deleted, or that stops being reached by
 # an early `return`, would otherwise cut this file's coverage while it kept
 # printing a green summary.
-PROBES_EXPECTED=584
+PROBES_EXPECTED=586
 
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/littlecpu-probe.XXXXXX") || {
   echo "error: could not create a temporary directory under ${TMPDIR:-/tmp}." >&2
@@ -2879,6 +2879,29 @@ d=$(ti_fixture)
 printf 'scratch.log\n' > "$d/.gitignore"
 printf 'noise\n' > "$d/scratch.log"
 probe "control: an ignored file that was never tracked is not a defect" 0 \
+  "tracked files, none matching a .gitignore rule" "$TI $d"
+
+# THE FALSE-POSITIVE DIRECTION: `check-ignore --no-index` also consults two
+# exclude sources this repository does not carry -- a developer's own
+# `core.excludesFile` and `$GIT_DIR/info/exclude`, neither committed and
+# neither shared. A rule on either must not turn this check red for a file
+# this tree tracks on purpose; each fixture below matches a tracked file
+# against a rule from exactly one of the two, with no matching rule anywhere
+# in the tree itself.
+d=$(ti_fixture)
+gx=$(new_case)/global-gitignore
+printf 'globalrule.json\n' > "$gx"
+printf 'built\n' > "$d/globalrule.json"
+git -C "$d" add -f globalrule.json
+git -C "$d" config core.excludesFile "$gx"
+probe "control: a rule from this developer's core.excludesFile is not this repository's to grade" 0 \
+  "tracked files, none matching a .gitignore rule" "$TI $d"
+
+d=$(ti_fixture)
+printf 'excluderule.json\n' >> "$d/.git/info/exclude"
+printf 'built\n' > "$d/excluderule.json"
+git -C "$d" add -f excluderule.json
+probe "control: a rule from this clone's \$GIT_DIR/info/exclude is not this repository's to grade" 0 \
   "tracked files, none matching a .gitignore rule" "$TI $d"
 
 begin_group "test/march_test.sh"

--- a/test/tracked_ignored_test.sh
+++ b/test/tracked_ignored_test.sh
@@ -19,6 +19,20 @@
 # the first place -- so a check that dropped the flag would be exactly as
 # inert as the .gitignore lines it exists to catch.
 #
+# `--no-index` ALSO consults two exclude sources this repository does not
+# carry, and both were measured rather than assumed. With `core.excludesFile`
+# pointed at a file naming `*.json`, `check-ignore --no-index` matched a
+# tracked `.json` file against it -- a rule on one developer's machine, red on
+# theirs and green everywhere else. `-c core.excludesFile=/dev/null` answers
+# that. `$GIT_DIR/info/exclude` is the same kind of rule -- per clone, never
+# committed -- and is a SEPARATE source: the same `.json` line written into
+# `.git/info/exclude` still matched with `core.excludesFile` neutralised, so
+# that config alone does not cover it. `--no-index` needs no object database,
+# and reads `$GIT_DIR/info/exclude` out of whatever `--git-dir` names, so
+# `--git-dir` is pointed at a throwaway repository with no `info/exclude` of
+# its own instead -- `--work-tree` keeps every path resolved against $REPO,
+# so a real .gitignore anywhere in it still matches exactly as before.
+#
 # A hit here is never a matter of taste: a tracked-and-ignored file is either a
 # dead rule (the file was committed first) or a commit that should not have
 # happened (the rule was there first and something bypassed it with
@@ -43,14 +57,26 @@ tmp=$(mktemp -d "${TMPDIR:-/tmp}/littlecpu-trackedignored.XXXXXX") || {
 }
 trap 'rm -rf "$tmp"' EXIT
 
-if ! git -C "$REPO" ls-files -z > "$tmp/files" 2> /dev/null || [ ! -s "$tmp/files" ]; then
+if ! git -c core.excludesFile=/dev/null -C "$REPO" ls-files -z > "$tmp/files" 2> /dev/null \
+   || [ ! -s "$tmp/files" ]; then
   echo "error: cannot enumerate any tracked files under $REPO. A tree git" >&2
   echo "cannot list is a scan of nothing reporting green." >&2
   exit 1
 fi
 
+# A bare repository with no info/exclude of its own, so the check below can be
+# pointed at it in place of $REPO's real $GIT_DIR -- see the note above.
+noexclude="$tmp/no-info-exclude"
+if ! git init -q --bare "$noexclude" > /dev/null 2> "$tmp/init-err"; then
+  echo "error: could not create a throwaway git directory under $tmp to" >&2
+  echo "isolate the check from this developer's \$GIT_DIR/info/exclude:" >&2
+  cat "$tmp/init-err" >&2
+  exit 1
+fi
+
 set +e
-git -C "$REPO" check-ignore --stdin -z --no-index -v < "$tmp/files" > "$tmp/hits" 2> "$tmp/err"
+git -C "$REPO" --git-dir="$noexclude" --work-tree="$REPO" -c core.excludesFile=/dev/null \
+  check-ignore --stdin -z --no-index -v < "$tmp/files" > "$tmp/hits" 2> "$tmp/err"
 rc=$?
 set -e
 


### PR DESCRIPTION
## The bug

`test/tracked_ignored_test.sh` runs `git check-ignore --no-index`, which also consults exclude sources this repository does not carry: a developer's own `core.excludesFile` (their personal `~/.gitignore`) and `$GIT_DIR/info/exclude` (per-clone, never committed). A rule on either one — an ordinary `*.log` or `*.json` line — matched a file this tree tracks on purpose and turned `make test` red on that one machine only. CI was unaffected, which made it harder to see rather than easier.

## The fix

- `-c core.excludesFile=/dev/null` on both the `ls-files` and `check-ignore` invocations neutralizes the first source.
- **`$GIT_DIR/info/exclude` needed its own handling — `--no-index` does not already exclude it.** Measured directly: a pattern written straight into `.git/info/exclude` still matched a tracked path even with `core.excludesFile` already neutralized, because `--no-index` reads `info/exclude` out of whatever `--git-dir` names and needs no object database to do it. So `check-ignore` is now pointed at a throwaway bare git directory (created fresh in `$tmp` on every run) that carries no `info/exclude` of its own, while `--work-tree` stays on the real repo so every actual `.gitignore` rule still resolves and matches exactly as before.

## Tests

Two new probes in `test/probe_gates.sh`'s `test/tracked_ignored_test.sh` group, one per exclude source, each asserting a **green** result under a hostile config (a tracked file matching a rule from `core.excludesFile` / `$GIT_DIR/info/exclude` alone, with no matching rule in the tree). This is the inverted shape from every other probe in the file, so each was proven to actually go red against the pre-fix script: I reverted `test/tracked_ignored_test.sh` to `origin/main`'s version in a scratch copy, re-ran `probe_gates.sh`, and both new probes reported RED (`exited 1, expected 0`, naming the fixture's `.json` file and its rule), then restored the fix and re-ran to confirm both go green again.

The six existing probes for this script are untouched and stay green, including the one demonstrating the original defect (a tracked file matching its own **in-repo** `.gitignore` rule is still caught and named).

`PROBES_EXPECTED` moved from 584 to **586**, read from the script's own mismatch error after adding the two probes, not computed.

Also ran `make test` end-to-end in a throwaway clone with `core.excludesFile` pointed at a fixture naming `*.json`, reproducing the exact false-positive shape the bug report described, and confirmed the suite stays green with the fix in place.

## Scope

Only `test/tracked_ignored_test.sh` and `test/probe_gates.sh` changed. No ADR — this is a bug fix in a grader, not an architectural decision. `make netlist-digest` is unaffected (no `rtl/` change).

Closes JEF-894
