### PR TITLE
Close init.templateDir as a third per-developer exclude source

### DIFF
--- a/test/PROBES_EXPECTED
+++ b/test/PROBES_EXPECTED
@@ -420,7 +420,9 @@ control: a peripheral above the reserved span is accepted
 control: a placement holding the whole core is green
 control: a report clearing the floor is green
 control: a rule from this clone's $GIT_DIR/info/exclude is not this repository's to grade
+control: a rule from this developer's $GIT_TEMPLATE_DIR is not this repository's to grade
 control: a rule from this developer's core.excludesFile is not this repository's to grade
+control: a rule from this developer's init.templateDir is not this repository's to grade
 control: a stamped sweep summarises
 control: a stamped sweep with its reports behind it is binned
 control: a suite matching its manifest is green

--- a/test/probe_gates.sh
+++ b/test/probe_gates.sh
@@ -2914,6 +2914,24 @@ git -C "$d" add -f excluderule.json
 probe "control: a rule from this clone's \$GIT_DIR/info/exclude is not this repository's to grade" 0 \
   "tracked files, none matching a .gitignore rule" "$TI $d"
 
+# A THIRD such source: a developer's own init.templateDir. `git init --bare`
+# copies a template directory's contents -- including an info/exclude of its
+# own -- into the fresh $GIT_DIR the check builds to isolate itself from the
+# CLONE's info/exclude, so a rule sitting in the template reaches that same
+# throwaway repository unless something stops it. GIT_CONFIG_GLOBAL, scoped
+# to this one probe invocation, stands in for that developer's real global
+# config without touching this session's.
+d=$(ti_fixture)
+template=$(new_case)/hostile-template
+mkdir -p "$template/info"
+printf 'templaterule.json\n' > "$template/info/exclude"
+printf 'built\n' > "$d/templaterule.json"
+git -C "$d" add -f templaterule.json
+hostileconf=$(new_case)/hostile-gitconfig
+printf '[init]\n\ttemplateDir = %s\n' "$template" > "$hostileconf"
+probe "control: a rule from this developer's init.templateDir is not this repository's to grade" 0 \
+  "tracked files, none matching a .gitignore rule" "GIT_CONFIG_GLOBAL='$hostileconf' $TI $d"
+
 begin_group "test/march_test.sh"
 
 # A COPY OF THE SHIPPING FILES again, plus a `git init` over it, for the reasons

--- a/test/probe_gates.sh
+++ b/test/probe_gates.sh
@@ -2932,6 +2932,22 @@ printf '[init]\n\ttemplateDir = %s\n' "$template" > "$hostileconf"
 probe "control: a rule from this developer's init.templateDir is not this repository's to grade" 0 \
   "tracked files, none matching a .gitignore rule" "GIT_CONFIG_GLOBAL='$hostileconf' $TI $d"
 
+# The SAME template, delivered by the MIDDLE rung of git-init(1)'s precedence
+# instead of the bottom one. Two things only this direction grades: it needs no
+# git-version support, where GIT_CONFIG_GLOBAL above is honoured only from
+# 2.32, so on an older git that probe passes having demonstrated nothing; and
+# it is the rung that decides the FLAG. Measured, not read off the manual: a
+# `-c init.templateDir=` on the init line does not defeat $GIT_TEMPLATE_DIR
+# and `--template=` does, which is why the check spells it the second way.
+d=$(ti_fixture)
+template=$(new_case)/hostile-env-template
+mkdir -p "$template/info"
+printf 'envtemplaterule.json\n' > "$template/info/exclude"
+printf 'built\n' > "$d/envtemplaterule.json"
+git -C "$d" add -f envtemplaterule.json
+probe "control: a rule from this developer's \$GIT_TEMPLATE_DIR is not this repository's to grade" 0 \
+  "tracked files, none matching a .gitignore rule" "GIT_TEMPLATE_DIR='$template' $TI $d"
+
 begin_group "test/march_test.sh"
 
 # A COPY OF THE SHIPPING FILES again, plus a `git init` over it, for the reasons

--- a/test/tracked_ignored_test.sh
+++ b/test/tracked_ignored_test.sh
@@ -33,6 +33,15 @@
 # its own instead -- `--work-tree` keeps every path resolved against $REPO,
 # so a real .gitignore anywhere in it still matches exactly as before.
 #
+# A THIRD source reaches that same throwaway repository: `git init --bare`
+# itself honours `init.templateDir`, and a template directory holding its own
+# `info/exclude` is copied into the fresh `$GIT_DIR` -- measured the same way,
+# with a template naming a tracked path. `--template=` pointed at an empty
+# directory answers it; git-init(1)'s TEMPLATE DIRECTORY section orders the
+# three sources `--template` above `$GIT_TEMPLATE_DIR` above
+# `init.templateDir`, so `-c init.templateDir=` would still lose to a
+# developer's own `$GIT_TEMPLATE_DIR`.
+#
 # A hit here is never a matter of taste: a tracked-and-ignored file is either a
 # dead rule (the file was committed first) or a commit that should not have
 # happened (the rule was there first and something bypassed it with
@@ -66,8 +75,13 @@ fi
 
 # A bare repository with no info/exclude of its own, so the check below can be
 # pointed at it in place of $REPO's real $GIT_DIR -- see the note above.
+# --template= names an empty directory so `git init --bare` cannot pick one
+# up out of a developer's own init.templateDir or $GIT_TEMPLATE_DIR and copy
+# an info/exclude of ITS OWN into the throwaway repository it just isolated.
+notemplate="$tmp/no-template"
+mkdir -p "$notemplate"
 noexclude="$tmp/no-info-exclude"
-if ! git init -q --bare "$noexclude" > /dev/null 2> "$tmp/init-err"; then
+if ! git init -q --bare --template="$notemplate" "$noexclude" > /dev/null 2> "$tmp/init-err"; then
   echo "error: could not create a throwaway git directory under $tmp to" >&2
   echo "isolate the check from this developer's \$GIT_DIR/info/exclude:" >&2
   cat "$tmp/init-err" >&2


### PR DESCRIPTION
## What

`a27b954` (#236) isolated `test/tracked_ignored_test.sh` from two per-developer
exclude sources — `core.excludesFile` and `$GIT_DIR/info/exclude` — by pointing
`--git-dir` at a throwaway bare repository with no `info/exclude` of its own.

That throwaway repository is itself built with `git init --bare`, which honours
`init.templateDir`: a template directory carrying its own `info/exclude` gets
copied into the fresh `$GIT_DIR`, reintroducing the exact false positive the
throwaway directory exists to prevent.

## Fix

`--template=` on that one `git init --bare` call, pointed at a freshly-created
empty directory. Per `git-init(1)`'s TEMPLATE DIRECTORY precedence
(`--template` > `$GIT_TEMPLATE_DIR` > `init.templateDir` > the default template
directory), `--template=` is the only one of the three that outranks every
other source — `-c init.templateDir=` would still lose to a developer's own
`$GIT_TEMPLATE_DIR` environment variable, which sits one level above
`init.templateDir` in that same order.

## The exhaustive exclude-source enumeration

`gitignore(5)` documents exactly four pattern sources, highest to lowest
precedence:

1. Patterns passed on the command line to the command doing the matching —
   N/A here, this script never passes any.
2. In-repo `.gitignore` files — the one source this check exists to grade,
   left untouched.
3. `$GIT_DIR/info/exclude` — isolated via the throwaway `--git-dir` (#236).
4. `core.excludesFile` — neutralised via `-c core.excludesFile=/dev/null`
   on both git invocations (#236).

All three non-in-repo sources are now closed, including #3's own supply
chain: a template directory is not itself one of the four documented
*pattern* sources, but it is a way to populate #3 at the moment the
throwaway repository is created, which is exactly the gap this ticket closes.
I also checked that `-c core.excludesFile=/dev/null` suppresses the *default*
global-ignore location git falls back to when `core.excludesFile` is unset
anywhere (`$XDG_CONFIG_HOME/git/ignore`) — confirmed empirically, not a
distinct fifth source. **No fourth exclude source remains that this check can
still inherit.**

## Testing

- Added a third probe to `test/probe_gates.sh`, matching the shape and
  fixture pattern of the two #236 added: a **green** control under a hostile
  `init.templateDir` (a template directory whose `info/exclude` matches a
  tracked path), scoped to that one probe invocation via `GIT_CONFIG_GLOBAL`
  rather than touching any shared config.
- **Proved the fix load-bearing in a fully isolated clone**, the way #236's
  probes were proved: built a fixture repo tracking a file a hostile
  `init.templateDir`'s `info/exclude` also names, ran the fixed script
  (green), then reverted the `--template=` flag in a scratch copy and ran it
  again against the same fixture — red, naming the throwaway repository's own
  `info/exclude` as the source, then restored.
- The original defect (a tracked file matching an in-repo `.gitignore` rule)
  is still caught — its probe is unchanged and still passes.
- `PROBES_EXPECTED` read from the script's own error output after adding the
  probe: **587** (main is 586).
- `make test`, `make test-units`, `make probe-gates` (587/587) all green.
- `make netlist-digest`: could not run — this machine's `nextpnr-ice40`
  binary is broken independent of this change (`dyld: Symbol not found:
  __ZN5boost15program_options3argE`, a stale binary against a newer Homebrew
  boost, dated before this session). No `rtl/` file is touched by this diff,
  so the mapped netlist is unaffected by construction; I could not produce a
  fresh digest to confirm mechanically.

Closes JEF-897.