### PR TITLE
Inset .data and the stack by one 2 KB block in every linker script

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,16 @@ references still resolve.
   placements; the price is +13.79% of Dhrystone's cycles (ADR-0129). Enforced by
   `components_traps` over `formal/traps.sv`, `test/decoder_tb.v`'s region vectors and
   `rtl/decoder.v`'s `FORMAL` block.
+  **So this core has a layout preference, and the shipping linker scripts pay it** (ADR-0158). A
+  64 KB window is 32 blocks and 30 of them are deep, so a program whose stack and `.data` sit one
+  2 KB block clear of the edges reaches the fast arm on essentially every access, and one that does
+  not pays a cycle per access. Every script under `test/` starts `.data` one block above `ram`'s
+  origin and puts `__stack_top` one block below its top, which takes Dhrystone's `REGION` column
+  from 212,752 cycles to 2 on RTL nobody touched. **A program that ignores the convention pays what
+  Dhrystone used to pay.** It is graded in the linker rather than remembered: two `ASSERT`s per
+  script, with `test/probe_gates.sh` planting a bad layout in each and requiring the link to fail.
+  `soc/compare/dhry.lds` is left at the conventional layout on purpose, so the stale cross-core
+  product is re-taken as a pair rather than one side at a time.
 - **Every inter-stage struct carries a `valid` bit** (3). A bubble is `valid = 0`; retire is
   `valid` reaching writeback, which gates `wen` and drives `rvfi_valid`.
 - **Hazards are stall-only** (4). No forwarding network: a RAW hazard stalls in decode against a
@@ -387,14 +397,21 @@ top, ECP5 only.
   minute (ADR-0078).
 - **`make dhrystone` and `make coremark` are the figures comparable to another project's** —
   Dhrystone to VexRiscv, CoreMark to Hazard3 and most cores published since — and neither is a
-  gate. Dhrystone: **0.664 DMIPS/MHz, 7.97 DMIPS at 12 MHz** at `-O2` (ADR-0129), quoted with the
+  gate. Dhrystone: **0.758 DMIPS/MHz, 9.10 DMIPS at 12 MHz** at `-O2` (ADR-0158), quoted with the
   absolute figure because Fmax above the requirement is margin and not speed (ADR-0089), and with
-  the flags, compiler and string library, which the program prints and will not compile without.
-  **It went 9.10 → 7.97 on purpose** — the region wait's price (ADR-0129) — and a CPI regression
-  with no conformance behind it is still a regression. **CoreMark is SIMULATED AT 16 KB OF ROM**,
+  the flags, the compiler, the string library and **the linker script** — the program prints the
+  first three and will not compile without them, and `test/bench/bench.lds` asserts the fourth at
+  link time. **It went 9.10 → 7.97 and back to 9.10, and the two moves differ in kind**: the region
+  wait spends 13.79% of Dhrystone's cycles to make an out-of-region access fault (ADR-0129), and
+  insetting the layout gives those cycles back with no RTL change, `make fit` and the netlist digest
+  both unmoved (ADR-0158). A CPI regression with no conformance behind it is still a regression, and
+  a figure recovered by moving the software is the firmware ceasing to pay a cost, never the core
+  getting faster. **CoreMark is SIMULATED AT 16 KB OF ROM**,
   double the part's 8, against `test/testbench.v`'s `ROM_WORDS`, and every printed figure says so;
   the five algorithm files are vendored unmodified and pinned by `test/bench/coremark/PINNED.sha256`
-  (ADR-0136). Hazard3's published 4.15 CoreMark/MHz is its RP2350 build, not its iCE40 one, and
+  (ADR-0136). **2.013 CoreMark/MHz** on the shipping layout against 1.811 on the conventional one,
+  so it travels with the linker script the way the DMIPS figure does (ADR-0158).
+  Hazard3's published 4.15 CoreMark/MHz is its RP2350 build, not its iCE40 one, and
   quoting it against an ice40 core is the mixed-configuration error ADR-0098 names.
 - **The only cross-core comparison that means anything is one harness**, `soc/compare/`: same part,
 memories, program, toolchain and seeds, against the VexRiscv in the pinned riscv-formal clone and
@@ -501,7 +518,9 @@ make test           # the test/asm suite (.S and .c) under cxxrtl + unit benches
 make test-units     # the unit benches alone; the list is checked against test/*_tb.v both ways
 make elaborate-strict # yosys elaborates every simulation source through `check`; the
                     # required `elaborate` CI job
-make probe-gates    # force every graded comparison red for its own reason; needs only yosys
+make probe-gates    # force every graded comparison red for its own reason. Two groups need a
+                    # real tool: yosys for the zkt netlist walk, and the cross linker
+                    # for the linker scripts' layout ASSERTs
 make mutation-check # delete a term from rtl/ and require exactly the detectors
                     # test/MUTATION_DETECTORS pairs with it to go red, both ways. ~3.5 min,
                     # not on `make test`; `make mutation-probe` forces its graders red and IS

--- a/docs/adr/0152-the-fast-arm-reads-the-immediates-sign.md
+++ b/docs/adr/0152-the-fast-arm-reads-the-immediates-sign.md
@@ -1,0 +1,159 @@
+# ADR-0152: The region fast arm can read the immediate's sign, and the layout convention got there first
+
+**Status:** Declined (the measurement stands) · 2026-09-03 · superseded as a change by ADR-0158,
+which recovers the same cycles in the linker for no cells and no period.
+
+## Context
+
+ADR-0129 moved the load/store region answer off the fetch loop and a cycle late: `reg_rs1` deep
+inside a mapped window — in it, and in neither its first 2 KB block nor its last — is answered in the
+issuing cycle off raw register bits with no adder, and anything nearer an edge bubbles one cycle and
+reads a flip-flop. The price was **+13.79% of Dhrystone's cycles**, 9.10 → 7.97 DMIPS, and it bought
+causes 5 and 7 for the twelve plain load and store encodings.
+
+That fast arm is symmetric and the offset is not. A 12-bit signed immediate moves the base's 2 KB
+block by at most one step, and only in the direction its sign allows: `immediate[31] == 0` can leave
+the block upward and never downward, `immediate[31] == 1` the reverse. So "in the window and not its
+LAST block" is enough for a non-negative offset and "in the window and not its FIRST block" for a
+negative one, and both edge blocks become answerable in the issuing cycle for half the offsets each.
+The decoder's own `ifdef FORMAL` block already asserts the fact this stands on —
+`immediate[31:12] == {20{immediate[31]}}` for every `ls_access` encoding — and the compressed load
+and store forms zero-extend, so they take the non-negative arm.
+
+**The prior evidence predicted this would be declined.** ADR-0145 added a second conditional case to
+this same `ls_text_deep`/`ls_supported` block and measured 16 of 16 paired seeds slower, median
+−5.89% of period, and 5 of 16 placements under the 12.00 MHz floor, with every candidate placement's
+critical path ending on a `region_stall`-adjacent net. `ls_settled` feeds
+`region_stall → stall → next_pc`, which is the fetch loop, and ADR-0116 and ADR-0128 measured seven
+spellings of the same-cycle answer at +9.10% to +17.30% of median period. This was built anyway on
+this repo's own rule that an inherited conclusion is not a measurement: ADR-0145 measured a second
+window ORed into the range test, not a sign-selected pair of block tests.
+
+## The decision
+
+**`rtl/decoder.v`'s `ls_text_deep` and `ls_ram_deep` split into an in-window test and the two end-block
+tests, and pick the end by `immediate[31]`.** `ls_settled`, `region_stall`, `ls_capture`, the held
+answer and `ls_supported` are untouched; the arm only ever widens, so nothing that waited before can
+fault now and nothing that faulted before can stop waiting. A window of a single block is both ends at
+once and both arms fold to constant zero, which keeps the timer's, the UART's and the SPI
+controller's windows off the fast path in the safe direction. The refusal stays one-sided — a miss
+means "wait for the flip-flop", never "fault" — so `mcause` is still a function of the access and not
+of the base register, and the neighbourhood test ADR-0129 declined for exactly that reason is still
+declined.
+
+## Correctness, before timing
+
+`rtl/decoder.v`'s `if (ls_settled) assert(ls_supported)` is the whole correctness argument and it is
+**proved by k-induction on the changed arm** (`make -C formal components_decoder`: successful proof
+by k-induction), with `formal/decoder-zkt-probe.py`'s two red directions still failing at their own
+lines (1387, 1389) as its prerequisite. `test/zkt_isolation_test.py` passes unchanged: `immediate[31]`
+is an instruction bit, `in.instr` is classified non-value, and the `EXPECT_TAINTED` chain
+(`ls_block`, `ls_text_deep`, `ls_ram_deep`, `ls_settled`, `region_stall`) survives verbatim. All **86
+generated riscv-formal checks pass**, matching `EXPECTED_FAIL` and `EXPECTED_CHECKS` exactly;
+`components_traps`, `components_pcloop` and `nonperturbation` pass; `complete` passes over its
+recorded exclusion set. **F and G re-measured and both flip points reproduce at 6 and 6**, which is
+expected rather than lucky — the arm strictly narrows when `region_stall` asserts, so neither the
+worst-case first retire nor the worst-case retire gap can grow. `make test` is 74/74 and
+`make cosim-suite` is 69/74 agreed, both matching their baselines.
+
+Three graders moved and each is a retire count rather than a claim. `test/decoder_tb.v`'s fast-path
+vectors were symmetric and are now stated in both directions — a first-block base waits under a
+negative offset and issues under a non-negative one, a last-block base the other way round — and five
+vectors that took the wait through a first-block base were moved to a last-block one, since the
+sign-aware arm settles the old base. `test/OBSERVED_FLOOR`'s `uart.S` line is re-derived, 1381 → 1380:
+it is a poll loop around a 10-bit frame, so how many times it goes round is a CPI question, and this
+change moves it the way the region wait moved it when that landed. `test/MUTATION_DETECTORS` gains one
+pairing: `lrsclock.S` is a retry loop under a live timer, and it now detects `mtip-fires-a-tick-early`
+by falling through its floor. **That pairing was one retire away from existing already** — measured
+both ways here, the mutation leaves `lrsclock.S` at exactly its floor of 156 on the base tree and at
+155 on this one, against 156 and 159 unmutated — so the claim it replaces ("the whole suite stays
+green under it") was true by a margin of zero. It is a weak, accidental grader kept for the reason
+`uart.S` is kept as one, and the file says so at the line.
+
+## The cycles
+
+`make cycles`, the 74-program `.S`/`.c` suite: **42 319 → 40 885 cycles, −3.39%**, CPI 2.00 → 1.94,
+with the REGION column **2224 → 780, −64.9%**.
+
+`make dhrystone`, `-O2`, 3580 bytes of the SoC's 8 KB ROM: **1 756 248 → 1 661 678 cycles, −5.38%**,
+REGION **212 752 → 118 171, −44.5%**, and **0.664 → 0.703 DMIPS/MHz**. At the board's 12 MHz that is
+**7.97 → 8.44 DMIPS**, which is a throughput figure and not margin.
+
+**The prize is 2.9× what the sketch that proposed it predicted.** That sketch put the whole win at
+the 32 516 first-block accesses (−1.85% of Dhrystone's cycles) and said the stack — 84.7% of the
+region column, which it read as a last-block base under positive offsets — was exactly the crossing
+this cannot settle. 94 581 cycles came out, so either that decomposition or the sign it assigned the
+stack's offsets is wrong; the measurement does not say which, and the 118 171 that remain are what a
+future attempt has left to price.
+
+Two probes in `rtl/littlecpu.v` are deliberately **not** updated and no longer predict the REGION
+column: `probe_ls_edges` counts what a region test answered from `reg_rs1` ALONE would stall on, which
+is a family of designs rather than the shipping arm, and it reads no immediate. It stays at 212 752 on
+Dhrystone against a column of 118 171, and the gap between the two is now the value of reading the
+sign. `probe_ls_bypasses` moves 4053 → 70 088 for a different reason: near-edge accesses issue a cycle
+earlier now, so many more of them land on a cycle the register file is writing their base register
+through.
+
+## The period, which was the whole question
+
+**Sixteen paired placements, `datainit.c`, same tree (`dba70e9`), same toolchain, base against
+candidate:**
+
+| | worst | median | best | spread | under 12.00 MHz |
+|---|---|---|---|---|---|
+| base | 12.06 MHz | 12.99 MHz | 13.37 MHz | 10.8% | **0 of 16** |
+| candidate | **12.53 MHz** | 12.85 MHz | 13.30 MHz | 6.1% | **0 of 16** |
+
+**The median period is +1.07% and 13 of 16 seeds are slower** (two-sided sign test p = 0.021) — a real
+systematic cost, and one smaller than the churn band `soc/bands.py` states for this part. The tail did
+not follow it: the worst placement is 3.8% FASTER, and **no placement on either side is under the
+12.00 MHz requirement**. Read the worst column as one sample of a distribution the way this repo reads
+every other margin — the base's own worst of sixteen has read 12.39, 12.21, 12.03 and 12.06 MHz on four
+trees — not as evidence that the change made the part faster.
+
+`make fit` is a null: **4109 → 4108 packed `ICESTORM_LC`** on the core's own top. The SoC's placed
+count is not: **4943 → 5055, +112 cells**, deterministic across all sixteen seeds a side. That is the
+top-dependent split ADR-0094 measured for a different edit, and at 5055 of 5280 it is the number a
+future change in this area has to budget against.
+
+## What this does not establish
+
+It does not refute ADR-0145, which measured a different term: a second window ORed into
+`rtl/imemory.v`'s range test and `rtl/decoder.v`'s, with a bank-index clamp beside it. It says only
+that "a term added to `ls_settled`" is not one class with one price — this one is two 5-bit equalities
+per window and a 2:1 mux on a bit the decoder already has, and it measures inside the churn band where
+that one measured −5.89% and missed the floor.
+
+It is not a claim that the fetch loop got cheaper. +1.07% at the median with p = 0.021 is a cost, and
+what pays for it is 5.38% of Dhrystone's cycles at a clock that still closes; margin above 12 MHz is
+not speed, so the trade is a CPI win bought with headroom this design had.
+
+It does not close the region column. 118 171 of Dhrystone's cycles are still spent waiting, the two
+locality probes no longer bound them, and nothing here measured which accesses they are.
+
+
+## Why it does not ship
+
+Measured against the CONVENTIONAL layout, this arm is worth 5.38% of Dhrystone's cycles. ADR-0158
+insets `.data` and the stack by one 2 KB block in every shipping linker script and takes the same
+`REGION` column from 212 752 cycles to 2, for no RTL, no cells and no period. Stacked on that
+layout — both changes in one tree, `make cycles` and `make dhrystone` re-run — this arm is worth
+**2 cycles** of Dhrystone's 1 543 495 and 208 of the suite's 41 052.
+
+Its costs do not shrink with its prize. The SoC grows **112 placed `ICESTORM_LC`**, outside the
+±50 churn band, on a design already at 94% of the part; the median period is **+1.07% at 13 of 16
+paired seeds, two-sided sign test p = 0.021**, which is the most significant of the three period
+readings taken this day. Two cycles do not buy that.
+
+**What the measurement is still good for.** It is the counter-example to reading ADR-0145's verdict
+as a rule about the block: a different term added to `ls_text_deep`/`ls_ram_deep` measured −5.89% of
+median with five placements under the floor, and this one measured +1.07% with none, so that ADR
+prices its own term and not the signal. It also establishes the arm's correctness, proved by
+k-induction against the unchanged `if (ls_settled) assert(ls_supported)`, so a future reader who
+needs it for a workload that cannot follow the layout convention has the design and its price
+rather than an estimate.
+
+**What would reopen it.** Firmware that cannot inset its own layout, or a second window narrow
+enough that the convention has nowhere to put a hot base. Re-take the sweep stacked on the shipping
+layout rather than against the conventional one; the numbers above are the only paired figures that
+describe the tree as it now stands.

--- a/docs/adr/0158-the-linker-scripts-inset-data-and-the-stack-by-one-block.md
+++ b/docs/adr/0158-the-linker-scripts-inset-data-and-the-stack-by-one-block.md
@@ -1,0 +1,109 @@
+# 0158 — The linker scripts inset `.data` and the stack by one 2 KB block
+
+Status: accepted · a SOFTWARE convention, not a core change. No file under `rtl/` moved, `make fit`
+reads the same 4109 `ICESTORM_LC` and `make netlist-digest` reads the same hash.
+
+## Context
+
+ADR-0129 bought precise load and store access faults for a cycle. `rtl/decoder.v` answers the region
+question off raw register bits when `reg_rs1` sits **deep** inside a mapped window — in it, and in
+neither its first 2 KB block nor its last — because a 12-bit signed offset reaches 2 KB either way,
+so the effective address is in the block `reg_rs1` names or one on either side. A base register in an
+edge block might cross the window edge, so the answer comes out of a flip-flop and the access bubbles
+one cycle.
+
+**Every linker script in this tree had put both of the things a compiled program dereferences most in
+exactly those two blocks.** `__stack_top = ORIGIN(ram) + LENGTH(ram)` is the last block of RAM, so
+every frame sat in it and every `lw`/`sw` off `sp` paid; `.data` started at `ORIGIN(ram)`, the first
+block, so every pointer and gp-relative access paid too. That is the whole of Dhrystone's `REGION`
+column — 212 752 of 1 756 248 cycles, 12.1% of the run — and 100.0% of the `.S` suite's load/stores
+sat near an edge, which is the figure ADR-0129 recorded as the pessimal case and read as a property
+of small hand-written programs. It was a property of the linker script.
+
+The core is not what put the data there. A 64 KB window has 32 blocks and 30 of them are deep, so a
+program that keeps its stack and its globals one block in reaches the fast arm on essentially every
+access, and one that does not pays a cycle per access. **This core has a layout preference**, and
+nothing in the tree stated it or checked it.
+
+## Decision
+
+Give `.data` an address one 2 KB block above `ram`'s ORIGIN, and put `__stack_top` one 2 KB block
+below `ram`'s top, in every linker script that describes a machine this core is on:
+`test/asm/boot.lds`, `test/asm/sections.lds`, `test/bench/bench.lds`, `test/bench/coremark.lds` and
+`test/board/board.lds`. The address goes on the output section, not on a bare top-level `.` — a
+`>ram` section takes its address from the region counter and would ignore one.
+
+`.tohost` keeps the first block in all of them. The runners watch the first word of RAM for the
+verdict, and a handful of accesses to one word is not what the convention is for. In
+`test/asm/sections.lds` that meant splitting `.tohost` out of the single `>ram` output section it
+shared with `.data` and `.rodata`, so `.data` could take an address of its own; the ROM load image
+gained no padding, because a `.S` program's ROM image is `--only-section=.text` and a `.c` program's
+`.data` keeps its `AT>rom` load address immediately after `.text`.
+
+**The placement is graded, not remembered.** Each script carries two linker `ASSERT`s — one over
+`ADDR(.data)`, one over `__stack_top - 1`, the highest byte the stack can reach, since `sp` is
+decremented before anything is stored through it — requiring both to land in a block that is neither
+`ram`'s first nor its last, with a message naming the cost. The link fails otherwise. Ten probes in
+`test/probe_gates.sh` plant a bad layout in each script and require the link to fail with that
+message, plus a control that links all five shipping scripts; `test/PROBES_EXPECTED` goes 590 → 600.
+
+**`soc/compare/dhry.lds` is deliberately left at the conventional layout.** It feeds the cross-core
+comparison whose DMIPS product CLAUDE.md already marks stale, both halves of which have to be
+re-taken together on one tree before it can be quoted again. Moving one side of a two-core
+measurement that is already owed a re-take would make the re-take harder to read, not easier. The
+layout is a variable that comparison should set deliberately, on the day it is re-run, for both
+cores at once.
+
+## The measurement
+
+Base commit `dba70e9`, macOS 26.3.1, `riscv64-elf-gcc` 16.2.0 with GNU ld 2.47.20260726, Yosys
+0.68+post. Every instrument re-run on the same tree, before and after, with nothing else changed.
+
+| instrument | before | after |
+|---|---|---|
+| `make dhrystone` cycles | 1 756 248 | **1 543 497** (−12.11%) |
+| `make dhrystone` `REGION` column | 212 752 | **2** |
+| DMIPS/MHz | 0.664 | **0.758** |
+| DMIPS at 12 MHz | 7.97 | **9.10** |
+| `make coremark` (16 KB ROM) | 1.811 CoreMark/MHz | **2.013** |
+| `make cycles` suite | 42 319 cycles, CPI 2.00 | **41 052**, CPI 1.94 (−2.99%) |
+| `make cycles` suite `REGION` | 2 224 | **947** |
+| `make fit` | 4109 `ICESTORM_LC` | **4109** |
+| `make netlist-digest` | `sha256:1a1d1fe3…` | **identical** |
+
+Dhrystone's near-edge locality counter goes 212 752 accesses (56.6% of its load/stores) to **2**
+(0.0%), and its `REGION` column follows it exactly — the counter was built to price this design
+without building it, and it prices this one to the cycle as well.
+
+The suite keeps 947 `REGION` cycles rather than reaching zero, and that is the convention working
+rather than failing: `.tohost` is in the first block on purpose, and several programs address the
+timer, the UART and deliberately unmapped addresses, none of which is three blocks wide and none of
+which can reach the fast arm at all.
+
+**Retire counts move by single digits and it is the linker, not the core.** Dhrystone retires
+950 430 → 950 427 and the `.S` suite 21 118 → 21 122, because moving `.data` and `__global_pointer$`
+changes which `la` sequences ld can relax. `test/OBSERVED_FLOOR` is graded with `>=` and no line
+needed to move; `make test` is 74/74 with the failure list matching `test/EXPECTED_FAIL`, and
+`make cosim-suite` is 69/74 against `test/COSIM_EXPECTED_FAIL` exactly.
+
+## What this does NOT establish
+
+- **The core did not get faster.** Its cycle count for any given access is exactly what it was.
+  What changed is where the shipping firmware keeps its stack and its globals, so it stops paying a
+  cost it never had to pay. A program that ignores the convention pays what Dhrystone used to pay,
+  on this same core.
+- **Any DMIPS or CoreMark figure quoted from here travels with the layout**, the way it already
+  travels with the flags, the compiler and the string library. 0.758 DMIPS/MHz and 2.013
+  CoreMark/MHz describe this core running a program linked one block in. They are not comparable to
+  a number taken on a script that was not, and they are not comparable to another project's unless
+  that project's layout is known.
+- **Nothing here is a fact about `soc/compare/`.** That harness still links Dhrystone at the
+  conventional layout for both cores, so its cycle factor is unchanged and its stale product is
+  stale in exactly the same way it was.
+- **Not a general result about linker layout.** It is a result about a window that is 32 blocks
+  wide, where 30 of them are deep. The timer, the UART and the SPI controller are one or two blocks
+  each, so nothing addressed through them reaches the fast arm whatever a script does, and no
+  inset would help.
+- **It closes nothing ADR-0129 opened.** The eighth stall reason is still there, still bubbles, and
+  is still what makes an out-of-region access fault. This spends less time in it; it does not
+  remove it.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -151,3 +151,123 @@ a gap.
 | [0140](0140-probes-expected-becomes-a-named-manifest-not-a-scalar.md) | `PROBES_EXPECTED` becomes a named manifest, not a scalar | Accepted · replaces `test/probe_gates.sh`'s single checked-in literal with `test/PROBES_EXPECTED`, one probe label per line, sorted, checked against the labels actually run under set equality in both directions — the rule `test/EXPECTED_FAIL`/`test/OBSERVED_FLOOR` already use. Reached after a rebase that git reported clean silently dropped six probes' worth of coverage: two commits' diffs to the scalar (515→556, 556→562) replayed onto a base already at 562 landed as a no-op then a near-miss, at 563, with nothing to conflict on. A named manifest's diff is a set of independent line insertions rather than an arithmetic transform, which is the shape git's line-based merge cannot get quietly wrong; sorting spreads unrelated PRs' insertions across the file by label text instead of concentrating every PR on one line, which is what had made three PRs in a row conflict on it. Considered and declined: a merge driver or per-group counts summed at runtime (a union merge can silently accept two groups while a third's count goes missing), and a count generated from the same file it grades (trivially agrees with a version that is already wrong, since both sides move together). Demonstrated by hand, both directions, since the check being replaced is this file's own coverage ratchet and cannot be probed without the file invoking itself |
 | [0145](0145-a-12-kb-text-window-two-windows-ored-not-a-magnitude-compare.md) | A 12 KB text window is priced and declined — the period, not the area | Declined (the measurement) · prices ADR-0135's 8 KB ceiling directly: two power-of-two windows ORed, 3072 = 2048 + 1024, which keeps both `rtl/imemory.v` range tests reductions and is correct everywhere it was built — the bank arrays go non-power-of-two (1536 words) with an index clamp that folds an out-of-range truncation back in before the array read, `rtl/decoder.v`'s `ls_supported`/`ls_text_deep` take the same two-window shape a plain load or store into the text region needs, and all 86 generated riscv-formal checks pass at the new 3072-word default `test/memmap_test.sh` forces onto `rtl/littlecpu.v`. **The period does not survive it**: sixteen paired placements, same tree, put the median at **−5.89%**, **16 of 16 seeds slower** (two-sided sign test p ≈ 3×10⁻⁵) and **5 of 16 under the 12.00 MHz floor** (worst 11.86 MHz against the base's 12.06) — `make fit`'s core-alone count is a null, so the cost is the fetch loop and not area. Every candidate's critical path starts or ends inside `rtl/imemory.v`. Shape (b), a magnitude comparison, is declined without its own sweep: the file's own header already measured that shape at a quarter of the whole period for the adjacent `next_is_last` test, and shape (a) already misses the floor. **All RTL and test changes are reverted in the same commit as this ADR** — the shipping ROM stays 2048 words, `test/asm/rvc.S` still does not run on silicon, and `soc/run_suite_board.sh` still batches |
 | [0150](0150-a-union-merge-driver-replaces-hand-rebasing-docs-adr-readme.md) | A union merge driver replaces hand-rebasing this table | Accepted · tested directly on this tree: two branches each appending a distinct row merge with no conflict under `merge=union` where they conflict under git's default strategy, and `test/adr_numbering_test.sh` still catches a genuine duplicate ADR number the same merge lets through, because that check reads the claimed number off the filenames on disk rather than off this table |
+| [0158](0158-the-linker-scripts-inset-data-and-the-stack-by-one-block.md) | The linker scripts inset `.data` and the stack by one 2 KB block | Accepted · a SOFTWARE convention, not a core change: no `rtl/` file moved, `make fit` reads the same 4109 `ICESTORM_LC` and `make netlist-digest` the same hash. 0129's region wait answers off raw register bits only when the base register sits deep inside a mapped window, and every script in the tree had put `__stack_top` in `ram`'s LAST 2 KB block and `.data` in its FIRST — so every `lw/sw` off `sp` and every pointer access bubbled a cycle. That was the whole of Dhrystone's `REGION` column. Insetting both by one block: Dhrystone 1 756 248 → **1 543 497** cycles with `REGION` 212 752 → **2**, **0.664 → 0.758 DMIPS/MHz** (7.97 → 9.10 DMIPS at 12 MHz), CoreMark **1.811 → 2.013**, the `.S` suite 42 319 → 41 052. Graded rather than remembered: two linker `ASSERT`s per script over `ADDR(.data)` and `__stack_top - 1`, with ten `test/probe_gates.sh` probes planting a bad layout and requiring the link to fail (590 → 600). `soc/compare/dhry.lds` is deliberately LEFT conventional — it feeds the cross-core comparison whose product 0098 already marks stale, and one side of a two-core measurement must not move alone. **The core did not get faster**: its cycle count per access is unchanged, the shipping firmware stopped paying a cost it did not have to, and any DMIPS or CoreMark figure quoted from here now travels with the layout the way it already travels with the flags |
+
+0001–0007 came from the design brief
+([`docs/ideas/finish-the-rewrite.md`](../ideas/finish-the-rewrite.md)). 0008–0011 came out of
+sprint planning, when the panel ran the toolchain and found the brief's assumptions needed
+resolving before work could start. 0012–0014 came out of integrating the first build sprint, when
+review of the build-repair and datapath-fix changes turned up decisions neither had recorded, and the test
+suite that fails in its entirety. 0010 supplements 0006; 0011 scopes 0005; 0012 supplements 0010;
+0013 implements 0006's pinning clause; 0014 supplements 0007 and 0008. 0015-0017 came out of
+integrating the second build sprint: 0015 extends 0009 with a stall source 0009 did not know
+existed, 0016 constrains the CI gate, and 0017 records what the newly-passing decoder
+component proof does and does not establish. 0018-0020 came out of integrating the third build
+sprint: 0018 supersedes 0016 now that required checks exist, 0019 makes the monitor sanitizer the
+place a generated-oracle defect gets repaired, and 0020 records that ADR-0006's non-perturbation
+guarantee is argued rather than proven. 0021-0023 came out of integrating the riscv-formal ladder
+port — the first time any formal check ran against the pipelined core. 0021 keeps the compressed
+checks in the ladder and records the C.JR/C.JALR decode defect they found; 0022 replaces the
+nightly's blanket failure-swallowing with an ADR-0014-style baseline; 0023 states what the run
+does and does not establish, and why M2 is not reached. 0024 closes one of 0023's three named
+holes by switching the ladder's default BMC engine. 0031 re-vendors the `genchecks` copy from the
+pin — retiring the local mechanism 0024 built to reach that engine, while leaving 0024's
+measurement intact — and records why none of the ten `fault`/`bus_*` checks it unlocks apply here.
+0032 came out of a time-boxed spike against the Sail RISC-V model and resolves the "Spike or Sail
+co-simulation" item that used to sit in the deferred list below. 0033 came out of integrating those
+three together: it audits the machinery M2 is *measured* by rather than the core it measures, and
+records what a green ladder and a matching baseline do not, on their own, establish. 0034 came out of
+integrating the CSR file: it records the two decode-side decisions ADR-0005's field list left open,
+corrects ADR-0027 on the counter `h` halves, measures what the `csrw_*` checks cannot see, and fixes
+a `CLAUDE.md` engineering rule that named the wrong file. 0035 amends 0014 and applies 0033's lens
+to the *simulation* gate: `test/run_tests.sh` had three ways to report success without having tested
+anything, so the failure set now records name **and** status and every build step is checked. 0036 was
+recorded integrating those three gate changes together: it ratifies putting `hang` on the ladder
+(`liveness` does not subsume it — it *assumes* a retire at its trigger cycle and is vacuous on a core
+that never retires), corrects 0031 on how the `csrc_*` family is actually reached, and closes the
+`case_default` question by measuring that yosys already errors on the latch. It also records a
+gap it did not close: `formal/EXPECTED_FAIL` still matches on names only, so a red check that flips
+from `FAIL` to `ERROR` keeps the ladder green — 0035's lesson, unapplied to the formal side. 0039
+finishes the first half of 0032's integration list: the whole `.S` suite now runs under
+co-simulation behind `make cosim-suite`, graded by 0014's set equality in 0035's name-and-status
+format, and `tohost` becomes the doubleword the HTIF protocol it borrows always specified — an
+amendment to 0008, and the one change here that touches what both existing sim legs read. 0040 is
+0038's question asked of the verification harness rather than of the area: it measures whether the
+riscv-formal ladder can model the negedge regfile 0038 recommends, finds that it refuses to rather
+than mis-modelling it, rejects `clk2fflogic` as the remedy on measured vacuity, and — applying 0033's
+lens once more — fixes a `make -C formal check` that could not re-run the ladder and had been
+re-grading the previous run's verdict. 0041 came out of integrating those three together: it
+measures what 0039's `tohost` change actually did to the architectural register trace (382 values,
+zero events), and records the co-simulation nightly 0039 deliberately omitted as owed work with its
+preconditions, so it stops depending on anyone's memory. 0043 takes 0039's two baselined
+divergences to zero without touching the core: the reference model was a `--config-override` on
+Sail's *default* RV32 machine, so it had atomics, bit-manipulation, float, supervisor mode, user
+mode and vectors that nobody chose, and `csrr misa` was the one register a test happened to read.
+It is now a complete `--config` describing 0002's RV32IMC_Zicsr, and the leftover — an
+implementation-defined value with no knob — is exempted by name, one register at a time, or moved
+to a bench with no reference model in it when the program *branches* on it.
+0046 is 0025 asked again of a pipeline it no longer described. 0025's own addendum said the sweep
+should be repeated once the CSR RTL existed and it never was, and `e4f5250` then added a fifth stall
+reason without touching the depth table — so the one M2 term marked met rested on a derivation two
+changes stale. It re-derives the numbers and changes how: the whole argument now rests on two
+quantities the ladder measures about itself in seconds (`hang` for the worst-case first retire,
+`liveness` for the worst-case retire gap) rather than on hand-tracing, which is the part that went
+stale. No depth moves. It also gives the 70 `insn_*` checks the liveness probe they had never had,
+and that probe exhibits the failure mode the whole file is about: swept below its floor, a check
+passes on a core that is broken.
+
+## Deferred decisions
+
+These are deliberately *not* decided yet. Each requires a new ADR before being built, because each
+trades away simplicity the current design depends on.
+
+- ~~**Forwarding network**~~ — **priced by
+  [ADR-0083](0083-the-forwarding-network-is-priced-and-declined-on-the-margin.md), and decided
+  AGAINST.** The old entry called it a CPI-only optimisation, safe to add once the core was verified.
+  It is verified now, and the cost is not CPI: both spellings were built, both run the suite and pass
+  every proof, and both are declined on the period they cost against a 12 MHz requirement that does
+  not slide. The ceiling is what settles it — deleting the scoreboard outright buys 0% of period, so
+  nothing in this direction pays for the muxes.
+- ~~**Radix-4 divider / early termination**~~ — **rejected outright by
+  [ADR-0038](0038-area-is-measured-in-logic-cells-and-two-levers-are-rejected.md).** CPI-only and it
+  *increases* area, which is the wrong direction on a part that does not currently place. The
+  "55–70% utilisation" figure this entry used to cite was a yosys cell count and was wrong; the
+  measured figure is 126%.
+- ~~**negedge-BRAM regfile**~~ — **resolved by [ADR-0042](0042-the-regfile-read-is-synchronous-and-costs-a-cycle.md),
+  and decided AGAINST.** The regfile did move to block RAM — 6971/132% to 4236/80%, which is the
+  whole area problem in one lever — but with a **posedge** read plus a one-cycle operand-fetch stall,
+  not a negedge strobe. All three reconciliations of invariant 6 with a synchronous EBR were built
+  and measured, and area does not choose between them (86 cells across the three, 1.6% of the part).
+  The negedge variant is 99 cells cheaper and costs **no** cycles; it was rejected because sby's
+  `prep` fails closed on mixed clock polarity, so the generated ladder cannot run against it at all —
+  every check, not one — and shipping it would mean a posedge substitution in `formal/wrapper.v` plus
+  an equivalence proof whose k-induction does not close. Serialising the two read ports onto one
+  array was built too: 44/52, three red checks, and it needs a second bypass level. See
+  [ADR-0040](0040-the-ladder-refuses-a-negedge-regfile-and-make-check-was-re-grading.md) for the
+  verification-side data the decision was made with.
+- ~~**FPGA timing closure / nextpnr flow**~~ — **built by
+  [ADR-0054](0054-the-memory-system-and-the-first-real-timing-number.md)**, ahead of its post-M4
+  slot and with every M2 term re-run rather than assumed. The SoC places on up5k/sg48 and
+  `make soc-timing` reports `icetime`'s critical path with its logic/routing split. ADR-0003's
+  second ROM read did become interleaved banks — at **word** granularity, not the halfword split
+  ADR-0044 named, because this core's fetch interface asks for two adjacent words and windows them
+  itself. The bootloader is half-built: the `.data` copy stub landed with
+  [ADR-0081](0081-the-data-image-lives-in-rom-and-crt0-copies-it.md), so the SoC runs a C program
+  that reads its own globals. ADR-0044's SPI-flash path stays deferred, now against the measured
+  ROM budget rather than a guess.
+- ~~**Interrupts**~~ — **the machine timer is built by
+  [ADR-0082](0082-the-machine-timer-interrupt-is-taken-at-a-decode-boundary.md).** The old entry's
+  reason ("no interrupt sources exist") was circular: `rtl/timer.v` is the source, and it is four
+  words on the data bus. `mie.MTIE` and `mip.MTIP` are real; `mip.MSIP`/`mip.MEIP` stay read-only
+  zero because this platform has neither source. What is still deferred is a controller, more
+  sources and a vectored `mtvec` — the same mechanism with more inputs.
+- ~~**Spike or Sail co-simulation**~~ — **resolved by [ADR-0032](0032-sail-co-simulation-is-worth-building-and-stays-opt-in.md).**
+  The old test ("revisit only if formal and simulation ever disagree") could only fire on a bug both
+  legs can see; a spike measured what neither can.
+  [ADR-0039](0039-co-simulation-runs-the-whole-suite-against-a-baseline.md) integrated it across the
+  whole suite against a baseline, and
+  [ADR-0095](0095-co-simulation-is-required-and-its-fetch-is-verified.md) makes it a required check
+  on `main` once the digest-verified fetch ADR-0032 asked for existed. Still `make cosim-run` /
+  `make cosim-suite` and never `make test`. The memory comparison remains future work; the nightly
+  job does not, having been overtaken by the gate.
+| [0152](0152-the-fast-arm-reads-the-immediates-sign.md) | The region fast arm can read the immediate's sign, and the layout convention got there first | Declined (the measurement stands) · worth 5.38% of Dhrystone's cycles against the conventional layout and **2 cycles** stacked on ADR-0158's, for +112 placed SoC cells and +1.07% of median period at 13 of 16 seeds, p = 0.021. Proved correct by k-induction against the unchanged `ls_settled` assertion, so the design and its price are on record for firmware that cannot inset its own layout. Also the counter-example to reading ADR-0145 as a rule about the signal rather than about its own term |

--- a/soc/compare/dhry.lds
+++ b/soc/compare/dhry.lds
@@ -18,6 +18,15 @@
  *
  * The two ORIGINs are soc/compare/bench.lds', unchanged, so the reset vector and
  * the RAM base are the ones both harness tops already implement.
+ *
+ * DELIBERATELY NOT INSET, AND DO NOT "FIX" IT. Every linker script under test/
+ * now starts `.data` one 2 KB block above its RAM origin and puts the stack one
+ * block below the top, because littlecpu's decoder answers a load or store's
+ * region question off raw register bits only when the base register is that far
+ * from a window edge. Doing it here would move ONE side of a two-core
+ * measurement whose product is already owed a re-take on one tree, which is the
+ * error this whole directory exists to prevent. The layout is a variable this
+ * comparison should set for both cores at once, on the day it is re-run.
  */
 MEMORY {
     rom(rx)  : ORIGIN = 0x00000000, LENGTH = 8K

--- a/test/PROBES_EXPECTED
+++ b/test/PROBES_EXPECTED
@@ -399,6 +399,12 @@ and the same for the check-set baseline
 assembler output on a successful build is still a defect
 assembler output on a successful build is still a defect
 baselining ERROR would re-create the btorsim hole with this gate's blessing
+bench.lds putting .data back at ram's origin is red
+bench.lds putting the stack back at the top of ram is red
+board.lds putting .data back at ram's origin is red
+board.lds putting the stack back at the top of ram is red
+boot.lds putting .data back at ram's origin is red
+boot.lds putting the stack back at the top of ram is red
 branch_taken carrying reg_rs1/reg_rs2 into hazard is red
 columns that do not add up blame the report, not the core
 columns that no longer add up to the cycle count are red
@@ -432,6 +438,7 @@ control: a tool that answers is stamped with its version and its path
 control: a tracked file with no matching ignore rule is clean
 control: a well-formed report publishes the frequency
 control: agreeing paths outside the checkout are green
+control: all five shipping scripts link at the inset layout
 control: an ECP5 sweep summarises against its own instrument
 control: an accounting that adds up prints the table
 control: an archive matching the vendored tree exactly is endorsed
@@ -477,6 +484,8 @@ control: the shipping tree states every band figure in one place
 control: the tracked monitor sanitizes, and rule 3 fires
 control: two identical netlists are equal
 control: two sweeps measured the same way are subtracted
+coremark.lds putting .data back at ram's origin is red
+coremark.lds putting the stack back at the top of ram is red
 data past the end of the simulated RAM is red, not silent
 decoder_output.rd widened past 5 bits is red (finding 5)
 every source line moving is the comment class, and is forgiven
@@ -524,6 +533,7 @@ runner exit 5 is TRAP-TO-ZERO, not a timeout with no cause
 runner exit 6 is MONITOR-SILENT: the oracle never looked
 running the generator from the wrong directory is refused, not done
 sby's trailing engine numbers are not part of the status
+sections.lds putting .data back at ram's origin is red
 starvation going red somewhere other than the bound is not evidence
 starvation going red somewhere other than the bound is not evidence
 status AGREE with a nonzero exit is a broken harness, not agreement

--- a/test/asm/boot.lds
+++ b/test/asm/boot.lds
@@ -29,6 +29,18 @@
  * `.rodata` stays in `rom` and is read over the data bus, which this core
  * allows (test/asm/textload.S is the program that says so). Copying it would
  * cost the same ROM plus the RAM to land in.
+ *
+ * THE 2 KB INSET IS THIS CORE'S LAYOUT CONVENTION and the ASSERTs at the bottom
+ * are what grade it. rtl/decoder.v answers a load or store's region question off
+ * raw register bits only when the base register sits deep inside a mapped
+ * window -- in it, and in neither its first 2 KB block nor its last. A 12-bit
+ * signed offset reaches 2 KB either way, so a base register in an edge block
+ * might cross the edge, the answer has to come from a flip-flop instead, and the
+ * access bubbles one cycle. So `.data` starts one 2 KB block above `ram`'s
+ * ORIGIN and the stack starts one block below its top, and both kinds of access
+ * then issue with no region term in them. `.tohost` keeps the first block: the
+ * runners watch the first word of RAM, and a handful of accesses to one word is
+ * not what the convention is for.
  */
 MEMORY {
     rom(rx)  : ORIGIN = 0x00000000, LENGTH = 16K
@@ -58,7 +70,7 @@ SECTIONS {
      * front of it. Put anything -- an ALIGN, a symbol, a literal -- above it
      * and the copy reads from the wrong place by however many bytes it added.
      */
-    .data : {
+    .data ORIGIN(ram) + 2048 : {
         __data_start = .;
         __global_pointer$ = . + 0x800;
         *(.sdata);
@@ -81,5 +93,19 @@ SECTIONS {
         __bss_end = .;
     } >ram
 
-    __stack_top = ORIGIN(ram) + LENGTH(ram);
+    __stack_top = ORIGIN(ram) + LENGTH(ram) - 2048;
+
+    /*
+     * The grader for the convention the header describes. `.data`'s own address,
+     * and the highest byte the stack can reach -- the stack descends and sp is
+     * decremented before anything is stored through it, so nothing is ever
+     * accessed at __stack_top itself. Both must land in a 2 KB block that is
+     * neither `ram`'s first nor its last.
+     */
+    ASSERT(ADDR(.data) >= ORIGIN(ram) + 2048 &&
+           ADDR(.data) < ORIGIN(ram) + LENGTH(ram) - 2048,
+           "layout: .data starts in ram's first or last 2 KB block, so every access through a pointer into it pays rtl/decoder.v's one-cycle region wait. Start it one 2 KB block above ORIGIN(ram).")
+    ASSERT(__stack_top - 1 >= ORIGIN(ram) + 2048 &&
+           __stack_top - 1 < ORIGIN(ram) + LENGTH(ram) - 2048,
+           "layout: __stack_top puts the top of the stack in ram's first or last 2 KB block, so every lw/sw off sp there pays rtl/decoder.v's one-cycle region wait. Put it one 2 KB block below ORIGIN(ram) + LENGTH(ram).")
 }

--- a/test/asm/sections.lds
+++ b/test/asm/sections.lds
@@ -31,6 +31,16 @@
  * which links the same map with `.data`'s load address in `rom` so the startup
  * can copy it -- the only shape the SoC can boot, since its SPRAM cannot be
  * initialised from a bitstream.
+ *
+ * `.tohost` IS ITS OWN OUTPUT SECTION so that `.data` can have its own address.
+ * rtl/decoder.v answers a load or store's region question off raw register bits
+ * only when the base register sits deep inside a mapped window -- in it, and in
+ * neither its first 2 KB block nor its last -- because a 12-bit signed offset
+ * reaches 2 KB either way, and an access whose base is in an edge block bubbles
+ * a cycle while the answer comes out of a flip-flop. `.data` therefore starts
+ * one 2 KB block above `ram`'s ORIGIN, which is the same convention
+ * test/asm/boot.lds' header states at length and the ASSERT below grades.
+ * `.tohost` keeps the first block: the runners watch the first word of RAM.
  */
 MEMORY {
     rom(rx)  : ORIGIN = 0x00000000, LENGTH = 16K
@@ -44,8 +54,12 @@ SECTIONS {
         . = ALIGN(4);
     } >rom
 
-    .data : {
+    .tohost : {
         *(.tohost);
+        . = ALIGN(4);
+    } >ram
+
+    .data ORIGIN(ram) + 2048 : {
         *(.data);
         *(.rodata);
         *(.rodata.*);
@@ -56,4 +70,8 @@ SECTIONS {
         *(.bss);
         . = ALIGN(4);
     } >ram
+
+    ASSERT(ADDR(.data) >= ORIGIN(ram) + 2048 &&
+           ADDR(.data) < ORIGIN(ram) + LENGTH(ram) - 2048,
+           "layout: .data starts in ram's first or last 2 KB block, so every access through a pointer into it pays rtl/decoder.v's one-cycle region wait. Start it one 2 KB block above ORIGIN(ram).")
 }

--- a/test/bench/bench.lds
+++ b/test/bench/bench.lds
@@ -15,6 +15,15 @@
  * one region, and ld reports the overflow in bytes. A Dhrystone that had to be
  * trimmed to fit would produce a number nothing could be compared against, so
  * overflowing here is the correct outcome to report rather than to fix.
+ *
+ * THE 2 KB INSET ON `.data` AND ON `__stack_top` TRAVELS WITH THE DMIPS FIGURE.
+ * It is the layout convention test/asm/boot.lds' header states and the ASSERTs
+ * at the bottom grade: a load or store whose base register sits in a mapped
+ * window's first or last 2 KB block bubbles a cycle in rtl/decoder.v, because a
+ * 12-bit offset could cross the window edge and the answer has to come out of a
+ * flip-flop. Dhrystone is stack-heavy, so a script without the inset measures a
+ * different number on the same core, and the layout is part of what the DMIPS
+ * figure is quoted with.
  */
 MEMORY {
     rom(rx)  : ORIGIN = 0x00000000, LENGTH = 8K
@@ -40,7 +49,7 @@ SECTIONS {
 
     /* __data_start is the first thing in this section so LOADADDR(.data) below
      * is that symbol's load address and not some padding in front of it. */
-    .data : {
+    .data ORIGIN(ram) + 2048 : {
         __data_start = .;
         __global_pointer$ = . + 0x800;
         *(.sdata);
@@ -63,5 +72,16 @@ SECTIONS {
         __bss_end = .;
     } >ram
 
-    __stack_top = ORIGIN(ram) + LENGTH(ram);
+    __stack_top = ORIGIN(ram) + LENGTH(ram) - 2048;
+
+    /* The grader. `.data`'s address, and the highest byte the stack can reach --
+     * the stack descends and sp is decremented before anything is stored
+     * through it, so nothing is ever accessed at __stack_top itself. Both must
+     * land in a 2 KB block that is neither `ram`'s first nor its last. */
+    ASSERT(ADDR(.data) >= ORIGIN(ram) + 2048 &&
+           ADDR(.data) < ORIGIN(ram) + LENGTH(ram) - 2048,
+           "layout: .data starts in ram's first or last 2 KB block, so every access through a pointer into it pays rtl/decoder.v's one-cycle region wait. Start it one 2 KB block above ORIGIN(ram).")
+    ASSERT(__stack_top - 1 >= ORIGIN(ram) + 2048 &&
+           __stack_top - 1 < ORIGIN(ram) + LENGTH(ram) - 2048,
+           "layout: __stack_top puts the top of the stack in ram's first or last 2 KB block, so every lw/sw off sp there pays rtl/decoder.v's one-cycle region wait. Put it one 2 KB block below ORIGIN(ram) + LENGTH(ram).")
 }

--- a/test/bench/coremark.lds
+++ b/test/bench/coremark.lds
@@ -15,6 +15,10 @@
  *
  *   rom  16 KB, test/testbench.v's ROM_WORDS = 4096.
  *   ram  64 KB, the same two SB_SPRAM256KA bench.lds gives Dhrystone.
+ *
+ * The 2 KB inset on `.data` and on `__stack_top` is bench.lds', for the reason
+ * that file's header gives, and it travels with the CoreMark/MHz figure the
+ * same way.
  */
 MEMORY {
     rom(rx)  : ORIGIN = 0x00000000, LENGTH = 16K
@@ -38,7 +42,7 @@ SECTIONS {
         . = ALIGN(4);
     } >ram
 
-    .data : {
+    .data ORIGIN(ram) + 2048 : {
         __data_start = .;
         __global_pointer$ = . + 0x800;
         *(.sdata);
@@ -61,5 +65,16 @@ SECTIONS {
         __bss_end = .;
     } >ram
 
-    __stack_top = ORIGIN(ram) + LENGTH(ram);
+    __stack_top = ORIGIN(ram) + LENGTH(ram) - 2048;
+
+    /* The grader. `.data`'s address, and the highest byte the stack can reach --
+     * the stack descends and sp is decremented before anything is stored
+     * through it, so nothing is ever accessed at __stack_top itself. Both must
+     * land in a 2 KB block that is neither `ram`'s first nor its last. */
+    ASSERT(ADDR(.data) >= ORIGIN(ram) + 2048 &&
+           ADDR(.data) < ORIGIN(ram) + LENGTH(ram) - 2048,
+           "layout: .data starts in ram's first or last 2 KB block, so every access through a pointer into it pays rtl/decoder.v's one-cycle region wait. Start it one 2 KB block above ORIGIN(ram).")
+    ASSERT(__stack_top - 1 >= ORIGIN(ram) + 2048 &&
+           __stack_top - 1 < ORIGIN(ram) + LENGTH(ram) - 2048,
+           "layout: __stack_top puts the top of the stack in ram's first or last 2 KB block, so every lw/sw off sp there pays rtl/decoder.v's one-cycle region wait. Put it one 2 KB block below ORIGIN(ram) + LENGTH(ram).")
 }

--- a/test/board/board.lds
+++ b/test/board/board.lds
@@ -11,6 +11,12 @@
  * sections.lds grants 16K because a simulator's memory is whatever the
  * testbench declares. That is not a formality -- test/asm/rvc.S is 12256 bytes
  * and does not fit a real ROM at all, which nothing said until something tried.
+ *
+ * The 2 KB inset on `.data` and on `__stack_top` is the layout convention
+ * test/asm/boot.lds' header states and the ASSERTs at the bottom grade: a load
+ * or store whose base register sits in a mapped window's first or last 2 KB
+ * block bubbles a cycle in rtl/decoder.v, because a 12-bit offset could cross
+ * the edge and the answer has to come from a flip-flop.
  */
 MEMORY {
     rom(rx)  : ORIGIN = 0x00000000, LENGTH = 8K
@@ -26,10 +32,10 @@ SECTIONS {
     } >rom
 
     /* Load in rom, run in ram. The three symbols are what the driver copies
-     * between; ALIGN(4) on all of them so the copy can move words. */
-    . = ALIGN(4);
+     * between; the run address is a 2 KB multiple and both ends are ALIGN(4),
+     * so the copy can move words. */
     __data_load = LOADADDR(.data);
-    .data : {
+    .data ORIGIN(ram) + 2048 : {
         __data_start = .;
         *(.tohost);
         *(.data);
@@ -61,5 +67,15 @@ SECTIONS {
         __driver_end = .;
     } >ram
 
-    __stack_top = ORIGIN(ram) + LENGTH(ram);
+    __stack_top = ORIGIN(ram) + LENGTH(ram) - 2048;
+
+    /* The grader. `.data`'s address, and the highest byte the stack can reach --
+     * the stack descends and sp is decremented before anything is stored
+     * through it, so nothing is ever accessed at __stack_top itself. */
+    ASSERT(ADDR(.data) >= ORIGIN(ram) + 2048 &&
+           ADDR(.data) < ORIGIN(ram) + LENGTH(ram) - 2048,
+           "layout: .data starts in ram's first or last 2 KB block, so every access through a pointer into it pays rtl/decoder.v's one-cycle region wait. Start it one 2 KB block above ORIGIN(ram).")
+    ASSERT(__stack_top - 1 >= ORIGIN(ram) + 2048 &&
+           __stack_top - 1 < ORIGIN(ram) + LENGTH(ram) - 2048,
+           "layout: __stack_top puts the top of the stack in ram's first or last 2 KB block, so every lw/sw off sp there pays rtl/decoder.v's one-cycle region wait. Put it one 2 KB block below ORIGIN(ram) + LENGTH(ram).")
 }

--- a/test/probe_gates.sh
+++ b/test/probe_gates.sh
@@ -12,11 +12,14 @@
 # also carries a control, because a grader degenerated into `exit 1` would
 # otherwise pass the lot.
 #
-# Hermetic: no RISC-V toolchain, no `sim`, no Sail, no sby -- but the
+# Almost hermetic: no `sim`, no Sail, no sby. Two groups need a real tool and
+# fail loudly rather than silently on a machine without it -- the
 # test/zkt_isolation_test.py group elaborates rtl/decoder.v with yosys, once per
-# fixture, so this file needs yosys and fails loudly rather than silently on a
-# machine without it. It is otherwise all fork and no work, so the wall time is
-# the host's property rather than this file's.
+# fixture, and the linker-layout group runs the RISC-V cross linker, because the
+# graders it forces red are ASSERT statements inside the linker scripts and
+# nothing else evaluates one. `make test` is the only caller and needs both. It
+# is otherwise all fork and no work, so the wall time is the host's property
+# rather than this file's.
 #
 # Five failure paths are demonstrated by hand instead of by a `probe` call:
 # four because they need the elaborated design or the pinned clone --
@@ -2649,6 +2652,105 @@ probe "the timer moving in the proof's copy alone is red" 1 \
 d=$(mm_fixture); sed -i.bak 's/LS_TEXT_WORDS = 2048/LS_TEXT_WORDS = 4096/' "$d/formal/traps.sv"
 probe "the proof describes the part's text window, not the harness's" 1 \
   "LS_TEXT_WORDS is 4096 against rtl/littlesoc.v's 2048" "$MM $d"
+
+begin_group "the linker scripts' layout ASSERTs"
+
+# The graders in this group are ASSERT statements inside the linker scripts
+# themselves, so forcing one red means running the real cross linker. That makes
+# this the second group in this file that is not hermetic, after the yosys one.
+#
+# WHAT THEY GRADE. rtl/decoder.v answers a load or store's region question off
+# raw register bits only when the base register sits deep inside a mapped window
+# -- in it, and in neither its first 2 KB block nor its last -- so an access
+# whose base is in an edge block bubbles a cycle. Every script therefore insets
+# `.data` and the stack by one 2 KB block, and every script asserts it: a layout
+# that silently gives the cost back is the failure being forced here.
+#
+# The two candidate names test/run_tests.sh and the Makefile already search for,
+# in their order. Deliberately NOT $CC: an earlier group in this file binds that
+# name to a stub of its own, and reading it here resolved the cross linker to a
+# python script.
+LAYOUT_CC=""
+for layout_candidate in riscv64-elf-gcc riscv64-unknown-elf-gcc; do
+  if command -v "$layout_candidate" > /dev/null 2>&1; then
+    LAYOUT_CC=$layout_candidate
+    break
+  fi
+done
+if [ -z "$LAYOUT_CC" ]; then
+  echo "error: no RISC-V cross compiler found, so the linker scripts' own" >&2
+  echo "ASSERTs cannot be forced red. Install one (make setup)." >&2
+  exit 1
+fi
+
+layout_fixture() {
+  local d; d=$(new_case)
+  mkdir -p "$d/test/asm" "$d/test/bench" "$d/test/board"
+  cp "$REPO"/test/asm/boot.lds "$REPO"/test/asm/sections.lds "$d/test/asm/"
+  cp "$REPO"/test/bench/bench.lds "$REPO"/test/bench/coremark.lds "$d/test/bench/"
+  cp "$REPO"/test/board/board.lds "$d/test/board/"
+  # No crt0 and no program: an ASSERT over ADDR(.data) and __stack_top is
+  # evaluated whatever the input objects contain, and a stub keeps the probe
+  # measuring the script rather than whatever the suite's startup happens to do.
+  cat > "$d/stub.S" <<'STUB'
+  .section .text.init,"ax",@progbits
+  .globl _start
+_start:
+  nop
+STUB
+  printf '%s' "$d"
+}
+
+layout_link() {  # $1 = fixture dir, $2 = script path inside it
+  "$LAYOUT_CC" -march=rv32imac_zicsr_zifencei_zkt -mabi=ilp32 -nostdlib \
+    -T "$1/$2" "$1/stub.S" -o "$1/out.elf"
+}
+
+LAYOUT_DATA_RED="layout: .data starts in ram's first or last 2 KB block"
+LAYOUT_STACK_RED="layout: __stack_top puts the top of the stack in ram's first or last 2 KB block"
+
+d=$(layout_fixture)
+probe "control: all five shipping scripts link at the inset layout" 0 \
+  "all five shipping scripts link" \
+  "layout_link $d test/asm/boot.lds && layout_link $d test/asm/sections.lds &&
+   layout_link $d test/bench/bench.lds && layout_link $d test/bench/coremark.lds &&
+   layout_link $d test/board/board.lds && echo 'all five shipping scripts link'"
+
+d=$(layout_fixture); sed -i.bak 's/ORIGIN(ram) + 2048 : {/ORIGIN(ram) : {/' "$d/test/asm/boot.lds"
+probe "boot.lds putting .data back at ram's origin is red" 1 \
+  "$LAYOUT_DATA_RED" "layout_link $d test/asm/boot.lds"
+
+d=$(layout_fixture); sed -i.bak 's/LENGTH(ram) - 2048;/LENGTH(ram);/' "$d/test/asm/boot.lds"
+probe "boot.lds putting the stack back at the top of ram is red" 1 \
+  "$LAYOUT_STACK_RED" "layout_link $d test/asm/boot.lds"
+
+d=$(layout_fixture); sed -i.bak 's/ORIGIN(ram) + 2048 : {/ORIGIN(ram) : {/' "$d/test/asm/sections.lds"
+probe "sections.lds putting .data back at ram's origin is red" 1 \
+  "$LAYOUT_DATA_RED" "layout_link $d test/asm/sections.lds"
+
+d=$(layout_fixture); sed -i.bak 's/ORIGIN(ram) + 2048 : {/ORIGIN(ram) : {/' "$d/test/bench/bench.lds"
+probe "bench.lds putting .data back at ram's origin is red" 1 \
+  "$LAYOUT_DATA_RED" "layout_link $d test/bench/bench.lds"
+
+d=$(layout_fixture); sed -i.bak 's/LENGTH(ram) - 2048;/LENGTH(ram);/' "$d/test/bench/bench.lds"
+probe "bench.lds putting the stack back at the top of ram is red" 1 \
+  "$LAYOUT_STACK_RED" "layout_link $d test/bench/bench.lds"
+
+d=$(layout_fixture); sed -i.bak 's/ORIGIN(ram) + 2048 : {/ORIGIN(ram) : {/' "$d/test/bench/coremark.lds"
+probe "coremark.lds putting .data back at ram's origin is red" 1 \
+  "$LAYOUT_DATA_RED" "layout_link $d test/bench/coremark.lds"
+
+d=$(layout_fixture); sed -i.bak 's/LENGTH(ram) - 2048;/LENGTH(ram);/' "$d/test/bench/coremark.lds"
+probe "coremark.lds putting the stack back at the top of ram is red" 1 \
+  "$LAYOUT_STACK_RED" "layout_link $d test/bench/coremark.lds"
+
+d=$(layout_fixture); sed -i.bak 's/ORIGIN(ram) + 2048 : {/ORIGIN(ram) : {/' "$d/test/board/board.lds"
+probe "board.lds putting .data back at ram's origin is red" 1 \
+  "$LAYOUT_DATA_RED" "layout_link $d test/board/board.lds"
+
+d=$(layout_fixture); sed -i.bak 's/LENGTH(ram) - 2048;/LENGTH(ram);/' "$d/test/board/board.lds"
+probe "board.lds putting the stack back at the top of ram is red" 1 \
+  "$LAYOUT_STACK_RED" "layout_link $d test/board/board.lds"
 
 begin_group "test/adr_numbering_test.sh"
 


### PR DESCRIPTION
Replaces #260, which GitHub auto-closed when its base branch was deleted on the #259 squash. Same content, rebuilt on `main`.

## The fact

`rtl/decoder.v`'s region wait bubbles a cycle whenever a load or store's base register sits in a mapped window's first or last 2 KB block, because only there can a 12-bit offset cross the window edge and the answer has to come from a flip-flop. Every linker script put `__stack_top` at the very top of RAM and `.data` at the bottom, which are exactly those two blocks. That is the whole of Dhrystone's REGION column: 212,752 of 1,756,248 cycles, 84.7% stack and 15.3% `.data`.

The core did not put the data there. A 64 KB window is 32 blocks and 30 of them are deep.

## Measured

| Instrument | Before | After |
|---|---|---|
| Dhrystone | 0.664 DMIPS/MHz, 7.97 DMIPS | **0.758, 9.10** |
| Dhrystone REGION | 212,752 cycles | **2** |
| CoreMark, 16 KB ROM | 1.811 CoreMark/MHz | **2.013** |
| `.S` suite | 42,319 cycles, CPI 2.00 | **41,052, CPI 1.94** |

No file under `rtl/` is touched, and `make fit` and `make netlist-digest` were re-run and are unmoved, so no sweep is owed.

## What this is not

The core did not get faster. The firmware stopped paying a cost it did not have to. Any DMIPS or CoreMark figure from here travels with the linker script the way the flags, compiler and string library already do, and CLAUDE.md now says so.

## Graded, not remembered

Two linker `ASSERT`s per script over `ADDR(.data)` and the highest byte the stack can reach, each naming the cost. Ten probes in `test/probe_gates.sh` plant a bad layout in each script and require the link to fail; `test/PROBES_EXPECTED` goes 590 to 600. `soc/compare/dhry.lds` stays conventional so the stale cross-core product is re-taken as a pair.

## The hardware alternative, measured and declined

ADR-0152. Letting the fast arm read the immediate's sign recovers the same cycles in RTL: 5.38% of Dhrystone against the conventional layout, **two cycles** against this one, for 112 placed SoC cells and +1.07% of median period at 13 of 16 paired seeds, p = 0.021. Proved correct by k-induction and kept on record for firmware that cannot inset its own layout. It is also the counter-example to reading ADR-0145's verdict as a rule about that signal rather than about its own term.

## Checks

`make test` 74/74 with the failure list and suite shape matching their baselines, `make lint`, `make cosim-suite` 69/74 matching `test/COSIM_EXPECTED_FAIL`, `make cycles`, `make dhrystone`, `make fit`, and the four graded documentation tests.

Retire counts move by a handful, because relocating `.data` and the global pointer changes which `la` sequences the linker can relax; `test/OBSERVED_FLOOR` grades with `>=`, so no floor moved. `make probe-gates` is no longer yosys-only, since forcing a linker assertion red needs a linker, and both the file header and the rulebook say so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pegfacb12zVYBBPLCdZq2A