### PR TITLE
Set the test and cosim budgets clear of a loaded pool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,11 @@ jobs:
     name: test
     # Fork-PR routing: see the note above `jobs:` for what this picks and why.
     runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'little-cpu-runners' || 'ubuntu-latest' }}
-    timeout-minutes: 10
+    # Two to five minutes on an idle pool, but the pool is one runner serving
+    # every job in this workflow and this job has been killed at 10m25s under
+    # contention -- a cancelled job reads as a failed gate rather than as a busy
+    # pool. The budget catches a run that hangs, so it sits clear of a loaded one.
+    timeout-minutes: 25
     steps:
       - name: Record job start
         run: echo "JOB_START=$(date +%s)" >> "$GITHUB_ENV"
@@ -226,7 +230,9 @@ jobs:
     name: cosim
     # Fork-PR routing: see the note above `jobs:` for what this picks and why.
     runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'little-cpu-runners' || 'ubuntu-latest' }}
-    timeout-minutes: 15
+    # Eight minutes on an idle pool, and the same single-runner contention that
+    # has killed `test`, `components` and `mutation-check` mid-run applies here.
+    timeout-minutes: 30
     steps:
       - name: Record job start
         run: echo "JOB_START=$(date +%s)" >> "$GITHUB_ENV"


### PR DESCRIPTION
Fourth and fifth instances of one fault: CI timeouts set against an idle pool, on a pool that is a single runner serving every job in this workflow across every open PR. A job killed by its budget reports as a failed gate rather than as a busy pool.

## Measured on main's own successful run

| Job | Runtime | Budget before | Budget now |
|---|---|---|---|
| `mutation-check` | **31m** | 25 | 45 (#261) |
| `components` | **12m** | 10 | 20 (#261) |
| `cosim` | 8m | 15 | **30** |
| `test` | 2m idle, **killed at 10m25s** under load | 10 | **25** |

The first two were already over their pre-fix budgets on main itself, so #261's fixes were necessary rather than precautionary. This PR does the same for the two that remain thin.

Everything else has eight to ten times headroom already (`elaborate`, `fit`, `nonperturbation`, `monitor-freshness`, `soc-timing`, `ecp5-timing` all run under two minutes) and is left alone.

The budgets exist to catch a job that hangs, and at three to twelve times a healthy run they still do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pegfacb12zVYBBPLCdZq2A