### PR TITLE
Fix make compare-product, and correct three figures the tree had overtaken

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -420,27 +420,39 @@ top, ECP5 only.
   software is the firmware ceasing to pay a cost, never the core getting faster. **CoreMark is
   SIMULATED AT 16 KB OF ROM**, double the part's 8, against `test/testbench.v`'s `ROM_WORDS`, and
   every printed figure says so; the five algorithm files are vendored unmodified and pinned by
-  `test/bench/coremark/PINNED.sha256` (ADR-0136). **2.013 CoreMark/MHz** on the shipping layout
-  against 1.811 on the conventional one, so it travels with the linker script the way the DMIPS
-  figure does (ADR-0158). Hazard3's published 4.15 CoreMark/MHz is its RP2350 build, not its iCE40
+  `test/bench/coremark/PINNED.sha256` (ADR-0136). **2.203 CoreMark/MHz**, and it travels with the
+  linker script the way the DMIPS figure does: the inset layout read 2.013 against 1.811 on the
+  conventional one when ADR-0158 measured it, and executor-only forwarding took the inset figure
+  to 2.203 afterwards (ADR-0154). Hazard3's published 4.15 CoreMark/MHz is its RP2350 build, not its iCE40
   one, and quoting it against an ice40 core is the mixed-configuration error ADR-0098 names.
 - **The only cross-core comparison that means anything is one harness**, `soc/compare/`: same part,
 memories, program, toolchain and seeds, against the VexRiscv in the pinned riscv-formal clone and
 Hazard3's iCE40 build (`soc/compare/hazard3_pin.mk`, ADR-0139). **A product is a measurement only
-when both factors were taken on one tree**, and the current one is **1.16× against VexRiscv in its
-favour**, twelve seeds a side on one tree (ADR-0098 as amended): 23.14 DMIPS against 26.87 at each
-core's worst placement, 1.17× median against median. Its halves pull opposite ways — the clock is
-1.60× theirs at the worst placement (30.13 against 48.24 MHz) and the cycles are **1.379× ours**
-(741.1 against 1021.9 per Dhrystone, 0.768 against 0.557 DMIPS/MHz). **Read the product, not a
-half.** Between ADR-0129 and here the cycle half rose and the clock half fell, and the product did
-not move at all, so either factor quoted alone tells you the opposite of the other. Re-take
+when both factors were taken on one tree AND one toolchain**, and the current pair of them, twelve
+seeds a side at the shared RV32I ISA (ADR-0098 as amended), is **1.16× against VexRiscv in its
+favour** — 23.47 DMIPS against 27.18 at each core's worst placement — and **0.97× against Hazard3,
+which is level rather than a win**: 22.83 against our 23.47, inside the 9.01% of its cycles the
+harness discloses it spends in a bus wait the others do not pay. Every half pulls the same way in
+both pairs: **we win cycles and lose clock.** Against VexRiscv the clock is 1.53× theirs (30.13
+against 46.06 MHz) and the cycles 1.319× ours (731.1 against 964.1 per Dhrystone, 0.779 against
+0.590 DMIPS/MHz); against Hazard3, 1.06× and 1.093×. **Read the product, not a half** — between
+ADR-0129 and here the cycle half rose and the clock half fell and the product did not move at all,
+so either factor alone tells you the opposite of the other. **CoreMark is the pair that separates
+them**: littlecpu against Hazard3 is **0.645×, a 1.55× throughput win for this core** on a
+benchmark that leans on the M extension, where the same pair is level on Dhrystone. VexRiscv's
+pinned build has no M and cannot run that image at all. **The toolchain is part of the stamp, not a
+detail**: the same twelve seeds moved VexRiscv 4.5% at its worst placement between two yosys builds
+while this core's up5k SoC came out bit-identical, so halves synthesised by different toolchains do
+not form a product. Re-take
 both halves before quoting the product, with what each side is and with the caveat that Dhrystone's
 cycles are simulated at a larger map than the clock is placed at (`make compare-dhrystone` prints
 the block arithmetic; ADR-0098 lists the distortions). **Hazard3's iCE40 build is the third core in the
-harness, and its DHRYSTONE factors are now both measured** — `soc/compare/dhry_tb.v`'s marker
-mechanism, built for VexRiscv's identical CSR-free gap, needed wiring rather than invention. Its
-CoreMark half is still not built: `CSR_COUNTER=0` means no `mcycle`, so it cannot self-time that
-run (ADR-0139). Read the three-way Dhrystone row only at the one ISA all three cores share, RV32I,
+harness, and BOTH its benchmark factors are now measured** — `soc/compare/dhry_tb.v`'s marker
+mechanism, built for VexRiscv's identical CSR-free gap, needed wiring rather than invention, and
+`CSR_COUNTER=0` leaving it no `mcycle` to self-time with is what that mechanism exists to route
+around (ADR-0139, ADR-0146). It discloses its own bus wait rather than correcting it — 9.01% of its
+Dhrystone cycles, 1.98% of its CoreMark ones — and on Dhrystone that artifact is larger than the
+gap, which is why that pair reads level. Read the three-way Dhrystone row only at the one ISA all three cores share, RV32I,
 which is what makes every pairwise ratio in it a comparison rather than three configurations. Two graded checks stand in front of every number:
 `soc/compare/placed_vs_synth.py` refuses a placed count under `COMPARE_MIN_RATIO` of the core's own
 synthesis — an all-NOP image once placed a quarter of this core with a plausible critical path

--- a/soc/compare/product.json
+++ b/soc/compare/product.json
@@ -2,74 +2,130 @@
   "note": "written by soc/compare/run_product.sh (make compare-product); do not hand-edit",
   "pairs": {
     "coremark": {
-      "cores": [
-        "hazard3"
-      ],
-      "reason": "make compare-coremark is not on this tree yet; run_product.sh will measure it once that lands",
-      "status": "not_yet_measured",
-      "target_core": "littlecpu"
-    },
-    "dhrystone": {
-      "base": "ab5af011b6a1d8a6b7e6e1027317c30121d2b6b6",
-      "cflags": "-march=rv32ic -mabi=ilp32 -O2 -std=c11 -ffreestanding -fno-tree-loop-distribute-patterns -Wall -Wextra -Werror",
+      "base": "122ef7bdd2b04e4810efc3b75fe6ad8ece637c6b",
+      "cflags": "-march=rv32ima -mabi=ilp32 -O2 -std=c11 -ffreestanding -fno-tree-loop-distribute-patterns -Wall -Wextra -Werror",
       "cores": {
+        "hazard3": {
+          "clock_mhz": {
+            "best_mhz": 33.78378378378378,
+            "best_ns": 29.6,
+            "median_mhz": 33.19502074688797,
+            "median_ns": 30.125,
+            "n": 12,
+            "spread_pct": 5.3378378378378315,
+            "worst_mhz": 32.07184092366902,
+            "worst_ns": 31.18
+          },
+          "cycle_factor": 1.3986326966757299
+        },
         "littlecpu": {
           "clock_mhz": {
-            "best_mhz": 32.69042170644001,
-            "best_ns": 30.59,
-            "median_mhz": 32.01536737634064,
-            "median_ns": 31.235,
-            "n": 4,
-            "spread_pct": 5.7862046420398805,
-            "worst_mhz": 30.902348578491967,
-            "worst_ns": 32.36
+            "best_mhz": 32.414910858995135,
+            "best_ns": 30.85,
+            "median_mhz": 30.585716470408318,
+            "median_ns": 32.695,
+            "n": 12,
+            "spread_pct": 7.5850891410048495,
+            "worst_mhz": 30.129557095510698,
+            "worst_ns": 33.19
           },
-          "cycle_factor": 0.7478312948536591
-        },
-        "vexriscv": {
-          "clock_mhz": {
-            "best_mhz": 50.83884087442806,
-            "best_ns": 19.67,
-            "median_mhz": 50.42864346949067,
-            "median_ns": 19.83,
-            "n": 4,
-            "spread_pct": 2.0335536349771153,
-            "worst_mhz": 49.82561036372695,
-            "worst_ns": 20.07
-          },
-          "cycle_factor": 0.556957381701911
+          "cycle_factor": 2.308189456190564
         }
       },
-      "date": "2026-08-30T17:17:07Z",
+      "date": "2026-09-05T19:55:40Z",
       "dirty": "yes",
-      "isa": "rv32ic",
+      "isa": "rv32ima",
       "products": {
-        "vexriscv": {
+        "hazard3": {
+          "hazard3_dmips": {
+            "median": 46.427641383426725,
+            "worst": 44.85672535842624
+          },
           "littlecpu_dmips": {
-            "median": 23.942093640264417,
-            "worst": 23.10974335147278
+            "median": 70.59762826703056,
+            "worst": 69.54472600754939
           },
           "ratio": {
-            "median": 1.1731056461291374,
-            "worst": 1.2008243046157592
-          },
-          "vexriscv_dmips": {
-            "median": 28.0866052295467,
-            "worst": 27.750741489880966
+            "median": 0.6576374096848897,
+            "worst": 0.6450054221733054
           }
         }
       },
       "ram_words": 512,
       "rom_words": 1024,
-      "seeds": "default 1 2 3",
+      "seeds": "default 1 2 3 4 5 6 7 8 9 10 11",
       "status": "measured",
       "target_core": "littlecpu",
       "tools": {
-        "icetime": "no version string sha256:4ba28c34e2628592 [/opt/homebrew/bin/icetime]",
-        "iverilog": "Icarus Verilog version 13.0 (stable) (v13_0) [/opt/homebrew/bin/iverilog]",
-        "nextpnr-ice40": "\"nextpnr-ice40\" -- Next Generation Place and Route (Version ) [/opt/homebrew/bin/nextpnr-ice40]",
+        "icetime": "oss-cad-suite 20260811 sha256:25a4ecb76c094f00 [/Users/jeff/.cache/little-cpu/oss-cad-suite/bin/icetime]",
+        "iverilog": "Icarus Verilog version 14.0 (devel) (s20260301-363-g1d2aa1b6f-dirty) [/Users/jeff/.cache/little-cpu/oss-cad-suite/bin/iverilog]",
+        "nextpnr-ice40": "\"nextpnr-ice40\" -- Next Generation Place and Route (Version nextpnr-0.11-1-g62e659ed) [/Users/jeff/.cache/little-cpu/oss-cad-suite/bin/nextpnr-ice40]",
         "riscv64-elf-gcc": "riscv64-elf-gcc (GCC) 16.2.0 [/opt/homebrew/bin/riscv64-elf-gcc]",
-        "yosys": "Yosys 0.68+post (git sha1 c12172fbae8af5e20f6fb52e3d4e92d56ed587b6, Release, AppleClang clang++ 21.0.0.21000101) [/opt/homebrew/bin/yosys]"
+        "yosys": "Yosys 0.68+48 (git sha1 ff5817c34-dirty, Release, Clang /usr/local/osxcross/target/bin/aarch64-apple-darwin25.5-clang++ 21.1.8) [/Users/jeff/.cache/little-cpu/oss-cad-suite/bin/yosys]"
+      },
+      "unit": "CoreMark/MHz"
+    },
+    "dhrystone": {
+      "base": "122ef7bdd2b04e4810efc3b75fe6ad8ece637c6b",
+      "cflags": "-march=rv32i -mabi=ilp32 -O2 -std=c11 -ffreestanding -fno-tree-loop-distribute-patterns -Wall -Wextra -Werror",
+      "cores": {
+        "littlecpu": {
+          "clock_mhz": {
+            "best_mhz": 32.414910858995135,
+            "best_ns": 30.85,
+            "median_mhz": 30.585716470408318,
+            "median_ns": 32.695,
+            "n": 12,
+            "spread_pct": 7.5850891410048495,
+            "worst_mhz": 30.129557095510698,
+            "worst_ns": 33.19
+          },
+          "cycle_factor": 0.7785270938863289
+        },
+        "vexriscv": {
+          "clock_mhz": {
+            "best_mhz": 50.47955577990914,
+            "best_ns": 19.81,
+            "median_mhz": 48.673643222195174,
+            "median_ns": 20.545,
+            "n": 12,
+            "spread_pct": 9.591115598182748,
+            "worst_mhz": 46.06172270842929,
+            "worst_ns": 21.71
+          },
+          "cycle_factor": 0.590334646528327
+        }
+      },
+      "date": "2026-09-05T19:55:40Z",
+      "dirty": "yes",
+      "isa": "rv32i",
+      "products": {
+        "vexriscv": {
+          "littlecpu_dmips": {
+            "median": 23.81180895813821,
+            "worst": 23.456676525650163
+          },
+          "ratio": {
+            "median": 1.2067011799622263,
+            "worst": 1.1592362952113793
+          },
+          "vexriscv_dmips": {
+            "median": 28.733737966820488,
+            "worst": 27.19183079356642
+          }
+        }
+      },
+      "ram_words": 512,
+      "rom_words": 1024,
+      "seeds": "default 1 2 3 4 5 6 7 8 9 10 11",
+      "status": "measured",
+      "target_core": "littlecpu",
+      "tools": {
+        "icetime": "oss-cad-suite 20260811 sha256:25a4ecb76c094f00 [/Users/jeff/.cache/little-cpu/oss-cad-suite/bin/icetime]",
+        "iverilog": "Icarus Verilog version 14.0 (devel) (s20260301-363-g1d2aa1b6f-dirty) [/Users/jeff/.cache/little-cpu/oss-cad-suite/bin/iverilog]",
+        "nextpnr-ice40": "\"nextpnr-ice40\" -- Next Generation Place and Route (Version nextpnr-0.11-1-g62e659ed) [/Users/jeff/.cache/little-cpu/oss-cad-suite/bin/nextpnr-ice40]",
+        "riscv64-elf-gcc": "riscv64-elf-gcc (GCC) 16.2.0 [/opt/homebrew/bin/riscv64-elf-gcc]",
+        "yosys": "Yosys 0.68+48 (git sha1 ff5817c34-dirty, Release, Clang /usr/local/osxcross/target/bin/aarch64-apple-darwin25.5-clang++ 21.1.8) [/Users/jeff/.cache/little-cpu/oss-cad-suite/bin/yosys]"
       },
       "unit": "DMIPS/MHz"
     }

--- a/soc/compare/run_product.sh
+++ b/soc/compare/run_product.sh
@@ -139,8 +139,13 @@ if ! DHRY_OUT=$(make compare-dhrystone 2>&1); then
 fi
 printf '%s\n' "$DHRY_OUT"
 
-LC_CYCLES=$(printf '%s\n' "$DHRY_OUT" | grep '^DHRY core=littlecpu' | sed -n 's/.*cycles=\([0-9]*\).*/\1/p')
-VEX_CYCLES=$(printf '%s\n' "$DHRY_OUT" | grep '^DHRY core=vexriscv' | sed -n 's/.*cycles=\([0-9]*\).*/\1/p')
+# FIRST match only. `make compare-dhrystone` prints a fourth row -- this core
+# alone at its native ISA, so the shared subset's cost is a number -- which
+# emits a SECOND `DHRY core=littlecpu` line. The product compares cores at the
+# ISA they SHARE, so the comparison row is the one to read and the solo row is
+# an aside. Taking both fed a two-line value into python3 -c below.
+LC_CYCLES=$(printf '%s\n' "$DHRY_OUT" | grep '^DHRY core=littlecpu' | sed -n 's/.*cycles=\([0-9]*\).*/\1/p' | head -1)
+VEX_CYCLES=$(printf '%s\n' "$DHRY_OUT" | grep '^DHRY core=vexriscv' | sed -n 's/.*cycles=\([0-9]*\).*/\1/p' | head -1)
 if [ -z "$LC_CYCLES" ] || [ -z "$VEX_CYCLES" ]; then
   echo "*** run_product.sh: could not find both cores' 'DHRY core=... cycles='" >&2
   echo "*** lines in make compare-dhrystone's output." >&2
@@ -155,6 +160,24 @@ DHRY_ISA=$(isa_from_cflags "$DHRY_CFLAGS")
 # the two files cannot state two different rates.
 DHRY_VAX_RATE=$(python3 -c "import sys; sys.path.insert(0, 'soc/compare'); \
   from dhry_dmips import VAX_DHRYSTONES_PER_SEC; print(VAX_DHRYSTONES_PER_SEC)")
+
+# Every one of these is interpolated into `python3 -c` below, where an empty or
+# multi-line value becomes SOURCE TEXT and fails as a SyntaxError that names
+# neither the variable nor this script. Check them here, where the diagnostic
+# can say which one and where it came from.
+for pair in "DHRY_RUNS=$DHRY_RUNS" "LC_CYCLES=$LC_CYCLES" \
+            "VEX_CYCLES=$VEX_CYCLES" "DHRY_VAX_RATE=$DHRY_VAX_RATE"; do
+  name=${pair%%=*}; value=${pair#*=}
+  case "$value" in
+    ''|*[!0-9.]*)
+      echo "*** run_product.sh: $name is '$value', which is not a number." >&2
+      echo "*** It is interpolated into a python3 -c expression below, so a" >&2
+      echo "*** blank or multi-line value there dies as a SyntaxError instead" >&2
+      echo "*** of naming itself. Fix what produced it." >&2
+      exit 1 ;;
+  esac
+done
+
 LC_DHRY_FACTOR=$(python3 -c "print($DHRY_RUNS * 1e6 / $LC_CYCLES / $DHRY_VAX_RATE)")
 VEX_DHRY_FACTOR=$(python3 -c "print($DHRY_RUNS * 1e6 / $VEX_CYCLES / $DHRY_VAX_RATE)")
 
@@ -173,11 +196,15 @@ python3 soc/compare/product_write.py "$OUT" dhrystone --measured \
 # whole run. Once `make compare-coremark` is real, a run that still falls back
 # here is a bug in this function to fix, not a steady state to keep tolerating.
 measure_coremark() {
+  # ` cycles=` with the leading space, and FIRST match only: hazard3 prints a
+  # second `COREMARK core=hazard3 wait_cycles=` line disclosing the bus wait the
+  # other core does not pay, and `wait_cycles=` contains `cycles=`. Matching both
+  # fed a two-line value into python3 -c below.
   if HZ_NS=$(sweep_clock hazard3) \
      && CM_OUT=$(make compare-coremark 2>&1) \
-     && LC_CM_CYCLES=$(printf '%s\n' "$CM_OUT" | grep '^COREMARK core=littlecpu' | sed -n 's/.*cycles=\([0-9]*\).*/\1/p') \
-     && HZ_CM_CYCLES=$(printf '%s\n' "$CM_OUT" | grep '^COREMARK core=hazard3' | sed -n 's/.*cycles=\([0-9]*\).*/\1/p') \
-     && CM_ITERATIONS=$(printf '%s\n' "$CM_OUT" | grep '^COREMARK core=littlecpu' | sed -n 's/.*iterations=\([0-9]*\).*/\1/p') \
+     && LC_CM_CYCLES=$(printf '%s\n' "$CM_OUT" | grep '^COREMARK core=littlecpu' | sed -n 's/.* cycles=\([0-9]*\).*/\1/p' | head -1) \
+     && HZ_CM_CYCLES=$(printf '%s\n' "$CM_OUT" | grep '^COREMARK core=hazard3' | sed -n 's/.* cycles=\([0-9]*\).*/\1/p' | head -1) \
+     && CM_ITERATIONS=$(make -s print-COMPARE_COREMARK_ITERATIONS) \
      && CM_CFLAGS=$(make -s print-COMPARE_COREMARK_CFLAGS) \
      && [ -n "$LC_CM_CYCLES" ] && [ -n "$HZ_CM_CYCLES" ] \
      && [ -n "$CM_ITERATIONS" ] && [ -n "$CM_CFLAGS" ]; then
@@ -195,8 +222,8 @@ measure_coremark() {
     return 0
   fi
   echo "*** run_product.sh: make compare-coremark's output did not match the" >&2
-  echo "*** 'COREMARK core=... cycles=... iterations=...' shape this script" >&2
-  echo "*** expects, or COMPARE_COREMARK_CFLAGS is unset. Recording CoreMark" >&2
+  echo "*** 'COREMARK core=... cycles=...' shape this script expects, or" >&2
+  echo "*** COMPARE_COREMARK_CFLAGS/ITERATIONS is unset. Recording CoreMark" >&2
   echo "*** as not yet measured; update measure_coremark() in" >&2
   echo "*** soc/compare/run_product.sh to match what landed." >&2
   return 1


### PR DESCRIPTION
## `make compare-product` could not complete

Three bugs, all one class: a shell variable interpolated into `python3 -c`, where an empty or multi-line value becomes **source text** and dies as a `SyntaxError` naming neither the variable nor the script.

| parse | second matching line | added by |
|---|---|---|
| `LC_CYCLES` | the native-ISA solo row | #247 |
| `HZ_CM_CYCLES` | `wait_cycles=` — which *contains* `cycles=` | #243 |
| `CM_ITERATIONS` | an `iterations=` field that never existed | — |

Two of these are lines added to a producer *after* the parser was written, by PRs that merged the same day. Each is individually correct; jointly they broke the consumer.

A **both-ways guard** now checks every value before it reaches `python3 -c` and names the offender. It is what turned the first failure from an anonymous traceback into:

```
*** run_product.sh: LC_CYCLES is '292425
294025', which is not a number.
```

`soc/compare/product.json` is stamped for the first time with **both pairs**.

## Three stale figures in CLAUDE.md

- **CoreMark 2.013 → 2.203** — forwarding landed after ADR-0158 measured the layout figure
- **The cross-core paragraph**, rewritten on a re-take of both factors at twelve seeds a side: both pairs, the CoreMark result that separates them, and the fact that halves synthesised by different toolchains do not form a product (the same seeds moved VexRiscv 4.5% between two yosys builds while our up5k SoC came out bit-identical)
- **"Hazard3's CoreMark half is still not built"** — #243 built it

## Caveat

The stamp's clock halves are hx8k's. `compare-on-up5k` moves the comparison to up5k and ECP5, so this artifact is re-taken there once that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pegfacb12zVYBBPLCdZq2A