### PR TITLE
Shard mutation-check across four CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,8 +172,8 @@ jobs:
   #
   # Same toolchain as `test`: this builds and runs `sim`, so it needs the cross
   # compiler, clang++ and yosys, and nothing that only synthesis or Sail needs.
-  mutation-check:
-    name: mutation-check
+  mutation-check-shard:
+    name: mutation-check-shard
     # SHARDED because this job is the run's critical path, not because the pool
     # is short of capacity: measured over a full run, twelve jobs did 44.9
     # minutes of work in 17.6 minutes of wall time -- an effective parallelism
@@ -245,9 +245,39 @@ jobs:
         run: |
           elapsed=$(( $(date +%s) - JOB_START ))
           {
-            echo "### mutation-check"
+            echo "### mutation-check shard ${{ matrix.shard }}"
             echo "wall time: ${elapsed}s"
           } >> "$GITHUB_STEP_SUMMARY"
+
+  # THE REQUIRED CHECK KEEPS ITS NAME. Sharding renames the job that does the
+  # work, and a required context that no longer reports blocks every pull
+  # request rather than failing one -- including the pull request that would
+  # introduce the new names. So `mutation-check` survives as a gate over the
+  # shards: branch protection needs no edit, and there is no window where the
+  # mutation gate is not required.
+  #
+  # `needs.<matrix job>.result` is success only when EVERY shard succeeded, and
+  # `if: always()` is what makes this run at all when one did not -- without it
+  # the gate is skipped, and a skipped required check leaves the pull request
+  # waiting rather than red.
+  #
+  # ubuntu-latest on purpose: it compares one string, and putting it on the
+  # self-hosted pool would spend a runner slot on a job that does no work.
+  mutation-check:
+    name: mutation-check
+    needs: mutation-check-shard
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require every shard to have passed
+        run: |
+          set -euo pipefail
+          result='${{ needs.mutation-check-shard.result }}'
+          echo "shards reported: $result"
+          if [ "$result" != success ]; then
+            echo "::error::a mutation-check shard did not pass; read the shard jobs for which pairing broke"
+            exit 1
+          fi
 
   # The only oracle here that reads the core's real register array instead of
   # the core's own report of what it retired. Every other leg evaluates a spec

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,24 @@ jobs:
   # compiler, clang++ and yosys, and nothing that only synthesis or Sail needs.
   mutation-check:
     name: mutation-check
+    # SHARDED because this job is the run's critical path, not because the pool
+    # is short of capacity: measured over a full run, twelve jobs did 44.9
+    # minutes of work in 17.6 minutes of wall time -- an effective parallelism
+    # of 2.55 against a scale set that reached five runners -- and the wall time
+    # was this job's alone, grinding after everything else had finished.
+    #
+    # Each shard measures its own baseline rather than sharing one. That is
+    # about 10s against 45s for a mutation, and the pool has idle capacity by
+    # the arithmetic above, so duplicating it costs nothing that is scarce and
+    # saves an artifact hand-off between jobs.
+    #
+    # fail-fast: false because every shard's verdict is wanted. A shard that
+    # cancels its siblings turns "these three pairings broke" into "one of them
+    # did", which is the report this check exists to give.
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
     # Fork-PR routing: see the note above `jobs:` for what this picks and why.
     runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'little-cpu-runners' || 'ubuntu-latest' }}
     # Eleven mutations, each rebuilding the cxxrtl runner: about nine minutes of
@@ -217,7 +235,7 @@ jobs:
         # there is no reason to route it through anything.
         run: |
           set -euo pipefail
-          if ! make mutation-check; then
+          if ! make mutation-check MUTATION_SHARD=${{ matrix.shard }}/4; then
             echo "::error::a declared mutation was not caught by exactly the detectors test/MUTATION_DETECTORS pairs with it"
             exit 1
           fi

--- a/Makefile
+++ b/Makefile
@@ -543,9 +543,13 @@ imem-share-test:
 abc-engine-test:
 	@./formal/test-abc-engine.sh
 
+# MUTATION_SHARD=<i>/<n> grades every nth mutation starting at i, so CI can run
+# the eleven of them as several jobs. Each shard still checks the manifest whole
+# and still measures its own baseline; the run is critical-path-bound rather
+# than throughput-bound, so that duplicated baseline lands in idle capacity.
 .PHONY: mutation-check
 mutation-check:
-	@./test/mutation_check.sh
+	@./test/mutation_check.sh $(if $(MUTATION_SHARD),--shard $(MUTATION_SHARD))
 
 .PHONY: mutation-probe
 mutation-probe:

--- a/test/mutation_check.sh
+++ b/test/mutation_check.sh
@@ -2,8 +2,9 @@
 # Applies a declared RTL mutation, runs the detectors, and requires exactly the
 # detectors it is paired with to go red.
 #
-# Usage: mutation_check.sh [--only <mutation>] [--repo <dir>] [--manifest <file>]
-#                          [--patches <dir>] [--expected-fail <file>]
+# Usage: mutation_check.sh [--only <mutation>] [--shard <i>/<n>] [--repo <dir>]
+#                          [--manifest <file>] [--patches <dir>]
+#                          [--expected-fail <file>]
 #
 # WHY THIS EXISTS, and how it differs from `make probe-gates`. probe-gates asks
 # whether a graded comparison can report a failure at all; it is hermetic, so it
@@ -48,19 +49,40 @@ MANIFEST=""
 PATCH_DIR=""
 EXPECTED_FAIL=""
 ONLY=""
+SHARD=""
 
 while [ "$#" -gt 0 ]; do
   case $1 in
     --only)          ONLY=${2:-};          shift 2 ;;
+    --shard)         SHARD=${2:-};         shift 2 ;;
     --repo)          REPO=${2:-};          shift 2 ;;
     --manifest)      MANIFEST=${2:-};      shift 2 ;;
     --patches)       PATCH_DIR=${2:-};     shift 2 ;;
     --expected-fail) EXPECTED_FAIL=${2:-}; shift 2 ;;
-    *) echo "usage: mutation_check.sh [--only <mutation>] [--repo <dir>]" >&2
-       echo "       [--manifest <file>] [--patches <dir>] [--expected-fail <file>]" >&2
+    *) echo "usage: mutation_check.sh [--only <mutation>] [--shard <i>/<n>]" >&2
+       echo "       [--repo <dir>] [--manifest <file>] [--patches <dir>]" >&2
+       echo "       [--expected-fail <file>]" >&2
        exit 1 ;;
   esac
 done
+
+# Checked HERE and not beside the selection below, which is after the baseline:
+# a malformed shard spent forty-five seconds measuring a baseline before being
+# told its arguments were wrong.
+shard_i=""
+shard_n=""
+if [ -n "$SHARD" ]; then
+  [ -z "$ONLY" ] || { echo "error: --shard and --only both select mutations; pass one." >&2; exit 1; }
+  case $SHARD in
+    *[!0-9/]*|*/*/*|/*|*/|"") echo "error: --shard wants <i>/<n>, got '$SHARD'." >&2; exit 1 ;;
+  esac
+  shard_i=${SHARD%%/*}
+  shard_n=${SHARD##*/}
+  if ! { [ "$shard_n" -ge 1 ] && [ "$shard_i" -ge 1 ] && [ "$shard_i" -le "$shard_n" ]; } 2>/dev/null; then
+    echo "error: --shard wants 1 <= i <= n with n >= 1, got '$SHARD'." >&2
+    exit 1
+  fi
+fi
 
 REPO=${REPO:-$(cd "$HERE/.." && pwd)}
 REPO=$(cd "$REPO" && pwd)
@@ -338,6 +360,24 @@ if [ -n "$ONLY" ]; then
   to_run=$ONLY
 fi
 
+# --shard i/n takes every nth mutation starting at i, over the SAME sorted list
+# every shard reads. Round-robin and not contiguous blocks: the mutations differ
+# in cost, and a block split puts a run of slow ones in one shard.
+#
+# THE MANIFEST COMPARISON ABOVE IS NOT SHARDED. Declared-against-present runs in
+# full in every shard, both directions, so a mutation added without a pairing is
+# caught by all of them rather than by whichever shard happened to own it. Only
+# the applying-and-grading below is divided.
+if [ -n "$SHARD" ]; then
+  to_run=$(printf '%s\n' "$to_run" | awk -v i="$shard_i" -v n="$shard_n" 'NR % n == i % n')
+  echo "shard $shard_i of $shard_n: $(printf '%s\n' "$to_run" | grep -c . ) of \
+$(grep -c . "$tmp/declared_mutations") mutations."
+  # An empty shard is a real configuration -- more shards than mutations -- and
+  # it must not report success for grading nothing.
+  [ -n "$to_run" ] || fail "shard $shard_i of $shard_n has no mutations in it: \
+there are fewer mutations than shards, so some shard grades nothing."
+fi
+
 graded=0
 failed=0
 for m in $to_run; do
@@ -414,4 +454,5 @@ if [ "$failed" -ne 0 ]; then
   echo "$failed of $graded mutations were not caught by exactly their detectors." >&2
   exit 1
 fi
-echo "$graded mutations, each caught by exactly the detectors it is paired with."
+echo "$graded mutations, each caught by exactly the detectors it is paired with\
+${SHARD:+ (shard $SHARD)}."

--- a/test/mutation_probe.sh
+++ b/test/mutation_probe.sh
@@ -181,6 +181,54 @@ expect_green "two mutations, each caught by exactly its detectors" \
   "2 mutations, each caught by exactly the detectors"
 
 echo
+echo "== --shard, which divides the mutations across CI jobs"
+reset_fixture
+drive --shard 1/2
+expect_green "a shard grades its own share and says which share it is" \
+  "1 mutations, each caught by exactly the detectors it is paired with (shard 1/2)"
+
+# The two halves together must be the whole. A stride that dropped or repeated a
+# mutation would still let every shard pass, and the check would silently stop
+# covering part of the manifest -- which is the failure this whole script is
+# about, one level up.
+reset_fixture
+drive --shard 1/2
+first=$out
+reset_fixture
+drive --shard 2/2
+expect_green "the other shard grades the rest" \
+  "1 mutations, each caught by exactly the detectors it is paired with (shard 2/2)"
+covered=$(printf '%s\n%s\n' "$first" "$out" | sed -n 's/^== \(.*\)$/\1/p' \
+          | grep -v '^baseline' | sort)
+declared=$(grep -vE '^#|^[[:space:]]*$' "$FIXTURE/test/MUTATION_DETECTORS" \
+           | sed -n 's/^\([^ ]*\) .*/\1/p' | sort -u)
+if [ "$covered" = "$declared" ]; then report "two shards cover every mutation exactly once" ok
+else out="shards covered:"$'\n'"$covered"$'\n'"declared:"$'\n'"$declared"
+     report "two shards cover every mutation exactly once" bad; fi
+
+reset_fixture
+drive --shard 3/2
+expect_red "a shard index past the shard count is refused" 1 \
+  "--shard wants 1 <= i <= n"
+
+reset_fixture
+drive --shard bogus
+expect_red "a shard spec that is not i/n is refused" 1 \
+  "--shard wants <i>/<n>"
+
+reset_fixture
+drive --shard 1/2 --only alpha
+expect_red "--shard and --only together are refused, not silently ranked" 1 \
+  "both select mutations"
+
+# More shards than mutations is a real misconfiguration, and the shard with
+# nothing in it must not report success for grading nothing.
+reset_fixture
+drive --shard 3/3
+expect_red "a shard with no mutations in it is refused, not green" 1 \
+  "has no mutations in it"
+
+echo
 echo "== a detector that stops firing"
 reset_fixture
 : > "$FIXTURE/stub/bench.alpha"


### PR DESCRIPTION
Stacked on #279 — it edits the same CI step. Review after that lands.

## Why this job and not another

Measured over a full run, not assumed: **twelve jobs did 44.9 min of work in 17.6 min of wall time** — an effective parallelism of **2.55** against a scale set that reached **five** runners. The pool is not short of capacity; it has a **long pole**, and the pole is this job, grinding on after everything else has finished.

That also decides what *not* to do. `components` after #281 is well under `formal`'s 6 min, so splitting it cannot shorten a pole it isn't. `formal` already runs its 149 checks in parallel internally.

## No branch-protection edit needed

`mutation-check` is a **required context** on `main`. A required context that stops reporting doesn't fail a PR, it **blocks every one** — including this PR, which would then never be mergeable. Editing protection first would open a window with no mutation gate at all.

So the name survives as a gate: **`mutation-check-shard`** is the matrix that does the work, and **`mutation-check`** needs it and passes only when every shard did. `needs.<matrix job>.result` is `success` only if all four succeeded, and `if: always()` is what makes the gate run when one didn't — without it the job is *skipped*, and a skipped required check leaves a PR waiting rather than red, which is the same blocked state by another route.

Protection is unchanged and never weakened.

## The split

`--shard <i>/<n>` takes every nth mutation starting at i, over the same sorted list every shard reads. **Round-robin, not contiguous blocks** — the mutations differ in cost, and a block split puts a run of slow ones in one shard.

**The manifest comparison is not sharded.** Declared-against-present runs in full in every shard, both directions, so a mutation added without a pairing is caught by all four rather than by whichever shard happened to own it. Only the applying and grading is divided.

**Each shard measures its own baseline** rather than sharing one through an artifact. Measured, that baseline is ~10 s against ~45 s for a mutation, and by the arithmetic above the duplication lands in capacity that is otherwise idle — simplicity bought with something that isn't scarce.

## The graders

`test/mutation_probe.sh` gains seven cases. The load-bearing one:

> **two shards cover every mutation exactly once**

A stride that dropped a mutation would leave every shard passing while coverage silently shrank — which is the failure this whole script exists to catch, one level up. The rest force the malformed spec, the out-of-range index, `--shard` with `--only`, and the shard with nothing in it, which must not report success for grading nothing.

The spec is also validated **where it is read**, before the baseline runs. My first cut spent 45 s measuring a baseline before telling the caller its arguments were wrong.

`fail-fast: false`, because a shard that cancels its siblings turns "these three pairings broke" into "one of them did".

## Expected effect

mutation-check is 7m16s on #279 (down from 17m28s). Four shards should put each near ~2 min, taking the run's pole to `formal` at ~6 min. I am **not** quoting a projected total — the last two numbers I projected from local runs were both wrong on the runner, so this gets measured on CI like anything else.

## Verification

`test/mutation_probe.sh` 25/25 forced red, each for its own reason, with `rtl/` restored every time · one shard run end-to-end locally: 3 of 11 mutations in 147 s, pairings intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJ77ZZJ6pDiL3vj3Qw9hKs