### PR TITLE
Clone the whole repo in CI: depth 1 was a default, not a decision

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,13 @@ jobs:
         run: echo "JOB_START=$(date +%s)" >> "$GITHUB_ENV"
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # The repo is 3.95 MiB and 473 commits, so a full clone costs about a
+          # second and buys every check the history it might need. Depth 1 is
+          # actions/checkout's default, not a decision anyone took here, and a
+          # grader that walks history under it does not fail loudly -- it grades
+          # nothing, which is the one outcome this tree refuses.
+          fetch-depth: 0
 
       - name: Set up OSS CAD Suite
         uses: ./.github/actions/setup-oss-cad-suite
@@ -117,6 +124,13 @@ jobs:
         run: echo "JOB_START=$(date +%s)" >> "$GITHUB_ENV"
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # The repo is 3.95 MiB and 473 commits, so a full clone costs about a
+          # second and buys every check the history it might need. Depth 1 is
+          # actions/checkout's default, not a decision anyone took here, and a
+          # grader that walks history under it does not fail loudly -- it grades
+          # nothing, which is the one outcome this tree refuses.
+          fetch-depth: 0
 
       # A fork PR routes here to ubuntu-latest (see the note above
       # `jobs:`), whose image has no RISC-V cross compiler baked in --
@@ -207,6 +221,13 @@ jobs:
         run: echo "JOB_START=$(date +%s)" >> "$GITHUB_ENV"
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # The repo is 3.95 MiB and 473 commits, so a full clone costs about a
+          # second and buys every check the history it might need. Depth 1 is
+          # actions/checkout's default, not a decision anyone took here, and a
+          # grader that walks history under it does not fail loudly -- it grades
+          # nothing, which is the one outcome this tree refuses.
+          fetch-depth: 0
 
       # Fork-PR routing only -- see the `test` job for why.
       - name: Install the RISC-V cross compiler (fork PR routing only)
@@ -299,6 +320,13 @@ jobs:
         run: echo "JOB_START=$(date +%s)" >> "$GITHUB_ENV"
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # The repo is 3.95 MiB and 473 commits, so a full clone costs about a
+          # second and buys every check the history it might need. Depth 1 is
+          # actions/checkout's default, not a decision anyone took here, and a
+          # grader that walks history under it does not fail loudly -- it grades
+          # nothing, which is the one outcome this tree refuses.
+          fetch-depth: 0
 
       # Fork-PR routing only -- see the `test` job for why.
       - name: Install the RISC-V cross compiler (fork PR routing only)
@@ -388,6 +416,13 @@ jobs:
         run: echo "JOB_START=$(date +%s)" >> "$GITHUB_ENV"
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # The repo is 3.95 MiB and 473 commits, so a full clone costs about a
+          # second and buys every check the history it might need. Depth 1 is
+          # actions/checkout's default, not a decision anyone took here, and a
+          # grader that walks history under it does not fail loudly -- it grades
+          # nothing, which is the one outcome this tree refuses.
+          fetch-depth: 0
 
       - name: Set up OSS CAD Suite
         uses: ./.github/actions/setup-oss-cad-suite
@@ -476,6 +511,13 @@ jobs:
         run: echo "JOB_START=$(date +%s)" >> "$GITHUB_ENV"
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # The repo is 3.95 MiB and 473 commits, so a full clone costs about a
+          # second and buys every check the history it might need. Depth 1 is
+          # actions/checkout's default, not a decision anyone took here, and a
+          # grader that walks history under it does not fail loudly -- it grades
+          # nothing, which is the one outcome this tree refuses.
+          fetch-depth: 0
 
       - name: Install svlint at the pin
         run: make lint-setup
@@ -511,6 +553,13 @@ jobs:
         run: echo "JOB_START=$(date +%s)" >> "$GITHUB_ENV"
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # The repo is 3.95 MiB and 473 commits, so a full clone costs about a
+          # second and buys every check the history it might need. Depth 1 is
+          # actions/checkout's default, not a decision anyone took here, and a
+          # grader that walks history under it does not fail loudly -- it grades
+          # nothing, which is the one outcome this tree refuses.
+          fetch-depth: 0
 
       - name: Set up OSS CAD Suite
         uses: ./.github/actions/setup-oss-cad-suite
@@ -573,6 +622,13 @@ jobs:
         run: echo "JOB_START=$(date +%s)" >> "$GITHUB_ENV"
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # The repo is 3.95 MiB and 473 commits, so a full clone costs about a
+          # second and buys every check the history it might need. Depth 1 is
+          # actions/checkout's default, not a decision anyone took here, and a
+          # grader that walks history under it does not fail loudly -- it grades
+          # nothing, which is the one outcome this tree refuses.
+          fetch-depth: 0
 
       # Fork-PR routing only -- see the `test` job for why.
       - name: Install the RISC-V cross compiler (fork PR routing only)
@@ -648,6 +704,13 @@ jobs:
         run: echo "JOB_START=$(date +%s)" >> "$GITHUB_ENV"
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # The repo is 3.95 MiB and 473 commits, so a full clone costs about a
+          # second and buys every check the history it might need. Depth 1 is
+          # actions/checkout's default, not a decision anyone took here, and a
+          # grader that walks history under it does not fail loudly -- it grades
+          # nothing, which is the one outcome this tree refuses.
+          fetch-depth: 0
 
       # Fork-PR routing only -- see the `test` job for why.
       - name: Install the RISC-V cross compiler (fork PR routing only)
@@ -762,6 +825,13 @@ jobs:
         run: echo "JOB_START=$(date +%s)" >> "$GITHUB_ENV"
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # The repo is 3.95 MiB and 473 commits, so a full clone costs about a
+          # second and buys every check the history it might need. Depth 1 is
+          # actions/checkout's default, not a decision anyone took here, and a
+          # grader that walks history under it does not fail loudly -- it grades
+          # nothing, which is the one outcome this tree refuses.
+          fetch-depth: 0
 
       - name: Set up OSS CAD Suite
         uses: ./.github/actions/setup-oss-cad-suite
@@ -805,6 +875,13 @@ jobs:
         run: echo "JOB_START=$(date +%s)" >> "$GITHUB_ENV"
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # The repo is 3.95 MiB and 473 commits, so a full clone costs about a
+          # second and buys every check the history it might need. Depth 1 is
+          # actions/checkout's default, not a decision anyone took here, and a
+          # grader that walks history under it does not fail loudly -- it grades
+          # nothing, which is the one outcome this tree refuses.
+          fetch-depth: 0
 
       - name: make monitor-check
         run: make monitor-check
@@ -883,6 +960,13 @@ jobs:
         run: echo "JOB_START=$(date +%s)" >> "$GITHUB_ENV"
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # The repo is 3.95 MiB and 473 commits, so a full clone costs about a
+          # second and buys every check the history it might need. Depth 1 is
+          # actions/checkout's default, not a decision anyone took here, and a
+          # grader that walks history under it does not fail loudly -- it grades
+          # nothing, which is the one outcome this tree refuses.
+          fetch-depth: 0
 
       - name: Set up OSS CAD Suite
         uses: ./.github/actions/setup-oss-cad-suite
@@ -992,6 +1076,13 @@ jobs:
         run: echo "JOB_START=$(date +%s)" >> "$GITHUB_ENV"
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # The repo is 3.95 MiB and 473 commits, so a full clone costs about a
+          # second and buys every check the history it might need. Depth 1 is
+          # actions/checkout's default, not a decision anyone took here, and a
+          # grader that walks history under it does not fail loudly -- it grades
+          # nothing, which is the one outcome this tree refuses.
+          fetch-depth: 0
 
       - name: Set up OSS CAD Suite
         uses: ./.github/actions/setup-oss-cad-suite


### PR DESCRIPTION
`actions/checkout` ships `fetch-depth: 1` and **no job here ever overrode it**. Nothing in `ci.yml` walks history, so the shallow clone broke nothing — until two new graders that *do* walk history arrived (#287, #288) and failed only in CI, having passed locally against a full clone.

## Why full rather than teaching each check to cope

The cost is nil: **3.95 MiB, 473 commits** — about a second per job.

And coping is the worse option, because of what coping looks like. A grader that walks history and degrades gracefully under a shallow clone doesn't fail there — **it grades nothing, quietly, in the one environment whose verdict counts.** This tree has a name for that shape: a comparison whose failure path never runs is not a comparison. Five of its recorded defects were exactly that.

So the fix is to give CI the history, not to teach graders to be silent without it.

## What changed

`fetch-depth: 0` on all 13 checkouts, with the reasoning at the first one. Nothing else.

## Note

I have not read the failing logs from #287/#288 — both runs' IDs 404 from the API, so the shallow clone is a diagnosis from the shape (both graders shell out to `git`, both green locally, both red only on CI) rather than from a log line. This change is right regardless of what those two turn out to need; if they still fail after it, the cause is something else and I'll say so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJ77ZZJ6pDiL3vj3Qw9hKs