### PR TITLE
Harden the fixture-freshness parser against evasion and mis-parse

### DIFF
--- a/test/PROBES_EXPECTED
+++ b/test/PROBES_EXPECTED
@@ -74,6 +74,7 @@ a Sail install back inside the checkout is red
 a SoC with no SPI controller at all does not pass by silence
 a SoC with no UART at all does not pass by silence
 a UART base off its own window is red
+a backslash-continued sed -i is still a raw edit
 a bare unpaired with no grader does not pass by silence
 a base tree whose make fails is refused, not quietly given ours
 a base tree whose synth flags moved is digested with ITS flags, and says so
@@ -143,6 +144,7 @@ a design that MET the target has measured the target
 a differing value is a divergence, located by change index
 a directory the glob stopped matching is red, not a suite of size zero
 a dirty tree names no base, so its sweep is not subtracted either
+a double-quoted heredoc delimiter is masked, so its stray apostrophe cannot hide a real sed -i after it
 a download whose bytes are not the pin is refused before extraction
 a dual directory that is not there is the failure this exists to see
 a duplicated manifest line would make comm non-symmetric
@@ -159,6 +161,7 @@ a file the manifest stopped naming is red before shasum ever runs
 a file the manifest stopped naming is red before shasum ever runs
 a file with no row in the index is named as orphaned
 a file with two rows in the index is named
+a fixture that opens its body on the head line is still inspected
 a floor line this loop cannot parse is a floor that is not enforced
 a formal harness that stops wiring rvfi at all is red
 a fourth core's ROM_WORDS with no Makefile entry to reach it is red
@@ -205,6 +208,7 @@ a malformed baseline line is named rather than skipped
 a malformed baseline line is named rather than skipped
 a malformed manifest line is red under --strict, not a silent pass
 a manifest entry that names no program is a typo, not a phantom
+a mid-word # does not hide a real sed -i after it
 a missing Sail install stops the run rather than scoring it
 a missing artifact refuses rather than reporting on nothing
 a missing asm directory is named
@@ -228,6 +232,8 @@ a mutated vendored byte fails the pin, and says so
 a mutated vendored byte fails the pin, and says so
 a mutation line with a stray extra field is red rather than read as the name
 a mutation with no program leg is a real entry, not a missing file
+a name defined twice is checked at both definitions, not just the last
+a nested helper's own closing brace does not end the outer fixture early
 a netlist from another tree is named, not binned as `neither`
 a netlist that is not there is refused, not read as equal
 a netlist with no block RAM at all is refused, not silently green
@@ -425,6 +431,7 @@ an empty status file is refused rather than read as a verdict
 an empty term table is a scan of nothing, not a green one
 an empty trace is fatal rather than an empty comparison
 an encoding failure reported only by the induction leg is not evidence
+an escaped apostrophe outside quotes does not mask a real sed -i
 an exception whose port is connected now is red
 an exception whose site stopped naming that ISA is red
 an exclusion with no reason written under it is rejected
@@ -476,6 +483,7 @@ and the reverse: a divergence reported with exit 0
 and the same for the check-set baseline
 assembler output on a successful build is still a defect
 assembler output on a successful build is still a defect
+awk -i inplace is a raw edit like sed -i
 baselining ERROR would re-create the btorsim hole with this gate's blessing
 bench.lds putting .data back at ram's origin is red
 bench.lds putting the stack back at the top of ram is red
@@ -624,6 +632,7 @@ one netlist placed twice giving two bitstreams voids the gate
 one red tool leaves no partial stamp on stdout
 one side alone is not a cross-core figure
 over budget names the count and the budget
+perl -pi is a raw edit like sed -i
 reg_rs1 laundered through out.rs1's own register is still red
 retires that stopped being spec-checked is its own status
 rule 1 declares a site count, so a generator change cannot ship unapplied
@@ -639,6 +648,8 @@ runner exit 6 is MONITOR-SILENT: the oracle never looked
 running the generator from the wrong directory is refused, not done
 sby's trailing engine numbers are not part of the status
 sections.lds putting .data back at ram's origin is red
+sed --in-place is a raw edit exactly like sed -i
+sed -i is a raw edit even when it is not the first flag
 starvation going red somewhere other than the bound is not evidence
 starvation going red somewhere other than the bound is not evidence
 status AGREE with a nonzero exit is a broken harness, not agreement

--- a/test/fixture_freshness_test.py
+++ b/test/fixture_freshness_test.py
@@ -6,7 +6,9 @@ matches nothing exits 0 having mutated nothing, and the probe built on the
 unmutated copy still goes red, but for the wrong reason ("exited 0, expected
 1"), which accuses the grader under test rather than the fixture that drifted.
 Every mutation is required to go through `mutate`/`mutate_remove`, which
-compare the file before and after and fail by name when nothing changed.
+compare the file before and after and fail by name when nothing changed. The
+same failure mode has other spellings -- `sed --in-place`, `perl -i`,
+`awk -i inplace` -- and this file catches those too.
 
 A fixture that TYPES OUT an artifact's shape by hand -- a nextpnr utilisation
 block, a `localparam` line -- rather than copying the real file has the
@@ -26,6 +28,12 @@ file is red too, because an exemption kept past its reason is how the next
 one gets waved through. Converting an allowlisted site is a one-line deletion
 here in the same commit that fixes it.
 
+Both checks read ONE quote/comment/escape-aware scan of the shell text
+(`_live_chars`), never two: a divergence between two hand-rolled trackers is
+how a fixture line went invisible to one check and not the other here before.
+`shlex` does not replace it -- it opens a comment on any `#`, including one
+buried mid-word, and knows nothing of heredocs or brace depth.
+
 Hermetic: reads test/probe_gates.sh as text. No toolchain, no simulator, no
 yosys, so this runs inside `make test` anywhere.
 """
@@ -33,9 +41,12 @@ import os
 import re
 import sys
 
-# Every remaining raw `sed -i` in test/probe_gates.sh, normalized (leading and trailing
-# whitespace stripped).
-SED_I_ALLOWLIST = []
+# Every remaining raw in-place edit in test/probe_gates.sh, normalized
+# (leading and trailing whitespace stripped). Empty on purpose: every call
+# site converted to `mutate`/`mutate_remove` in the same change that added
+# them. An entry here is a call site not yet converted -- state which one and
+# why it is still bare.
+RAW_EDIT_ALLOWLIST = []
 
 # Fixture functions (name containing "fixture") that type out an artifact's shape with a
 # literal heredoc, copy no real file, and carry no `fixture_anchor` -- so a rewritten
@@ -55,13 +66,24 @@ FIXTURE_ANCHOR_ALLOWLIST = {
     "cd_fixture": "soc/compare/coremark_dmips.py's run.log shape",
 }
 
-FUNC_START_RE = re.compile(r'^([a-zA-Z0-9_]+)\(\) \{(\s*#.*)?$')
-# ONE definition of "a heredoc opens here", read by both the masker below and the anchor
-# check: an earlier pair of regexes disagreed about the UNQUOTED delimiter a fixture
-# needs when its body interpolates a `$1`, so the anchor check skipped `br_fixture` --
-# the fixture behind the only detector of a block RAM read through its own reset -- while
-# the masker saw it.
-HEREDOC_START_RE = re.compile(r"(?<!<)<<(?!<)-?\s*'?([A-Za-z_][A-Za-z_0-9]*)'?")
+# `{` need not be last on the line: a head that opens its body on the same
+# line is a definition too, and _find_function_end reads from the head itself,
+# so the rest of that line is already counted.
+FUNC_START_RE = re.compile(r'^([a-zA-Z0-9_]+)\(\)\s*\{')
+# ONE definition of "a heredoc opens here", read by both the masker below and
+# the anchor check: an earlier pair of regexes disagreed about the UNQUOTED
+# delimiter a fixture needs when its body interpolates a `$1`, so the anchor
+# check skipped `br_fixture` -- the fixture behind the only detector of a block
+# RAM read through its own reset -- while the masker saw it. The delimiter may
+# be bare, single-quoted or double-quoted; `\1` requires the closing mark, if
+# any, to match the opening one.
+# `(?<!<)`/`(?!<)` rule out a here-string (`<<<`), which is not a heredoc and
+# has no closing delimiter line to hunt for -- matching it here sent an
+# earlier version of this scan looking for a line that never comes and masked
+# the rest of the file.
+HEREDOC_START_RE = re.compile(
+    r"(?<!<)<<(?!<)-?\s*([\"'])?([A-Za-z_][A-Za-z_0-9]*)\1?"
+)
 
 def heredoc_mask(lines):
     """True at every line that is BODY TEXT of a heredoc (or its own closing
@@ -73,7 +95,7 @@ def heredoc_mask(lines):
     while i < n:
         m = HEREDOC_START_RE.search(lines[i])
         if m:
-            token = m.group(1)
+            token = m.group(2)
             j = i + 1
             while j < n and lines[j].rstrip('\n').strip() != token:
                 mask[j] = True
@@ -85,11 +107,98 @@ def heredoc_mask(lines):
             i += 1
     return mask
 
+
+def _live_chars(lines, mask):
+    """Yields (lineno, char) for every character of real, unquoted,
+    uncommented shell text. A heredoc-body line yields nothing; quoted text
+    and an escaped character are DATA and yield nothing, so neither a quote
+    nor a brace can be smuggled past by escaping it; `#` opens a comment only
+    at the start of a word, so `x=foo#bar sed -i f` cannot hide what follows.
+    A trailing unescaped backslash eats its own newline the way bash does,
+    and every other line boundary yields a real newline, so two lines that
+    are not continued cannot glue into one word.
+    """
+    in_squote = in_dquote = False
+    at_word_start = True
+    for lineno, raw in enumerate(lines):
+        if mask[lineno]:
+            continue
+        line = raw.rstrip('\n')
+        i, n = 0, len(line)
+        continued = False
+        while i < n:
+            c = line[i]
+            if in_squote:
+                if c == "'":
+                    in_squote = False
+                i += 1
+                continue
+            if c == '\\' and i + 1 == n:
+                continued = True
+                break
+            if in_dquote:
+                if c == '\\' and i + 1 < n:
+                    i += 2
+                    continue
+                if c == '"':
+                    in_dquote = False
+                i += 1
+                continue
+            if c == '\\' and i + 1 < n:
+                i += 2
+                at_word_start = False
+                continue
+            if c in ' \t':
+                at_word_start = True
+                yield (lineno, c)
+                i += 1
+                continue
+            if c == '#' and at_word_start:
+                break
+            if c == "'":
+                in_squote = True
+                at_word_start = False
+                i += 1
+                continue
+            if c == '"':
+                in_dquote = True
+                at_word_start = False
+                i += 1
+                continue
+            yield (lineno, c)
+            at_word_start = False
+            i += 1
+        if not continued:
+            yield (lineno, '\n')
+            at_word_start = True
+
+
+def _find_function_end(lines, mask, start, name):
+    """Real brace depth from `start`'s opening `{`, over the live-code
+    stream, so a nested `helper() { ...; }` or a bare `{ ...; }` grouping
+    block inside a fixture cannot be mistaken for the fixture's own close --
+    the previous version stopped at the first line that was exactly `}`,
+    which either one supplies early."""
+    depth = 0
+    for lineno, c in _live_chars(lines[start:], mask[start:]):
+        if c == '{':
+            depth += 1
+        elif c == '}':
+            depth -= 1
+            if depth == 0:
+                return start + lineno
+    sys.exit(
+        f"error: test/probe_gates.sh:{start + 1} {name}() never closes its "
+        f"opening brace."
+    )
+
+
 def function_bodies(lines, mask):
-    """name -> (start, end), 0-based, end inclusive, for every top-level
-    `name() {` ... `}` in the file. This file's convention is a bare `}` at
-    the start of its own line closing every such function, so that is the
-    boundary read here."""
+    """name -> list of (start, end), 0-based, end inclusive, for every
+    top-level `name() {` ... `}` in the file, closed by real brace depth. A
+    name defined more than once yields one entry per definition -- an
+    earlier definition must not go invisible to either check just because a
+    later one reused its name."""
     bodies = {}
     i, n = 0, len(lines)
     while i < n:
@@ -98,91 +207,74 @@ def function_bodies(lines, mask):
             continue
         m = FUNC_START_RE.match(lines[i])
         if m:
+            name = m.group(1)
             start = i
-            j = i + 1
-            while j < n and lines[j].rstrip('\n') != '}':
-                j += 1
-            bodies[m.group(1)] = (start, j)
-            i = j + 1
+            end = _find_function_end(lines, mask, start, name)
+            bodies.setdefault(name, []).append((start, end))
+            i = end + 1
         else:
             i += 1
     return bodies
 
-def unquoted_sed_i_lines(text):
-    """0-based line indices where `sed -i` starts OUTSIDE any quote, tracking
-    quote state across the whole file the way a shell would. This is what
-    tells an actual invocation apart from the same six characters sitting
-    inside a probe's quoted fixture text or its expected-output string --
-    both of which this file's own probes for this check have to plant."""
-    in_squote = in_dquote = False
-    line = 0
+
+# Each tool's flag shape, checked against every token on the same statement
+# after the tool's own word (i.e. up to the next real newline in the
+# live-code stream). sed and perl both accept a suffix glued directly onto
+# the flag (`-i.bak`), so `\S*` rather than `\b` closes those patterns; perl
+# also combines `-i` with other single-letter flags in one token (`-pi`,
+# `-npi`), restricted to the ones it actually combines with to avoid an
+# unrelated flag that merely contains the letter i (`-Iinc`).
+_SED_FLAG_RE = re.compile(r'^(-i\S*|--in-place\S*)$')
+_PERL_FLAG_RE = re.compile(r'^-[pn]*i(\.\S+)?$')
+
+
+def _raw_edit_hits(lines, mask, exclude_ranges):
+    """(lineno, call-text) for every raw in-place edit -- `sed -i`,
+    `sed --in-place`, `perl -i`/`-pi`/`-npi`, `awk -i inplace` -- that starts
+    outside any quote, comment, or heredoc body, and outside
+    mutate()/mutate_remove()/fixture_anchor()'s own implementations."""
+    text = []
+    linenos = []
+    for lineno, c in _live_chars(lines, mask):
+        text.append(c)
+        linenos.append(lineno)
+    text = ''.join(text)
+
     hits = []
-    i, n = 0, len(text)
-    while i < n:
-        c = text[i]
-        if c == '\n':
-            line += 1
-            i += 1
+    for m in re.finditer(r'\bsed\b|\bperl\b|\bawk\b', text):
+        lineno = linenos[m.start()]
+        if any(lo <= lineno <= hi for lo, hi in exclude_ranges):
             continue
-        if in_squote:
-            if c == "'":
-                in_squote = False
-            i += 1
-            continue
-        if in_dquote:
-            if c == '\\' and i + 1 < n:
-                # A backslash escapes the next character, and that character is a NEWLINE
-                # on every line-continued command here.
-                if text[i + 1] == '\n':
-                    line += 1
-                i += 2
-                continue
-            if c == '"':
-                in_dquote = False
-            i += 1
-            continue
-        if c == '\\' and i + 1 < n:
-            if text[i + 1] == '\n':
-                line += 1
-            i += 2
-            continue
-        if c == "'":
-            in_squote = True
-            i += 1
-            continue
-        if c == '"':
-            in_dquote = True
-            i += 1
-            continue
-        if c == '#':
-            nl = text.find('\n', i)
-            i = nl if nl != -1 else n
-            continue
-        if text.startswith('sed -i', i):
-            hits.append(line)
-        i += 1
+        nl = text.find('\n', m.end())
+        rest = text[m.end():nl if nl != -1 else len(text)]
+        tokens = rest.split()
+        tool = m.group(0)
+        hit = False
+        if tool == 'sed' and any(_SED_FLAG_RE.match(t) for t in tokens):
+            hit = True
+        elif tool == 'perl' and any(_PERL_FLAG_RE.match(t) for t in tokens):
+            hit = True
+        elif tool == 'awk':
+            for k, t in enumerate(tokens[:-1]):
+                if t == '-i' and tokens[k + 1] == 'inplace':
+                    hit = True
+                    break
+        if hit:
+            hits.append((lineno, lines[lineno].strip()))
     return hits
 
-def check_sed_i(lines, mask, exclude_ranges):
-    text = ''.join(lines)
-    hits = []
-    for idx in unquoted_sed_i_lines(text):
-        if mask[idx]:
-            continue
-        if any(lo <= idx <= hi for lo, hi in exclude_ranges):
-            continue
-        hits.append((idx + 1, lines[idx].strip()))
 
+def check_raw_edits(lines, mask, exclude_ranges):
     rc = 0
-    allowed = set(SED_I_ALLOWLIST)
+    allowed = set(RAW_EDIT_ALLOWLIST)
     seen = set()
-    for lineno, call in hits:
+    for lineno, call in _raw_edit_hits(lines, mask, exclude_ranges):
         seen.add(call)
         if call not in allowed:
             rc = 1
             print(
-                f"error: test/probe_gates.sh:{lineno} calls `sed -i` directly: "
-                f"{call}",
+                f"error: test/probe_gates.sh:{lineno + 1} calls a raw "
+                f"in-place edit directly: {call}",
                 file=sys.stderr,
             )
             print(
@@ -194,32 +286,34 @@ def check_sed_i(lines, mask, exclude_ranges):
         if call not in seen:
             rc = 1
             print(
-                f"error: SED_I_ALLOWLIST exempts '{call}', and it no longer "
+                f"error: RAW_EDIT_ALLOWLIST exempts '{call}', and it no longer "
                 f"appears in test/probe_gates.sh. Delete the entry.",
                 file=sys.stderr,
             )
     return rc
 
-def check_fixture_anchors(lines, mask):
-    bodies = function_bodies(lines, mask)
+
+def check_fixture_anchors(lines, mask, bodies):
     rc = 0
-    unanchored = set()
-    for name, (start, end) in bodies.items():
+    unanchored = {}
+    for name, ranges in bodies.items():
         if 'fixture' not in name:
             continue
-        body = ''.join(lines[start:end + 1])
-        has_heredoc = bool(HEREDOC_START_RE.search(body))
-        has_cp_repo = 'cp "$REPO' in body or "cp '$REPO" in body
-        has_anchor = 'fixture_anchor' in body
-        if has_heredoc and not has_cp_repo and not has_anchor:
-            unanchored.add(name)
+        for start, end in ranges:
+            body = ''.join(lines[start:end + 1])
+            has_heredoc = bool(HEREDOC_START_RE.search(body))
+            has_cp_repo = 'cp "$REPO' in body or "cp '$REPO" in body
+            has_anchor = 'fixture_anchor' in body
+            if has_heredoc and not has_cp_repo and not has_anchor:
+                unanchored.setdefault(name, []).append(start)
 
     for name in sorted(unanchored):
-        if name not in FIXTURE_ANCHOR_ALLOWLIST:
-            rc = 1
-            start = bodies[name][0] + 1
+        if name in FIXTURE_ANCHOR_ALLOWLIST:
+            continue
+        rc = 1
+        for start in unanchored[name]:
             print(
-                f"error: test/probe_gates.sh:{start} {name}() types out an "
+                f"error: test/probe_gates.sh:{start + 1} {name}() types out an "
                 f"artifact's shape with no fixture_anchor and no cp \"$REPO/...\" "
                 f"of a real file. It will grade a format nothing produces any "
                 f"more and never go red on its own.",
@@ -250,23 +344,23 @@ def main():
     mask = heredoc_mask(lines)
     bodies = function_bodies(lines, mask)
     exclude_ranges = [
-        bodies[name] for name in ('mutate', 'mutate_remove', 'fixture_anchor')
-        if name in bodies
+        r for name in ('mutate', 'mutate_remove', 'fixture_anchor')
+        for r in bodies.get(name, [])
     ]
-    if len(exclude_ranges) != 3:
+    if not all(name in bodies for name in ('mutate', 'mutate_remove', 'fixture_anchor')):
         sys.exit(
             "error: mutate(), mutate_remove() and fixture_anchor() are not all "
-            "defined in test/probe_gates.sh, so a raw sed -i cannot be told "
-            "apart from their own implementation."
+            "defined in test/probe_gates.sh, so a raw in-place edit cannot be "
+            "told apart from their own implementation."
         )
 
-    rc = check_sed_i(lines, mask, exclude_ranges)
-    rc |= check_fixture_anchors(lines, mask)
+    rc = check_raw_edits(lines, mask, exclude_ranges)
+    rc |= check_fixture_anchors(lines, mask, bodies)
     if rc:
         sys.exit(1)
 
     print(
-        "no bare sed -i outside mutate()/mutate_remove(), "
+        "no bare in-place edit outside mutate()/mutate_remove(), "
         f"{len(FIXTURE_ANCHOR_ALLOWLIST)} fixtures still owed an anchor"
     )
 

--- a/test/probe_gates.sh
+++ b/test/probe_gates.sh
@@ -5532,7 +5532,7 @@ ffr_fixture() {
 
 d=$(ffr_fixture)
 probe "control: the shipping fixtures are all mutate/mutate_remove, every anchor holds" 0 \
-  "no bare sed -i" "$(ffr "$d")"
+  "no bare in-place edit" "$(ffr "$d")"
 
 d=$(ffr_fixture)
 printf '\nsed -i.bak "s/x/y/" foo.txt\n' >> "$d/test/probe_gates.sh"
@@ -5562,15 +5562,133 @@ probe "a hand-typed fixture is red on an unquoted heredoc delimiter too" 1 \
   "another_synthetic_fixture() types out" "$(ffr "$d")"
 
 d=$(ffr_fixture)
-mutate "$d/test/fixture_freshness_test.py" 's/SED_I_ALLOWLIST = \[\]/SED_I_ALLOWLIST = ["bogus entry"]/'
+mutate "$d/test/fixture_freshness_test.py" 's/RAW_EDIT_ALLOWLIST = \[\]/RAW_EDIT_ALLOWLIST = ["bogus entry"]/'
 probe "an allow-listed sed -i that no longer appears anywhere is red too" 1 \
-  "SED_I_ALLOWLIST exempts 'bogus entry'" "$(ffr "$d")"
+  "RAW_EDIT_ALLOWLIST exempts 'bogus entry'" "$(ffr "$d")"
 
 d=$(ffr_fixture)
 mutate "$d/test/probe_gates.sh" \
   's|cp_fixture() {|cp_fixture() {\n  fixture_anchor "$REPO/test/cosim.py" "#!/usr/bin/env python3"|'
 probe "an allow-listed fixture that gained a real anchor is red until the entry is deleted" 1 \
   "is no longer an anchorless synthetic fixture" "$(ffr "$d")"
+
+# A name defined twice used to let the SECOND definition silently exempt the
+# FIRST from the anchor check: `function_bodies()` stored one range per name
+# in a plain dict, so an earlier body -- possibly the anchorless one -- went
+# invisible the moment a later definition reused its name.
+d=$(ffr_fixture)
+cat >> "$d/test/probe_gates.sh" <<'FIXTURE'
+dup_name_fixture() {
+  cat > "$d/x" <<'TOK'
+foo
+TOK
+}
+dup_name_fixture() {
+  fixture_anchor "$REPO/test/cosim.py" "#!/usr/bin/env python3"
+}
+FIXTURE
+probe "a name defined twice is checked at both definitions, not just the last" 1 \
+  "dup_name_fixture() types out" "$(ffr "$d")"
+
+# A head that opens its body on the same line is a definition too. The anchor
+# used to require `{` to be last on the line, so this shape registered as no
+# function at all and its heredoc was invisible to the anchor check.
+d=$(ffr_fixture)
+cat >> "$d/test/probe_gates.sh" <<'FIXTURE'
+oneline_head_fixture() { cat > "$d/x" <<'TOK'
+foo
+TOK
+}
+FIXTURE
+probe "a fixture that opens its body on the head line is still inspected" 1 \
+  "oneline_head_fixture() types out" "$(ffr "$d")"
+
+# A nested `helper() { ...; }` closing on its own line used to end the OUTER
+# fixture early: the previous scan stopped at the first line that was
+# exactly `}`, with no brace-depth counter to tell an inner close from the
+# fixture's own. The truncated body excluded the heredoc entirely, so the
+# fixture went invisible to the anchor check rather than red.
+d=$(ffr_fixture)
+cat >> "$d/test/probe_gates.sh" <<'FIXTURE'
+nested_brace_fixture() {
+  helper() {
+    :
+}
+  cat > "$d/x" <<'TOK'
+foo
+TOK
+}
+FIXTURE
+probe "a nested helper's own closing brace does not end the outer fixture early" 1 \
+  "nested_brace_fixture() types out" "$(ffr "$d")"
+
+# `#` only opens a comment at the start of a word in bash; the previous scan
+# treated every unquoted `#` as a comment opener, so a decoy like this masked
+# a real invocation sitting right after it.
+d=$(ffr_fixture)
+printf '\nx=foo#bar sed -i decoy.txt\n' >> "$d/test/probe_gates.sh"
+probe "a mid-word # does not hide a real sed -i after it" 1 \
+  "sed -i decoy.txt" "$(ffr "$d")"
+
+# A regression pin, not a fix: outside quotes, an escaped quote character was
+# already treated as literal DATA rather than as opening a string, so this
+# stays green. Planted because a broad security pass flagged the shape as
+# suspect; this proves it does not reproduce against the shipping scanner.
+d=$(ffr_fixture)
+cat >> "$d/test/probe_gates.sh" <<'FIXTURE'
+echo \' ; sed -i real.txt
+FIXTURE
+probe "an escaped apostrophe outside quotes does not mask a real sed -i" 1 \
+  "sed -i real.txt" "$(ffr "$d")"
+
+d=$(ffr_fixture)
+printf '\nsed --in-place file.txt\n' >> "$d/test/probe_gates.sh"
+probe "sed --in-place is a raw edit exactly like sed -i" 1 \
+  "sed --in-place file.txt" "$(ffr "$d")"
+
+# -i is not always the first flag, and the scan checks every token after
+# `sed`, not just the first, for exactly this reason.
+d=$(ffr_fixture)
+printf "\nsed -e 's/x/y/' -i file.txt\n" >> "$d/test/probe_gates.sh"
+probe "sed -i is a raw edit even when it is not the first flag" 1 \
+  "-e 's/x/y/' -i file.txt" "$(ffr "$d")"
+
+d=$(ffr_fixture)
+printf '\nperl -pi -e "s/x/y/" file.txt\n' >> "$d/test/probe_gates.sh"
+probe "perl -pi is a raw edit like sed -i" 1 \
+  "perl -pi -e" "$(ffr "$d")"
+
+d=$(ffr_fixture)
+printf "\nawk -i inplace '{print}' file.txt\n" >> "$d/test/probe_gates.sh"
+probe "awk -i inplace is a raw edit like sed -i" 1 \
+  "awk -i inplace" "$(ffr "$d")"
+
+# Backslash-newline continuations are joined before searching, so a wrapped
+# invocation -- this file wraps long commands exactly this way throughout --
+# cannot hide a real sed -i between the two physical lines.
+d=$(ffr_fixture)
+cat >> "$d/test/probe_gates.sh" <<'FIXTURE'
+sed \
+  -i file.txt
+FIXTURE
+probe "a backslash-continued sed -i is still a raw edit" 1 \
+  "directly: sed" "$(ffr "$d")"
+
+# A double-quoted heredoc delimiter used to be invisible to the masker, so
+# its raw body text fed the quote tracker; an unbalanced quote inside it
+# (ordinary prose, not an attack) desynced the tracker for the rest of the
+# file and swallowed a real sed -i after the heredoc closed.
+d=$(ffr_fixture)
+cat >> "$d/test/probe_gates.sh" <<'FIXTURE'
+dq_delim_fixture() {
+  cat > "$d/x" <<"TOK"
+don't break the quote tracker
+TOK
+}
+sed -i real_after_heredoc.txt
+FIXTURE
+probe "a double-quoted heredoc delimiter is masked, so its stray apostrophe cannot hide a real sed -i after it" 1 \
+  "sed -i real_after_heredoc.txt" "$(ffr "$d")"
 
 actual_labels=$(printf '%s\n' "${probe_labels[@]}" | LC_ALL=C sort)
 expected_labels=$(grep -vE '^#|^[[:space:]]*$' "$PROBES_MANIFEST" | LC_ALL=C sort)


### PR DESCRIPTION
## What

`test/fixture_freshness_test.py` hand-rolls a shell parser over `test/probe_gates.sh` to enforce two ratchets: every in-place edit goes through `mutate`/`mutate_remove`, and every hand-typed fixture declares a `fixture_anchor`. A security pass found seven ways it could be evaded or mis-parsed. This closes all seven.

**Live on main:**
- **Duplicate top-level names silently dropped the earlier body.** `function_bodies()` stored `name -> (start, end)` in a plain dict; a later definition overwrote an earlier one, exempting it from both checks. Now returns a list of ranges per name and both checks iterate every occurrence. Six duplicate names existed on main (`rc_fixture`, `ba_fixture`, `bas`, `line_of`, `assert_red`, `cover_red`); none of the fixture-named ones contained a heredoc in their own body, so no previously-invisible fixture became newly visible.
- **A bare `}` closed a function with no brace-depth counter**, so a nested `helper() { ...; }` or a plain `{ ...; }` grouping block truncated a fixture's body early — dropping its heredoc out of the recorded range and exempting it from the anchor check with nothing said. Function ends are now found by real brace depth over a shared quote/comment/escape-aware scan (`_live_chars`).
- **The quote tracker treated every unquoted `#` as a comment opener**, where bash only starts one at a word boundary, so `x=foo#bar sed -i f` hid a real invocation. Fixed in the same shared scanner. Its other claimed gap — an unescaped backslash outside quotes opening a spurious string — did **not** reproduce against the shipping code on inspection; I added a regression probe pinning that finding rather than a fix, and note the decision here rather than silently doing nothing.

**Drift risk, closed:**
- `sed --in-place`, `perl -i`/`-pi`/`-npi`, and `awk -i inplace` are now detected alongside `sed -i`.
- Backslash-newline continuations are joined by the shared scanner before searching, so a wrapped invocation (this file's own convention for long commands) can't hide between two physical lines.
- `HEREDOC_START_RE` now matches a double-quoted delimiter (`<<"EOF"`) as well as single-quoted and bare ones, so such a body is masked instead of feeding its raw text — including any stray apostrophe — to the quote tracker.

### Decision: shlex was considered and declined

`shlex`'s posix-mode `commenters` starts a comment on *any* `#`, including one buried mid-word — the same bug being fixed here, not a fix for it. Getting the word-boundary rule right still means hand-rolling the tracker, and shlex has no notion of heredocs or brace depth at all. Adopting it would not remove the hand-rolled scanner, only hide an equally hand-rolled one behind a stdlib import. Instead, the two checks (brace-depth function-body finder, raw-edit-command finder) now key off **one** shared scanner instead of two independently hand-rolled ones — the exact kind of divergence that let `br_fixture` go invisible to one check and not the other before this ticket (ADR-0164).

### Scope

Stayed in the parser per the ticket. No fixture was newly anchored, and `FIXTURE_ANCHOR_ALLOWLIST` is unchanged (still 12 entries) — no previously-anchorless fixture became newly visible under the widened scan.

## Testing

- 11 new probes in `test/probe_gates.sh`, each a red direction for one of the shapes above (two demonstrate the live evasions directly: a duplicate-name fixture and a nested-brace fixture that only go red under the fix). Bare `perl -i` has no probe of its own -- `perl -pi` covers the flag pattern.
- `test/PROBES_EXPECTED` updated by hand (718 → 729).
- `make probe-gates`: 729 graded comparisons, every failure path executed.
- `make test`: 75/75 against `test/EXPECTED_FAIL`, matching both ways.
- Ran `/simplify` on the diff: threaded the already-computed `function_bodies()` result into `check_fixture_anchors` instead of recomputing it, widened the sed flag check to scan every token (not just the first) matching perl's existing behavior, and updated the stale "no bare sed -i" success message. Re-ran the full suite after.
- Self-review against soundcheck's PR gate: no Critical/High findings (test-only tooling parsing a tracked repo file, no eval/shell-out/network/credential surface introduced).

Closes JEF-951.


---

**Integration notes (architect).** Rebased onto `main` after #291's tree-wide comment cut; conflicts in both files resolved to this branch's rewrite, minus one comment block #291 had deleted, with the new prose cut to the density #291 established.

The security pass's sharpest finding did not reproduce and I am recording that rather than acting on it: `FUNC_START_RE`'s `$` anchor was reported to make three `*fixture*` functions invisible to `check_fixture_anchors`. It does not — the pattern's second alternative `(\s*#.*)?$` admits a trailing comment, which is the shape all of `br_fixture`, `ecp5_stale_fixture`, `wr_fixture` and `pd_fixture` use. Enumerated: 17 function heads in the file are missed by the strict anchor and **none** has `fixture` in its name, so the anchor check misses nothing today.

The anchor is relaxed anyway, to `^([a-zA-Z0-9_]+)\(\)\s*\{`, because a one-liner head is a definition and a future fixture written that way would escape. Verified a no-op on this tree (same 12 owed anchors, same green), so it is future-proofing with a red direction attached rather than a fix: one probe added, "a fixture that opens its body on the head line is still inspected", which is the +1 over the branch's own 728.

Deferred, with reasons:
- **`check_fixture_anchors` reads only names containing `fixture`**, so `test/probe_gates.sh`'s top-level hand-typed `sby` status/log stubs are outside its reach. Real, and ADR-0164 already ratifies exactly this boundary — "a shape-based predicate was declined: it reads every helper in the file and buys a longer allowlist that grades nothing", with the stated cost being a fixture named without the word. Widening it is an amendment to that ADR, not an integration fix. Filed as follow-up.
- **`heredoc_mask` uses `.search`**, so only the first heredoc on a line is masked; **the closing-delimiter check always strips**, treating every heredoc as `<<-`; **`_live_chars` has no `$'...'` handling**. All three need text that does not exist in the file today, and each fix changes what the shared masker considers live — which is the one thing in this rewrite worth not changing without its own red direction. Filed as follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pegfacb12zVYBBPLCdZq2A
