### PR TITLE
Split the two longest CI jobs: one per component proof, and the two check sets apart

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,8 +225,26 @@ jobs:
             echo "wall time: ${elapsed}s"
           } >> "$GITHUB_STEP_SUMMARY"
 
-  components:
-    name: components
+  components-proof:
+    name: components-proof
+    # One job per proof: independent sby tasks, serial only because they shared a job.
+    strategy:
+      fail-fast: false
+      matrix:
+        proof: [executor, decoder, accessor, pcloop, traps, busarbiter]
+        include:
+          - proof: executor
+            title: Executor arithmetic BMC
+          - proof: decoder
+            title: Decoder component proof
+          - proof: accessor
+            title: Accessor one-transaction proof
+          - proof: pcloop
+            title: Fetcher/decoder PC-loop proof (+ its anti-vacuity cover)
+          - proof: traps
+            title: Trap commit proof
+          - proof: busarbiter
+            title: Bus arbiter proof (+ its cover and its forced red directions)
     runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'little-cpu-runners' || 'ubuntu-latest' }}
     timeout-minutes: 20
     steps:
@@ -257,33 +275,35 @@ jobs:
           echo "host free -h (NOT the pod's limit):"
           free -h 2>/dev/null || true
 
-      - name: Executor arithmetic BMC
-        run: make -C formal components_executor
-
-      - name: Decoder component proof
-        run: make -C formal components_decoder
-
-      - name: Accessor one-transaction proof
-        run: make -C formal components_accessor
-
-      - name: Fetcher/decoder PC-loop proof (+ its anti-vacuity cover)
-        run: make -C formal components_pcloop
-
-      - name: Trap commit proof
-        run: make -C formal components_traps
-
-      # Starvation has no other grader: no torture program can catch it.
-      - name: Bus arbiter proof (+ its cover and its forced red directions)
-        run: make -C formal components_busarbiter
+      - name: ${{ matrix.title }}
+        run: make -C formal components_${{ matrix.proof }}
 
       - name: Report job wall time
         if: always()
         run: |
           elapsed=$(( $(date +%s) - JOB_START ))
           {
-            echo "### components"
+            echo "### components-proof (${{ matrix.proof }})"
             echo "wall time: ${elapsed}s"
           } >> "$GITHUB_STEP_SUMMARY"
+
+  components:
+    name: components
+    # THE REQUIRED CHECK KEEPS ITS NAME. `if: always()` is what makes it run when a proof
+    # did not -- a skipped required check leaves the pull request waiting, not red.
+    needs: components-proof
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require every component proof to have passed
+        run: |
+          set -euo pipefail
+          result='${{ needs.components-proof.result }}'
+          echo "components-proof: $result"
+          if [ "$result" != success ]; then
+            echo "::error::a component proof did not pass; read components-proof"
+            exit 1
+          fi
 
   lint:
     name: lint
@@ -647,6 +667,50 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
           exit "$status"
 
+      - name: Report job wall time
+        if: always()
+        run: |
+          elapsed=$(( $(date +%s) - JOB_START ))
+          {
+            echo "### formal-checks"
+            echo "wall time: ${elapsed}s"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  formal-checks-nano:
+    name: formal-checks-nano
+    # A SECOND check set, 79 against littlecpu's 86, and each grades a complete baseline.
+    # Split by set rather than sharded, because a shard of one set grades nothing.
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'little-cpu-runners' || 'ubuntu-latest' }}
+    timeout-minutes: 20
+    steps:
+      - name: Record job start
+        run: echo "JOB_START=$(date +%s)" >> "$GITHUB_ENV"
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up OSS CAD Suite
+        uses: ./.github/actions/setup-oss-cad-suite
+
+      # As in the other half: without btorsim this gate goes green on a set that never ran.
+      - name: Confirm the BMC toolchain is complete
+        run: |
+          set -euo pipefail
+          missing=0
+          for tool in yosys sby btormc btorsim; do
+            if path=$(command -v "$tool"); then
+              echo "$tool: $path"
+            else
+              echo "::error::$tool is not on PATH in the OSS CAD Suite"
+              missing=1
+            fi
+          done
+          if [ "$missing" -ne 0 ]; then
+            echo "::error::formal/check-baseline.sh cannot tell ERROR from FAIL," \
+                 "so an incomplete toolchain would make this gate green on a" \
+                 "check set that never really ran. Refusing to report a verdict."
+            exit 1
+          fi
+
       - name: Generate and run the nanocpu checks (make -C nano/formal check)
         run: make -C nano/formal check JOBS=4
 
@@ -676,7 +740,7 @@ jobs:
         run: |
           elapsed=$(( $(date +%s) - JOB_START ))
           {
-            echo "### formal-checks"
+            echo "### formal-checks-nano"
             echo "wall time: ${elapsed}s"
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -730,17 +794,18 @@ jobs:
 
   formal:
     name: formal
-    needs: [formal-checks, formal-extra]
+    needs: [formal-checks, formal-checks-nano, formal-extra]
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - name: Require both halves to have passed
+      - name: Require every formal half to have passed
         run: |
           set -euo pipefail
           checks='${{ needs.formal-checks.result }}'
+          nano='${{ needs.formal-checks-nano.result }}'
           extra='${{ needs.formal-extra.result }}'
-          echo "formal-checks: $checks   formal-extra: $extra"
-          if [ "$checks" != success ] || [ "$extra" != success ]; then
+          echo "formal-checks: $checks   nano: $nano   formal-extra: $extra"
+          if [ "$checks" != success ] || [ "$nano" != success ] || [ "$extra" != success ]; then
             echo "::error::a formal half did not pass; read formal-checks and formal-extra"
             exit 1
           fi


### PR DESCRIPTION
Measured on run 34118311842 (main, 18 jobs): **19.6 min wall against 42.5 min of job time** — effective parallelism 2.17. The two longest poles were `formal-checks` at 669s and `components` at 552s, and nothing could finish before them.

## `components` → one job per proof

Six independent sby proofs ran one after another in a single job, for no reason but that they shared it. Now a six-way matrix.

**The required context keeps its name**: `components` survives as a gate over the matrix, so branch protection needs no edit and there is no window in which the proof set is unrequired.

## `formal-checks` → one job per check set

Since the nanocpu import this job has been running **two** check sets — 86 for littlecpu and 79 for nano, 165 in one job. They are now a job each, and `formal` gates on both.

**Split by check set, not by sharding one set**, and that difference is the whole argument. `formal/check-baseline.sh` grades two set-equalities in both directions over a complete run; a shard holds a fraction of the statuses and can grade neither. Sharding would mean shipping per-check statuses between jobs and grading the union somewhere else — a new failure mode on the one path in this repo whose entire job is to notice that a check stopped being asked. Splitting by set keeps each job grading a complete baseline of its own.

The nano half also gains the btorsim guard its sibling already had: without btorsim, sby reports `ERROR` where it means `FAIL`, `check-baseline.sh` cannot tell them apart, and the gate goes green on a set that never really ran.

## What this does and does not buy

Neither job's *work* changes — the same 165 checks and six proofs run the same way. What changes is that they can run concurrently, which **only pays if there are runners free to take them**. The same measurement shows why: `mutation-check-shard (1)` waited 999 seconds to start while shard 2 started at +9s, so today's four shards are already serialised by runner availability. This lowers the floor; runner count is what closes the gap between 42.5 minutes of work and 19.6 minutes of wall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJ77ZZJ6pDiL3vj3Qw9hKs