### PR TITLE
product_check: stop the artifact making its own stamp stale

### DIFF
--- a/soc/compare/product_check.py
+++ b/soc/compare/product_check.py
@@ -48,6 +48,7 @@ Usage:
 
 import argparse
 import json
+import os
 import subprocess
 import sys
 
@@ -68,15 +69,23 @@ def load(path):
     except (OSError, json.JSONDecodeError) as exc:
         refuse(f"*** {path} could not be read as the product artifact: {exc}")
 
-def moved_paths(repo, base):
+# The artifact lives INSIDE a watched prefix, so writing it counts as the tree moving:
+# stamping dhrystone and then writing coremark made dhrystone stale against its own file,
+# and `make compare-product` could never exit 0. Excluded by the path the caller actually
+# gave, not by a prefix -- a prefix would stop this noticing a real soc/compare/ change.
+def moved_paths(repo, base, artifact=None):
     """Every path under rtl/ or soc/compare/ that differs between `base` and the
     working tree (committed or not -- a stamp is stale the moment either
     factor's inputs move, whether or not the move has been committed yet).
     """
     try:
+        pathspec = ["rtl/", "soc/compare/"]
+        if artifact is not None:
+            rel = os.path.relpath(os.path.abspath(artifact), os.path.abspath(repo))
+            if not rel.startswith(os.pardir):
+                pathspec.append(":(exclude)" + rel)
         out = subprocess.run(
-            ["git", "-C", repo, "diff", "--name-only", base, "--",
-             "rtl/", "soc/compare/"],
+            ["git", "-C", repo, "diff", "--name-only", base, "--"] + pathspec,
             capture_output=True, text=True, check=True,
         )
     except FileNotFoundError:
@@ -89,7 +98,7 @@ def moved_paths(repo, base):
                "this check can confirm is still current.")
     return [line for line in out.stdout.splitlines() if line]
 
-def stale_reasons(pair, repo, current):
+def stale_reasons(pair, repo, current, artifact=None):
     """Every reason a MEASURED `pair` is stale, or [] if it is fresh.
 
     `current` is a dict of field name to the value the build has right now --
@@ -120,7 +129,7 @@ def stale_reasons(pair, repo, current):
         reasons.append("it was measured on a tree with uncommitted changes, so "
                        "its base commit does not fully describe what was "
                        "measured")
-    paths = moved_paths(repo, pair["base"])
+    paths = moved_paths(repo, pair["base"], artifact)
     if paths:
         reasons.append("rtl/ or soc/compare/ changed since "
                        f"{pair['base'][:12]}: {', '.join(paths)}")
@@ -140,7 +149,7 @@ def report_pair(benchmark, pair, args):
                "'measured' nor 'not_yet_measured'. That is not a stamp this "
                "script knows how to grade.")
 
-    reasons = stale_reasons(pair, args.repo, args.current)
+    reasons = stale_reasons(pair, args.repo, args.current, args.product_json)
     if reasons:
         print(f"*** STALE: {benchmark}'s product stamp is from "
              f"{pair['base'][:12]} ({pair['date']}), and:")

--- a/test/PROBES_EXPECTED
+++ b/test/PROBES_EXPECTED
@@ -99,6 +99,7 @@ a capitalised spelling is the same word and is caught too
 a carry hop is counted apart from a LUT level
 a casing keyword the table does not define stops rather than guessing
 a cause proof going red somewhere else is not evidence either
+a cell type outside the read liberty is refused, not priced at zero
 a cell type that moved is reported as a count, both ways
 a cell type the log never mentions reads as zero, not a crash
 a census under the other gate names that gate, not the ice40 one
@@ -190,6 +191,7 @@ a harness with no line in the baseline is red
 a harness with no line in the baseline is red
 a hop class nothing classifies would move the split silently
 a hop sum that does not reconcile blames the script, not the design
+a liberty file that does not match the pinned digest is refused
 a line naming a mutation test/mutations/ does not have is red
 a line with no harness behind it is red too
 a line with no harness behind it is red too
@@ -217,9 +219,11 @@ a missing Sail install stops the run rather than scoring it
 a missing artifact refuses rather than reporting on nothing
 a missing asm directory is named
 a missing baseline file is exit 2, not an empty expected set
+a missing liberty file is refused before the JSON is even opened
 a missing parser stops the run rather than grading with a second one
 a missing ramdiff for the SECOND CoreMark core is red, not silently skipped
 a missing ramdiff for the SECOND core is red, not silently skipped
+a missing stat.json is refused, not read as a zero-area design
 a mistyped baseline path cannot compare nothing and pass
 a mistyped baseline path cannot compare nothing and pass
 a mistyped floor path cannot make every floor lookup miss
@@ -400,6 +404,7 @@ a tree with no source file at all is red rather than vacuously green
 a trip prints the trend too, since that is the run that needs it
 a truncated netlist is refused, which is what a full disk leaves
 a truncated report blames the run rather than parsing what is left
+a truncated stat.json is refused, not read as an empty report
 a wait bound that admits a starved hart is red
 a wait bound that admits a starved hart is red
 a wire that does not carry its class's name is named
@@ -521,6 +526,7 @@ control: a good CoreMark run reports all three cores' figures
 control: a good run reports both cores' figures
 control: a good three-way run reports all three cores' figures
 control: a measurement within budget is green
+control: a measurement within budget is green
 control: a model file OUTSIDE isa_rv32imc.txt is not one this check can see
 control: a netlist digests, and the digest is a sha256
 control: a nextpnr that wrote its pair is graded, exit 1 and all
@@ -607,6 +613,7 @@ data past the end of the simulated RAM is red, not silent
 decoder_output.rd widened past 5 bits is red (finding 5)
 deleting an rtl file and leaving its line is red
 every source line moving is the comment class, and is forgiven
+excluding the artifact does not blind the check to a real soc/compare/ change
 fixture_anchor whose literal left the real file is fixture-stale, named
 half of a macro-guarded group is red, where none of it is not
 hazard reading ls_answer_valid directly is red (finding 1)
@@ -684,6 +691,7 @@ the UART moving in the core's copy alone is red
 the UART moving in the proof's copy alone is red
 the address the flash-reading program uses is checked against the controller
 the address the printing program writes is checked against the UART
+the artifact moving does not make its own stamp stale
 the baud rate is still refused beside the clock a top may set
 the benchmark script must keep linking against the part's rom
 the benchmark's own FAIL verdict stops the number being quoted
@@ -739,12 +747,14 @@ the third core's ROM drifting behind the other two is red
 the timer address the programs arm is checked against the timer
 the timer moving in the core's copy alone is red
 the timer moving in the proof's copy alone is red
+the trend against a recorded figure is printed beside the verdict
 the trend against the recorded count is printed beside the verdict
 the two definitions the predicates are built from are pinned literally
 the wait-state bias is disclosed as a percentage of hazard3's own cycles
 the word coming back in a formal harness comment is red, and located
 the wrong count is named against the log's real one
 three sweeps have no one difference, so they are refused
+total above the ratchet names the figure and the budget
 two CoreMark cores whose RAMs differ are red, not a ratio
 two arms that cannot be told apart are not two arms
 two arms that cannot be told apart are not two arms
@@ -770,13 +780,5 @@ wrong argument count is exit 2
 wrong argument count is exit 2
 wrong argument count is exit 2 -- the inputs are broken, not the checks
 zero CoreMark iterations would divide the work by nothing
-zero runs would divide the work by nothing
-a cell type outside the read liberty is refused, not priced at zero
-a liberty file that does not match the pinned digest is refused
-a missing liberty file is refused before the JSON is even opened
-a missing stat.json is refused, not read as a zero-area design
-a truncated stat.json is refused, not read as an empty report
-control: a measurement within budget is green
-the trend against a recorded figure is printed beside the verdict
-total above the ratchet names the figure and the budget
 zero cells is refused, not read as a zero-area design
+zero runs would divide the work by nothing

--- a/test/probe_gates.sh
+++ b/test/probe_gates.sh
@@ -5337,6 +5337,33 @@ git -C "$d/repo" -c user.email=probe@example -c user.name=probe commit -qam touc
 probe "a soc/compare/ change since the stamp's base is STALE, and the file is named" 1 \
   "soc/compare/dhry_tb.v" "$(product_check_run "$d" dhrystone 'cflags=-march=rv32ic -O2')"
 
+# The artifact really lives at soc/compare/product.json, INSIDE a watched prefix, and the
+# fixture above deliberately does not: that is why nothing caught `make compare-product`
+# invalidating its own dhrystone stamp by writing coremark next to it.
+product_check_real_layout() {
+  local d; d=$(product_check_fixture)
+  mkdir -p "$d/repo/soc/compare"
+  git -C "$d/repo" -c user.email=probe@example -c user.name=probe \
+    mv product.json soc/compare/product.json >/dev/null 2>&1 \
+    || mv "$d/repo/product.json" "$d/repo/soc/compare/product.json"
+  git -C "$d/repo" add -A
+  git -C "$d/repo" -c user.email=probe@example -c user.name=probe commit -qm artifact
+  printf '%s' "$d"
+}
+
+d=$(product_check_real_layout)
+printf '\n' >> "$d/repo/soc/compare/product.json"
+probe "the artifact moving does not make its own stamp stale" 0 \
+  "dhrystone: fresh, stamped" \
+  "python3 $REPO/soc/compare/product_check.py $d/repo/soc/compare/product.json dhrystone --repo $d/repo --current 'cflags=-march=rv32ic -O2'"
+
+d=$(product_check_real_layout)
+printf '\n' >> "$d/repo/soc/compare/product.json"
+echo '/* touched */' >> "$d/repo/soc/compare/dhry_tb.v"
+probe "excluding the artifact does not blind the check to a real soc/compare/ change" 1 \
+  "soc/compare/dhry_tb.v" \
+  "python3 $REPO/soc/compare/product_check.py $d/repo/soc/compare/product.json dhrystone --repo $d/repo --current 'cflags=-march=rv32ic -O2'"
+
 d=$(product_check_fixture)
 probe "a CFLAGS change with no rtl/ or soc/compare/ move is STALE too, named by field" 1 \
   "cflags changed: stamped '-march=rv32ic -O2', now '-march=rv32ic -O3'" \


### PR DESCRIPTION
`make compare-product` could not exit 0. It writes both pairs into `soc/compare/product.json`, and `product_check.py` watches `rtl/` and `soc/compare/` for changes since the stamped commit — so writing the coremark result made the dhrystone stamp, written seconds earlier, stale against its own file:

```
*** STALE: dhrystone's product stamp is from c63a998805e3, and:
***   rtl/ or soc/compare/ changed since c63a998805e3: soc/compare/product.json
*** Re-run `make compare-product` before quoting dhrystone's product again.
```

That is the entire list of changed paths. The weekly scheduled re-take has been failing this way.

**Excluded by the path the caller gave, not by a prefix.** `soc/compare/` has to keep being watched whole; a prefix exclusion would stop this noticing a real change sitting beside the artifact.

## The probe is the interesting part

There were already probes for an `rtl/` change and a `soc/compare/` change, and neither could see this — because the fixture writes the artifact to `$d/repo/product.json`, **outside** the watched prefix. The fixture did not reproduce the layout it was grading, so the one interaction that mattered was unreachable.

Two probes now use the real layout: the artifact moving on its own is fresh, and a real `soc/compare/` change beside it is still stale and still named by file.

Verified against the actual reproduction as well as the fixture — on a tree where `product.json` is the sole difference from its stamp, main's checker reports STALE and this one reports fresh and prints the figures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJ77ZZJ6pDiL3vj3Qw9hKs