### PR TITLE
Run CI on merge_group so the queue can replace up-to-date branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,10 @@ name: CI
 
 on:
   pull_request:
+  # A merge queue tests each PR against the tip it will actually land on, so
+  # branch protection no longer has to demand every branch be up to date --
+  # which re-staled all six other PRs on every merge.
+  merge_group:
   push:
     branches: [main]
 


### PR DESCRIPTION
`strict: true` on branch protection means one merge re-stales every other open PR. With seven open tonight that is seven sequential CI rounds, and refreshing them eagerly costs **792 job-runs against 176** — six PRs' work discarded per merge, competing for the same eight runners as the PR actually merging.

Measured on run 34437903120 (33 jobs, sharding live): total job-time **78.8 min**, of which setup is **2.6 min (3%)**. So CI is not slow — one PR round is ~10 min against a free pool, bounded by throughput (78.8/8 ≈ 9.9) and critical path (`components-proof (executor)`, 7.3). The cost is the multiplication, not the constant.

A merge queue tests each entry against the tip it will actually land on, so no PR is refreshed against another's merge.

## This PR adds only the trigger

Enabling the queue is a branch-protection setting and **must be done after this lands** — turned on first, the queue would have no checks reporting into it and every entry would hang.

## Why nothing else changes

- `runs-on:` picks the self-hosted pool for any non-`pull_request` event, correct for a queue ref, which is trusted.
- The fork-PR cross-compiler installs are guarded on `pull_request` and skip; the self-hosted image already carries the toolchain.
- `cancel-in-progress` is `github.event_name == 'pull_request'`, so a queued merge is never cancelled mid-flight, and each queue entry gets its own `github.ref` so entries do not cancel each other.

`actionlint` clean.