### PR TITLE
Give every component proof one engine, not a race against a loser

### DIFF
--- a/formal/components.sby
+++ b/formal/components.sby
@@ -10,10 +10,12 @@ busarbiter all
 all: mode prove
 
 [engines]
-all: smtbmc
+# No `all:` line: on a one-CPU pod it races a task's own engine, never replacing it.
+decoder: smtbmc
+accessor: smtbmc
+traps: smtbmc
 pcloop: smtbmc boolector
-# The executor task is most of this job's wall time and bitwuzla proves it in 101s
-# against the default's 245s.
+# executor is most of this job's clock; bitwuzla proves it in 101s against 245s.
 executor: smtbmc bitwuzla
 
 busarbiter: smtbmc --keep-going


### PR DESCRIPTION
## The bug

`all: smtbmc` in `formal/components.sby` is not a default that a task's own line replaces — **sby adds it**. So `executor`, `pcloop` and `busarbiter` each ran the default engine *alongside* their chosen one, and in every case the default never returned a status. The CI log shows both: `engine_0: smtbmc` and `engine_1: smtbmc bitwuzla`, with `engine_0 (smtbmc) did not return a status`.

## Why it costs real time

The executor job reports **406s of process time against 420s of clock** — a ratio below 1.0, which means those four solver processes never ran in parallel. **The pod is effectively one CPU**, so the losing engine was not idle overhead; it was taking about half the core the winner needed. That is most of the gap between the 101s this proof measures locally and the 429s the job takes on CI.

## The change

Each task names exactly one engine. No engine is changed, so no task's memory footprint moves — the pod carries strictly less than before, having dropped a whole solver process.

Verified locally, one engine apiece and all six still proving:

| task | time | engines |
|---|---|---|
| executor | 88s | 1 |
| traps | 27s | 1 |
| decoder | 8s | 1 |
| pcloop | 3s | 1 |
| accessor | 2s | 1 |
| busarbiter | 0s | 1 |

The engine-count check is the point: my first attempt at this edit added a `busarbiter: smtbmc` line without noticing the file already ends with `busarbiter: smtbmc --keep-going`, which reproduced the exact bug being fixed. Counting engines per task caught it.

## Not included

`traps` measures 22s on bitwuzla against 28s on the default, a ~21% win. Left out deliberately: an engine change moves the memory footprint, and this repo has already had a components job OOM-killed by an engine chosen on the clock alone. That wants its own measurement of peak RSS against the pod's limit, not a drive-by.