### PR TITLE
Drop the merge_group trigger: this account cannot have a merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,6 @@ name: CI
 
 on:
   pull_request:
-  # A merge queue tests each PR against the tip it will actually land on, so
-  # branch protection no longer has to demand every branch be up to date --
-  # which re-staled all six other PRs on every merge.
-  merge_group:
   push:
     branches: [main]
 


### PR DESCRIPTION
Reverts the trigger added in #319. It was built on an assumption I did not check first: that a merge queue was configurable here. It is not.

**Evidence it is an account limitation, not a misconfiguration.** The rulesets API works on this repo — I created a trivial `non_fast_forward` ruleset and deleted it. But a ruleset carrying `merge_queue` is rejected with `Invalid rule 'merge_queue'` **even with no parameters at all**. Merge queue is an organization feature; this repo is on a personal account and is staying there.

**Why revert rather than leave it.** The trigger is inert, which is harmless. Its comment is not: it claims branch protection no longer has to demand every branch be up to date, and that is exactly what still happens on every merge. A comment that describes a mechanism the repo does not have is worse than no comment.

`actionlint` clean.

## What this does not change

The measurement behind #319 still stands and is the useful part: total job-time 78.8 min against a ~10 min round, with setup at 3%, so CI is not slow — `strict: true` turns one round into N. With the queue unavailable, the only remaining lever on that multiplication is dropping `strict`, which is a deliberate safety trade and the repo owner's call, not something to smuggle in here.