### PR TITLE
Correct the engine-race comment: the pod is not one CPU

### DIFF
--- a/formal/components.sby
+++ b/formal/components.sby
@@ -10,7 +10,7 @@ busarbiter all
 all: mode prove
 
 [engines]
-# No `all:` line: on a one-CPU pod it races a task's own engine, never replacing it.
+# No `all:` line: sby ADDS it to a task's own engine instead of replacing it.
 decoder: smtbmc
 accessor: smtbmc
 traps: smtbmc


### PR DESCRIPTION
#320 landed a comment reading *"on a one-CPU pod it races a task's own engine"*, and its commit message argued the losing engine was taking about half the core the winner needed. **Measured on the pod, that premise is false.**

    /sys/fs/cgroup/cpu.max    = 400000 100000    -> a 4-CPU quota
    /sys/fs/cgroup/memory.max = 3221225472       -> 3 GB
    nproc                     = 16               -> the HOST's cpus
    free -h                   = 27Gi             -> the HOST's memory

With four CPUs and sby running roughly four processes, the redundant engine was not meaningfully starving the winner. I inferred "one CPU" from an sby run reporting 406s of process time against 420s of clock, and never checked `cpu.max`.

**What #320 fixed is still real and still worth having:** sby *adds* an `all:` engine to a task's own rather than replacing it, so `executor`, `pcloop` and `busarbiter` each ran a second engine that never returned a status. Dropping a process that reports nothing is correct however many CPUs are idle. The local measurement behind it stands too — executor went 101s to 92s with the race removed.

This corrects only the explanation, so the next person does not reason from a CPU count that was never checked.

The general lesson, which is why the commit message spells it out: `nproc` and `free` report the **host**, `cpu.max` and `memory.max` report the **pod**. This repo had already been burned once by believing `free -h` inside a container.