### PR TITLE
formal/remeasure-fg.py demands a red direction and reads back the depth it generated

### DIFF
--- a/formal/Makefile
+++ b/formal/Makefile
@@ -52,7 +52,8 @@ RTL_SOURCES := ../rtl/structs.v ../rtl/fetcher.v ../rtl/regfile.v \
                ../rtl/accessor.v ../rtl/writeback.v ../rtl/littlecpu.v
 
 .PHONY: remeasure-fg
-remeasure-fg: remeasure-fg.py depth_rules.py genchecks-local.py checks.cfg $(RTL_SOURCES) | $(RISCV_FORMAL_DIR)
+remeasure-fg: remeasure-fg.py depth_rules.py genchecks-local.py checks.cfg $(RTL_SOURCES) \
+              interrupt-tie-off multihart-tie-off | $(RISCV_FORMAL_DIR)
 	python3 $<
 
 dmemcheck: dmemcheck.sby dmemcheck.sv arbiter.v $(RTL_SOURCES) | $(RISCV_FORMAL_DIR)

--- a/formal/remeasure-fg.py
+++ b/formal/remeasure-fg.py
@@ -3,6 +3,8 @@
 # is derived from -- and grades what it measures against the `#derive` lines that declare
 # them.
 
+import argparse
+import importlib.util
 import os
 import shutil
 import subprocess
@@ -13,6 +15,19 @@ import depth_rules
 HERE = os.path.dirname(os.path.abspath(__file__))
 CFG = os.path.join(HERE, "checks.cfg")
 PROBE = "fg-probe"
+GENCHECKS_DEFAULT = os.path.join(HERE, "genchecks-local.py")
+
+def _load_sibling(name):
+    """genchecks-audit.py is a hyphenated filename, so it is loaded by path rather
+    than imported by name."""
+    spec = importlib.util.spec_from_file_location(
+        name.replace("-", "_"), os.path.join(HERE, f"{name}.py")
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+genchecks_audit = _load_sibling("genchecks-audit")
 
 # The two trigger depths G is measured at, so a flip point is bracketed rather than
 # sampled once.
@@ -21,7 +36,19 @@ TRIGS = (10, 15)
 # How far either side of the declared figure to sweep.
 BELOW, ABOVE = 2, 1
 
-def probe(depth_line, check):
+def expected_cycles(depth_line):
+    """The RISCV_FORMAL_*_CYCLE(S) values `depth_line` should produce, read off the
+    same fields genchecks-local.py's check generation indexes into: hang is
+    (start, depth), liveness is (start, trig, depth)."""
+    label, *nums = depth_line.split()
+    nums = [int(n) for n in nums]
+    if label == "hang":
+        return {"CHECK_CYCLE": nums[1]}
+    if label == "liveness":
+        return {"CHECK_CYCLE": nums[2], "TRIG_CYCLE": nums[1]}
+    raise SystemExit(f"error: don't know which fields of {depth_line!r} are which")
+
+def probe(depth_line, check, genchecks):
     """Generate a one-check set from checks.cfg with `depth_line` as the whole
     of [depth], run it, and return sby's status."""
     lines = []
@@ -43,7 +70,7 @@ def probe(depth_line, check):
 
     shutil.rmtree(os.path.join(HERE, PROBE), ignore_errors=True)
     subprocess.run(
-        [sys.executable, "genchecks-local.py", PROBE],
+        [sys.executable, genchecks, PROBE],
         cwd=HERE,
         check=True,
         stdout=subprocess.DEVNULL,
@@ -54,6 +81,24 @@ def probe(depth_line, check):
             f"error: `{depth_line}` generated no {check} check. The [depth] key "
             "that names it has been renamed upstream, or the line is malformed."
         )
+
+    generated = {}
+    with open(sby) as f:
+        for line in f:
+            match = genchecks_audit.DEFINE_RE.match(line.rstrip("\n"))
+            if match:
+                generated[match.group(1)] = int(match.group(2))
+    for name, want in expected_cycles(depth_line).items():
+        got = generated.get(name)
+        if got != want:
+            raise SystemExit(
+                f"error: {PROBE}/{check}.sby defines RISCV_FORMAL_{name} = {got}, "
+                f"not the {want} this row swept ('{depth_line}'). genchecks-local.py's "
+                "[depth] field order has drifted from what this script assumes, so "
+                "every row would run at the same unasked-for depth while still "
+                "reporting PASS/FAIL."
+            )
+
     subprocess.run(
         ["sby", "-f", f"{PROBE}/{check}.sby"],
         cwd=HERE,
@@ -70,13 +115,14 @@ def probe(depth_line, check):
     with open(status_file) as f:
         return f.read().split()[0]
 
-def sweep(label, check, rows):
+def sweep(label, check, rows, genchecks):
     """Run one sweep of `check` and return the lowest value that PASSes, or
     None. `rows` is a list of (value, description, depth_line)."""
     print(f"\n{label}")
     flip = None
+    saw_fail = False
     for value, description, depth_line in rows:
-        status = probe(depth_line, check)
+        status = probe(depth_line, check, genchecks)
         print(f"  {description:<28} {status}")
         if status not in ("PASS", "FAIL"):
             raise SystemExit(
@@ -86,12 +132,22 @@ def sweep(label, check, rows):
             )
         if status == "PASS":
             if flip is None:
+                if not saw_fail:
+                    raise SystemExit(
+                        f"error: {check} passed at {value}, the lowest value "
+                        "swept, with no FAIL beneath it. A flip point needs a "
+                        "red direction to bracket it, not just a green one; "
+                        "widen BELOW in this file so the sweep reaches one."
+                    )
                 flip = value
-        elif flip is not None:
-            raise SystemExit(
-                f"error: {check} is red at {value} and green below it. The "
-                "sweep is not monotonic, so there is no flip point to report."
-            )
+        else:
+            saw_fail = True
+            if flip is not None:
+                raise SystemExit(
+                    f"error: {check} is red at {value} and green below it. The "
+                    "sweep is not monotonic, so there is no flip point to "
+                    "report."
+                )
     if flip is None:
         raise SystemExit(
             f"error: {check} is red at every value swept, so the flip point is "
@@ -101,6 +157,15 @@ def sweep(label, check, rows):
     return flip
 
 def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--genchecks",
+        default=GENCHECKS_DEFAULT,
+        help="generator to run against checks.cfg; overridable so a probe can "
+        "substitute one that reproduces a drifted [depth] field order",
+    )
+    args = parser.parse_args()
+
     if os.path.realpath(os.getcwd()) != os.path.realpath(HERE):
         print(f"error: run from {HERE}, not {os.getcwd()}", file=sys.stderr)
         return 1
@@ -121,6 +186,7 @@ def main():
             (cycle, f"check cycle {cycle}", f"hang     1     {cycle}")
             for cycle in range(max(1, f_declared - BELOW), f_declared + 1 + ABOVE)
         ],
+        args.genchecks,
     )
     # rvfi_hang_check.sv asserts a registered flag, so it first holds one cycle after the
     # last cycle a trace can go without retiring.
@@ -140,6 +206,7 @@ def main():
                 )
                 for gap in range(max(1, g_declared - BELOW), g_declared + 1 + ABOVE)
             ],
+            args.genchecks,
         )
         print(f"  => flip point {flip}, so G = {flip}")
         if g_measured is not None and flip != g_measured:

--- a/formal/remeasure-fg.py
+++ b/formal/remeasure-fg.py
@@ -43,9 +43,9 @@ def expected_cycles(depth_line):
     label, *nums = depth_line.split()
     nums = [int(n) for n in nums]
     if label == "hang":
-        return {"CHECK_CYCLE": nums[1]}
+        return {"CHECK_CYCLE": nums[1], "RESET_CYCLES": nums[0]}
     if label == "liveness":
-        return {"CHECK_CYCLE": nums[2], "TRIG_CYCLE": nums[1]}
+        return {"CHECK_CYCLE": nums[2], "TRIG_CYCLE": nums[1], "RESET_CYCLES": nums[0]}
     raise SystemExit(f"error: don't know which fields of {depth_line!r} are which")
 
 def probe(depth_line, check, genchecks):

--- a/test/PROBES_EXPECTED
+++ b/test/PROBES_EXPECTED
@@ -134,6 +134,7 @@ a constraint file that describes a different oscillator is red
 a constraint that is not the declared one is a different measurement
 a copy wrapped across lines is caught, not read as two harmless ones
 a core folded away on ECP5 is red against the same floor
+a core sweep whose lowest value already passes is refused a flip point, not reported one
 a core that cannot hold the CoreMark image is named, not left to the reader
 a core that cannot hold the image is named, not left to the reader
 a core that reached the start of the loop and not the end is red
@@ -192,6 +193,7 @@ a gap opening between the UART and the SPI controller is red
 a gap opening between the data RAM and the timer is red
 a gap opening between the timer's reservation and the UART is red
 a gate failure reported only by the induction leg is not evidence
+a generated .sby whose depth drifted from what the core's sweep asked for is refused, not read anyway
 a generated .sby whose depth drifted from what was swept is refused, not read anyway
 a generated check that was never scheduled resolves to NO-STATUS
 a generation that produced no checks at all is refused

--- a/test/PROBES_EXPECTED
+++ b/test/PROBES_EXPECTED
@@ -195,6 +195,7 @@ a gap opening between the timer's reservation and the UART is red
 a gate failure reported only by the induction leg is not evidence
 a generated .sby whose depth drifted from what the core's sweep asked for is refused, not read anyway
 a generated .sby whose depth drifted from what was swept is refused, not read anyway
+a generated .sby whose reset window drifted from what the core's sweep asked for is refused, not read anyway
 a generated check that was never scheduled resolves to NO-STATUS
 a generation that produced no checks at all is refused
 a graded target quietly depending on netlist-digest is red, and named

--- a/test/probe_gates.sh
+++ b/test/probe_gates.sh
@@ -1160,6 +1160,45 @@ mutate "$d/checks.cfg" 's/^hang     1     14$/hang     1     10/'
 probe "a nano [depth] entry lowered below its own floor fails generation, not just the baseline diff" 1 \
   "hang: depth 10 is below F+1 = 13" "cd '$d' && $GA ."
 
+begin_group "formal/remeasure-fg.py"
+
+# fg-probe.cfg and fg-probe/ are gitignored scratch, the same as `make -C formal
+# remeasure-fg` writes into the real formal directory; both probes clean up after.
+RFG_MAIN="cd '$REPO/formal' && rm -rf fg-probe fg-probe.cfg"
+
+mkdir -p "$tmp/bin-sby-pass-main"
+cat > "$tmp/bin-sby-pass-main/sby" <<'STUB'
+#!/bin/sh
+# Stands in for sby: reports PASS unconditionally.
+d=$(dirname "$2")
+check=$(basename "$2" .sby)
+mkdir -p "$d/$check"
+echo "PASS 2 0" > "$d/$check/status"
+STUB
+chmod +x "$tmp/bin-sby-pass-main/sby"
+
+probe "a core sweep whose lowest value already passes is refused a flip point, not reported one" 1 \
+  "with no FAIL beneath it" \
+  "$RFG_MAIN && PATH='$tmp/bin-sby-pass-main':\$PATH python3 remeasure-fg.py; rc=\$?; rm -rf fg-probe fg-probe.cfg; exit \$rc"
+
+cat > "$tmp/fake-genchecks-main.py" <<'PY'
+#!/usr/bin/env python3
+# Stands in for formal/genchecks-local.py, writing cycles that never match what was swept.
+import os, sys
+cfgname = sys.argv[1]
+with open(f"{cfgname}.cfg") as f:
+    lines = f.read().splitlines()
+check = lines[lines.index("[depth]") + 1].split()[0]
+name = "hang.sby" if check == "hang" else "liveness_ch0.sby"
+os.makedirs(cfgname, exist_ok=True)
+with open(os.path.join(cfgname, name), "w") as f:
+    f.write("`define RISCV_FORMAL_CHECK_CYCLE 1\n`define RISCV_FORMAL_TRIG_CYCLE 1\n")
+PY
+
+probe "a generated .sby whose depth drifted from what the core's sweep asked for is refused, not read anyway" 1 \
+  "not the 4 this row swept" \
+  "$RFG_MAIN && python3 remeasure-fg.py --genchecks '$tmp/fake-genchecks-main.py'; rc=\$?; rm -rf fg-probe fg-probe.cfg; exit \$rc"
+
 begin_group "nano/formal/remeasure-fg.py"
 
 # fg-probe.cfg and fg-probe/ are gitignored scratch, the same as `make -C nano/formal

--- a/test/probe_gates.sh
+++ b/test/probe_gates.sh
@@ -1179,7 +1179,7 @@ chmod +x "$tmp/bin-sby-pass-main/sby"
 
 probe "a core sweep whose lowest value already passes is refused a flip point, not reported one" 1 \
   "with no FAIL beneath it" \
-  "$RFG_MAIN && PATH='$tmp/bin-sby-pass-main':\$PATH python3 remeasure-fg.py; rc=\$?; rm -rf fg-probe fg-probe.cfg; exit \$rc"
+  "$RFG_MAIN && PATH='$tmp/bin-sby-pass-main':\$PATH python3 remeasure-fg.py; rc=\$?; rm -rf '$REPO/formal/fg-probe' '$REPO/formal/fg-probe.cfg'; exit \$rc"
 
 cat > "$tmp/fake-genchecks-main.py" <<'PY'
 #!/usr/bin/env python3
@@ -1197,7 +1197,37 @@ PY
 
 probe "a generated .sby whose depth drifted from what the core's sweep asked for is refused, not read anyway" 1 \
   "not the 4 this row swept" \
-  "$RFG_MAIN && python3 remeasure-fg.py --genchecks '$tmp/fake-genchecks-main.py'; rc=\$?; rm -rf fg-probe fg-probe.cfg; exit \$rc"
+  "$RFG_MAIN && python3 remeasure-fg.py --genchecks '$tmp/fake-genchecks-main.py'; rc=\$?; rm -rf '$REPO/formal/fg-probe' '$REPO/formal/fg-probe.cfg'; exit \$rc"
+
+cat > "$tmp/fake-genchecks-main-reset.py" <<'PY'
+#!/usr/bin/env python3
+# Stands in for formal/genchecks-local.py, writing a correct CHECK_CYCLE/TRIG_CYCLE but a
+# RESET_CYCLES that ignores what this row actually swept -- the reset-window half of a
+# [depth] field-order drift, which a check_cycle-only readback would miss.
+import os, sys
+cfgname = sys.argv[1]
+with open(f"{cfgname}.cfg") as f:
+    lines = f.read().splitlines()
+label, *nums = lines[lines.index("[depth]") + 1].split()
+nums = [int(n) for n in nums]
+os.makedirs(cfgname, exist_ok=True)
+if label == "hang":
+    body = f"`define RISCV_FORMAL_RESET_CYCLES 99\n`define RISCV_FORMAL_CHECK_CYCLE {nums[1]}\n"
+    name = "hang.sby"
+else:
+    body = (
+        f"`define RISCV_FORMAL_RESET_CYCLES 99\n"
+        f"`define RISCV_FORMAL_TRIG_CYCLE {nums[1]}\n"
+        f"`define RISCV_FORMAL_CHECK_CYCLE {nums[2]}\n"
+    )
+    name = "liveness_ch0.sby"
+with open(os.path.join(cfgname, name), "w") as f:
+    f.write(body)
+PY
+
+probe "a generated .sby whose reset window drifted from what the core's sweep asked for is refused, not read anyway" 1 \
+  "RISCV_FORMAL_RESET_CYCLES = 99, not the 1 this row swept" \
+  "$RFG_MAIN && python3 remeasure-fg.py --genchecks '$tmp/fake-genchecks-main-reset.py'; rc=\$?; rm -rf '$REPO/formal/fg-probe' '$REPO/formal/fg-probe.cfg'; exit \$rc"
 
 begin_group "nano/formal/remeasure-fg.py"
 
@@ -1218,7 +1248,7 @@ chmod +x "$tmp/bin-sby-pass/sby"
 
 probe "a sweep whose lowest value already passes is refused a flip point, not reported one" 1 \
   "with no FAIL beneath it" \
-  "$RFG && PATH='$tmp/bin-sby-pass':\$PATH python3 remeasure-fg.py; rc=\$?; rm -rf fg-probe fg-probe.cfg; exit \$rc"
+  "$RFG && PATH='$tmp/bin-sby-pass':\$PATH python3 remeasure-fg.py; rc=\$?; rm -rf '$REPO/nano/formal/fg-probe' '$REPO/nano/formal/fg-probe.cfg'; exit \$rc"
 
 cat > "$tmp/fake-genchecks.py" <<'PY'
 #!/usr/bin/env python3
@@ -1236,7 +1266,7 @@ PY
 
 probe "a generated .sby whose depth drifted from what was swept is refused, not read anyway" 1 \
   "not the 10 this row swept" \
-  "$RFG && python3 remeasure-fg.py --genchecks '$tmp/fake-genchecks.py'; rc=\$?; rm -rf fg-probe fg-probe.cfg; exit \$rc"
+  "$RFG && python3 remeasure-fg.py --genchecks '$tmp/fake-genchecks.py'; rc=\$?; rm -rf '$REPO/nano/formal/fg-probe' '$REPO/nano/formal/fg-probe.cfg'; exit \$rc"
 
 begin_group "soc/timing_split.py"
 


### PR DESCRIPTION
The main core's copy of `formal/remeasure-fg.py` had the same two gaps that were fixed in `nano/formal/remeasure-fg.py` in PR #316, correctly left out of that ticket's scope. This ports the fix, unchanged in shape, then closes two further gaps a follow-up verification pass found in the port.

## The port

Two gaps let the sweep report a confident F or G with nothing behind it:

- `sweep()` took the first PASS as the flip point without ever requiring a FAIL beneath it. It now refuses and names the fix (widen `BELOW`) the same way the existing all-red arm already does for the other end of the range.
- `probe()` checked only that `genchecks-local.py` wrote a `.sby` with the right name, never that its generated cycle defines matched the depth this row actually swept.

`genchecks-local.py`'s own path is now a `--genchecks` override (default unchanged) so both directions can be forced red in `test/probe_gates.sh`.

## Two gaps in the port itself, found by a follow-up verification pass

- **`expected_cycles()` compared `CHECK_CYCLE` and `TRIG_CYCLE` but never `RESET_CYCLES`.** A `[depth]` field-order drift that moved `start` (the reset window) rather than `depth`/`trig` would still pass the readback as long as the other two fields lined up -- the sweep would run under a reset window nobody asked for while still reporting PASS/FAIL as if nothing had drifted. `RESET_CYCLES` is now compared too (`formal/genchecks-audit.py`'s `DEFINE_RE` already matches the trailing `S`), with its own forced-red probe: a generator that writes the *correct* `CHECK_CYCLE`/`TRIG_CYCLE` but a `RESET_CYCLES` that ignores the row.
- **The banner claims a precondition the target didn't enforce.** `remeasure-fg` prints "under the interrupt tie-off `formal/check-interrupt-tie-off.py` enforces", but the Makefile target never ran it, unlike `check`, which lists `interrupt-tie-off` and `multihart-tie-off` as prerequisites. Added both, so a drifted `irq_timer` tie-off (or a multi-hart tie-off drift) is caught before the sweep runs rather than silently widening G.
- (Smaller, also fixed while in there) the three new probes' trailing cleanup ran even when the leading `cd` failed -- separated by `;` rather than `&&` -- which would delete `fg-probe`/`fg-probe.cfg` relative to whatever directory `probe_gates.sh` was invoked from rather than `formal/`. Not a live hazard (both operands are literal names, so it can't widen past those two paths), but anchored all five occurrences to absolute paths, including the two pre-existing ones in the nano group for consistency.

Deferred, out of this PR's scope per the coordinator: `range(max(1, f_declared - BELOW), ...)`'s "widen BELOW" advice is unfollowable if the floor ever clamps to 1 -- not reachable at F=6/G=6 today and fails closed, so a future-proofing nit rather than a defect.

## Testing

- `make probe-gates`: green, **840 graded comparisons, every failure path executed** (837 on main, +3 for the probes added here).
- `make comment-density-test`: green, 343 files scanned, all at or under 5%.
- `make test`: green, 75/75 suite programs PASS, failure list matches `test/EXPECTED_FAIL` exactly.
- `make -C formal remeasure-fg`, with the cached OSS CAD Suite on `PATH` (`export PATH="$HOME/.cache/little-cpu/oss-cad-suite/bin:$PATH"` -- `formal/Makefile` has no PATH prepend of its own, unlike the root Makefile since #311, so a bare `make -C formal ...` resolves to Homebrew's yosys/btormc/boolector and finds no `btorsim`, which turns every real FAIL into sby `ERROR (rc=16)`): reproduces the sweep for real, tie-off checks now running first --

  ```
  MULTI-HART TIE-OFF: PASS

  F -- worst-case first retire, from `hang`'s check cycle:
    check cycle 4                FAIL
    check cycle 5                FAIL
    check cycle 6                FAIL
    check cycle 7                PASS
    => flip point 7, so F = 6

  G -- worst-case retire gap, from `liveness` at trig 10:   (and trig 15, same shape)
    gap 4 (check cycle 14)       FAIL
    gap 5 (check cycle 15)       FAIL
    gap 6 (check cycle 16)       PASS
    gap 7 (check cycle 17)       PASS
    => flip point 6, so G = 6

  Measured: F = 6, G = 6. Declared: F = 6, G = 6.
  Both reproduce.
  ```

## Scope notes

- Ported verbatim per the ticket's instruction ("do not redesign it"); the two follow-up fixes above were requested by the coordinator's own verification pass on this PR and are scoped to the same two files plus the Makefile prerequisite they depend on.
- `/simplify`: reviewed by inspection; nothing further to change.
- `/soundcheck:pr-review`: 0 Critical/High findings -- dev-only tooling script, list-form `subprocess.run` (no shell, no injection surface), `--genchecks` is a maintainer-supplied CLI override with no untrusted-input path.
- Not this PR's to fix, filed separately: `formal/Makefile` not prepending the cached OSS CAD Suite onto `PATH` the way the root Makefile does since #311 -- also affects `pono` (#323) and `bitwuzla` (#320).
- Worth knowing, no action needed: these probes reuse `formal/fg-probe/` and `formal/fg-probe.cfg`, the same scratch a real `make -C formal remeasure-fg` uses, so `make probe-gates` and a real sweep can't run concurrently in one workspace without one clobbering the other's in-flight scratch. It fails loudly ("sby wrote no status") rather than reporting a wrong F or G if that happens, so not isolated further.

Closes JEF-997

🤖 Generated with [Claude Code](https://claude.com/claude-code)