### PR TITLE
genchecks-audit.py names a missing riscv-formal clone instead of blaming the ISA string

### DIFF
--- a/formal/genchecks-audit.py
+++ b/formal/genchecks-audit.py
@@ -164,6 +164,24 @@ def main():
         print(f"error: run from {base}, not {os.getcwd()}", file=sys.stderr)
         return 1
 
+    # genchecks-local.py resolves its instruction-list clone relative to its own
+    # realpath, not to <harness-dir>, so a gitignored clone missing from a fresh
+    # worktree is invisible until it opens `{clone}/insns/isa_<isa>.txt` and gets a
+    # FileNotFoundError it blames on the ISA string. Catch the real cause first.
+    riscv_formal_dir = os.path.join(
+        os.path.dirname(os.path.realpath(GENCHECKS)), "riscv-formal"
+    )
+    if not os.path.isdir(riscv_formal_dir):
+        print(
+            f"error: {riscv_formal_dir} is missing. genchecks-local.py reads its\n"
+            "       instruction list out of that clone, so its absence surfaces\n"
+            "       downstream as \"Current isa string '...' not supported\" -- \n"
+            "       nothing is wrong with the ISA string. Fetch the pinned clone:\n"
+            "       make -C formal riscv-formal (formal/pin.mk has the SHA).",
+            file=sys.stderr,
+        )
+        return 1
+
     # genchecks-local.py runs in-process via runpy and reads sys.argv[1] as a cfg name,
     # so this script's own <harness-dir> argument must not leak into it.
     saved_argv = sys.argv

--- a/formal/genchecks-audit.py
+++ b/formal/genchecks-audit.py
@@ -164,10 +164,7 @@ def main():
         print(f"error: run from {base}, not {os.getcwd()}", file=sys.stderr)
         return 1
 
-    # genchecks-local.py resolves its instruction-list clone relative to its own
-    # realpath, not to <harness-dir>, so a gitignored clone missing from a fresh
-    # worktree is invisible until it opens `{clone}/insns/isa_<isa>.txt` and gets a
-    # FileNotFoundError it blames on the ISA string. Catch the real cause first.
+    # A missing gitignored clone otherwise surfaces later as an ISA-string error.
     riscv_formal_dir = os.path.join(
         os.path.dirname(os.path.realpath(GENCHECKS)), "riscv-formal"
     )

--- a/formal/genchecks-audit.py
+++ b/formal/genchecks-audit.py
@@ -172,7 +172,7 @@ def main():
         print(
             f"error: {riscv_formal_dir} is missing. genchecks-local.py reads its\n"
             "       instruction list out of that clone, so its absence surfaces\n"
-            "       downstream as \"Current isa string '...' not supported\" -- \n"
+            "       downstream as \"Current isa string '...' not supported\" --\n"
             "       nothing is wrong with the ISA string. Fetch the pinned clone:\n"
             "       make -C formal riscv-formal (formal/pin.mk has the SHA).",
             file=sys.stderr,

--- a/test/PROBES_EXPECTED
+++ b/test/PROBES_EXPECTED
@@ -243,6 +243,7 @@ a missing liberty file is refused before the JSON is even opened
 a missing parser stops the run rather than grading with a second one
 a missing ramdiff for the SECOND CoreMark core is red, not silently skipped
 a missing ramdiff for the SECOND core is red, not silently skipped
+a missing riscv-formal clone is named, not blamed on the ISA string
 a missing stat.json is refused, not read as a zero-area design
 a mistyped baseline path cannot compare nothing and pass
 a mistyped baseline path cannot compare nothing and pass

--- a/test/probe_gates.sh
+++ b/test/probe_gates.sh
@@ -1146,6 +1146,22 @@ probe "running the generator from the wrong directory is refused, not done" 1 \
 
 GA="python3 $REPO/formal/genchecks-audit.py"
 
+# genchecks-local.py resolves its riscv-formal clone relative to its own realpath, not
+# to the <harness-dir> argument, so this fixture copies both scripts for real -- a
+# symlink back to formal/ would resolve through it to the clone this checkout already
+# has, passing the probe while testing nothing.
+ga_missing_clone_fixture() {
+  local d; d=$(new_case)
+  cp "$REPO/formal/genchecks-audit.py" "$d/genchecks-audit.py"
+  cp "$REPO/formal/genchecks-local.py" "$d/genchecks-local.py"
+  cp "$REPO/formal/depth_rules.py" "$d/depth_rules.py"
+  printf '%s' "$d"
+}
+
+d=$(ga_missing_clone_fixture)
+probe "a missing riscv-formal clone is named, not blamed on the ISA string" 1 \
+  "riscv-formal is missing" "cd '$d' && python3 genchecks-audit.py ."
+
 # A second harness's checks.cfg: genchecks-audit.py takes the harness directory as
 # an argument, so this fixture never touches the real nano/formal tree.
 ga_nano_fixture() {


### PR DESCRIPTION
## Problem

`formal/riscv-formal` is gitignored, so a fresh git worktree never gets a clone. `genchecks-local.py` resolves that clone relative to its own `realpath`, not to the `<harness-dir>` argument passed to `genchecks-audit.py`. When the clone is absent, `genchecks-local.py`'s `except FileNotFoundError` on `{basedir}/insns/isa_{isa}.txt` prints:

    Current isa string 'rv32imc' not supported

— which names the wrong cause and sent three separate sessions chasing a phantom red in `test/probe_gates.sh`'s nano `[depth]` probe.

## Fix

`genchecks-audit.py` now checks for the clone (computed the same way `genchecks-local.py` does: relative to `GENCHECKS`'s own realpath) before invoking `genchecks-local.py`, and refuses with the real cause and the fetch command (`make -C formal riscv-formal`) if it's missing.

- The refusal lives in `genchecks-audit.py` only. `genchecks-local.py` is byte-unchanged (`make -C formal genchecks-check` still passes) — it stays the verbatim vendored copy its own header requires.
- A forced-red probe builds a fixture with **real copies** (`shutil`/`cp`, never symlinks) of `genchecks-audit.py`, `genchecks-local.py` and `depth_rules.py`, and no `riscv-formal` directory. A symlinked script would resolve through `realpath` back to the real `formal/` clone this checkout already has, passing the probe while testing nothing — the trap the ticket called out.
- `test/PROBES_EXPECTED` gets one new line, inserted in `LC_ALL=C sort` position in the body (never appended, never regenerated).

## Scope decision

The ticket's "worth considering" section raises a `make doctor` diagnostic for the missing clone. I scoped that **out**: `make doctor`'s documented purpose (CLAUDE.md) is the RISC-V compiler / yosys / nextpnr-ice40 / icetime path, and widening it to cover the formal toolchain crosses into a second target's stated scope for no acceptance-criterion this ticket names. Auto-cloning is explicitly out per the ticket (the pin stays authoritative). Flagging as a candidate follow-up rather than bundling it here.

## Testing

- `make -C formal genchecks-check` — green, `genchecks-local.py` still matches the pin byte-for-byte (header + basedir only).
- `make probe-gates` — green, **838** graded comparisons (837 on main + 1 new probe).
- `make comment-density-test` — green, 343 files scanned, all at or under 5%.
- `make test` — green, exit 0 (75/75 `.S`/`.c` suite matching `test/EXPECTED_FAIL`, unit benches, probe-gates, and every repo-scanning `*-test` target).
- Manually verified the new diagnostic fires correctly against a real missing-clone fixture, and that a normal run against the real `formal/riscv-formal` (present in this worktree) is unaffected.

## Security self-review

Ran `/soundcheck:pr-review` equivalent manually: no untrusted input reaches a shell/SQL/path construction in this diff; new fixture paths come from `mktemp`; no secrets. No Critical/High findings.

Closes JEF-998

🤖 Generated with [Claude Code](https://claude.com/claude-code)