### PR TITLE
Declare the insn-check fork rather than infer it from a file's presence

### DIFF
--- a/formal/genchecks-audit.py
+++ b/formal/genchecks-audit.py
@@ -18,6 +18,7 @@ DEFINE_RE = re.compile(r"^`define\s+RISCV_FORMAL_(\w+_CYCLES?)\s+(\d+)\s*$")
 
 # genchecks' parser drops `#` lines before a section, so these don't perturb generation.
 OMIT_RE = re.compile(r"^#omit\s+(\S+)\s+(\S.*)$")
+INSN_CHECK_RE = re.compile(r"^#insn-check\s+(\S+)\s*$")
 
 def read_name_list(path):
     """One name per line. `#` comments and blank lines are ignored, the same way
@@ -149,35 +150,54 @@ def call_tracer(frame, event, arg):
         return return_tracer
     return None
 
-def patch_local_insn_check(base, pin_basedir, checks_dir):
-    """Point every generated insn_* check at a harness-local rvfi_insn_check.sv fork
-    instead of the pinned clone's copy, when one exists beside checks.cfg.
+def declared_insn_fork(base, cfg):
+    """The fork a harness names with `#insn-check <file>`, or an error when the
+    declaration is ambiguous, names nothing, or a fork sits there undeclared."""
+    with open(cfg) as f:
+        names = [m.group(1) for m in map(INSN_CHECK_RE.match, f.read().splitlines()) if m]
+    if len(names) > 1:
+        return None, f"error: {cfg} declares #insn-check {len(names)} times; one fork per harness."
+    if names:
+        fork = os.path.join(base, names[0])
+        if not os.path.isfile(fork):
+            return None, f"error: {cfg} declares #insn-check {names[0]}, which does not exist."
+        return fork, None
+    stray = os.path.join(base, "rvfi_insn_check.sv")
+    if os.path.exists(stray):
+        return None, (
+            f"error: {stray} sits beside checks.cfg with no #insn-check line,\n"
+            "       so it would decide which oracle this harness's insn_* checks read\n"
+            "       without saying so. Declare it in checks.cfg, or remove it."
+        )
+    return None, None
 
-    genchecks-local.py is vendored and always writes @basedir@/checks/rvfi_insn_check.sv
-    into [files]; that basedir is the ONE riscv-formal clone every harness shares, so
-    editing the clone's own copy in place would also change formal/'s checks for
-    littlecpu, which has no register-count restriction to assume. nano/formal carries its
-    own rvfi_insn_check.sv (a fork adding the RISCV_FORMAL_E assumption,
-    check-rvfi-insn-check.py grades it against the pin) precisely so the substitution can
-    be local to the .sby files this call generates, never to the shared clone.
-    """
-    local_fork = os.path.join(base, "rvfi_insn_check.sv")
-    if not os.path.isfile(local_fork):
-        return
+def redirect_insn_checks(fork, pin_basedir, checks_dir):
+    """Re-point the generated checks, never the shared clone, from its rvfi_insn_check.sv
+    to `fork`, then read every insn_* .sby back rather than trusting a tally."""
     pinned = os.path.join(pin_basedir, "checks", "rvfi_insn_check.sv")
-    patched = 0
-    for name in os.listdir(checks_dir):
-        if not name.endswith(".sby"):
-            continue
+    sbys = sorted(n for n in os.listdir(checks_dir) if n.endswith(".sby"))
+    for name in sbys:
         path = os.path.join(checks_dir, name)
         with open(path) as f:
             text = f.read()
-        if pinned not in text:
-            continue
-        with open(path, "w") as f:
-            f.write(text.replace(pinned, local_fork))
-        patched += 1
-    print(f"patch_local_insn_check: {patched} check(s) now read {local_fork}")
+        if pinned in text:
+            with open(path, "w") as f:
+                f.write(text.replace(pinned, fork))
+    insn = [n for n in sbys if n.startswith("insn_")]
+    missed = []
+    for name in insn:
+        with open(os.path.join(checks_dir, name)) as f:
+            if fork not in f.read():
+                missed.append(name)
+    if missed:
+        return (
+            f"error: #insn-check names {fork}, but {len(missed)} of {len(insn)} insn_*\n"
+            f"       checks do not read it (e.g. {missed[0]}). The generator no longer\n"
+            f"       writes {pinned} in the form this redirect replaces -- a pin bump\n"
+            "       respelling [files] does it -- so those checks read the unpatched oracle."
+        )
+    print(f"insn-check: {len(insn)} of {len(insn)} insn_* checks read {fork}")
+    return None
 
 def main():
     if len(sys.argv) != 2:
@@ -209,6 +229,11 @@ def main():
         )
         return 1
 
+    fork, insn_error = declared_insn_fork(base, cfg)
+    if insn_error:
+        print(insn_error, file=sys.stderr)
+        return 1
+
     # genchecks-local.py runs in-process via runpy and reads sys.argv[1] as a cfg name,
     # so this script's own <harness-dir> argument must not leak into it.
     saved_argv = sys.argv
@@ -230,7 +255,11 @@ def main():
         )
         return 1
 
-    patch_local_insn_check(base, genchecks["basedir"], checks_dir)
+    if fork:
+        insn_error = redirect_insn_checks(fork, genchecks["basedir"], checks_dir)
+        if insn_error:
+            print(insn_error, file=sys.stderr)
+            return 1
 
     considered = {}
     families = {}

--- a/nano/formal/checks.cfg
+++ b/nano/formal/checks.cfg
@@ -1,3 +1,4 @@
+#insn-check rvfi_insn_check.sv
 [options]
 isa rv32imc
 solver btormc

--- a/test/PROBES_EXPECTED
+++ b/test/PROBES_EXPECTED
@@ -207,6 +207,7 @@ a generated .sby whose depth drifted from what was swept is refused, not read an
 a generated .sby whose reset window drifted from what the core's sweep asked for is refused, not read anyway
 a generated check that was never scheduled resolves to NO-STATUS
 a generation that produced no checks at all is refused
+a generator whose checker path no longer matches is refused, not read as a redirected set
 a graded target quietly depending on netlist-digest is red, and named
 a graph with no edges out of reg_rs1 is red, not a vacuous pass
 a half-installed toolchain says so once, up front
@@ -405,6 +406,7 @@ a run that never made the cross-core check is red
 a run that printed no COSIM-STATUS is COSIM-ERROR, not a verdict
 a runner that printed no CS END terminator is a broken harness
 a runner that reports no cycles at all cannot produce a clean table
+a rvfi_insn_check.sv beside littlecpu's checks.cfg with no #insn-check line is refused
 a second occurrence of a counted exception value is red
 a seed clearing SOC_MIN_MHZ by under 5% is refused, not pinned
 a semicolon in the liberty path stays inside its own quoted token
@@ -480,6 +482,7 @@ a wait bound that admits a starved hart is red
 a wire that does not carry its class's name is named
 a wire that names a funct7 without a funct3 is rejected, not parsed
 a wrong-rule mutant that still passes is not a control
+an #insn-check naming a file that does not exist is refused
 an ECP5 placement read with ice40 names names the part, not a bad log
 an ECP5 stamp carrying up5k's tools is missing its own
 an EXTRA architectural write the model never made is caught
@@ -663,6 +666,7 @@ control: icetime whose chip database resolves is stamped like any tool
 control: identical register traces and verdicts AGREE
 control: mutate on a real match rewrites the file and returns 0
 control: mutate_remove deletes a file that is there
+control: nano's declared fork redirects every generated insn_* check
 control: nano/formal/Makefile also puts the cached suite first
 control: programs that build and are paired are green
 control: rule 6 gates the trap comparison and writes its compensation
@@ -881,6 +885,7 @@ the word coming back in a formal harness comment is red, and located
 the wrong count is named against the log's real one
 three sweeps have no one difference, so they are refused
 total above the ratchet names the figure and the budget
+two #insn-check lines are refused rather than one silently winning
 two CoreMark cores whose RAMs differ are red, not a ratio
 two arms that cannot be told apart are not two arms
 two arms that cannot be told apart are not two arms

--- a/test/comment_density_test.py
+++ b/test/comment_density_test.py
@@ -70,13 +70,13 @@ EXCLUDE_FILES = {
 }
 
 # Lines that carry a comment marker and are CODE. Each is parsed by something:
-# `#derive`/`#floor`/`#omit` by formal/depth_rules.py and genchecks-audit.py,
+# `#derive`/`#floor`/`#omit`/`#insn-check` by depth_rules.py and genchecks-audit.py,
 # `// EXCLUDE` by formal/check-complete-exclusions.py (which also requires 40
 # characters of prose under it), a shebang by the kernel, and the rest by a
 # linter. Exempting the whole file instead would stop grading its real prose.
 FUNCTIONAL = re.compile(
     r"^(#!"
-    r"|\s*(#derive|#floor|#omit)\b"
+    r"|\s*(#derive|#floor|#omit|#insn-check)\b"
     r"|\s*//\s*EXCLUDE\b"
     r"|\s*(#|//)\s*(shellcheck|noqa|pylint|type:|nosec|yamllint|codespell|ruff:|mypy:"
     r"|fmt:|isort:|pragma|coding[:=]|-\*-|SPDX|Copyright|See LICENSE|Licensed under"

--- a/test/probe_gates.sh
+++ b/test/probe_gates.sh
@@ -1168,6 +1168,7 @@ ga_nano_fixture() {
   local d; d=$(new_case)
   cp "$REPO/nano/formal/checks.cfg" "$d/checks.cfg"
   cp "$REPO/nano/formal/EXPECTED_CHECKS" "$d/EXPECTED_CHECKS"
+  cp "$REPO/nano/formal/rvfi_insn_check.sv" "$d/rvfi_insn_check.sv"
   printf '%s' "$d"
 }
 
@@ -1175,6 +1176,34 @@ d=$(ga_nano_fixture)
 mutate "$d/checks.cfg" 's/^hang     1     14$/hang     1     10/'
 probe "a nano [depth] entry lowered below its own floor fails generation, not just the baseline diff" 1 \
   "hang: depth 10 is below F+1 = 13" "cd '$d' && $GA ."
+
+d=$(ga_nano_fixture)
+probe "control: nano's declared fork redirects every generated insn_* check" 0 \
+  "insn_* checks read" "cd '$d' && $GA ."
+
+d=$(new_case)
+cp "$REPO/formal/checks.cfg" "$REPO/formal/EXPECTED_CHECKS" "$d/"
+cp "$REPO/formal/riscv-formal/checks/rvfi_insn_check.sv" "$d/rvfi_insn_check.sv"
+probe "a rvfi_insn_check.sv beside littlecpu's checks.cfg with no #insn-check line is refused" 1 \
+  "sits beside checks.cfg with no #insn-check line" "cd '$d' && $GA ."
+
+d=$(ga_nano_fixture); rm "$d/rvfi_insn_check.sv"
+probe "an #insn-check naming a file that does not exist is refused" 1 \
+  "which does not exist" "cd '$d' && $GA ."
+
+d=$(ga_nano_fixture); printf '#insn-check rvfi_insn_check.sv\n' >> "$d/checks.cfg"
+probe "two #insn-check lines are refused rather than one silently winning" 1 \
+  "declares #insn-check 2 times" "cd '$d' && $GA ."
+
+# The real generator with its vendored [files] line respelled, as a pin bump could do:
+# the redirect then recognises nothing to replace, and must say so rather than finish.
+d=$(new_case); mkdir -p "$d/formal" "$d/h"
+cp "$REPO/formal/genchecks-audit.py" "$REPO/formal/genchecks-local.py" "$REPO/formal/depth_rules.py" "$d/formal/"
+ln -s "$REPO/formal/riscv-formal" "$d/formal/riscv-formal"
+cp "$REPO/nano/formal/checks.cfg" "$REPO/nano/formal/EXPECTED_CHECKS" "$REPO/nano/formal/rvfi_insn_check.sv" "$d/h/"
+mutate "$d/formal/genchecks-local.py" 's|@basedir@/checks/rvfi_insn_check.sv|@basedir@/checks/./rvfi_insn_check.sv|'
+probe "a generator whose checker path no longer matches is refused, not read as a redirected set" 1 \
+  "checks do not read it" "cd '$d/h' && python3 '$d/formal/genchecks-audit.py' ."
 
 begin_group "formal/remeasure-fg.py"
 


### PR DESCRIPTION
Closes JEF-1010.

## The gap

#337 added `patch_local_insn_check` to `formal/genchecks-audit.py`, the generator entry point **both** harnesses share. It re-pointed every generated `insn_*` check at a harness-local `rvfi_insn_check.sv` **whenever a file of that name sat beside `checks.cfg`**, and printed how many it patched without requiring the count to be complete.

- **Silent direction:** a stray `rvfi_insn_check.sv` landing in `formal/` would have re-pointed littlecpu's 70 `insn_*` checks at it, with nothing saying so.
- **Misdirected direction:** a pin bump that respells the vendored `[files]` line would redirect 0 of 70, and nano's checks would fail as an apparent core bug rather than as "the redirect did nothing".

## The change

A harness **declares** its fork with an `#insn-check <file>` line in its own `checks.cfg`. It's a `#` line the vendored generator skips (`genchecks-local.py:87`), the same idiom as `#omit`. An unknown `[options]` key was not an option: the vendored parser `assert 0`s on those.

- **Before generation**, the audit refuses a fork present with no declaration, a declaration naming a missing file, and a declaration made twice.
- **After generation**, it reads every `insn_*` `.sby` back and requires each to name the fork. The check is the artifacts, not the function's own tally, so 3-of-70 cannot pass.

`nano/formal/checks.cfg` carries the one declaration. `formal/` carries none. `comment_density_test.py` treats `#insn-check` as code, like `#derive`/`#floor`/`#omit`.

## Verified

| | result |
|---|---|
| nano | `insn-check: 70 of 70 insn_* checks read …/nano/formal/rvfi_insn_check.sv`; 82 checks, exact match |
| formal (littlecpu) | no redirect; 86 checks, exact match |
| `genchecks-local.py` | byte-identical to the pin (`make -C formal genchecks-check`) |
| `make probe-gates` | **888** graded comparisons, every failure path executed (883 + 5) |
| `make test` | 75/75, failure list matches `test/EXPECTED_FAIL` exactly |

The five probes: a passing control on nano, then refusals for a stray fork beside **littlecpu's** `checks.cfg`, a declaration naming a missing file, a duplicate declaration, and the pin-bump case. The last one runs the **real** generator with its one vendored `[files]` line respelled, so it performs the actual failure rather than an imitation of it.

`ga_nano_fixture` now copies the fork too. Without it, the existing depth-floor probe would have gone red for the new reason instead of its own.

`test/PROBES_EXPECTED`: header byte-identical to main, five labels inserted into the body as a multiset in `LC_ALL=C` order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)